### PR TITLE
Polyfill datalist 

### DIFF
--- a/demos/datalist/datalist-eng.html
+++ b/demos/datalist/datalist-eng.html
@@ -102,43 +102,29 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <p>The <code>datalist</code> tag specifies a list of pre-defined options for an <code>input</code> element.</p>
 
 <!-- Start of Datalist content -->
-<div class="span-8">
-<div class="span-4 row-start">
+<div class="span-3">
 	<section>
-		<h2 class="background-dark margin-bottom-medium">Usage</h2>
-		<pre class="wet-boew-prettify prettyprint linenums"><code>&lt;label for="city"&gt;City&lt;/label&gt;
-&lt;input type="text" id="city" name="city" list="suggestions" /&gt;
-&lt;datalist id="suggestions"&gt;
-	&lt;!--[if lte IE 9]&gt;&lt;select&gt;&lt;![endif]--&gt;
-	&lt;option label="" value="Calgary"&gt;&lt;/option&gt;
-	&lt;option label="" value="Edmonton"&gt;&lt;/option&gt;
-	&lt;option label="" value="Iqualuit"&gt;&lt;/option&gt;
-	&lt;option label="" value="Ottawa"&gt;&lt;/option&gt;
-	&lt;option label="" value="Montreal"&gt;&lt;/option&gt;
-	&lt;option label="" value="St. John"&gt;&lt;/option&gt;
-	&lt;option label="" value="St. John's"&gt;&lt;/option&gt;
-	&lt;option label="" value="Toronto"&gt;&lt;/option&gt;
-	&lt;option label="" value="Vancouver"&gt;&lt;/option&gt;
-	&lt;option label="" value="Whitehorse"&gt;&lt;/option&gt;
-	&lt;option label="" value="Winnipeg"&gt;&lt;/option&gt;
-	&lt;option label="" value="Yellowknife"&gt;&lt;/option&gt;
-	&lt;!--[if lte IE 9]&gt;&lt;/select&gt;&lt;![endif]--&gt;
-&lt;/datalist&gt;</code></pre>
-	</section>
-</div>
-<div class="span-4 row-end">
-	<section>
-		<h2 class="background-dark margin-bottom-medium">Examples</h2>
+		<h2 class="background-dark margin-bottom-medium">Example</h2>
 		<form action="#" method="get">
 			<label for="city">City</label>
     		<input type="text" id="city" name="city" list="suggestions" />
     		<datalist id="suggestions">
 				<!--[if lte IE 9]><select><![endif]-->
-        		<option label="" value="Calgary"></option>
-        		<option label="" value="Edmonton"></option>
-        		<option label="" value="Iqualuit"></option>
-        		<option label="" value="Ottawa"></option>
+				<option label="" value="Barrie"></option>
+				<option label="" value="Calgary"></option>
+				<option label="" value="Charlottetown"></option>
+				<option label="" value="Chibougamau"></option>
+				<option label="" value="Chilliwack"></option>
+				<option label="" value="Cold Lake"></option>
+				<option label="" value="Dorval"></option>
+				<option label="" value="Edmonton"></option>
+				<option label="" value="Flin Flon"></option>
+				<option label="" value="Hamilton"></option>
+				<option label="" value="Iqualuit"></option>
+				<option label="" value="Ottawa"></option>
+				<option label="" value="Miramichi"></option>
 				<option label="" value="Montreal"></option>
+				<option label="" value="Red Deer"></option>
 				<option label="" value="St. John"></option>
 				<option label="" value="St. John's"></option>
 				<option label="" value="Toronto"></option>
@@ -151,6 +137,38 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 		</form>
 	</section>
 </div>
