### PR TITLE
Ant task cleanup

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -8,19 +8,27 @@
 	<target name="default" depends="clean,build,clean-css" description="Performs a Cleand and Build when calling ant without any target"></target>
 
 	<target name="build" depends="">
-		<subant dir="${src.dir}" target="build"/>
+		<subant target="build">
+			<fileset dir="${src.dir}" includes="**/build.xml"/>
+		</subant>
 	</target>
 
 	<target name="clean-css">
-		<subant dir="${src.dir}" target="clean-css"/>
+		<subant target="clean-css">
+			<fileset dir="${src.dir}" includes="**/build.xml"/>
+		</subant>
 	</target>
 	
 	<target name="clean">
-		<subant dir="${src.dir}" target="clean"/>
+		<subant target="clean">
+			<fileset dir="${src.dir}" includes="**/build.xml"/>
+		</subant>
 	</target>
 
 	<target name="test">
-		<subant dir="${src.dir}" target="test"/>
+		<subant target="test">
+			<fileset dir="${src.dir}" includes="**/**/build.xml"/>
+		</subant>
 	</target>
 	
 	<target name="preflight" description="Sets tabbing and encoding as indicated by the contributor guidelines">

--- a/build.xml
+++ b/build.xml
@@ -2,80 +2,25 @@
 <project name="wet-boew" default="default" basedir=".">
 	<description>Web Experience Toolkit</description>
 
-	<!-- Version and build time-->
-	<property name="wet-boew-build.version" value="v3.0.2a1"/>
-	<tstamp>
-		<format property="wet-boew-build.starttime" pattern="yyyy-MM-dd hh:mm aa" locale="en,CA"/>
-	</tstamp>
-
 	<property name="src.dir" value="src"/>
 	<property name="build.dir" value="build"/>
 
 	<target name="default" depends="clean,build,clean-css" description="Performs a Cleand and Build when calling ant without any target"></target>
 
 	<target name="build" depends="">
-		<echo level="info" message="---Building WET Core Framework---"/>
-		<ant dir="${src.dir}/js" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
-		<echo level="info" message="---Building Base CSS---"/>
-		<ant dir="${src.dir}/base" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
-		<echo level="info" message="---Building CSS Grid System---"/>
-		<ant dir="${src.dir}/grids" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
-		<echo level="info" message="---Building GCWU Theme---"/>
-		<ant dir="${src.dir}/theme-gcwu-fegc" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
-		<echo level="info" message="---Building GCWU Intranet Theme---"/>
-		<ant dir="${src.dir}/theme-gcwu-intranet" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
-		<echo level="info" message="---Building CLF2 Theme---"/>
-		<ant dir="${src.dir}/theme-clf2-nsi2" antfile="build.xml" target="build" inheritAll="false">
-			<propertyset>
-				<propertyref prefix="wet-boew-build"/>
-			</propertyset>
-		</ant>
+		<subant dir="${src.dir}" target="build"/>
 	</target>
 
 	<target name="clean-css">
-		<ant dir="${src.dir}/base" target="clean-css" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/grids" target="clean-css" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/js" target="clean-css" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/theme-gcwu-fegc" target="clean-css" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/theme-gcwu-intranet" target="clean-css" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/theme-clf2-nsi2" target="clean-css" antfile="build.xml" inheritAll="false"/>
+		<subant dir="${src.dir}" target="clean-css"/>
 	</target>
 	
 	<target name="clean">
-		<ant dir="${src.dir}/base" target="clean" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/grids" target="clean" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/js" target="clean" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/theme-gcwu-fegc" target="clean" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/theme-gcwu-intranet" target="clean" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/theme-clf2-nsi2" target="clean" antfile="build.xml" inheritAll="false"/>
+		<subant dir="${src.dir}" target="clean"/>
 	</target>
 
 	<target name="test">
