### PR TITLE
Fix for using the sass @import declaration which was not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ nbproject/*
 .sass-cache/
 .DS_Store
 jruby.jar
+build/lib/vendors

--- a/src/base/build.properties
+++ b/src/base/build.properties
@@ -16,7 +16,7 @@ antcontribs.jar=${lib.dir}/ant-contrib-1.0b3.jar
 cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 
 #jRuby Properties
-jruby.jar=${lib.dir}/jruby-complete-1.6.7.2.jar
+jruby.jar=${lib.dir}/jruby.jar
 
 #jLESS Properties
 #jless.jar=test.jar

--- a/src/base/build.xml
+++ b/src/base/build.xml
@@ -10,7 +10,7 @@
   <!-- Include jruby + gems (compass + sass + zengrids) -->
   <target name="build-jar" depends="jar.check" unless="jar.exists">
     <mkdir dir="${lib.dir}/jruby-compiled" />
-    <get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
+    <get src="http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-complete-1.7.0.preview1.jar" dest="${lib.dir}/jruby.jar"/>
     <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>  
     <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>  
     <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/> 
@@ -21,7 +21,6 @@
       <arg line="-uf jruby.jar -C vendors ." />
     </exec>
     <delete dir="${lib.dir}/jruby-compiled" />
-    <delete dir="${lib.dir}/vendors" />
   </target>
   <target name="jar.check">
     <condition property="jar.exists">
@@ -32,7 +31,7 @@
   <!-- Compile all of the SCSS files into their CSS counterparts "ant compile.sass" -->
   <target name="compile.sass">
     <java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
-        <arg line="${src.dir}/compile.rb ${lib.dir}/gems/ compile ${src.dir}"/>
+        <arg line="${src.dir}/compile.rb ${lib.dir}/vendors/gems/ compile ${src.dir}"/>
     </java>
     <echo level="info">
 ---Converted CSS SCSS Files into CSS---
@@ -41,7 +40,7 @@
   <!-- Watch for any polling changes in the SCSS directory "ant watch.sass" -->
   <target name="watch.sass">
     <java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
-        <arg line="${src.dir}/compile.rb ${lib.dir}/gems/ watch ${src.dir}"/>
+        <arg line="${src.dir}/compile.rb ${lib.dir}/jruby.jar/gems/ watch ${src.dir}"/>
     </java>
     <echo level="info">
 ---Watching for SCSS Changes in CSS Directory---

--- a/src/base/build.xml
+++ b/src/base/build.xml
@@ -40,7 +40,7 @@
   <!-- Watch for any polling changes in the SCSS directory "ant watch.sass" -->
   <target name="watch.sass">
     <java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
-        <arg line="${src.dir}/compile.rb ${lib.dir}/jruby.jar/gems/ watch ${src.dir}"/>
+        <arg line="${src.dir}/compile.rb ${lib.dir}/vendors/gems/ watch ${src.dir}"/>
     </java>
     <echo level="info">
 ---Watching for SCSS Changes in CSS Directory---

--- a/src/base/compile.rb
+++ b/src/base/compile.rb
@@ -1,5 +1,7 @@
 # Load All of the Gems inside the jRuby jar passed in by first argument 
-$LOAD_PATH.unshift "#{ARGV[0]}"
+Dir.entries(ARGV[0]).each do |lib|  
+    $LOAD_PATH.unshift "#{ARGV[0]}/#{lib}/lib"  
+end 
 
 # Require the following Gems
 require 'rubygems'   

--- a/src/grids/build.properties
+++ b/src/grids/build.properties
@@ -16,7 +16,7 @@ antcontribs.jar=${lib.dir}/ant-contrib-1.0b3.jar
 cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 
 #jRuby Properties
-jruby.jar=${lib.dir}/jruby-complete-1.6.7.2.jar
+jruby.jar=${lib.dir}/jruby.jar
 
 #jLESS Properties
 #jless.jar=test.jar

--- a/src/grids/build.xml
+++ b/src/grids/build.xml
@@ -10,7 +10,7 @@
   <!-- Include jruby + gems (compass + sass + zengrids) -->
   <target name="build-jar" depends="jar.check" unless="jar.exists">
     <mkdir dir="${lib.dir}/jruby-compiled" />
-    <get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
+    <get src="http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-complete-1.7.0.preview1.jar" dest="${lib.dir}/jruby.jar"/>
     <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>  
     <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>  
     <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/> 
@@ -21,7 +21,6 @@
       <arg line="-uf jruby.jar -C vendors ." />
     </exec>
     <delete dir="${lib.dir}/jruby-compiled" />
-    <delete dir="${lib.dir}/vendors" />
   </target>
   <target name="jar.check">
     <condition property="jar.exists">
@@ -56,7 +55,7 @@
   <!-- Watch for any polling changes in the SCSS directory "ant watch.sass" -->
   <target name="watch.sass">
     <java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
-        <arg line="${src.dir}/compile.rb ${lib.dir}/gems/ watch ${src.dir}"/>
+        <arg line="${src.dir}/compile.rb ${lib.dir}/vendors/gems/ watch ${src.dir}"/>
     </java>
     <echo level="info">
 ---Watching for SCSS Changes in Grids Directory---

--- a/src/grids/compile.rb
+++ b/src/grids/compile.rb
@@ -1,5 +1,7 @@
 # Load All of the Gems inside the jRuby jar passed in by first argument 
-$LOAD_PATH.unshift "#{ARGV[0]}"
+Dir.entries(ARGV[0]).each do |lib|  
+    $LOAD_PATH.unshift "#{ARGV[0]}/#{lib}/lib"  
+end 
 
 # Require the following Gems
 require 'rubygems'   

--- a/src/js/build.properties
+++ b/src/js/build.properties
@@ -23,7 +23,7 @@ cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 #nodecoffeescript.command=-cb
 
 #jRuby Properties
-jruby.jar=${lib.dir}/jruby-complete-1.6.7.2.jar
+jruby.jar=${lib.dir}/jruby.jar
 
 #jLESS Properties
 #jless.jar=test.jar

--- a/src/js/build.xml
+++ b/src/js/build.xml
@@ -10,7 +10,7 @@
   <!-- Include jruby + gems (compass + sass + zengrids) -->
   <target name="build-jar" depends="jar.check" unless="jar.exists">
     <mkdir dir="${lib.dir}/jruby-compiled" />
-    <get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
+    <get src="http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-complete-1.7.0.preview1.jar" dest="${lib.dir}/jruby.jar"/>
     <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>  
     <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>  
     <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/> 
@@ -21,7 +21,6 @@
       <arg line="-uf jruby.jar -C vendors ." />
     </exec>
     <delete dir="${lib.dir}/jruby-compiled" />
-    <delete dir="${lib.dir}/vendors" />
   </target>
   <target name="jar.check">
     <condition property="jar.exists">
@@ -47,7 +46,7 @@
   <!-- Compile all of the SCSS files into their CSS counterparts "ant compile.sass" -->
   <target name="compile.sass">
     <java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
-        <arg line="${src.dir}/compile.rb ${lib.dir}/gems/ compile ${src.dir}"/>
+        <arg line="${src.dir}/compile.rb ${lib.dir}/vendors/gems/ compile ${src.dir}"/>
     </java>
     <echo level="info">
 ---Converted JS SCSS Files into CSS---
@@ -56,7 +55,7 @@
   <!-- Watch for any polling changes in the SCSS directory "ant watch.sass" -->
   <target name="watch.sass">
     <java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
-        <arg line="${src.dir}/compile.rb ${lib.dir}/gems/ watch ${src.dir}"/>
+        <arg line="${src.dir}/compile.rb ${lib.dir}/vendors/gems/ watch ${src.dir}"/>
     </java>
     <echo level="info">
 ---Watching for SCSS Changes in JS Directory---

--- a/src/js/compile.rb
+++ b/src/js/compile.rb
@@ -1,5 +1,7 @@
 # Load All of the Gems inside the jRuby jar passed in by first argument 
-$LOAD_PATH.unshift "#{ARGV[0]}"
+Dir.entries(ARGV[0]).each do |lib|  
+    $LOAD_PATH.unshift "#{ARGV[0]}/#{lib}/lib"  
+end 
 
 # Require the following Gems
 require 'rubygems'   

--- a/src/theme-gcwu-fegc/build.properties
+++ b/src/theme-gcwu-fegc/build.properties
@@ -16,4 +16,4 @@ antcontribs.jar=${lib.dir}/ant-contrib-1.0b3.jar
 cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 
 #jRuby Properties
-jruby.jar=${lib.dir}/jruby-complete-1.6.7.2.jar
+jruby.jar=${lib.dir}/jruby.jar

--- a/src/theme-gcwu-fegc/build.xml
+++ b/src/theme-gcwu-fegc/build.xml
@@ -10,7 +10,7 @@
   <!-- Include jruby + gems (compass + sass + zengrids) -->
   <target name="build-jar" depends="jar.check" unless="jar.exists">
     <mkdir dir="${lib.dir}/jruby-compiled" />
-    <get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
+    <get src="http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-complete-1.7.0.preview1.jar" dest="${lib.dir}/jruby.jar"/>
     <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>  
     <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>  
     <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/> 
@@ -21,7 +21,6 @@
       <arg line="-uf jruby.jar -C vendors ." />
     </exec>
     <delete dir="${lib.dir}/jruby-compiled" />
-    <delete dir="${lib.dir}/vendors" />
   </target>
   <target name="jar.check">
     <condition property="jar.exists">
@@ -48,7 +47,7 @@
   <!-- Compile all of the SCSS files into their CSS counterparts "ant compile.sass" -->
   <target name="compile.sass">
     <java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
-        <arg line="${src.dir}/compile.rb ${lib.dir}/gems/ compile ${src.dir}"/>
+        <arg line="${src.dir}/compile.rb ${lib.dir}/vendors/gems/ compile ${src.dir}"/>
     </java>
     <echo level="info">
 ---Converted GCWU SCSS Files into CSS---
@@ -57,7 +56,7 @@
   <!-- Watch for any polling changes in the SCSS directory "ant watch.sass" -->
   <target name="watch.sass">
     <java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
-        <arg line="${src.dir}/compile.rb ${lib.dir}/gems/ watch ${src.dir}"/>
+        <arg line="${src.dir}/compile.rb ${lib.dir}/vendors/gems/ watch ${src.dir}"/>
     </java>
     <echo level="info">
 ---Watching for SCSS Changes in GCWU Directory---

--- a/src/theme-gcwu-fegc/compile.rb
+++ b/src/theme-gcwu-fegc/compile.rb
@@ -1,5 +1,7 @@
 # Load All of the Gems inside the jRuby jar passed in by first argument 
-$LOAD_PATH.unshift "#{ARGV[0]}"
+Dir.entries(ARGV[0]).each do |lib|  
+    $LOAD_PATH.unshift "#{ARGV[0]}/#{lib}/lib"  
+end 
 
 # Require the following Gems
 require 'rubygems'   

--- a/src/theme-gcwu-intranet/build.properties
+++ b/src/theme-gcwu-intranet/build.properties
@@ -16,7 +16,7 @@ antcontribs.jar=${lib.dir}/ant-contrib-1.0b3.jar
 cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 
 #jRuby Properties
-jruby.jar=${lib.dir}/jruby-complete-1.6.7.2.jar
+jruby.jar=${lib.dir}/jruby.jar
 
 #jLESS Properties
 #jless.jar=test.jar

--- a/src/theme-gcwu-intranet/build.xml
+++ b/src/theme-gcwu-intranet/build.xml
@@ -10,7 +10,7 @@
   <!-- Include jruby + gems (compass + sass + zengrids) -->
   <target name="build-jar" depends="jar.check" unless="jar.exists">
     <mkdir dir="${lib.dir}/jruby-compiled" />
-    <get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
+    <get src="http://jruby.org.s3.amazonaws.com/downloads/1.7.0.preview1/jruby-complete-1.7.0.preview1.jar" dest="${lib.dir}/jruby.jar"/>
     <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>  
     <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>  
     <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/> 
@@ -21,7 +21,6 @@
       <arg line="-uf jruby.jar -C vendors ." />
     </exec>
     <delete dir="${lib.dir}/jruby-compiled" />
-    <delete dir="${lib.dir}/vendors" />
   </target>
   <target name="jar.check">
     <condition property="jar.exists">
@@ -32,7 +31,7 @@
   <!-- Compile all of the SCSS files into their CSS counterparts "ant compile.sass" -->
   <target name="compile.sass">
     <java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
-        <arg line="${src.dir}/compile.rb ${lib.dir}/gems/ compile ${src.dir}"/>
+        <arg line="${src.dir}/compile.rb ${lib.dir}/vendors/gems/ compile ${src.dir}"/>
     </java>
     <echo level="info">
 ---Converted Intranet SCSS Files into CSS---
@@ -41,7 +40,7 @@
   <!-- Watch for any polling changes in the SCSS directory "ant watch.sass" -->
   <target name="watch.sass">
     <java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
-        <arg line="${src.dir}/compile.rb ${lib.dir}/gems/ watch ${src.dir}"/>
+        <arg line="${src.dir}/compile.rb ${lib.dir}/vendors/gems/ watch ${src.dir}"/>
     </java>
     <echo level="info">
 ---Watching for SCSS Changes in Intranet Directory---

--- a/src/theme-gcwu-intranet/compile.rb
+++ b/src/theme-gcwu-intranet/compile.rb
@@ -1,5 +1,7 @@
 # Load All of the Gems inside the jRuby jar passed in by first argument 
-$LOAD_PATH.unshift "#{ARGV[0]}"
+Dir.entries(ARGV[0]).each do |lib|  
+    $LOAD_PATH.unshift "#{ARGV[0]}/#{lib}/lib"  
+end 
 
 # Require the following Gems
 require 'rubygems'   


### PR DESCRIPTION
The @import declaration for sass was not working this is because the compile.rb command was set to read the directory structure inside jruby.jar for some reason dir.entries has problems doing this. Instead keeping the vendors/ directory during build out and point compile argv(0) to that.
