### PR TITLE
Fix theme build dependancy

### DIFF
--- a/build/build-tasks.properties
+++ b/build/build-tasks.properties
@@ -27,3 +27,8 @@ compass.gem=compass-0.12.1.gem
 jshint.jar=${lib.dir}/ant-jshint-0.3.1-deps.jar
 jshint.globals.file=${tasks.basedir}/jshint.globals.properties
 jshint.failbuild=false
+
+#Core project paths
+jssrc.dir=${tasks.basedir}/../src/js
+gridsrc.dir=${tasks.basedir}/../src/grids
+basesrc.dir=${tasks.basedir}/../src/base

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -162,6 +162,37 @@
         <var name="file.recurse" unset="true"/>
 	</target>
 	
+	<target name="build-theme-deps" description="Initializes the Grid, JS and Base CSS projects so that the Sass has been compiled">
+		<if>
+			<available type="dir" file="${gridsrc.dir}/css"/>
+			<then />
+			<else>
+				<ant dir="${gridsrc.dir}" target="-init" inheritAll="false"/>
+			</else>
+		</if>		
+		<if>
+			<available type="dir" file="${basesrc.dir}/css"/>
+			<then />
+			<else>
+				<ant dir="${basesrc.dir}" target="-init" inheritAll="false"/>
+			</else>
+		</if>		
+		<if>
+			<available type="dir" file="${jssrc.dir}/css"/>
+			<then />
+			<else>
+				<ant dir="${jssrc.dir}" target="-init" inheritAll="false"/>
+			</else>
+		</if>
+	</target>
+	
+	<target name="clean-theme-deps" description="Clean the Grid, JS and Base CSS files. Used for after building an individual theme">
+		<ant dir="${gridsrc.dir}" target="clean-css" inheritAll="false"/>
+		<ant dir="${basesrc.dir}" target="clean-css" inheritAll="false"/>
+		<ant dir="${jssrc.dir}" target="clean-css" inheritAll="false"/>
+		<antcall target="clean-css" inheritAll="false"/>
+	</target>
+	
 	<target name="clean-css">
 		<delete dir="${src.dir}/css" />
 	</target>

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -167,21 +167,21 @@
 			<available type="dir" file="${gridsrc.dir}/css"/>
 			<then />
 			<else>
-				<ant dir="${gridsrc.dir}" target="-init" inheritAll="false"/>
+				<ant dir="${gridsrc.dir}" target="compile.sass" inheritAll="false"/>
 			</else>
 		</if>		
 		<if>
 			<available type="dir" file="${basesrc.dir}/css"/>
 			<then />
 			<else>
-				<ant dir="${basesrc.dir}" target="-init" inheritAll="false"/>
+				<ant dir="${basesrc.dir}" target="compile.sass" inheritAll="false"/>
 			</else>
 		</if>		
 		<if>
 			<available type="dir" file="${jssrc.dir}/css"/>
 			<then />
 			<else>
-				<ant dir="${jssrc.dir}" target="-init" inheritAll="false"/>
+				<ant dir="${jssrc.dir}" target="compile.sass" inheritAll="false"/>
 			</else>
 		</if>
 	</target>

--- a/src/grids/build.xml
+++ b/src/grids/build.xml
@@ -9,14 +9,14 @@
 
 	<target name="build" depends="-init, -minify" />
 
-	<target name="-minify" depends="compile.sass, -merge-css">
+	<target name="-minify" depends="-merge-css">
 		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}/premin" toDir="${build.dir}">
 			<include name="css/*.*" />
 		</yui-compressor>
 		<delete dir="${build.dir}/premin"/>
 	</target>
 
-	<target name="-merge-css">
+	<target name="-merge-css" depends="compile.sass">
 		<copy todir="${build.dir}/premerge/css">
 			<fileset dir="${src.dir}/css">
 				<include name="util*.css"/>

--- a/src/js/build.xml
+++ b/src/js/build.xml
@@ -9,7 +9,7 @@
 
 	<target name="build" depends="-init, -minify" />
 
