### PR TITLE
#746 regression with hasAttribute in IE7

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -795,7 +795,7 @@
 				menulinkslen = menulinks.length;
 				while (menulinkslen--) {
 					menulink = menulinks[menulinkslen];
-					menulink.href = menulink.hasAttribute('href') ? menulink.getAttribute('href') : '#'; //Fix for empty A tags
+					menulink.href = menulink.getAttribute('href') !== '' ? menulink.getAttribute('href') : '#'; //Fix for empty A tags
 					if ((!hrefBug && menulink.getAttribute('href').slice(0, 1) !== '#') || (hrefBug && (menulink.href.indexOf('#') === -1 || pageurl !== menulink.hostname + menulink.pathname.replace(/^([^\/])/, '/$1')))) {
 						menulinkurl = menulink.hostname + menulink.pathname.replace(/^([^\/])/, '/$1');
 						menulinkurllen = menulinkurl.length;
@@ -824,6 +824,7 @@
 					menulinkslen = menulinks.length;
 					while (menulinkslen--) {
 						menulink = menulinks[menulinkslen];
+						menulink.href = menulink.getAttribute('href') !== '' ? menulink.getAttribute('href') : '#'; //Fix for empty A tags
 						if ((!hrefBug && menulink.getAttribute('href').slice(0, 1) !== '#') || (hrefBug && (menulink.href.indexOf('#') === -1 || pageurl !== menulink.hostname + menulink.pathname.replace(/^([^\/])/, '/$1')))) {
 							menulinkurl = menulink.hostname + menulink.pathname.replace(/^([^\/])/, '/$1');
 							menulinkurllen = menulinkurl.length;


### PR DESCRIPTION
Found that the menus weren't working because IE7 doesn't support the hasAttribute method.
There are a few uses of hasAttribute in formvalid.js that should also be looked at.

Also, extended this fix to breadcrumbs processing.
