### PR TITLE
Don't fixclrf on minified files

### DIFF
--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -242,10 +242,6 @@
 				<exclude name="**/*.min.js" />
 			</fileset>
 		</delete>
-		<fixcrlf srcdir="${build.dir}" fixlast="false" encoding="UTF-8" outputencoding="UTF-8">
-			<include name="**/*-min.css" />
-			<include name="**/*-min.js" />
-		</fixcrlf>
 	</target>
 	
 	<target name="-copy-css" depends="compile.sass">


### PR DESCRIPTION
This was necessary when the minified files were checked in because of
YUI outputing files with LF line endings under Windows.
