### PR TITLE
Ignore .orig files from KDIFF3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ ethumbs.db
 Thumbs.db
 /.project
 jshint.out.xml
+*.orig


### PR DESCRIPTION
Don't check in temp files creating using the visual merge tool KDIFF3
