### PR TITLE
No gems in jar

### DIFF
--- a/build/build-tasks.properties
+++ b/build/build-tasks.properties
@@ -13,6 +13,7 @@ cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 
 #jRuby Properties
 jruby.version=1.6.8
+jruby.jar=jruby-complete-${jruby.version}.jar
 
 #Gems
 gem.dir=${lib.dir}/jruby-compiled

--- a/build/build-tasks.properties
+++ b/build/build-tasks.properties
@@ -14,13 +14,7 @@ cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 #jRuby Properties
 jruby.version=1.6.8
 jruby.jar=jruby-complete-${jruby.version}.jar
-
-#Gems
 gem.dir=${lib.dir}/jruby-compiled
-sass.gem=sass-3.2.1.gem
-chunky_png.gem=chunky_png-1.2.6.gem
-fssm.gem=fssm-0.2.9.gem
-compass.gem=compass-0.12.2.gem
 
 #JSLint
 jshint.jar=${lib.dir}/ant-jshint-0.3.1-deps.jar

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -64,9 +64,6 @@
 		<java jar="${lib.dir}/jruby-complete-${jruby.version}.jar" fork="true">
 			<arg line="-S gem install -i &quot;${lib.dir}/vendors-${jruby.depends}&quot; &quot;${gem.dir}/${sass.gem}&quot; &quot;${gem.dir}/${chunky_png.gem}&quot; &quot;${gem.dir}/${fssm.gem}&quot; &quot;${gem.dir}/${compass.gem}&quot;"/>
 		</java>
-		<exec executable="jar" dir="${lib.dir}/">
-			<arg line="-uf jruby-complete-${jruby.version}.jar -C vendors-${jruby.depends} ." />
-		</exec>
 		<move file="${lib.dir}/jruby-complete-${jruby.version}.jar" tofile="${lib.dir}/${jruby.jar}"/>
 		<delete dir="${gem.dir}" />
 	</target>

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -70,10 +70,12 @@
 			</not>
 			<then>
 				<mkdir dir="${gem.dir}" />
-				<get src="http://production.cf.rubygems.org/gems/${sass.gem}" dest="${gem.dir}/${sass.gem}" skipexisting="true"/>
-				<get src="http://production.cf.rubygems.org/gems/${chunky_png.gem}" dest="${gem.dir}/${chunky_png.gem}" skipexisting="true"/>
-				<get src="http://production.cf.rubygems.org/gems/${fssm.gem}" dest="${gem.dir}/${fssm.gem}" skipexisting="true"/>
-				<get src="http://production.cf.rubygems.org/gems/${compass.gem}" dest="${gem.dir}/${compass.gem}" skipexisting="true"/>
+				<parallel>
+					<get src="http://production.cf.rubygems.org/gems/${sass.gem}" dest="${gem.dir}/${sass.gem}" skipexisting="true"/>
+					<get src="http://production.cf.rubygems.org/gems/${chunky_png.gem}" dest="${gem.dir}/${chunky_png.gem}" skipexisting="true"/>
+					<get src="http://production.cf.rubygems.org/gems/${fssm.gem}" dest="${gem.dir}/${fssm.gem}" skipexisting="true"/>
+					<get src="http://production.cf.rubygems.org/gems/${compass.gem}" dest="${gem.dir}/${compass.gem}" skipexisting="true"/>
+				</parallel>
 				<java jar="${lib.dir}/${jruby.jar}" fork="true">
 					<arg line="-S gem install -i &quot;${lib.dir}/vendors-${jruby.depends}&quot; &quot;${gem.dir}/${sass.gem}&quot; &quot;${gem.dir}/${chunky_png.gem}&quot; &quot;${gem.dir}/${fssm.gem}&quot; &quot;${gem.dir}/${compass.gem}&quot;"/>
 				</java>

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -58,14 +58,18 @@
 		<checksum file="${tasks.basedir}/gem.properties" property="jruby.depends"/>
 		<if>
 			<not>