-	<target name = "-minify" depends="compile.sass, build-js, -base64-encode">
+	<target name = "-minify" depends="-merge-css, -base64-encode, build-js">
 		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}/premin" toDir="${build.dir}">
 			<include name="*.*" />
 			<include name="i18n/*.*" />
@@ -112,7 +112,10 @@
 		<replaceregexp flags="gis" file="${build.dir}/workers.js" match="/\*.*?\*/" replace="" encoding="utf8" />
 	</target>
 	<!--Build CSS Tasks -->
-	<target name="-base64-encode" depends="-merge-css">
+	<target name="-base64-encode">
+		<copy todir="${build.dir}/images">
+			<fileset dir="${src.dir}/images"/>
+		</copy>
 		<property name="image.dir" location="${build.dir}/images"/>
 
 		<cssurlembed skipMissing="true" root="${image.dir}">
@@ -120,11 +123,8 @@
 				<include name="pe-ap.css"/>
 			</fileset>
 		</cssurlembed>
-		<copy todir="${build.dir}/images">
-			<fileset dir="${src.dir}/images"/>
-		</copy>
 	</target>
-	<target name="-merge-css">
+	<target name="-merge-css" depends="compile.sass">
 		<copy todir="${build.dir}/premerge/css">
 			<fileset dir="${src.dir}/css"/>
 		</copy>

--- a/src/theme-clf2-nsi2/build.xml
+++ b/src/theme-clf2-nsi2/build.xml
@@ -9,7 +9,7 @@
 
 	<target name="build" description="" depends="-init, -minify" />
 
-	<target name="-minify" depends="compile.sass, -base64-encode">
+	<target name="-minify" depends="-merge-css, -base64-encode">
 		<move todir="${build.dir}/css/premin">
 			<fileset dir="${build.dir}/css"/>
 		</move>
@@ -34,7 +34,10 @@
 	</target>
   
 	<!--Build CSS Tasks -->
-	<target name="-base64-encode" depends="-merge-css">
+	<target name="-base64-encode">
+		<copy todir="${build.dir}/images">
+			<fileset dir="${src.dir}/images" />
+		</copy>
 		<copy todir="${build.dir}/encode/css">
 			<fileset dir="${build.dir}/css">
 				<include name="theme.css"/>
@@ -59,14 +62,11 @@
 		<delete dir="${build.dir}/encode"/>
 	</target>
 	
-	<target name="-merge-css" depends="build-theme-deps">
+	<target name="-merge-css" depends="compile.sass, build-theme-deps">
 		<copy todir="${build.dir}/pre/merge/css">
 			<fileset dir="${src.dir}/css"/>
 		</copy>
 		<replace dir="${build.dir}/pre/merge/css" token="@charset &quot;utf-8&quot;;" value=" "/>
-		<copy todir="${build.dir}/images">
-			<fileset dir="${src.dir}/images" />
-		</copy>
 		<copy todir="${build.dir}/pre/merge/../css">
 			<fileset dir="${src.dir}/../base/css"/>
 		</copy>

--- a/src/theme-clf2-nsi2/build.xml
+++ b/src/theme-clf2-nsi2/build.xml
@@ -59,7 +59,7 @@
 		<delete dir="${build.dir}/encode"/>
 	</target>
 	
-	<target name="-merge-css">
+	<target name="-merge-css" depends="build-theme-deps">
 		<copy todir="${build.dir}/pre/merge/css">
 			<fileset dir="${src.dir}/css"/>
 		</copy>

--- a/src/theme-gcwu-fegc/build.xml
+++ b/src/theme-gcwu-fegc/build.xml
@@ -71,7 +71,7 @@
 		<delete dir="${build.dir}/encode"/>
 	</target>
 	
-	<target name="-merge-css">
+	<target name="-merge-css" depends="build-theme-deps">
 		<copy todir="${build.dir}/pre/merge/jquerymobile">
 			<fileset dir="${src.dir}/jquerymobile">
 				<include name="*.css"/>

