### PR TITLE
Jruby build versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 nbproject/*
 .sass-cache/
 .DS_Store
-jruby.jar
+jruby*.jar
 build/lib/vendors
 build/lib/jruby-compiled
 _notes/

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ nbproject/*
 .sass-cache/
 .DS_Store
 jruby*.jar
-build/lib/vendors
+build/lib/vendors*
 build/lib/jruby-compiled
 _notes/
 

--- a/build/README.md
+++ b/build/README.md
@@ -1,35 +1,3 @@
 # Building the Web Experience Toolkit (WET)
 
-[![Build Status](https://secure.travis-ci.org/wet-boew/wet-boew.png?branch=master)](http://travis-ci.org/wet-boew/wet-boew)
-
-Web Experience Toolkit (WET) uses Ant(1.8+), JRuby(1.6.7.2), YUI Compressor, and several Ruby gems.
-
-## Windows
-
-* Ant: download from [Apache](http://ant.apache.org) and extract to C:\ant
-* Java JDK: download from [Oracle](http://www.oracle.com/technetwork/java/javase/downloads/index.html) if your current installation doesn't meet the minimum stated by "[Which version of Java is required to run Apache Ant?"](http://ant.apache.org/faq.html#java-version)
-* open a command prompt to the root directory and run:
-> build.cmd 
-
-### *nix (OS X, Linux)
-
-* Ant: many distributions come with a verions of Ant, but ensure that a version later than 1.8 is installed by running the following at the terminal:
-> ant -version
-
-* open a shell to the root directory and run:
-> ant
-
-## Proxy Issues
-The build will download several files during the first build so those behind restrictive firewalls may encounter issues.
-You will need to set your proxy information in the ANT_OPTS environmental variable. See the [Ant Proxy manual](http://ant.apache.org/manual/proxy.html) for further information.
-
-* On Windows you can use the build.cmd to set the ANT_OPTS variable: 
-	> build.cmd -Dhttp.proxyHost=PROXY -Dhttp.proxyPort=PORT
-
-* If issues are still encountered, you may manually download the required files to their expected location before running Ant.
-	1. [jRuby](http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar) to build/lib and rename it jruby-download.jar
-	2. Create the folder build/lib/jruby-compiled and copy the gems inside with version number removed from the file name
-		* [sass.gem](http://production.cf.rubygems.org/gems/sass-3.1.19.gem)
-		* [chunky_png.gem](http://production.cf.rubygems.org/gems/chunky_png-1.2.5.gem)
-		* [fssm.gem](http://production.cf.rubygems.org/gems/fssm-0.2.9.gem)
-		* [compass.gem](http://production.cf.rubygems.org/gems/compass-0.12.1.gem)
+https://github.com/wet-boew/wet-boew/wiki/Developing-for-WET#wiki-Building_WET

--- a/build/build-tasks.properties
+++ b/build/build-tasks.properties
@@ -12,7 +12,8 @@ antcontribs.jar=${lib.dir}/ant-contrib-1.0b3.jar
 cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 
 #jRuby Properties
-jruby.jar=jruby-v1.0.0.jar
+jruby.depends=1.0.0
+jruby.jar=jruby-v${jruby.depends}.jar
 jruby.version=1.6.7.2
 
 #Gems

--- a/build/build-tasks.properties
+++ b/build/build-tasks.properties
@@ -12,7 +12,15 @@ antcontribs.jar=${lib.dir}/ant-contrib-1.0b3.jar
 cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 
 #jRuby Properties
-jruby.jar=${lib.dir}/jruby.jar
+jruby.jar=jruby-v1.0.0.jar
+jruby.version=1.6.7.2
+
+#Gems
+gem.dir=${lib.dir}/jruby-compiled
+sass.gem=sass-3.1.19.gem
+chunky_png.gem=chunky_png-1.2.5.gem
+fssm.gem=fssm-0.2.9.gem
+compass.gem=compass-0.12.1.gem
 
 #JSLint
 jshint.jar=${lib.dir}/ant-jshint-0.3.1-deps.jar

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -50,9 +50,6 @@
 	<target name="-build-jruby" depends="-jruby.jar.check" unless="jruby.jar.exists">
 		<mkdir dir="${lib.dir}/jruby-compiled" />
 		<delete dir="${lib.dir}/vendors" />
-		<delete>
-			<fileset dir="${lib.dir}" includes="jruby*.jar" excludes="jruby-complete-${jruby.version}.jar"/>
-		</delete>
 		<get src="http://jruby.org.s3.amazonaws.com/downloads/${jruby.version}/jruby-complete-${jruby.version}.jar" dest="${lib.dir}/jruby-complete-${jruby.version}.jar" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${sass.gem}" dest="${gem.dir}/${sass.gem}" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${chunky_png.gem}" dest="${gem.dir}/${chunky_png.gem}" skipexisting="true"/>

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -42,32 +42,36 @@
 	<!-- Include the compiled jruby.jar file -->
 	<path id="jruby.classpath">
 		<fileset dir="${lib.dir}">
-		  <include name="jruby*.jar"/>
+			<include name="${jruby.jar}"/>
 		</fileset>
-	</path>
-	
+	</path>	
+
 	<!-- Include jruby + gems (compass + sass) -->
 	<target name="-build-jruby" depends="-jruby.jar.check" unless="jruby.jar.exists">
 		<mkdir dir="${lib.dir}/jruby-compiled" />
-		<get src="http://jruby.org.s3.amazonaws.com/downloads/1.6.7.2/jruby-complete-1.6.7.2.jar" dest="${lib.dir}/jruby-download.jar" skipexisting="true"/>
-		<get src="http://production.cf.rubygems.org/gems/sass-3.1.19.gem" dest="${lib.dir}/jruby-compiled/sass.gem" skipexisting="true"/>
-		<get src="http://production.cf.rubygems.org/gems/chunky_png-1.2.5.gem" dest="${lib.dir}/jruby-compiled/chunky_png.gem" skipexisting="true"/>
-		<get src="http://production.cf.rubygems.org/gems/fssm-0.2.9.gem" dest="${lib.dir}/jruby-compiled/fssm.gem" skipexisting="true"/>
-		<get src="http://production.cf.rubygems.org/gems/compass-0.12.1.gem" dest="${lib.dir}/jruby-compiled/compass.gem" skipexisting="true"/>
-		<java jar="${lib.dir}/jruby-download.jar" fork="true">
-			<arg line="-S gem install -i &quot;${lib.dir}/vendors&quot; &quot;${lib.dir}/jruby-compiled/sass.gem&quot; &quot;${lib.dir}/jruby-compiled/chunky_png.gem&quot; &quot;${lib.dir}/jruby-compiled/fssm.gem&quot; &quot;${lib.dir}/jruby-compiled/compass.gem&quot;"/>
+		<delete dir="${lib.dir}/vendors" />
+		<delete>
+			<fileset dir="${lib.dir}" includes="jruby*.jar" excludes="jruby-complete-${jruby.version}.jar"/>
+		</delete>
+		<get src="http://jruby.org.s3.amazonaws.com/downloads/${jruby.version}/jruby-complete-${jruby.version}.jar" dest="${lib.dir}/jruby-complete-${jruby.version}.jar" skipexisting="true"/>
+		<get src="http://production.cf.rubygems.org/gems/${sass.gem}" dest="${gem.dir}/${sass.gem}" skipexisting="true"/>
+		<get src="http://production.cf.rubygems.org/gems/${chunky_png.gem}" dest="${gem.dir}/${chunky_png.gem}" skipexisting="true"/>
+		<get src="http://production.cf.rubygems.org/gems/${fssm.gem}" dest="${gem.dir}/${fssm.gem}" skipexisting="true"/>
+		<get src="http://production.cf.rubygems.org/gems/${compass.gem}" dest="${gem.dir}/${compass.gem}" skipexisting="true"/>
+		<java jar="${lib.dir}/jruby-complete-${jruby.version}.jar" fork="true">
+			<arg line="-S gem install -i &quot;${lib.dir}/vendors&quot; &quot;${gem.dir}/${sass.gem}&quot; &quot;${gem.dir}/${chunky_png.gem}&quot; &quot;${gem.dir}/${fssm.gem}&quot; &quot;${gem.dir}/${compass.gem}&quot;"/>
 		</java>
 		<exec executable="jar" dir="${lib.dir}/">
-		  <arg line="-uf jruby-download.jar -C vendors ." />
+			<arg line="-uf jruby-complete-${jruby.version}.jar -C vendors ." />
 		</exec>
-		<move file="${lib.dir}/jruby-download.jar" tofile="${lib.dir}/jruby.jar"/>
-		<delete dir="${lib.dir}/jruby-compiled" />
+		<move file="${lib.dir}/jruby-complete-${jruby.version}.jar" tofile="${lib.dir}/${jruby.jar}"/>
+		<delete dir="${gem.dir}" />
 	</target>
-		
+
 	<target name="-jruby.jar.check">
-		<condition property="jruby.jar.exists">
-		  <available file="${lib.dir}/jruby.jar" type="file"/>
-		</condition>
+	<condition property="jruby.jar.exists">
+	<available file="${lib.dir}/${jruby.jar}" type="file"/>
+	</condition>
 	</target>
 	
 	<!-- Compile all of the SCSS files into their CSS counterparts "ant compile.sass" -->

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -49,26 +49,26 @@
 	<!-- Include jruby + gems (compass + sass) -->
 	<target name="-build-jruby" depends="-jruby.jar.check" unless="jruby.jar.exists">
 		<mkdir dir="${lib.dir}/jruby-compiled" />
-		<delete dir="${lib.dir}/vendors" />
+		<delete dir="${lib.dir}/vendors-${jruby.depends}" />
 		<get src="http://jruby.org.s3.amazonaws.com/downloads/${jruby.version}/jruby-complete-${jruby.version}.jar" dest="${lib.dir}/jruby-complete-${jruby.version}.jar" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${sass.gem}" dest="${gem.dir}/${sass.gem}" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${chunky_png.gem}" dest="${gem.dir}/${chunky_png.gem}" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${fssm.gem}" dest="${gem.dir}/${fssm.gem}" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${compass.gem}" dest="${gem.dir}/${compass.gem}" skipexisting="true"/>
 		<java jar="${lib.dir}/jruby-complete-${jruby.version}.jar" fork="true">
-			<arg line="-S gem install -i &quot;${lib.dir}/vendors&quot; &quot;${gem.dir}/${sass.gem}&quot; &quot;${gem.dir}/${chunky_png.gem}&quot; &quot;${gem.dir}/${fssm.gem}&quot; &quot;${gem.dir}/${compass.gem}&quot;"/>
+			<arg line="-S gem install -i &quot;${lib.dir}/vendors-${jruby.depends}&quot; &quot;${gem.dir}/${sass.gem}&quot; &quot;${gem.dir}/${chunky_png.gem}&quot; &quot;${gem.dir}/${fssm.gem}&quot; &quot;${gem.dir}/${compass.gem}&quot;"/>
 		</java>
 		<exec executable="jar" dir="${lib.dir}/">
-			<arg line="-uf jruby-complete-${jruby.version}.jar -C vendors ." />
+			<arg line="-uf jruby-complete-${jruby.version}.jar -C vendors-${jruby.depends} ." />
 		</exec>
 		<move file="${lib.dir}/jruby-complete-${jruby.version}.jar" tofile="${lib.dir}/${jruby.jar}"/>
 		<delete dir="${gem.dir}" />
 	</target>
 
 	<target name="-jruby.jar.check">
-	<condition property="jruby.jar.exists">
-	<available file="${lib.dir}/${jruby.jar}" type="file"/>
-	</condition>
+		<condition property="jruby.jar.exists">
+			<available file="${lib.dir}/${jruby.jar}" type="file"/>
+		</condition>
 	</target>
 	
 	<!-- Compile all of the SCSS files into their CSS counterparts "ant compile.sass" -->
@@ -82,7 +82,7 @@
 	<target name="call.sass">
 		<java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
 			<arg path="${tasks.basedir}/compile.rb"/>
-			<arg path="${lib.dir}/vendors/gems/"/>
+			<arg path="${lib.dir}/vendors-${jruby.depends}/gems/"/>
 			<arg value="${command}"/>
 			<arg path="${src.dir}"/>
 		</java>


### PR DESCRIPTION
This is a fixup of https://github.com/wet-boew/wet-boew/pull/555 to allow switching between branches without having to rebuild the jRuby dependencies each time. This will leave the jruby-v*.jar and vendor- folder copies so each branch can use the one they require.

_(Description from previous PR )_
Since the gems and jRuby jar currently are excluded from the repo there is no way to tell the build that to use update gems or jRuby versions.
Now by changing the https://github.com/nschonni/wet-boew/blob/jruby-build-versioning/build/build-tasks.properties#L15 dependancy version we can trigger a rebuild of jRuby and Gems on the next build.
- Adjust https://github.com/nschonni/wet-boew/blob/jruby-build-versioning/build/build-tasks.properties#L16 to change the jRuby version
- Change https://github.com/nschonni/wet-boew/blob/jruby-build-versioning/build/build-tasks.properties#L20 to 21 to change the versions of the gems

This will allow us to update jRuby to the latest stable version version (1.6.8) and a few other outdated gems in a later PR.

https://github.com/wet-boew/wet-boew/wiki/Developing-for-WET#wiki-Building_WET will need to be updated if this PR is accepted.
