### PR TITLE
Fix subant build numbers

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -2,12 +2,6 @@
 <project name="wet-boew" default="default" basedir=".">
 	<description>Web Experience Toolkit</description>
 
-	<!-- Version and build time-->
-	<property name="wet-boew-build.version" value="v3.1.0-a1"/>
-	<tstamp>
-		<format property="wet-boew-build.starttime" pattern="yyyy-MM-dd hh:mm aa" locale="en,CA"/>
-	</tstamp>
-
 	<property name="src.dir" value="src"/>
 	<property name="build.dir" value="build"/>
 
@@ -15,47 +9,19 @@
 
 	<target name="build" depends="">
 		<echo level="info" message="---Building WET Core Framework---"/>
-		<ant dir="${src.dir}/js" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
+		<ant dir="${src.dir}/js" antfile="build.xml" target="build" inheritAll="false" />
 		<echo level="info" message="---Building Base CSS---"/>
-		<ant dir="${src.dir}/base" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
+		<ant dir="${src.dir}/base" antfile="build.xml" target="build" inheritAll="false" />
 		<echo level="info" message="---Building CSS Grid System---"/>
-		<ant dir="${src.dir}/grids" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
+		<ant dir="${src.dir}/grids" antfile="build.xml" target="build" inheritAll="false" />
 		<echo level="info" message="---Building GCWU Theme---"/>
-		<ant dir="${src.dir}/theme-gcwu-fegc" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
+		<ant dir="${src.dir}/theme-gcwu-fegc" antfile="build.xml" target="build" inheritAll="false" />
 		<echo level="info" message="---Building GCWU Intranet Theme---"/>
-		<ant dir="${src.dir}/theme-gcwu-intranet" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
+		<ant dir="${src.dir}/theme-gcwu-intranet" antfile="build.xml" target="build" inheritAll="false" />
 		<echo level="info" message="---Building CLF2 Theme---"/>
-		<ant dir="${src.dir}/theme-clf2-nsi2" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
+		<ant dir="${src.dir}/theme-clf2-nsi2" antfile="build.xml" target="build" inheritAll="false" />
 		<echo level="info" message="---Building Base Theme---"/>
-		<ant dir="${src.dir}/theme-base" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
+		<ant dir="${src.dir}/theme-base" antfile="build.xml" target="build" inheritAll="false" />
 	</target>
 
 	<target name="clean-css">

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -3,6 +3,12 @@
 	<dirname property="tasks.basedir" file="${ant.file.build-tasks}"/>
 	<property file="${tasks.basedir}/build-tasks.properties"/>
 	
+	<!-- Version and build time-->
+	<property name="wet-boew-build.version" value="v3.1.0-a1"/>
+	<tstamp>
+		<format property="wet-boew-build.starttime" pattern="yyyy-MM-dd hh:mm aa" locale="en,CA"/>
+	</tstamp>
+	
 	<!-- ant contribs task definition  -->
 	<path id="antcontrib.classpath">
 		<pathelement location="${antcontribs.jar}" />

--- a/src/js/build.xml
+++ b/src/js/build.xml
@@ -5,7 +5,7 @@
 	<property file="build.properties"/>
 	<import file="${build.dir}/../build-tasks.xml"/>
 
-	<target name="default" depends="clean,build" description="Performs a Clean and Build when calling ant without any target"></target>
+	<target name="default" depends="clean,build,clean-css" description="Performs a Clean and Build when calling ant without any target"></target>
 
 	<target name="build" depends="-init, -minify" />
 


### PR DESCRIPTION
This allows the Ant to be run in the sub-folders again. Currently running in the sub-folders will not do the version replacement for the minified content.
Also added a call to "clean-css" in the default JavaScript task so that the quick 20 second build can be used for working on plugins.
