### PR TITLE
[tabs] Fixes jQuery 1.9 compatibility issue.

### DIFF
--- a/src/js/sass/includes/_tabbedinterface.scss
+++ b/src/js/sass/includes/_tabbedinterface.scss
@@ -7,7 +7,13 @@
 .tabs li a, .tabs-style-1 .tabs, .tabs-style-1 .tabs li a:hover, .tabs-style-1 .tabs li a:focus, .tabs-style-1 .tabs li a:active, .tabs-style-2 .tabs li.tabs-toggle, .tabs-style-3 .tabs-panel, .tabs-style-4 .tabs li a:hover,  .tabs-style-4 .tabs li a:focus,  .tabs-style-4 .tabs li a:active {
 	background:url(../images/tabs/gradient.png) repeat-x 0 0 #eee;
 }
- 
+
+.tabs.started a.active {
+	&,&:hover,&:focus,&:active {
+		cursor: pointer;
+	}
+}
+
 .tabs {
     border-bottom:solid 1px #ccc;
     margin:0;
@@ -119,7 +125,7 @@
     position:absolute;
     top:0;
     left:0;
-    cursor:text;
+    cursor:pointer;
     background-color:#000;
     @include opacity(0.1);
 }

--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -231,6 +231,7 @@
 						$pbar;
 					$current = $tabs.filter('.' + opts.tabActiveClass);
 					$pbar = $current.siblings('.tabs-roller');
+					$nav.addClass('started');
 					elm.find('.tabs-toggle').data('state', 'started');
 					return $pbar.show().animate({
 						width : $current.parent().width()
@@ -246,6 +247,7 @@
 					clearTimeout(elm.data('interval'));
 					elm.find('.tabs-roller').width(0).hide().stop();
 					elm.find('.tabs-toggle').data('state', 'stopped');
+					$nav.removeClass('started');
 					$toggleButton.removeClass('tabs-stop').addClass('tabs-start').html(startText + '<span class="wb-invisible">' + startHiddenText + '</span>');
 					return $('.wb-invisible', $toggleButton).text(startHiddenText);
 				};
@@ -286,8 +288,6 @@
 					var $pbar;
 					$pbar = $('<div class="tabs-roller">').hide().on('click', function () {
 						return $(this).siblings('a').trigger('click');
-					}).on('hover', function () {
-						return $(this).css('cursor', 'text');
 					});
 					if (pe.ie > 0 && pe.ie < 8) {
 						$('.tabs-style-2 .tabs, .tabs-style-2 .tabs li').css('filter', '');


### PR DESCRIPTION
Removes call to hover(), uses CSS :hover to change the cursor instead.
#907
