### PR TITLE
Older JAVA Versions on Windows SASS Compile Fix (Order Matters and Dependencies have to be specified completely)

### DIFF
--- a/src/base/build.xml
+++ b/src/base/build.xml
@@ -11,11 +11,13 @@
   <target name="build-jar" depends="jar.check" unless="jar.exists">
     <mkdir dir="${lib.dir}/jruby-compiled" />
     <get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
-    <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>  
-    <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>  
-    <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/> 
+    <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/chunky_png-1.2.5.gem" dest="${lib.dir}/jruby-compiled/chunky_png.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/fssm-0.2.9.gem" dest="${lib.dir}/jruby-compiled/fssm.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/>
     <java jar="${lib.dir}/jruby.jar" fork="true">
-        <arg line="-S gem install -i ${lib.dir}/vendors ${lib.dir}/jruby-compiled/compass.gem ${lib.dir}/jruby-compiled/sass.gem ${lib.dir}/jruby-compiled/zen-grids.gem"/>
+        <arg line="-S gem install -i ${lib.dir}/vendors ${lib.dir}/jruby-compiled/sass.gem ${lib.dir}/jruby-compiled/chunky_png.gem ${lib.dir}/jruby-compiled/fssm.gem ${lib.dir}/jruby-compiled/compass.gem ${lib.dir}/jruby-compiled/zen-grids.gem"/>
     </java>
     <exec executable="jar" dir="${lib.dir}/">
       <arg line="-uf jruby.jar -C vendors ." />

--- a/src/grids/build.xml
+++ b/src/grids/build.xml
@@ -11,11 +11,13 @@
   <target name="build-jar" depends="jar.check" unless="jar.exists">
     <mkdir dir="${lib.dir}/jruby-compiled" />
     <get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
-    <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>  
-    <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>  
-    <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/> 
+    <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/chunky_png-1.2.5.gem" dest="${lib.dir}/jruby-compiled/chunky_png.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/fssm-0.2.9.gem" dest="${lib.dir}/jruby-compiled/fssm.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/>
     <java jar="${lib.dir}/jruby.jar" fork="true">
-        <arg line="-S gem install -i ${lib.dir}/vendors ${lib.dir}/jruby-compiled/compass.gem ${lib.dir}/jruby-compiled/sass.gem ${lib.dir}/jruby-compiled/zen-grids.gem"/>
+        <arg line="-S gem install -i ${lib.dir}/vendors ${lib.dir}/jruby-compiled/sass.gem ${lib.dir}/jruby-compiled/chunky_png.gem ${lib.dir}/jruby-compiled/fssm.gem ${lib.dir}/jruby-compiled/compass.gem ${lib.dir}/jruby-compiled/zen-grids.gem"/>
     </java>
     <exec executable="jar" dir="${lib.dir}/">
       <arg line="-uf jruby.jar -C vendors ." />

--- a/src/js/build.xml
+++ b/src/js/build.xml
@@ -11,11 +11,13 @@
   <target name="build-jar" depends="jar.check" unless="jar.exists">
     <mkdir dir="${lib.dir}/jruby-compiled" />
     <get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
-    <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>  
-    <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>  
-    <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/> 
+    <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/chunky_png-1.2.5.gem" dest="${lib.dir}/jruby-compiled/chunky_png.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/fssm-0.2.9.gem" dest="${lib.dir}/jruby-compiled/fssm.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/>
     <java jar="${lib.dir}/jruby.jar" fork="true">
-        <arg line="-S gem install -i ${lib.dir}/vendors ${lib.dir}/jruby-compiled/compass.gem ${lib.dir}/jruby-compiled/sass.gem ${lib.dir}/jruby-compiled/zen-grids.gem"/>
+        <arg line="-S gem install -i ${lib.dir}/vendors ${lib.dir}/jruby-compiled/sass.gem ${lib.dir}/jruby-compiled/chunky_png.gem ${lib.dir}/jruby-compiled/fssm.gem ${lib.dir}/jruby-compiled/compass.gem ${lib.dir}/jruby-compiled/zen-grids.gem"/>
     </java>
     <exec executable="jar" dir="${lib.dir}/">
       <arg line="-uf jruby.jar -C vendors ." />

--- a/src/theme-gcwu-fegc/build.xml
+++ b/src/theme-gcwu-fegc/build.xml
@@ -11,11 +11,13 @@
   <target name="build-jar" depends="jar.check" unless="jar.exists">
     <mkdir dir="${lib.dir}/jruby-compiled" />
     <get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
-    <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>  
-    <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>  
-    <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/> 
+    <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/chunky_png-1.2.5.gem" dest="${lib.dir}/jruby-compiled/chunky_png.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/fssm-0.2.9.gem" dest="${lib.dir}/jruby-compiled/fssm.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/>
     <java jar="${lib.dir}/jruby.jar" fork="true">
-        <arg line="-S gem install -i ${lib.dir}/vendors ${lib.dir}/jruby-compiled/compass.gem ${lib.dir}/jruby-compiled/sass.gem ${lib.dir}/jruby-compiled/zen-grids.gem"/>
+        <arg line="-S gem install -i ${lib.dir}/vendors ${lib.dir}/jruby-compiled/sass.gem ${lib.dir}/jruby-compiled/chunky_png.gem ${lib.dir}/jruby-compiled/fssm.gem ${lib.dir}/jruby-compiled/compass.gem ${lib.dir}/jruby-compiled/zen-grids.gem"/>
     </java>
     <exec executable="jar" dir="${lib.dir}/">
       <arg line="-uf jruby.jar -C vendors ." />

--- a/src/theme-gcwu-intranet/build.xml
+++ b/src/theme-gcwu-intranet/build.xml
@@ -11,11 +11,13 @@
   <target name="build-jar" depends="jar.check" unless="jar.exists">
     <mkdir dir="${lib.dir}/jruby-compiled" />
     <get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
-    <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>  
-    <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>  
-    <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/> 
+    <get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/chunky_png-1.2.5.gem" dest="${lib.dir}/jruby-compiled/chunky_png.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/fssm-0.2.9.gem" dest="${lib.dir}/jruby-compiled/fssm.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>
+    <get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/>
     <java jar="${lib.dir}/jruby.jar" fork="true">
-        <arg line="-S gem install -i ${lib.dir}/vendors ${lib.dir}/jruby-compiled/compass.gem ${lib.dir}/jruby-compiled/sass.gem ${lib.dir}/jruby-compiled/zen-grids.gem"/>
+        <arg line="-S gem install -i ${lib.dir}/vendors ${lib.dir}/jruby-compiled/sass.gem ${lib.dir}/jruby-compiled/chunky_png.gem ${lib.dir}/jruby-compiled/fssm.gem ${lib.dir}/jruby-compiled/compass.gem ${lib.dir}/jruby-compiled/zen-grids.gem"/>
     </java>
     <exec executable="jar" dir="${lib.dir}/">
       <arg line="-uf jruby.jar -C vendors ." />


### PR DESCRIPTION
Older JAVA Versions on Windows SASS Compile Fix (Order Matters and Dependencies have to be specified completely)