+<div class="span-5 row-start">
+	<section>
+		<h2 class="background-dark margin-bottom-medium">Usage</h2>
+		<pre class="wet-boew-prettify prettyprint linenums"><code>&lt;label for="city"&gt;City&lt;/label&gt;
+&lt;input type="text" id="city" name="city" list="suggestions" /&gt;
+&lt;datalist id="suggestions"&gt;
+   &lt;!--[if lte IE 9]&gt;&lt;select&gt;&lt;![endif]--&gt;
+   &lt;option label="" value="Barrie"&gt;&lt;/option&gt;
+   &lt;option label="" value="Calgary"&gt;&lt;/option&gt;
+   &lt;option label="" value="Charlottetown"&gt;&lt;/option&gt;
+   &lt;option label="" value="Chibougamau"&gt;&lt;/option&gt;
+   &lt;option label="" value="Chilliwack"&gt;&lt;/option&gt;
+   &lt;option label="" value="Cold Lake"&gt;&lt;/option&gt;
+   &lt;option label="" value="Dorval"&gt;&lt;/option&gt;
+   &lt;option label="" value="Edmonton"&gt;&lt;/option&gt;
+   &lt;option label="" value="Flin Flon"&gt;&lt;/option&gt;
+   &lt;option label="" value="Hamilton"&gt;&lt;/option&gt;
+   &lt;option label="" value="Iqualuit"&gt;&lt;/option&gt;
+   &lt;option label="" value="Ottawa"&gt;&lt;/option&gt;
+   &lt;option label="" value="Miramichi"&gt;&lt;/option&gt;
+   &lt;option label="" value="Montreal"&gt;&lt;/option&gt;
+   &lt;option label="" value="Red Deer"&gt;&lt;/option&gt;
+   &lt;option label="" value="St. John"&gt;&lt;/option&gt;
+   &lt;option label="" value="St. John's"&gt;&lt;/option&gt;
+   &lt;option label="" value="Toronto"&gt;&lt;/option&gt;
+   &lt;option label="" value="Vancouver"&gt;&lt;/option&gt;
+   &lt;option label="" value="Whitehorse"&gt;&lt;/option&gt;
+   &lt;option label="" value="Winnipeg"&gt;&lt;/option&gt;
+   &lt;option label="" value="Yellowknife"&gt;&lt;/option&gt;
+   &lt;!--[if lte IE 9]&gt;&lt;/select&gt;&lt;![endif]--&gt;
+&lt;/datalist&gt;</code></pre>
+	</section>
 </div>
 <!-- End of Datalist content -->
 

--- a/demos/datalist/datalist-fra.html
+++ b/demos/datalist/datalist-fra.html
@@ -101,31 +101,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <p>La balise <code lang="en">datalist</code> spécifie une liste d'options pré-définis pour un élément <code lang="en">input</code>.</p>
 
 <!-- Start of Datalist content -->
-<div class="span-8">
-<div class="span-4 row-start">
-	<section>
-		<h2 class="background-dark margin-bottom-medium">Usage</h2>
-		<pre class="wet-boew-prettify prettyprint linenums"><code>&lt;label for="city"&gt;Ville&lt;/label&gt;
-&lt;input type="text" id="city" name="city" list="suggestions" /&gt;
-&lt;datalist id="suggestions"&gt;
-	&lt;!--[if lte IE 9]&gt;&lt;select&gt;&lt;![endif]--&gt;
-	&lt;option label="" value="Calgary"&gt;&lt;/option&gt;
-	&lt;option label="" value="Edmonton"&gt;&lt;/option&gt;
-	&lt;option label="" value="Iqualuit"&gt;&lt;/option&gt;
-	&lt;option label="" value="Ottawa"&gt;&lt;/option&gt;
-	&lt;option label="" value="Montréal"&gt;&lt;/option&gt;
-	&lt;option label="" value="St. John"&gt;&lt;/option&gt;
-	&lt;option label="" value="St. John's"&gt;&lt;/option&gt;
-	&lt;option label="" value="Toronto"&gt;&lt;/option&gt;
-	&lt;option label="" value="Vancouver"&gt;&lt;/option&gt;
-	&lt;option label="" value="Whitehorse"&gt;&lt;/option&gt;
-	&lt;option label="" value="Winnipeg"&gt;&lt;/option&gt;
-	&lt;option label="" value="Yellowknife"&gt;&lt;/option&gt;
-	&lt;!--[if lte IE 9]&gt;&lt;/select&gt;&lt;![endif]--&gt;
-&lt;/datalist&gt;</code></pre>
-	</section>
-</div>
-<div class="span-4 row-end">
+<div class="span-3">
 	<section>
 		<h2 class="background-dark margin-bottom-medium">Exemple</h2>
 		<form action="#" method="get">
@@ -133,11 +109,21 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
     		<input id="city" name="city" list="suggestions" />
     		<datalist id="suggestions">
 				<!--[if lte IE 9]><select><![endif]-->