-				<and>
 					<available file="${lib.dir}/${jruby.jar}" type="file"/>
+			</not>
+			<then>
+				<get src="http://jruby.org.s3.amazonaws.com/downloads/${jruby.version}/jruby-complete-${jruby.version}.jar" dest="${lib.dir}/${jruby.jar}" skipexisting="true"/>
+			</then>
+		</if>
+		<if>
+			<not>
 					<available file="${lib.dir}/vendors-${jruby.depends}" type="dir"/>
-				</and>
 			</not>
 			<then>
 				<mkdir dir="${gem.dir}" />
-				<get src="http://jruby.org.s3.amazonaws.com/downloads/${jruby.version}/jruby-complete-${jruby.version}.jar" dest="${lib.dir}/${jruby.jar}" skipexisting="true"/>
 				<get src="http://production.cf.rubygems.org/gems/${sass.gem}" dest="${gem.dir}/${sass.gem}" skipexisting="true"/>
 				<get src="http://production.cf.rubygems.org/gems/${chunky_png.gem}" dest="${gem.dir}/${chunky_png.gem}" skipexisting="true"/>
 				<get src="http://production.cf.rubygems.org/gems/${fssm.gem}" dest="${gem.dir}/${fssm.gem}" skipexisting="true"/>

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -54,23 +54,21 @@
 
 	<!-- Include jruby + gems (compass + sass) -->
 	<target name="-build-jruby" depends="-jruby.jar.check" unless="jruby.jar.exists">
-		<mkdir dir="${lib.dir}/jruby-compiled" />
+		<mkdir dir="${gem.dir}" />
 		<delete dir="${lib.dir}/vendors-${jruby.depends}" />
-		<get src="http://jruby.org.s3.amazonaws.com/downloads/${jruby.version}/jruby-complete-${jruby.version}.jar" dest="${lib.dir}/jruby-complete-${jruby.version}.jar" skipexisting="true"/>
+		<get src="http://jruby.org.s3.amazonaws.com/downloads/${jruby.version}/jruby-complete-${jruby.version}.jar" dest="${lib.dir}/${jruby.jar}" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${sass.gem}" dest="${gem.dir}/${sass.gem}" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${chunky_png.gem}" dest="${gem.dir}/${chunky_png.gem}" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${fssm.gem}" dest="${gem.dir}/${fssm.gem}" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${compass.gem}" dest="${gem.dir}/${compass.gem}" skipexisting="true"/>
-		<java jar="${lib.dir}/jruby-complete-${jruby.version}.jar" fork="true">
+		<java jar="${lib.dir}/${jruby.jar}" fork="true">
 			<arg line="-S gem install -i &quot;${lib.dir}/vendors-${jruby.depends}&quot; &quot;${gem.dir}/${sass.gem}&quot; &quot;${gem.dir}/${chunky_png.gem}&quot; &quot;${gem.dir}/${fssm.gem}&quot; &quot;${gem.dir}/${compass.gem}&quot;"/>
 		</java>
-		<move file="${lib.dir}/jruby-complete-${jruby.version}.jar" tofile="${lib.dir}/${jruby.jar}"/>
 		<delete dir="${gem.dir}" />
 	</target>
 
 	<target name="-jruby.jar.check">
 		<checksum file="${tasks.basedir}/build-tasks.properties" property="jruby.depends"/>
-		<property name="jruby.jar" value="jruby-${jruby.depends}.jar" />
 		<condition property="jruby.jar.exists">
 			<available file="${lib.dir}/${jruby.jar}" type="file"/>
 		</condition>

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -64,7 +64,6 @@
 		<java jar="${lib.dir}/${jruby.jar}" fork="true">
 			<arg line="-S gem install -i &quot;${lib.dir}/vendors-${jruby.depends}&quot; &quot;${gem.dir}/${sass.gem}&quot; &quot;${gem.dir}/${chunky_png.gem}&quot; &quot;${gem.dir}/${fssm.gem}&quot; &quot;${gem.dir}/${compass.gem}&quot;"/>
 		</java>