-		<echo level="info" message="---Running with JSHint---"/>
-		<ant dir="${src.dir}/js" target="test" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/theme-gcwu-fegc" target="test" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/theme-gcwu-intranet" target="test" antfile="build.xml" inheritAll="false"/>
-		<ant dir="${src.dir}/theme-clf2-nsi2" target="test" antfile="build.xml" inheritAll="false"/>
+		<subant dir="${src.dir}" target="test"/>
 	</target>
 	
 	<target name="preflight" description="Sets tabbing and encoding as indicated by the contributor guidelines">

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -3,6 +3,12 @@
 	<dirname property="tasks.basedir" file="${ant.file.build-tasks}"/>
 	<property file="${tasks.basedir}/build-tasks.properties"/>
 	
+	<!-- Version and build time-->
+	<property name="wet-boew-build.version" value="v3.0.2a1"/>
+	<tstamp>
+		<format property="wet-boew-build.starttime" pattern="yyyy-MM-dd hh:mm aa" locale="en,CA"/>
+	</tstamp>
+	
 	<!-- ant contribs task definition  -->
 	<path id="antcontrib.classpath">
 		<pathelement location="${antcontribs.jar}" />

--- a/src/base/build.xml
+++ b/src/base/build.xml
@@ -8,5 +8,7 @@
 	<target name="default" depends="clean,build" description="Performs a Clean and Build when calling ant without any target"></target>
 
 	<target name="build" depends="-init, compile.sass" />
+	
+	<target name="test" description="Placeholder for future test tasks"/>
 
 </project>

--- a/src/grids/build.xml
+++ b/src/grids/build.xml
@@ -58,4 +58,6 @@
 		</copy>
 		<delete dir="${build.dir}/premerge"/>
 	</target>
+	
+	<target name="test" description="Placeholder for future test tasks"/>
 </project>

--- a/src/js/build.xml
+++ b/src/js/build.xml
@@ -113,11 +113,10 @@
 	</target>
 	<!--Build CSS Tasks -->
 	<target name="-base64-encode" depends="-merge-css">
-		<copy todir="${build.dir}/premin/images">
-			<fileset dir="${src.dir}/images"/>
-		</copy>
-		<cssurlembed skipMissing="true">
-			<fileset dir="${build.dir}/premin/css/">
+		<property name="image.dir" location="${build.dir}/images"/>
+
+		<cssurlembed skipMissing="true" root="${image.dir}">
+			<fileset dir="${build.dir}/premin/css">
 				<include name="pe-ap.css"/>
 			</fileset>
 		</cssurlembed>

--- a/src/theme-clf2-nsi2/build.xml
+++ b/src/theme-clf2-nsi2/build.xml
@@ -35,12 +35,6 @@
   
 	<!--Build CSS Tasks -->
 	<target name="-base64-encode" depends="-merge-css">
-		<copy todir="${build.dir}/images">
-			<fileset dir="${src.dir}/images"/>
-		</copy>
-		<copy todir="${build.dir}/encode/images">
-			<fileset dir="${src.dir}/images"/>
-		</copy>
 		<copy todir="${build.dir}/encode/css">
 			<fileset dir="${build.dir}/css">
 				<include name="theme.css"/>
@@ -48,8 +42,10 @@
 				<include name="theme-serv.css"/>
 			</fileset>
 		</copy>
-		<cssurlembed skipMissing="true">
-			<fileset dir="${build.dir}/encode/css/">
+
+		<property name="image.dir" location="${build.dir}/images"/>
+		<cssurlembed skipMissing="true" root="${image.dir}">
+			<fileset dir="${build.dir}/encode/css">
 				<include name="theme.css"/>
 				<include name="theme-sp-pe.css"/>
 				<include name="theme-serv.css"/>

--- a/src/theme-gcwu-fegc/build.xml
+++ b/src/theme-gcwu-fegc/build.xml
@@ -38,12 +38,6 @@
 		<copy todir="${build.dir}/images">
 			<fileset dir="${src.dir}/images"/>
 		</copy>
