### PR TITLE
Added summary element support to Grid SCSS button classes.

### DIFF
--- a/src/grids/sass/includes/_button.scss
+++ b/src/grids/sass/includes/_button.scss
@@ -36,7 +36,7 @@
 	}
 
 	/* without line 29 the buttons would not be coloured in IE, move to fixes? */
-	input, button, a {
+	input, button, a, summary {
 		&.button-accent {
 			@include color-button($accent);
 		}


### PR DESCRIPTION
@cfarquharson, @pjackson28, @canasa Would you guys be on board with this?

The expanded effect with a button-styled summary isn't as prominent as the default one, but even without the default highlighted bar effect, the CSS-based dropdown arrow can still be relied on to visually identify the current expanded/collapsed state of the details.
