### PR TITLE
Zen Grids gem removed

### DIFF
--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -50,7 +50,6 @@
 		<get src="http://production.cf.rubygems.org/gems/chunky_png-1.2.5.gem" dest="${lib.dir}/jruby-compiled/chunky_png.gem"/>
 		<get src="http://production.cf.rubygems.org/gems/fssm-0.2.9.gem" dest="${lib.dir}/jruby-compiled/fssm.gem"/>
 		<get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>
-		<get src="http://production.cf.rubygems.org/gems/zen-grids-1.2.gem" dest="${lib.dir}/jruby-compiled/zen-grids.gem"/>
 		<java jar="${lib.dir}/jruby.jar" fork="true">
 			<arg line="-S gem install -i &quot;${lib.dir}/vendors&quot; &quot;${lib.dir}/jruby-compiled/sass.gem&quot; &quot;${lib.dir}/jruby-compiled/chunky_png.gem&quot; &quot;${lib.dir}/jruby-compiled/fssm.gem&quot; &quot;${lib.dir}/jruby-compiled/compass.gem&quot; &quot;${lib.dir}/jruby-compiled/zen-grids.gem&quot;"/>
 		</java>

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -42,7 +42,7 @@
 		</fileset>
 	</path>
 	
-	<!-- Include jruby + gems (compass + sass + zengrids) -->
+	<!-- Include jruby + gems (compass + sass) -->
 	<target name="-build-jruby" depends="-jruby.jar.check" unless="jruby.jar.exists">
 		<mkdir dir="${lib.dir}/jruby-compiled" />
 		<get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby.jar"/>
@@ -51,7 +51,7 @@
 		<get src="http://production.cf.rubygems.org/gems/fssm-0.2.9.gem" dest="${lib.dir}/jruby-compiled/fssm.gem"/>
 		<get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem"/>
 		<java jar="${lib.dir}/jruby.jar" fork="true">
-			<arg line="-S gem install -i &quot;${lib.dir}/vendors&quot; &quot;${lib.dir}/jruby-compiled/sass.gem&quot; &quot;${lib.dir}/jruby-compiled/chunky_png.gem&quot; &quot;${lib.dir}/jruby-compiled/fssm.gem&quot; &quot;${lib.dir}/jruby-compiled/compass.gem&quot; &quot;${lib.dir}/jruby-compiled/zen-grids.gem&quot;"/>
+			<arg line="-S gem install -i &quot;${lib.dir}/vendors&quot; &quot;${lib.dir}/jruby-compiled/sass.gem&quot; &quot;${lib.dir}/jruby-compiled/chunky_png.gem&quot; &quot;${lib.dir}/jruby-compiled/fssm.gem&quot; &quot;${lib.dir}/jruby-compiled/compass.gem&quot;"/>
 		</java>
 		<exec executable="jar" dir="${lib.dir}/">
 		  <arg line="-uf jruby.jar -C vendors ." />

--- a/build/compile.rb
+++ b/build/compile.rb
@@ -7,7 +7,6 @@ end
 require 'rubygems'   
 require 'compass'  
 require 'compass/exec'
-require 'zen-grids'
 
 # Run Compass + Gems!
 exit Compass::Exec::SubCommandUI.new([ARGV[1], ARGV[2], "-c" + File.join(File.dirname(__FILE__), 'config.rb'),"-q"]).run!

--- a/src/README.md
+++ b/src/README.md
@@ -36,7 +36,7 @@ DEVELOPING WITH SASS AND ANT
 
 Steps performed for SASS ANT Support in ../build/lib (Compile + Watch Feature)
 
-  $ java -jar jruby-complete-1.6.7.2.jar -S gem install -i ./vendors compass sass zen-grids
+  $ java -jar jruby-complete-1.6.7.2.jar -S gem install -i ./vendors compass sass
   $ jar uf jruby-complete-1.6.7.2.jar -C vendors .
   $ rm -rf vendors
   $ java -jar jruby-complete-1.6.7.2.jar -S gem list


### PR DESCRIPTION
This is no longer referenced in any of the SCSS files.
The compass span-\* are used for grids now
