### PR TITLE
Ensure line endings are normalized

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
+# Set default behaviour, in case users don't have core.autocrlf set.
+* text=auto
+
 # These files are text and should be normalized (convert crlf => lf)
 *.js      text
 *.css     text


### PR DESCRIPTION
Ran into an issue under Windows showing that minified files had been
changed because YUI compressor uses CR line endings even under Windows.
