### PR TITLE
Confused font sizing rule

### DIFF
--- a/src/base/sass/_base.scss
+++ b/src/base/sass/_base.scss
@@ -8,6 +8,7 @@ body {
 	font-size: 80%;
 	margin: 0;
 	padding: 0;
+	@extend %base-verdana-font;
 }
 
 a {
@@ -36,12 +37,12 @@ table {
 	border-spacing: 0;
 }
 
-textarea, input, body {
+%base-verdana-font {
 	font-family: Verdana, Arial, Helvetica, sans-serif;
-	font-size: 80%;
 }
 
 textarea, input {
+	@extend %base-verdana-font;
 	font-size: 100%;
 }
 


### PR DESCRIPTION
Rule seemed to be used for the common font declaration only as font sizes were
specified for all the elements elsewhere in the same sheet.
