### PR TITLE
Slideout Panel Behaviour Fixes

### DIFF
--- a/src/js/sass/slideout.scss
+++ b/src/js/sass/slideout.scss
@@ -16,7 +16,7 @@
 #slideoutInnerWrapper {
 	overflow: hidden;
 	position: relative;
-	width: 295px;
+	width: 293px;
 }
 
 .slideoutWrapper { /* Follows on scrolling */
@@ -53,7 +53,7 @@
 	padding: 8px;
 	position: relative; 
 	margin: auto;
-	width: 245px;
+	width: 246px;
 	#slideoutClose {
 		float: right;
 	}


### PR DESCRIPTION
- Prevent slideout panel content from being inaccessible by removing
  position: fixed if not enough screen height to display entire panel.
- Fix gap between edge of panel and right side of #wb-core-in container.
- Fix #slideoutToggle so it doesn't get overlapped by panel during
  open width animation.
- Fix clicking on slideout panel link (issue #322).
- Repositioning panel on screen resize if open.
- JSLinted code
