### PR TITLE
Inplace minify CSS and JS files

### DIFF
--- a/src/grids/build.xml
+++ b/src/grids/build.xml
@@ -10,31 +10,25 @@
 	<target name="build" depends="-init, -minify" />
 
 	<target name="-minify" depends="-merge-css">
-		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}/premin" toDir="${build.dir}">
-			<include name="css/*.*" />
+		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}" toDir="${build.dir}">
+			<include name="**/*.css" />
+			<exclude name="**/*-min.css" />
 		</yui-compressor>
-		<delete dir="${build.dir}/premin"/>
+		<delete>
+			<fileset dir="${build.dir}">
+				<include name="**/*.css" />
+				<exclude name="**/*-min.css" />
+			</fileset>
+		</delete>
 	</target>
 
 	<target name="-merge-css" depends="compile.sass">
-		<copy todir="${build.dir}/premerge/css">
-			<fileset dir="${src.dir}/css">
-				<include name="util*.css"/>
-				<include name="includes/*.css"/>
-				<exclude name="responsive*.css"/>
-			</fileset>
-		</copy>
-		<replace dir="${build.dir}/premerge/css" token="@charset &quot;utf-8&quot;;" value=" "/>
 		<copy todir="${build.dir}/images">
 			<fileset dir="${src.dir}/images" />
 		</copy>
-		<filelist id="corefiles" dir="${build.dir}/premerge/css">
-			<file name="util.css"/>
-			<file name="util-ie.css"/>
-		</filelist>
 
-		<copy todir="${build.dir}/premin/css">
-			<filelist dir="${build.dir}/premerge/css">
+		<copy todir="${build.dir}/css">
+			<filelist dir="${src.dir}/css">
 				<file name="util.css"/>
 				<file name="util-ie.css"/>
 			</filelist>
@@ -46,7 +40,6 @@
 				</replacetokens>
 			</filterchain>
 		</copy>
-		<delete dir="${build.dir}/premerge"/>
 	</target>
 	
 	<target name="test" description="Placeholder for future test tasks"/>

--- a/src/js/build.xml
+++ b/src/js/build.xml
@@ -10,16 +10,24 @@
 	<target name="build" depends="-init, -minify" />
 
 	<target name = "-minify" depends="-merge-css, -base64-encode, build-js">
-		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}/premin" toDir="${build.dir}">
-			<include name="*.*" />
-			<include name="i18n/*.*" />
-			<include name="i18n/formvalid/*.*" />
-			<include name="dependencies/*.*"/>
-			<include name="dependencies/prettify/*.*"/>
-			<include name="polyfills/*.*"/>
-			<include name="css/*.*" />
+		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}" toDir="${build.dir}">
+			<include name="**/*.css" />
+			<include name="**/*.js" />
+			<exclude name="**/*-min.css" />
+			<exclude name="**/settings.js" />
+			<exclude name="**/*-min.js" />
+			<exclude name="**/*.min.js" />
 		</yui-compressor>
-		<delete dir="${build.dir}/premin"/>
+		<delete>
+			<fileset dir="${build.dir}">
+				<include name="**/*.css" />
+				<include name="**/*.js" />
+				<exclude name="**/settings.js" />
+				<exclude name="**/*-min.css" />
+				<exclude name="**/*-min.js" />
+				<exclude name="**/*.min.js" />
+			</fileset>
+		</delete>
 	</target>
 
 	<target name="build-js" depends="-build-pe">
@@ -34,14 +42,14 @@
 				</fileset>
 			</resources>  
 		</copy>
-		<copy todir="${build.dir}/premin">  
+		<copy todir="${build.dir}">  
 			<resources>
 				<fileset dir="${src.dir}">
 					<include name="i18n/**"/>
 				</fileset>
 			</resources>  
 		</copy>
-		<copy todir="${build.dir}/premin">
+		<copy todir="${build.dir}">
 			<resources>
 				<fileset dir="${src.dir}">
 					<include name="dependencies/**"/>
@@ -57,7 +65,7 @@
 				</replacetokens>
 			</filterchain>
 		</copy> 
-		<copy todir="${build.dir}/premin">
+		<copy todir="${build.dir}">
 			<resources>
 				<fileset dir="${src.dir}">
 					<include name="dependencies/**"/>
@@ -69,7 +77,7 @@
 				</fileset>
 			</resources> 
 		</copy> 
-		<copy todir="${build.dir}/premin">
+		<copy todir="${build.dir}">
 			<filterchain>
 				<replaceregex byline="false" pattern="\/\*" replace="\/\*!"/>
 			</filterchain>
@@ -90,7 +98,7 @@
 
 	<!-- Build JS Tasks -->
 	<target name="-build-pe" depends="-merge-workers">
-		<concat dest="${build.dir}/premin/pe-ap.js" fixlastline="yes">
+		<concat dest="${build.dir}/pe-ap.js" fixlastline="yes">
 			<file file="${src.dir}/pe-ap.js"/>
 			<file file="${build.dir}/workers.js"/>
 			<filterchain>
@@ -119,13 +127,13 @@
 		<property name="image.dir" location="${build.dir}/images"/>
 
 		<cssurlembed skipMissing="true" root="${image.dir}">
-			<fileset dir="${build.dir}/premin/css">
+			<fileset dir="${build.dir}/css">
 				<include name="pe-ap.css"/>
 			</fileset>
 		</cssurlembed>
 	</target>
 	<target name="-merge-css" depends="compile.sass">
