### PR TITLE
Switched from an arbitrary version number for jRuby and dependencies to...

### DIFF
--- a/build/build-tasks.properties
+++ b/build/build-tasks.properties
@@ -12,8 +12,6 @@ antcontribs.jar=${lib.dir}/ant-contrib-1.0b3.jar
 cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 
 #jRuby Properties
-jruby.depends=1.0.0
-jruby.jar=jruby-v${jruby.depends}.jar
 jruby.version=1.6.7.2
 
 #Gems

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -72,6 +72,8 @@
 	</target>
 
 	<target name="-jruby.jar.check">
+		<checksum file="${tasks.basedir}/build-tasks.properties" property="jruby.depends"/>
+		<property name="jruby.jar" value="jruby-${jruby.depends}.jar" />
 		<condition property="jruby.jar.exists">
 			<available file="${lib.dir}/${jruby.jar}" type="file"/>
 		</condition>


### PR DESCRIPTION
... a hash.

The hash is generated via the build-tasks.properties files so any change to the prioperties will update jRuby as well.
