### PR TITLE
More potential broken link fixes

### DIFF
--- a/demos/charts/complex-eng.html
+++ b/demos/charts/complex-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="complex-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/charts/simple-eng.html
+++ b/demos/charts/simple-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="simple-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/charts/simpleCustomized-eng.html
+++ b/demos/charts/simpleCustomized-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="simpleCustomized-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-base-eng.html
+++ b/demos/grids/grid-base-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-base-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-base-full-eng.html
+++ b/demos/grids/grid-base-full-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-base-full-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-basic-eng.html
+++ b/demos/grids/grid-basic-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-basic-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-border-eng.html
+++ b/demos/grids/grid-border-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-border-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-button-eng.html
+++ b/demos/grids/grid-button-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-button-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-color-eng.html
+++ b/demos/grids/grid-color-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-color-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-form-eng.html
+++ b/demos/grids/grid-form-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-form-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-icon-eng.html
+++ b/demos/grids/grid-icon-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-icon-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-image-eng.html
+++ b/demos/grids/grid-image-eng.html
@@ -55,7 +55,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-image-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-message-eng.html
+++ b/demos/grids/grid-message-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-message-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-module-eng.html
+++ b/demos/grids/grid-module-eng.html
@@ -59,7 +59,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-module-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-opacity-eng.html
+++ b/demos/grids/grid-opacity-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-opacity-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-other-eng.html
+++ b/demos/grids/grid-other-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-other-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-position-eng.html
+++ b/demos/grids/grid-position-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-position-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-proximity-eng.html
+++ b/demos/grids/grid-proximity-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-proximity-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-specialty-eng.html
+++ b/demos/grids/grid-specialty-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-specialty-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-structure-eng.html
+++ b/demos/grids/grid-structure-eng.html
@@ -57,7 +57,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-structure-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-table-eng.html
+++ b/demos/grids/grid-table-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-table-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/grids/grid-text-eng.html
+++ b/demos/grids/grid-text-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="grid-text-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/app-eng.html
+++ b/demos/opt-cont/app-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="app-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/clr-eng.html
+++ b/demos/opt-cont/clr-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="clr-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/dk-sv-eng.html
+++ b/demos/opt-cont/dk-sv-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="dk-sv-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/frm-eng.html
+++ b/demos/opt-cont/frm-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="frm-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/hdg-eng.html
+++ b/demos/opt-cont/hdg-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="hdg-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/img-eng.html
+++ b/demos/opt-cont/img-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="img-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/img-org-desc-eng.html
+++ b/demos/opt-cont/img-org-desc-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="img-org-desc-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/index-eng.html
+++ b/demos/opt-cont/index-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="index-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/kb-cv-eng.html
+++ b/demos/opt-cont/kb-cv-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="kb-cv-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/lin-eng.html
+++ b/demos/opt-cont/lin-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="lin-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/qlg-eng.html
+++ b/demos/opt-cont/qlg-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="qlg-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/smm-eng.html
+++ b/demos/opt-cont/smm-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="smm-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/tbl-eng.html
+++ b/demos/opt-cont/tbl-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="tbl-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/tbl-simp-eng.html
+++ b/demos/opt-cont/tbl-simp-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="tbl-simp-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/opt-cont/wcag-eng.html
+++ b/demos/opt-cont/wcag-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="wcag-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/About-the-Table-Usability-Concept.html
+++ b/demos/tableparser/About-the-Table-Usability-Concept.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/Data-Cell.html
+++ b/demos/tableparser/Data-Cell.html
@@ -77,7 +77,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/ExtendedDefinition.html
+++ b/demos/tableparser/ExtendedDefinition.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/How-to-use-colgroup-element.html
+++ b/demos/tableparser/How-to-use-colgroup-element.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/Key-Description-Cell-Table-Row.html
+++ b/demos/tableparser/Key-Description-Cell-Table-Row.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/RowLevel.html
+++ b/demos/tableparser/RowLevel.html
@@ -68,7 +68,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/Summary-Cell.html
+++ b/demos/tableparser/Summary-Cell.html
@@ -67,7 +67,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/SummaryRowGroup.html
+++ b/demos/tableparser/SummaryRowGroup.html
@@ -56,7 +56,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/Table-CaseStudies-2.html
+++ b/demos/tableparser/Table-CaseStudies-2.html
@@ -206,7 +206,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/Table-CaseStudies-3.html
+++ b/demos/tableparser/Table-CaseStudies-3.html
@@ -56,7 +56,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/Table-CaseStudies.html
+++ b/demos/tableparser/Table-CaseStudies.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/Witch_Zebra_You_Like.html
+++ b/demos/tableparser/Witch_Zebra_You_Like.html
@@ -212,7 +212,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/colgroupheader-techniques.html
+++ b/demos/tableparser/colgroupheader-techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/colgroupsummary-techniques.html
+++ b/demos/tableparser/colgroupsummary-techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/colheader-description-techniques.html
+++ b/demos/tableparser/colheader-description-techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/columngroup.html
+++ b/demos/tableparser/columngroup.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/datacolgroup-techniques.html
+++ b/demos/tableparser/datacolgroup-techniques.html
@@ -56,7 +56,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/docs-eng.html
+++ b/demos/tableparser/docs-eng.html
@@ -65,7 +65,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="index-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/financial.html
+++ b/demos/tableparser/financial.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/headercolgroupstructure-techniques.html
+++ b/demos/tableparser/headercolgroupstructure-techniques.html
@@ -56,7 +56,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/headerrowgroupstructure-techniques.html
+++ b/demos/tableparser/headerrowgroupstructure-techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/index-eng.html
+++ b/demos/tableparser/index-eng.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/keycell-techniques.html
+++ b/demos/tableparser/keycell-techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/layoutcell-techniques.html
+++ b/demos/tableparser/layoutcell-techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/rowgroupheader-description-techniques.html
+++ b/demos/tableparser/rowgroupheader-description-techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/rowgrouping-techniques.html
+++ b/demos/tableparser/rowgrouping-techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/rowheader-description-techniques.html
+++ b/demos/tableparser/rowheader-description-techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/summariesrowgroup-techniques.html
+++ b/demos/tableparser/summariesrowgroup-techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/techniques.html
+++ b/demos/tableparser/techniques.html
@@ -54,7 +54,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 

--- a/demos/tableparser/validator-htmltable.html
+++ b/demos/tableparser/validator-htmltable.html
@@ -596,7 +596,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.gc.ca/home.html">Canada.gc.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.gc.ca/depts/major/depind-eng.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="zebra-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="#" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 


### PR DESCRIPTION
A few components currently only use English working example pages, yet still contain language toggle links to non-existent French files. Since it's probably unlikely that French versions of those example pages will be integrated before WET 3.0 launches, I figured it may make sense to change the affected toggle links to point to "#" in the meantime.