-        		<option label="" value="Calgary"></option>
-        		<option label="" value="Edmonton"></option>
-        		<option label="" value="Iqualuit"></option>
-        		<option label="" value="Ottawa"></option>
-				<option label="" value="Montréal"></option>
+				<option label="" value="Barrie"></option>
+				<option label="" value="Calgary"></option>
+				<option label="" value="Charlottetown"></option>
+				<option label="" value="Chibougamau"></option>
+				<option label="" value="Chilliwack"></option>
+				<option label="" value="Cold Lake"></option>
+				<option label="" value="Dorval"></option>
+				<option label="" value="Edmonton"></option>
+				<option label="" value="Flin Flon"></option>
+				<option label="" value="Hamilton"></option>
+				<option label="" value="Iqualuit"></option>
+				<option label="" value="Ottawa"></option>
+				<option label="" value="Miramichi"></option>
+				<option label="" value="Montreal"></option>
+				<option label="" value="Red Deer"></option>
 				<option label="" value="St. John"></option>
 				<option label="" value="St. John's"></option>
 				<option label="" value="Toronto"></option>
@@ -150,6 +136,38 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 		</form>
 	</section>
 </div>
+<div class="span-5">
+	<section>
+		<h2 class="background-dark margin-bottom-medium">Usage</h2>
+		<pre class="wet-boew-prettify prettyprint linenums"><code>&lt;label for="city"&gt;Ville&lt;/label&gt;
+&lt;input type="text" id="city" name="city" list="suggestions" /&gt;
+&lt;datalist id="suggestions"&gt;
+   &lt;!--[if lte IE 9]&gt;&lt;select&gt;&lt;![endif]--&gt;
+   &lt;option label="" value="Barrie"&gt;&lt;/option&gt;
+   &lt;option label="" value="Calgary"&gt;&lt;/option&gt;
+   &lt;option label="" value="Charlottetown"&gt;&lt;/option&gt;
+   &lt;option label="" value="Chibougamau"&gt;&lt;/option&gt;
+   &lt;option label="" value="Chilliwack"&gt;&lt;/option&gt;
+   &lt;option label="" value="Cold Lake"&gt;&lt;/option&gt;
+   &lt;option label="" value="Dorval"&gt;&lt;/option&gt;
+   &lt;option label="" value="Edmonton"&gt;&lt;/option&gt;
+   &lt;option label="" value="Flin Flon"&gt;&lt;/option&gt;
+   &lt;option label="" value="Hamilton"&gt;&lt;/option&gt;
+   &lt;option label="" value="Iqualuit"&gt;&lt;/option&gt;
+   &lt;option label="" value="Ottawa"&gt;&lt;/option&gt;
+   &lt;option label="" value="Miramichi"&gt;&lt;/option&gt;
+   &lt;option label="" value="Montreal"&gt;&lt;/option&gt;
+   &lt;option label="" value="Red Deer"&gt;&lt;/option&gt;
+   &lt;option label="" value="St. John"&gt;&lt;/option&gt;
+   &lt;option label="" value="St. John's"&gt;&lt;/option&gt;
+   &lt;option label="" value="Toronto"&gt;&lt;/option&gt;
+   &lt;option label="" value="Vancouver"&gt;&lt;/option&gt;
+   &lt;option label="" value="Whitehorse"&gt;&lt;/option&gt;
+   &lt;option label="" value="Winnipeg"&gt;&lt;/option&gt;
+   &lt;option label="" value="Yellowknife"&gt;&lt;/option&gt;
+   &lt;!--[if lte IE 9]&gt;&lt;/select&gt;&lt;![endif]--&gt;
+&lt;/datalist&gt;</code></pre>
+	</section>
 </div>
 <!-- End of Datalist content -->
 

--- a/src/js/polyfills/datalist.js
+++ b/src/js/polyfills/datalist.js
@@ -120,8 +120,6 @@
 				} else if (type === 'click' || type === 'vclick') {
 					if (!autolist.hasClass('al-hide')) {
 						closeOptions();
-					} else {
-						showOptions('');
 					}
 					return false;
 				} else if (type === 'focus' && pe.ie > 0 && pe.ie < 8) {
@@ -194,10 +192,6 @@
 					pe.focus(elm);
 					closeOptions();
 				}
-			});
-
-			$(container).on("focusoutside", function () {
-				closeOptions();
 			});
 
 			$(document).on("click vclick touchstart", function (e) {

--- a/src/js/sass/includes/_datalist.scss
+++ b/src/js/sass/includes/_datalist.scss
@@ -17,6 +17,7 @@ ul.wb-autolist {
 	padding-left:0;
 	z-index:50;
 	background:#fff;
+	max-height:18em;
 	width:100%;
 	border: {
 		width: 0 1px 1px;


### PR DESCRIPTION
Matched the polyfill behaviour more closely to native datalist behaviour:
- Added max-height to trigger vertical scrollbar on long item lists
- Stopped click event on input from displaying full list of items
- Removed focusoutside event  on `$(container)` to allow use of item list vertical scrollbar