--- a/src/theme-gcwu-fegc/build.xml
+++ b/src/theme-gcwu-fegc/build.xml
@@ -9,7 +9,7 @@
 
 	<target name="build" depends="-init, -minify" />
   
-	<target name="-minify" depends="compile.sass, -base64-encode">
+	<target name="-minify" depends="-merge-css, -base64-encode">
 		<move todir="${build.dir}/css/premin">
 			<fileset dir="${build.dir}/css"/>
 		</move>
@@ -34,7 +34,7 @@
 	</target>
   
 	<!--Build CSS Tasks -->
-	<target name="-base64-encode" depends="-merge-css">
+	<target name="-base64-encode">
 		<copy todir="${build.dir}/images">
 			<fileset dir="${src.dir}/images"/>
 		</copy>
@@ -71,7 +71,7 @@
 		<delete dir="${build.dir}/encode"/>
 	</target>
 	
-	<target name="-merge-css" depends="build-theme-deps">
+	<target name="-merge-css" depends="compile.sass, build-theme-deps">
 		<copy todir="${build.dir}/pre/merge/jquerymobile">
 			<fileset dir="${src.dir}/jquerymobile">
 				<include name="*.css"/>

--- a/src/theme-gcwu-intranet/build.xml
+++ b/src/theme-gcwu-intranet/build.xml
@@ -74,7 +74,14 @@
 		<delete dir="${build.dir}/encode"/>
 	</target>
 	
-	<target name="-merge-css">
+	<target name="-merge-css" depends="build-theme-deps">
+		<if>
+			<available type="dir" file="../theme-gcwu-fegc/css"/>
+			<then />
+			<else>
+				<ant dir="../theme-gcwu-fegc" target="-init" inheritAll="false"/>
+			</else>
+		</if>	
 		<copy todir="${build.dir}/pre/merge/jquerymobile">
 			<fileset dir="${src.dir}/jquerymobile">
 				<include name="*.css"/>

--- a/src/theme-gcwu-intranet/build.xml
+++ b/src/theme-gcwu-intranet/build.xml
@@ -9,7 +9,7 @@
 
 	<target name="build" depends="-init, -minify" />
 
-	<target name="-minify" depends="compile.sass, build-css">
+	<target name="-minify" depends="-merge-css, -base64-encode">
 		<move todir="${build.dir}/css/premin">
 			<fileset dir="${build.dir}/css"/>
 		</move>
@@ -32,11 +32,9 @@
 		<delete dir="${build.dir}/css/premin"/>
 		<delete dir="${build.dir}/js/premin"/>
 	</target>
-
-	<target name="build-css" depends="-base64-encode" />
   
 	<!--Build CSS Tasks -->
-	<target name="-base64-encode" depends="-merge-css">
+	<target name="-base64-encode">
 		<copy todir="${build.dir}/images">
 			<fileset dir="${src.dir}/../theme-gcwu-fegc/images"/>
 			<fileset dir="${src.dir}/images"/>
@@ -74,12 +72,12 @@
 		<delete dir="${build.dir}/encode"/>
 	</target>
 	
-	<target name="-merge-css" depends="build-theme-deps">
+	<target name="-merge-css" depends="compile.sass, build-theme-deps">
 		<if>
-			<available type="dir" file="../theme-gcwu-fegc/css"/>
-			<then />
+			<available type="dir" file="${src.dir}/../theme-gcwu-fegc/css"/>
+			<then/>
 			<else>
-				<ant dir="../theme-gcwu-fegc" target="-init" inheritAll="false"/>
+				<ant dir="${src.dir}/../theme-gcwu-fegc" target="compile.sass" inheritAll="false"/>
 			</else>
 		</if>	
 		<copy todir="${build.dir}/pre/merge/jquerymobile">


### PR DESCRIPTION
The themes have a dependency on the Grid, JS, and Base CSS projects so currently running ant in any of the theme folders before building each of the other projects fails.
This now checks and compiles any missing Sass dependencies.

The same line should be applied to the Base theme's build file in the master branch.
<code>&lt;target name="-merge-css" depends="compile.sass, build-theme-deps"&gt;</code>