-		<delete dir="${gem.dir}" />
 	</target>
 
 	<target name="-jruby.jar.check">

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -2,6 +2,7 @@
 <project name="build-tasks" default="default" basedir=".">
 	<dirname property="tasks.basedir" file="${ant.file.build-tasks}"/>
 	<property file="${tasks.basedir}/build-tasks.properties"/>
+	<property file="${tasks.basedir}/gem.properties"/>
 	
 	<!-- Version and build time-->
 	<property name="wet-boew-build.version" value="v3.0.2-a1"/>
@@ -55,7 +56,6 @@
 	<!-- Include jruby + gems (compass + sass) -->
 	<target name="-build-jruby" depends="-jruby.jar.check" unless="jruby.jar.exists">
 		<mkdir dir="${gem.dir}" />
-		<delete dir="${lib.dir}/vendors-${jruby.depends}" />
 		<get src="http://jruby.org.s3.amazonaws.com/downloads/${jruby.version}/jruby-complete-${jruby.version}.jar" dest="${lib.dir}/${jruby.jar}" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${sass.gem}" dest="${gem.dir}/${sass.gem}" skipexisting="true"/>
 		<get src="http://production.cf.rubygems.org/gems/${chunky_png.gem}" dest="${gem.dir}/${chunky_png.gem}" skipexisting="true"/>
@@ -67,11 +67,14 @@
 	</target>
 
 	<target name="-jruby.jar.check">
-		<checksum file="${tasks.basedir}/build-tasks.properties" property="jruby.depends"/>
+		<checksum file="${tasks.basedir}/gem.properties" property="jruby.depends"/>
 		<condition property="jruby.jar.exists">
-			<available file="${lib.dir}/${jruby.jar}" type="file"/>
+			<and>
+				<available file="${lib.dir}/${jruby.jar}" type="file"/>
+				<available file="${lib.dir}/vendors-${jruby.depends}" type="dir"/>
+			</and>
 		</condition>
-	</target>
+	</target>	
 	
 	<!-- Compile all of the SCSS files into their CSS counterparts "ant compile.sass" -->
 	<target name="compile.sass">

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -18,7 +18,7 @@
 		<classpath refid="antcontrib.classpath" />
 	</taskdef>
 	
-	<target name="-init" depends="-build-jruby">
+	<target name="-init">
 		<mkdir dir="${build.dir}"/>
 	</target>
 	
@@ -46,36 +46,6 @@
 		<classpath refid="jshint.classpath" />
 	</taskdef>
 	
-	<!-- Include the compiled jruby.jar file -->
-	<path id="jruby.classpath">
-		<fileset dir="${lib.dir}">
-			<include name="${jruby.jar}"/>
-		</fileset>
-	</path>	
-
-	<!-- Include jruby + gems (compass + sass) -->
-	<target name="-build-jruby" depends="-jruby.jar.check" unless="jruby.jar.exists">
-		<mkdir dir="${gem.dir}" />
-		<get src="http://jruby.org.s3.amazonaws.com/downloads/${jruby.version}/jruby-complete-${jruby.version}.jar" dest="${lib.dir}/${jruby.jar}" skipexisting="true"/>
-		<get src="http://production.cf.rubygems.org/gems/${sass.gem}" dest="${gem.dir}/${sass.gem}" skipexisting="true"/>
-		<get src="http://production.cf.rubygems.org/gems/${chunky_png.gem}" dest="${gem.dir}/${chunky_png.gem}" skipexisting="true"/>
-		<get src="http://production.cf.rubygems.org/gems/${fssm.gem}" dest="${gem.dir}/${fssm.gem}" skipexisting="true"/>
-		<get src="http://production.cf.rubygems.org/gems/${compass.gem}" dest="${gem.dir}/${compass.gem}" skipexisting="true"/>
-		<java jar="${lib.dir}/${jruby.jar}" fork="true">
-			<arg line="-S gem install -i &quot;${lib.dir}/vendors-${jruby.depends}&quot; &quot;${gem.dir}/${sass.gem}&quot; &quot;${gem.dir}/${chunky_png.gem}&quot; &quot;${gem.dir}/${fssm.gem}&quot; &quot;${gem.dir}/${compass.gem}&quot;"/>
-		</java>
-	</target>
-
-	<target name="-jruby.jar.check">
-		<checksum file="${tasks.basedir}/gem.properties" property="jruby.depends"/>
-		<condition property="jruby.jar.exists">
-			<and>
-				<available file="${lib.dir}/${jruby.jar}" type="file"/>
-				<available file="${lib.dir}/vendors-${jruby.depends}" type="dir"/>
-			</and>
-		</condition>
-	</target>	
-	
 	<!-- Compile all of the SCSS files into their CSS counterparts "ant compile.sass" -->
 	<target name="compile.sass">
 		<antcall target="call.sass">