-		<copy todir="${build.dir}/encode/images">
-			<fileset dir="${src.dir}/images"/>
-		</copy>
-		<copy todir="${build.dir}/encode/css/images">
-			<fileset dir="${src.dir}/jquerymobile/images"/>
-		</copy>
 		<copy todir="${build.dir}/encode/css">
 			<fileset dir="${build.dir}/css">
 				<include name="theme.css"/>
@@ -52,14 +46,23 @@
 				<include name="jquery.mobile.css"/>
 			</fileset>
 		</copy>
-		<cssurlembed skipMissing="true">
-			<fileset dir="${build.dir}/encode/css/">
+		
+		<property name="image.dir" location="${build.dir}/images"/>
+		<cssurlembed skipMissing="true" root="${image.dir}">
+			<fileset dir="${build.dir}/encode/css">
 				<include name="theme.css"/>
 				<include name="theme-sp-pe.css"/>
 				<include name="theme-serv.css"/>
+			</fileset>
+		</cssurlembed>
+		
+		<property name="jquerymobile.dir" location="${src.dir}/jquerymobile"/>
+		<cssurlembed skipMissing="false" root="${jquerymobile.dir}">
+			<fileset dir="${build.dir}/encode/css">
 				<include name="jquery.mobile.css"/>
 			</fileset>
 		</cssurlembed>
+		
 		<copy todir="${build.dir}/css">
 			<fileset dir="${build.dir}/encode/css">
 				<include name="*.css"/>

--- a/src/theme-gcwu-intranet/build.xml
+++ b/src/theme-gcwu-intranet/build.xml
@@ -41,13 +41,6 @@
 			<fileset dir="${src.dir}/../theme-gcwu-fegc/images"/>
 			<fileset dir="${src.dir}/images"/>
 		</copy>
-		<copy todir="${build.dir}/encode/images">
-			<fileset dir="${src.dir}/../theme-gcwu-fegc/images"/>
-			<fileset dir="${src.dir}/images"/>
-		</copy>
-		<copy todir="${build.dir}/encode/css/images">
-			<fileset dir="${src.dir}/jquerymobile/images"/>
-		</copy>
 		<copy todir="${build.dir}/encode/css">
 			<fileset dir="${build.dir}/css">
 				<include name="theme.css"/>
@@ -56,14 +49,23 @@
 				<include name="jquery.mobile.css"/>
 			</fileset>
 		</copy>
-		<cssurlembed skipMissing="true">
-			<fileset dir="${build.dir}/encode/css/">
+		
+		<property name="image.dir" location="${build.dir}/images"/>
+		<cssurlembed skipMissing="true" root="${image.dir}">
+			<fileset dir="${build.dir}/encode/css">
 				<include name="theme.css"/>
 				<include name="theme-sp-pe.css"/>
 				<include name="theme-serv.css"/>
+			</fileset>
+		</cssurlembed>
+		
+		<property name="jquerymobile.dir" location="${src.dir}/jquerymobile"/>
+		<cssurlembed skipMissing="true" root="${jquerymobile.dir}">
+			<fileset dir="${build.dir}/encode/css">
 				<include name="jquery.mobile.css"/>
 			</fileset>
 		</cssurlembed>
+		
 		<copy todir="${build.dir}/css">
 			<fileset dir="${build.dir}/encode/css">
 				<include name="*.css"/>
@@ -101,9 +103,6 @@
 			<fileset dir="${src.dir}/css"/>
 		</copy>
 		<replace dir="${build.dir}/pre/merge/css" token="@charset &quot;utf-8&quot;;" value=" "/>
-		<copy todir="${build.dir}/images">
-			<fileset dir="${src.dir}/images" />
-		</copy>
 		<copy todir="${build.dir}/pre/merge/../css">
 			<fileset dir="${src.dir}/../base/css"/>
 		</copy>


### PR DESCRIPTION
- Moves build number to common task like master to prevent issues like https://github.com/wet-boew/wet-boew/pull/567#issuecomment-9543824
  -Using single subant calls for root build
  -Inplace base64 encode images instead of copying them several times

If you merge this into master as well, make sure the build number is corrected
