### PR TITLE
Remove js zero units

### DIFF
--- a/src/js/workers/eventscalendar.js
+++ b/src/js/workers/eventscalendar.js
@@ -357,7 +357,7 @@
 			events = getEvents(elm);
 			containerid = $(elm).attr('class').split(' ').slice(-1);
 
-			if ($('#wb-main-in').css('padding-left') === '0px') {
+			if ($('#wb-main-in').css('padding-left') === '0px') { //jQuery returns 0px even if no units specified in CSS "padding-left: 0;"
 				$('#' + containerid).css('margin-left', '10px');
 			}
 

--- a/src/js/workers/menubar.js
+++ b/src/js/workers/menubar.js
@@ -50,7 +50,7 @@
 				_sm.attr({'aria-expanded':'true', 'aria-hidden':'false'}).toggleClass('mb-sm mb-sm-open');
 
 				if ((Math.floor(_sm.offset().left + _sm.width()) - Math.floor($menuBoundary.offset().left + $menuBoundary.width())) >= -1) {
-					_sm.css('right', '0px');
+					_sm.css('right', '0');
 				}
 				_node.addClass('mb-active');
 				return;


### PR DESCRIPTION
- Don't need to specify units when setting a zero value
- Note that using jQuery .css() will return units even when not set in the CSS file http://jsfiddle.net/yAnFL/29/
