### PR TITLE
Update jRuby to 1.7.1

### DIFF
--- a/build/build-tasks.properties
+++ b/build/build-tasks.properties
@@ -12,12 +12,12 @@ antcontribs.jar=${lib.dir}/ant-contrib-1.0b3.jar
 cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 
 #jRuby Properties
-jruby.version=1.6.8
+jruby.version=1.7.1
 jruby.jar=jruby-complete-${jruby.version}.jar
 
 #Gems
 gem.dir=${lib.dir}/jruby-compiled
-sass.gem=sass-3.2.1.gem
+sass.gem=sass-3.2.3.gem
 chunky_png.gem=chunky_png-1.2.6.gem
 fssm.gem=fssm-0.2.9.gem
 compass.gem=compass-0.12.2.gem

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -89,6 +89,7 @@
 	
 	<target name="call.sass">
 		<java fork="true" failonerror="true" jar="${lib.dir}/${jruby.jar}">
+			<arg value="--1.8"/>
 			<arg path="${tasks.basedir}/compile.rb"/>
 			<arg path="${lib.dir}/vendors-${jruby.depends}/gems/"/>
 			<arg value="${command}"/>


### PR DESCRIPTION
Need to force run-time into 1.8 mode as Compass has some incompatibilities with jRuby under 1.9 mode.
Sass gem updated as well as the hash was changed anyway by updating the property file.