-		<copy todir="${build.dir}/premin/css">
+		<copy todir="${build.dir}/css">
 			<filelist dir="${src.dir}/css">
 				<file name="pe-ap.css"/>
 				<file name="pe-ap-ie.css"/>

--- a/src/theme-clf2-nsi2/build.xml
+++ b/src/theme-clf2-nsi2/build.xml
@@ -10,10 +10,7 @@
 	<target name="build" description="" depends="-init, -minify" />
 
 	<target name="-minify" depends="-merge-css, -base64-encode">
-		<move todir="${build.dir}/css/premin">
-			<fileset dir="${build.dir}/css"/>
-		</move>
-		<copy todir="${build.dir}/js/premin">
+		<copy todir="${build.dir}/js">
 			<fileset dir="${src.dir}/js"/>
 			<filterchain>
 				<concatfilter prepend="${build.dir}/../build-js-head.txt"/>
@@ -23,14 +20,20 @@
 				</replacetokens>
 			</filterchain>
 		</copy>
-		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}/css/premin" toDir="${build.dir}/css">
-			<include name="*.*" />
+		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}" toDir="${build.dir}">
+			<include name="**/*.css" />
+			<include name="**/*.js" />
+			<exclude name="**/*-min.css" />
+			<exclude name="**/*-min.js" />
 		</yui-compressor>
-		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}/js/premin" toDir="${build.dir}/js">
-			<include name="*.*" />
-		</yui-compressor>
-		<delete dir="${build.dir}/css/premin"/>
-		<delete dir="${build.dir}/js/premin"/>
+		<delete>
+			<fileset dir="${build.dir}">
+				<include name="**/*.css" />
+				<include name="**/*.js" />
+				<exclude name="**/*-min.css" />
+				<exclude name="**/*-min.js" />
+			</fileset>
+		</delete>
 	</target>
   
 	<!--Build CSS Tasks -->

--- a/src/theme-gcwu-fegc/build.xml
+++ b/src/theme-gcwu-fegc/build.xml
@@ -10,10 +10,7 @@
 	<target name="build" depends="-init, -minify" />
   
 	<target name="-minify" depends="-merge-css, -base64-encode">
-		<move todir="${build.dir}/css/premin">
-			<fileset dir="${build.dir}/css"/>
-		</move>
-		<copy todir="${build.dir}/js/premin">
+		<copy todir="${build.dir}/js">
 			<fileset dir="${src.dir}/js"/>
 			<filterchain>
 				<concatfilter prepend="${build.dir}/../build-js-head.txt"/>
@@ -23,14 +20,20 @@
 				</replacetokens>
 			</filterchain>
 		</copy>
-		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}/css/premin" toDir="${build.dir}/css">
-			<include name="*.*" />
+		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}" toDir="${build.dir}">
+			<include name="**/*.css" />
+			<include name="**/*.js" />
+			<exclude name="**/*-min.css" />
+			<exclude name="**/*-min.js" />
 		</yui-compressor>
-		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}/js/premin" toDir="${build.dir}/js">
-			<include name="*.*" />
-		</yui-compressor>
-		<delete dir="${build.dir}/css/premin"/>
-		<delete dir="${build.dir}/js/premin"/>
+		<delete>
+			<fileset dir="${build.dir}">
+				<include name="**/*.css" />
+				<include name="**/*.js" />
+				<exclude name="**/*-min.css" />
+				<exclude name="**/*-min.js" />
+			</fileset>
+		</delete>
 	</target>
   
 	<!--Build CSS Tasks -->

--- a/src/theme-gcwu-intranet/build.xml
+++ b/src/theme-gcwu-intranet/build.xml
@@ -10,10 +10,7 @@
 	<target name="build" depends="-init, -minify" />
 
 	<target name="-minify" depends="-merge-css, -base64-encode">
-		<move todir="${build.dir}/css/premin">
-			<fileset dir="${build.dir}/css"/>
-		</move>
-		<copy todir="${build.dir}/js/premin">
+		<copy todir="${build.dir}/js">
 			<fileset dir="${src.dir}/js"/>
 			<filterchain>
 				<concatfilter prepend="${build.dir}/../build-js-head.txt"/>
@@ -23,14 +20,20 @@
 				</replacetokens>
 			</filterchain>
 		</copy>
-		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}/css/premin" toDir="${build.dir}/css">
-			<include name="*.*" />
+		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}" toDir="${build.dir}">
+			<include name="**/*.css" />
+			<include name="**/*.js" />
+			<exclude name="**/*-min.css" />
+			<exclude name="**/*-min.js" />
 		</yui-compressor>
-		<yui-compressor warn="false" munge="true" preserveAllSemiColons="false" fromDir="${build.dir}/js/premin" toDir="${build.dir}/js">
-			<include name="*.*" />
-		</yui-compressor>
-		<delete dir="${build.dir}/css/premin"/>
-		<delete dir="${build.dir}/js/premin"/>
+		<delete>
+			<fileset dir="${build.dir}">
+				<include name="**/*.css" />
+				<include name="**/*.js" />
+				<exclude name="**/*-min.css" />
+				<exclude name="**/*-min.js" />
+			</fileset>
+		</delete>
 	</target>
   
 	<!--Build CSS Tasks -->


### PR DESCRIPTION
Ran into an something when creating #645 where running "ant build" multiple times without running clean will create _-min-min-min._ files.
This patch means no extra copying of the files and no clean is required between in-place builds.