@@ -85,7 +55,32 @@
 	</target>
 	
 	<target name="call.sass">
-		<java classname="org.jruby.Main" fork="true" failonerror="true" classpathref="jruby.classpath">
+		<checksum file="${tasks.basedir}/gem.properties" property="jruby.depends"/>
+		<if>
+			<not>
+				<and>
+					<available file="${lib.dir}/${jruby.jar}" type="file"/>
+					<available file="${lib.dir}/vendors-${jruby.depends}" type="dir"/>
+				</and>
+			</not>
+			<then>
+				<mkdir dir="${gem.dir}" />
+				<get src="http://jruby.org.s3.amazonaws.com/downloads/${jruby.version}/jruby-complete-${jruby.version}.jar" dest="${lib.dir}/${jruby.jar}" skipexisting="true"/>
+				<get src="http://production.cf.rubygems.org/gems/${sass.gem}" dest="${gem.dir}/${sass.gem}" skipexisting="true"/>
+				<get src="http://production.cf.rubygems.org/gems/${chunky_png.gem}" dest="${gem.dir}/${chunky_png.gem}" skipexisting="true"/>
+				<get src="http://production.cf.rubygems.org/gems/${fssm.gem}" dest="${gem.dir}/${fssm.gem}" skipexisting="true"/>
+				<get src="http://production.cf.rubygems.org/gems/${compass.gem}" dest="${gem.dir}/${compass.gem}" skipexisting="true"/>
+				<java jar="${lib.dir}/${jruby.jar}" fork="true">
+					<arg line="-S gem install -i &quot;${lib.dir}/vendors-${jruby.depends}&quot; &quot;${gem.dir}/${sass.gem}&quot; &quot;${gem.dir}/${chunky_png.gem}&quot; &quot;${gem.dir}/${fssm.gem}&quot; &quot;${gem.dir}/${compass.gem}&quot;"/>
+				</java>
+			</then>
+		</if>
+		<java classname="org.jruby.Main" fork="true" failonerror="true">
+			<classpath>
+				<fileset dir="${lib.dir}">
+					<include name="${jruby.jar}"/>
+				</fileset>
+			</classpath>
 			<arg path="${tasks.basedir}/compile.rb"/>
 			<arg path="${lib.dir}/vendors-${jruby.depends}/gems/"/>
 			<arg value="${command}"/>

--- a/build/gem.properties
+++ b/build/gem.properties
@@ -1,0 +1,5 @@
+#Gems
+sass.gem=sass-3.2.1.gem
+chunky_png.gem=chunky_png-1.2.6.gem
+fssm.gem=fssm-0.2.9.gem
+compass.gem=compass-0.12.2.gem


### PR DESCRIPTION
Since some gems we use don't support running inside the jRuby jar, the compilation step can be skipped. 
- Reuse the jruby jar between gem version changes
- Keep downloaded gems for reuse
- Hash on only the gem properties when checking if a rebuild is required
