### PR TITLE
Remove background rule with no image

### DIFF
--- a/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen-images.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen-images.scss
@@ -4,14 +4,6 @@
  */
 @import "compass/css3/images";
 
-#wb-body,#wb-body-sec,#wb-body-sec-sup,#wb-body-sec-sup,#wb-head-in {
-	background:{
-		repeat: no-repeat, repeat-x;
-		position: center 3.08em;
-		color: #fff;
-	}
-}
-
 #gcwu-srch-submit {
 	background:#ccc url(../images/search-button.gif) 0 0 repeat-x;
 	&:focus,&:hover {


### PR DESCRIPTION
The intranet theme doesn't seem to use the background images of the Web Usability theme. Note that this isn't currently mentioned in http://wet-boew.github.com/wet-boew/demos/theme-gcwu-intranet/index-eng.html#hdrchgs

Fixes gh-905
