### PR TITLE
Update custom CSSLint with debugging

### DIFF
--- a/build/build-tasks.properties
+++ b/build/build-tasks.properties
@@ -12,12 +12,12 @@ antcontribs.jar=${lib.dir}/ant-contrib-1.0b3.jar
 cssurlembed.jar=${lib.dir}/cssembed-0.4.5.jar
 
 #jRuby Properties
-jruby.version=1.7.1
+jruby.version=1.7.2
 jruby.jar=jruby-complete-${jruby.version}.jar
 
 #Gems
 gem.dir=${lib.dir}/jruby-compiled
-sass.gem=sass-3.2.3.gem
+sass.gem=sass-3.2.5.gem
 chunky_png.gem=chunky_png-1.2.6.gem
 fssm.gem=fssm-0.2.9.gem
 compass.gem=compass-0.12.2.gem
@@ -26,8 +26,3 @@ compass.gem=compass-0.12.2.gem
 jshint.jar=${lib.dir}/ant-jshint-0.3.1-deps.jar
 jshint.globals.file=${tasks.basedir}/jshint.globals.properties
 jshint.failbuild=false
-
-#Core project paths
-jssrc.dir=${tasks.basedir}/../src/js
-gridsrc.dir=${tasks.basedir}/../src/grids
-basesrc.dir=${tasks.basedir}/../src/base

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -89,7 +89,6 @@
 	
 	<target name="call.sass">
 		<java fork="true" failonerror="true" jar="${lib.dir}/${jruby.jar}">
-			<arg value="--1.8"/>
 			<arg path="${tasks.basedir}/compile.rb"/>
 			<arg path="${lib.dir}/vendors-${jruby.depends}/gems/"/>
 			<arg value="${command}"/>

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -89,6 +89,7 @@
 	
 	<target name="call.sass">
 		<java fork="true" failonerror="true" jar="${lib.dir}/${jruby.jar}">
+			<arg value="--1.8"/>
 			<arg path="${tasks.basedir}/compile.rb"/>
 			<arg path="${lib.dir}/vendors-${jruby.depends}/gems/"/>
 			<arg value="${command}"/>

--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -95,7 +95,12 @@
 			<arg value="${command}"/>
 			<arg path="${src.dir}"/>
 			<arg value="${dist.dir}/css"/>
+			<arg value="${isdebugging}"/>
 		</java>
+	</target>
+	
+	<target name="usedebugging">
+		<property name="isdebugging" value="true"/>
 	</target>
 	
 	<!-- Watch for any polling changes in the SCSS directory "ant watch.sass" -->
@@ -141,7 +146,7 @@
 	<property name="csslint.ignores" value="ids,important,qualified-headings,universal-selector,unqualified-attributes,star-property-hack,unique-headings,adjoining-classes,floats,overqualified-elements,font-sizes,regex-selectors,duplicate-properties,box-sizing"/>
 	<property name="csslint.errors" value="outline-none"/>
 
-	<target name="csslint" description="Runs CSSLint on CSS produced by the project's Sass files and outputs results to the console" depends="prepare-files">
+	<target name="csslint" description="Runs CSSLint on CSS produced by the project's Sass files and outputs results to the console" depends="usedebugging, prepare-files">
 		<apply executable="java" failonerror="false" parallel="false">
 			<fileset dir="${dist.dir}/css">
 				<include name="*.css"/>

--- a/build/config.rb
+++ b/build/config.rb
@@ -1,6 +1,6 @@
 # Change this to :production when ready to deploy the CSS to the live server.
-environment = :development
-#environment = :production
+# environment = :development
+environment = :production
 
 # In development, we can turn on the FireSass-compatible debug_info.
 firesass = false

--- a/build/config.rb
+++ b/build/config.rb
@@ -1,6 +1,6 @@
 # Change this to :production when ready to deploy the CSS to the live server.
 # environment = :development
-environment = :production
+environment = (ARGV[4]) ? :development : :production
 
 # In development, we can turn on the FireSass-compatible debug_info.
 firesass = false

--- a/build/lib/csslint-rhino.js
+++ b/build/lib/csslint-rhino.js
@@ -21,7 +21,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-/* Build time: 1-January-2013 02:46:05 */
+/* Build time: 11-January-2013 01:17:18 */
 var CSSLint = (function(){
 
 /*!
@@ -47,7 +47,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-/* Version v0.2.1, Build time: 4-December-2012 11:58:48 */
+/* Version v0.2.1, Build time: 11-January-2013 01:15:29 */
 var parserlib = {};
 (function(){
 
@@ -957,7 +957,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-/* Version v0.2.1, Build time: 4-December-2012 11:58:48 */
+/* Version v0.2.1, Build time: 11-January-2013 01:15:29 */
 (function(){
 var EventTarget = parserlib.util.EventTarget,
 TokenStreamBase = parserlib.util.TokenStreamBase,
@@ -2588,7 +2588,7 @@ Parser.prototype = function(){
                 while(tokenStream.match([Tokens.PLUS, Tokens.MINUS, Tokens.DIMENSION,
                         Tokens.NUMBER, Tokens.STRING, Tokens.IDENT, Tokens.LENGTH,
                         Tokens.FREQ, Tokens.ANGLE, Tokens.TIME,
-                        Tokens.RESOLUTION])){
+                        Tokens.RESOLUTION, Tokens.SLASH])){
                     
                     value += tokenStream.token().value;
                     value += this._readWhitespace();                        
@@ -3534,7 +3534,7 @@ var Properties = {
     "-o-animation-name"                : { multi: "none | <ident>", comma: true },
     "-o-animation-play-state"          : { multi: "running | paused", comma: true },        
     
-    "appearance"                    : "icon | window | desktop | workspace | document | tooltip | dialog | button | push-button | hyperlink | radio-button | checkbox | menu-item | tab | menu | menubar | pull-down-menu | pop-up-menu | list-menu | radio-group | checkbox-group | outline-tree | range | field | combo-box | signature | password | normal | inherit",
+    "appearance"                    : "icon | window | desktop | workspace | document | tooltip | dialog | button | push-button | hyperlink | radio-button | checkbox | menu-item | tab | menu | menubar | pull-down-menu | pop-up-menu | list-menu | radio-group | checkbox-group | outline-tree | range | field | combo-box | signature | password | normal | none | inherit",
     "azimuth"                       : function (expression) {
         var simple      = "<angle> | leftwards | rightwards | inherit",
             direction   = "left-side | far-left | left | center-left | center | center-right | right | far-right | right-side",
@@ -6393,7 +6393,7 @@ var CSSLint = (function(){
         formatters = [],
         api        = new parserlib.util.EventTarget();
         
-    api.version = "@VERSION@";
+    api.version = "0.9.9";
 
     //-------------------------------------------------------------------------
     // Rule Management
@@ -6973,72 +6973,6 @@ CSSLint.addRule({
         });       
     }
 
-});
-/*
- * Rule: Use the bulletproof @font-face syntax to avoid 404's in old IE
- * (http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax)
- */
-/*global CSSLint*/
-CSSLint.addRule({
-
-    //rule information
-    id: "bulletproof-font-face",
-    name: "Use the bulletproof @font-face syntax",
-    desc: "Use the bulletproof @font-face syntax to avoid 404's in old IE (http://www.fontspring.com/blog/the-new-bulletproof-font-face-syntax).",
-    browsers: "All",
-
-    //initialization
-    init: function(parser, reporter){
-        var rule = this,
-            count = 0,
-            fontFaceRule = false,
-            firstSrc     = true,
-            ruleFailed    = false,
-            line, col;
-
-        // Mark the start of a @font-face declaration so we only test properties inside it
-        parser.addListener("startfontface", function(event){
-            fontFaceRule = true;
-        });
-
-        parser.addListener("property", function(event){
-            // If we aren't inside an @font-face declaration then just return
-            if (!fontFaceRule) {
-                return;
-            }
-
-            var propertyName = event.property.toString().toLowerCase(),
-                value        = event.value.toString();
-
-            // Set the line and col numbers for use in the endfontface listener
-            line = event.line;
-            col  = event.col;
-
-            // This is the property that we care about, we can ignore the rest
-            if (propertyName === 'src') {
-                var regex = /^\s?url\(['"].+\.eot\?.*['"]\)\s*format\(['"]embedded-opentype['"]\).*$/i;
-
-                // We need to handle the advanced syntax with two src properties
-                if (!value.match(regex) && firstSrc) {
-                    ruleFailed = true;
-                    firstSrc = false;
-                } else if (value.match(regex) && !firstSrc) {
-                    ruleFailed = false;
-                }
-            }
-
-
-        });
-
-        // Back to normal rules that we don't need to test
-        parser.addListener("endfontface", function(event){
-            fontFaceRule = false;
-
-            if (ruleFailed) {
-                reporter.report("@font-face declaration doesn't follow the fontspring bulletproof syntax.", line, col, rule);
-            }
-        });
-    }
 });
 /*
  * Rule: Include all compatible vendor prefixes to reach a wider

--- a/demos/arb-rra/arb-rra-eng.html
+++ b/demos/arb-rra/arb-rra-eng.html
@@ -97,7 +97,12 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Accessibility responsibility breakdown (WCAG 2.0)</h1>
+<h1 id="wb-cont" class="inline-block">Accessibility responsibility breakdown (WCAG 2.0)</h1>
+
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Accessibility-responsibility-breakdown" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
 
 <div class="span-8">
 <p>The Web Content Accessibility Guidelines (WCAG) 2.0 offer sixty one (61) success criteria incorporating best practices for promoting content accessibility for persons with disabilities. These success criteria affect all phases of a Web site project. The responsibilities associated with them must be assigned to the various individuals involved to ensure the success of the content accessibility project. This is especially true in the context of conformance obligations if such obligations are in place in your organization.</p>

--- a/demos/arb-rra/arb-rra-fra.html
+++ b/demos/arb-rra/arb-rra-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Répartition des responsabilités d'accessibilité (WCAG 2.0)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/R%C3%A9partition-des-responsabilit%C3%A9s-d%27accessibilit%C3%A9" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="span-8">
 <p>Les <span lang="en">Web Content Accessibility Guidelines</span> (WCAG) 2.0 présentent soixante et un (61) critères de succès qui incarnent autant de bonnes pratiques visant à favoriser la mise en accessibilité des contenus pour les personnes handicapées. Ces critères de succès ont des impacts sur toutes les étapes d’un projet de site Web. Les responsabilités qui en découlent doivent donc être réparties à travers les différents intervenants concernés afin d’assurer le succès de la démarche de mise en accessibilité des contenus. C’est doublement vrai dans des contextes d’obligations de conformité, si de telles obligations sont en vigueur sur votre territoire.</p>
 <section>

--- a/demos/arb-rra/arb-rra-planAccess-eng.html
+++ b/demos/arb-rra/arb-rra-planAccess-eng.html
@@ -100,6 +100,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Planning accessibility</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Accessibility-responsibility-breakdown" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <p>Accessibility is not simply an extra link that can be added to the Web production chain. It must be incorporated in each existing link of that chain. The only way to successfully accomplish accessibility is to assign responsibility and share the tasks in order to produce accessible content.</p>
 <section>
 	<h2>Changing habits</h2>

--- a/demos/arb-rra/arb-rra-planAccess-fra.html
+++ b/demos/arb-rra/arb-rra-planAccess-fra.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Planifier l’accessibilité</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/R%C3%A9partition-des-responsabilit%C3%A9s-d%27accessibilit%C3%A9" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <p>L’accessibilité ne constitue pas un simple maillon supplémentaire que l’on peut ajouter à la chaîne de production Web. Elle doit plutôt s’intégrer à chacun des maillons de cette chaîne. La seule façon de relever avec succès le défi de l’accessibilité est de répartir la responsabilité et de partager les tâches pour produire un contenu accessible.</p>
 <section>
 	<h2>Bousculer les habitudes</h2>

--- a/demos/archived/archived-eng.html
+++ b/demos/archived/archived-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">ARCHIVED - Archived Web page template</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Archiving-content" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <p><strong>Scroll down and the "archived" notice will fade in (at the top of your window)</strong></p>
 <p><img src="../../dist/js/images/archived/warning.gif" alt="Warning" title="Warning" class="margin-bottom-none" />The <a href="http://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=24227">Standard on Web Usability</a> replaces this content. This content is archived because Common Look and Feel 2.0 Standards have been rescinded.</p>
 

--- a/demos/archived/archived-fra.html
+++ b/demos/archived/archived-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">ARCHIVÉE - Modèle de page Web archivée</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Contenu-archiv%C3%A9" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <p><strong>Faites défiler la page et l'avis "archivé" apparaît au haut de la fenêtre.</strong></p>
 <p><img src="../../dist/js/images/archived/warning.gif" alt="Avertissement" title="Avertissement" class="margin-bottom-none" />La <a href="http://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=24227">Norme sur la facilité d'emploi des sites Web</a> remplace ce contenu. Cette page Web a été archivée parce que les Normes sur la normalisation des sites Internet 2.0 ont étés annulées.</p>
 <div id="archived" class="wet-boew-archived span-8"><section>

--- a/demos/charts/complex-eng.html
+++ b/demos/charts/complex-eng.html
@@ -87,7 +87,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Complex Charts - Web Experience Toolkit (WET)</li>
+<li>Complex Charts</li>
 </ol>
 </div></div>
 </nav>
@@ -97,9 +97,12 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Complex Charts - Web Experience Toolkit (WET)</h1>
+<h1 id="wb-cont">Complex Charts</h1>
 
-
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Charts-and-graphs" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
 
 <table class="wet-boew-charts wb-charts-graphclass-abc123 wb-charts-graphclass-supersize">
 <caption>Current account balances</caption>

--- a/demos/charts/simple-eng.html
+++ b/demos/charts/simple-eng.html
@@ -99,7 +99,10 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Charts - Web Experience Toolkit (WET)</h1>
 
-
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Charts-and-graphs" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
 
 			<table class="wet-boew-charts wb-charts-line">
 				<caption>2009 Individual Sales by Category</caption>

--- a/demos/charts/simpleCustomized-eng.html
+++ b/demos/charts/simpleCustomized-eng.html
@@ -87,7 +87,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Charts - Customized - Web Experience Toolkit (WET)</li>
+<li>Charts - Customized</li>
 </ol>
 </div></div>
 </nav>
@@ -97,8 +97,12 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Charts - Customized - Web Experience Toolkit (WET)</h1>
+<h1 id="wb-cont">Charts - Customized</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Charts-and-graphs" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
 
 <h2 id="figure16">Figure 1</h2>
 

--- a/demos/datalist/datalist-eng.html
+++ b/demos/datalist/datalist-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Auto-complete for text input fields (datalist polyfill)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Auto-complete-for-text-input-fields-%28input-list---datalist-polyfill%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <p>The <code>datalist</code> tag specifies a list of pre-defined options for an <code>input</code> element.</p>
 
 <!-- Start of Datalist content -->

--- a/demos/datalist/datalist-fra.html
+++ b/demos/datalist/datalist-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Remplissage automatique des champs de saisie (correctif pour datalist)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Remplissage-automatique-des-champs-de-saisie-%28correctif-pour-l%E2%80%99%C3%A9l%C3%A9ment-input-list---datalist%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <p>La balise <code lang="en">datalist</code> spécifie une liste d'options pré-définis pour un élément <code lang="en">input</code>.</p>
 
 <!-- Start of Datalist content -->

--- a/demos/datepicker/datepicker-eng.html
+++ b/demos/datepicker/datepicker-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Date picker - Calendar interface - Web Experience Toolkit (WET)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Date-picker-%28input-type%3D%27date%27-polyfill%2C-Calendar-interface%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section>
 <h2>Examples</h2>
 <form method="get" action="#">

--- a/demos/datepicker/datepicker-fra.html
+++ b/demos/datepicker/datepicker-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Sélecteur de date - Interface du calendrier - Boîte à outils de l'expérience Web (BOEW)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/S%C3%A9lecteur-de-date-%28correctif-pour-input-type%3D%27date%27%2C-interface-du-calendrier%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section><h2>Exemples</h2>
 <form method="get" action="#">
 	<div>

--- a/demos/details/details-eng.html
+++ b/demos/details/details-eng.html
@@ -123,6 +123,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Expandable/collapsible content (details/summary polyfill)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Expandable-collapsible-content-%28details-summary-polyfill%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <p>The HTML5 <code>details</code> and <code>summary</code> elements are used to provide expandable/collapsible content. This component adds support for these elements in browsers that do not already have native support.</p>
 
 <section><h2>Examples</h2>

--- a/demos/details/details-fra.html
+++ b/demos/details/details-fra.html
@@ -122,6 +122,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Contenu en arborescence affichable/masquable (correctif pour <span lang="en">details/summary</span>)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Contenu-affichable-masquable-%28correctif-pour-les-%C3%A9l%C3%A9ments-details-summary%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <p>Les éléments HTML5 &#171;&#160;<code lang="en">details</code>&#160;&#187; et &#171;&#160;<code lang="en">summary</code>&#160;&#187; sont utilisés pour fournir le contenu en arborescence affichable/masquable. Ce composant ajoute le soutien pour ces éléments dans les navigateurs qui n'ont pas déjà la prise en charge native.</p>
 
 <section><h2>Exemples</h2>

--- a/demos/eventscalendar/eventscalendar-eng.html
+++ b/demos/eventscalendar/eventscalendar-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Events Calendar - Calendar interface - Web Experience Toolkit (WET)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Events-calendar-%28Calendar-interface%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section>
     <h2>Linking Options</h2>
     <section>

--- a/demos/eventscalendar/eventscalendar-fra.html
+++ b/demos/eventscalendar/eventscalendar-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Événements - Interface du calendrier - Boîte à outils de l'expérience Web (BOEW)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Calendrier-d%27%C3%A9v%C3%A9nements-%28interface-du-calendrier%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section>
     <h2>Options de liaison</h2>
     <section>

--- a/demos/feedback/feedback-eng.html
+++ b/demos/feedback/feedback-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Feedback form</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Feedback-form" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <div class="wet-boew-formvalid wet-boew-feedback span-8">
 <p>If you have difficulty with the following form, you can use any of our <a href="#osc-avs">other service channels</a> to contact us. Please read the <a href="#pics-ecrp">Personal Information Collection Statement</a> before completing this form.
 <form action="#" method="get" id="feeback-form"><div>

--- a/demos/feedback/feedback-fra.html
+++ b/demos/feedback/feedback-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Feuille de réponse</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Feuille-de-r%C3%A9ponse" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="wet-boew-formvalid wet-boew-feedback span-8">
 <p>Si vous avez des problèmes avec le formulaire suivant, vous pouvez utiliser une des <a href="#osc-avs">autres voies de service</a> pour communiquer avec nous. S'il vous plaît lire l'<a href="#pics-ecrp">énoncé de collecte de renseignements personnels</a> avant de compléter ce formulaire.</p>
 <form action="#" method="get" id="feeback-form"><div>

--- a/demos/footnotes/footnotes-eng.html
+++ b/demos/footnotes/footnotes-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Footnotes</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Footnotes" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section><h2>Overview</h2>
 <p>The purpose of the Footnotes sub-project is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the <a href="#fnb">Footnotes</a> section. Supporting CSS is used to lay out the footnotes and hide navigational aids<sup id="fnb1-ref"><a class="footnote-link" href="#fnb1"><span class="wb-invisible">Footnote </span>1</a></sup>.</p>
 </section>

--- a/demos/footnotes/footnotes-fra.html
+++ b/demos/footnotes/footnotes-fra.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Notes de bas de page</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Notes-de-bas-de-page" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section><h2>Vue d'ensemble</h2>
 <p>Le sous-projet Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section <a href="#fnb">Notes de bas de page</a>. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation<sup id="fnb1-ref"><a class="footnote-link" href="#fnb1"><span class="wb-invisible">Note de bas de page </span>1</a></sup>.</p>
 </section>

--- a/demos/formvalid/formvalid-eng.html
+++ b/demos/formvalid/formvalid-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Form validation</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Form-validation" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <div class="wet-boew-formvalid span-8">
 <form action="#" method="get" id="validation-example">
 <fieldset><legend>Contact information</legend>

--- a/demos/formvalid/formvalid-fra.html
+++ b/demos/formvalid/formvalid-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Validation des formulaires</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Validation-des-formulaires" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="wet-boew-formvalid span-8">
 <form action="#" method="get" id="validation-example">
 <fieldset><legend>Coordonnées</legend>

--- a/demos/langselect/lang-eng.html
+++ b/demos/langselect/lang-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Language Selector (PHP only)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Language-selector" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section><h2>Heading 2 (<code>h2</code>) default appearance</h2>
 	<section><h3>Heading 3 (<code>h3</code>) default appearance</h3>
 		<section><h4>Heading 4 (<code>h4</code>) default appearance</h4>

--- a/demos/langselect/lang-fra.html
+++ b/demos/langselect/lang-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Sélecteur de langue (PHP seulement)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/S%C3%A9lecteur-de-langue" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section><h2>En-tête 2 (<code>h2</code>) - apparence par défaut</h2>
 	<section><h3>En-tête 3 (<code>h3</code>) - apparence par défaut</h3>
 		<section><h4>En-tête 4 (<code>h4</code>) - apparence par défaut</h4>

--- a/demos/langselect/lang-js-eng.html
+++ b/demos/langselect/lang-js-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Language Selector (JavaScript + PHP)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Language-selector" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section><h2>Heading 2 (<code>h2</code>) default appearance</h2>
 	<section><h3>Heading 3 (<code>h3</code>) default appearance</h3>
 		<section><h4>Heading 4 (<code>h4</code>) default appearance</h4>

--- a/demos/langselect/lang-js-fra.html
+++ b/demos/langselect/lang-js-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Sélecteur de langue (JavaScript + PHP)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/S%C3%A9lecteur-de-langue" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section><h2>En-tête 2 (<code>h2</code>) - apparence par défaut</h2>
 	<section><h3>En-tête 3 (<code>h3</code>) - apparence par défaut</h3>
 		<section><h4>En-tête 4 (<code>h4</code>) - apparence par défaut</h4>

--- a/demos/lightbox/lightbox-eng.html
+++ b/demos/lightbox/lightbox-eng.html
@@ -109,6 +109,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Light Box</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Light-Box" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section>
 	<div class="span-4 module-table-contents">
 		<h2>Table of contents</h2>

--- a/demos/lightbox/lightbox-fra.html
+++ b/demos/lightbox/lightbox-fra.html
@@ -108,6 +108,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Lightbox</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Lightbox" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section>
 	<div class="span-4 module-table-contents">
 		<h2>Table des matières</h2>

--- a/demos/mathlib/mathlib-eng.html
+++ b/demos/mathlib/mathlib-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Mathematical/scientific formula display (MathML polyfill)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Mathematical-Scientific-formula-display-%28MathML-polyfill%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section><h2>Overview</h2>
 <p>This polyfill loads MathJax when MathML is detected on the page and the browser has inadequate MathML support.</p>
 <section><h3>Known issues</h3>

--- a/demos/mathlib/mathlib-fra.html
+++ b/demos/mathlib/mathlib-fra.html
@@ -97,6 +97,12 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
 <h1 id="wb-cont">Affichage des formules mathématiques ou scientifiques (correctif pour MathML)</h1>
+
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Affichage-de-formules-math%C3%A9matiques-et-scientifiques-%28correctif-MathML%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div lang="en">
 <section><h2>Overview</h2>
 <p>This polyfill loads MathJax when MathML is detected on the page and the browser has inadequate MathML support.</p>

--- a/demos/menubar/hsitenavbar-eng.html
+++ b/demos/menubar/hsitenavbar-eng.html
@@ -96,6 +96,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Menu bar - Horizontal site navigation bar</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Menu-bar" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section><h2>Heading 2 (<code>h2</code>) default appearance</h2>
 	<section><h3>Heading 3 (<code>h3</code>) default appearance</h3>
 		<section><h4>Heading 4 (<code>h4</code>) default appearance</h4>

--- a/demos/menubar/hsitenavbar-fra.html
+++ b/demos/menubar/hsitenavbar-fra.html
@@ -97,6 +97,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Barre de menu - Barre de navigation horizontale</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Barre-de-menu" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section><h2>En-tête 2 (<code>h2</code>) - apparence par défaut</h2>
 	<section><h3>En-tête 3 (<code>h3</code>) - apparence par défaut</h3>
 		<section><h4>En-tête 4 (<code>h4</code>) - apparence par défaut</h4>

--- a/demos/menubar/megamenu-eng.html
+++ b/demos/menubar/megamenu-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Menu bar - Mega menu</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Menu-bar" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section><h2>Heading 2 (<code>h2</code>) default appearance</h2>
 	<section><h3>Heading 3 (<code>h3</code>) default appearance</h3>
 		<section><h4>Heading 4 (<code>h4</code>) default appearance</h4>

--- a/demos/menubar/megamenu-fra.html
+++ b/demos/menubar/megamenu-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Barre de menu - Mégamenu</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Barre-de-menu" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section><h2>En-tête 2 (<code>h2</code>) - apparence par défaut</h2>
 	<section><h3>En-tête 3 (<code>h3</code>) - apparence par défaut</h3>
 		<section><h4>En-tête 4 (<code>h4</code>) - apparence par défaut</h4>

--- a/demos/multimedia/multimedia-audio-eng.html
+++ b/demos/multimedia/multimedia-audio-eng.html
@@ -98,8 +98,13 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
 <h1 id="wb-cont">Multimedia player Audio - Web Experience Toolkit (WET)</h1>
-<section>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Multimedia-player" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
+<section>
 	<p>The new version of the multimedia player leverages native HTML5 audio tag and relies on Flash as a fallback mechanism when the HTML5 audio tag is not implemented. The MP3 format (H264 codec) is the minimum requirement for the player because the Flash fallback relies on it and MP3 is a widely supported format on many mobile devices. An optional but highly recommended format, OGG Vorbis, should be added as well to allow some browsers such as Firefox that do not include native support for MP3 to leverage the HTML5 native performance gains. The multimedia player's timeline relies on the HTML5 progress element and uses a polyfill when the element is not supported.</p>
 
     <div class="wet-boew-multimedia span-4">

--- a/demos/multimedia/multimedia-audio-fra.html
+++ b/demos/multimedia/multimedia-audio-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Lecteur Multimedia Audio - Boîte à outils de l'expérience Web (BOEW)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Lecteur-Multim%C3%A9dia" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section>
 	<div class="wet-boew-multimedia span-4">
 	<h2>Exemple Audio (Chevauchée des Walkyries)</h2>

--- a/demos/multimedia/multimedia-eng.html
+++ b/demos/multimedia/multimedia-eng.html
@@ -98,6 +98,12 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
 <h1 id="wb-cont">Multimedia player - Web Experience Toolkit (WET)</h1>
+
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Multimedia-player" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section>
 
 	<p>The new version of the multimedia player leverages native HTML5 video and relies on Flash as a fallback mechanism when the HTML5 video tag is not implemented. The MPEG 4 format (H264 codec) is the minimum requirement for the player because the Flash fallback relies on it and H264 is the standard video format on many mobile devices. An optional but highly recommended Webm (VP8 codec) should be added as well to allow some browsers such as Firefox that do not include native support for H264 to leverage the HTML5 native performance gains. The multimedia player's timeline relies on the HTML5 progress element and uses a polyfill when the element is not supported.</p>

--- a/demos/multimedia/multimedia-fra.html
+++ b/demos/multimedia/multimedia-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Lecteur Multimedia Audio - Boîte à outils de l'expérience Web (BOEW)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Lecteur-Multim%C3%A9dia" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section>
 <div>
 

--- a/demos/php/index-eng.html
+++ b/demos/php/index-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">PHP variant</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Php-variant" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <div class="span-4">
 <section><h2 id="home">Home pages</h2>
 <ul>

--- a/demos/php/index-fra.html
+++ b/demos/php/index-fra.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Variant pour PHP</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Variants-%28fra%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="span-4">
 <section><h2 id="accueil">Pages d'accueil</h2>
 <ul>

--- a/demos/prettify/prettify-eng.html
+++ b/demos/prettify/prettify-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Prettify (source code)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Prettify-%28source-code%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <p>Syntax highlighting of source code snippets in an html page using <a href="http://code.google.com/p/google-code-prettify/" rel="external">google-code-prettify</a>.</p>
 
 <section>

--- a/demos/prettify/prettify-fra.html
+++ b/demos/prettify/prettify-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Prettify (code source)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Prettify-%28code-source%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <p>Mise en surbrillance de syntaxe des extraits de code source dans une page html en utilisant <a href="http://code.google.com/p/google-code-prettify/" rel="external">google-code-prettify</a>.</p>
 
 <section>

--- a/demos/progress/progress-eng.html
+++ b/demos/progress/progress-eng.html
@@ -104,6 +104,11 @@ progress {
 <!-- MainContentStart -->
 <h1 id="wb-cont">Progress bar (progress polyfill)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Progress-bar-%28progress-polyfill%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <p>The HTML5 <code>progress</code> elements is used to provide a progress bar. This component adds support for this elements in browsers that do not already have native support.</p>
 
 <section><h2>Examples</h2>

--- a/demos/progress/progress-fra.html
+++ b/demos/progress/progress-fra.html
@@ -103,6 +103,11 @@ progress {
 <!-- MainContentStart -->
 <h1 id="wb-cont">Barre de progression (correctif pour <span lang="en">progress</span>)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Barre-de-progression-%28correctif-pour-l%27%C3%A9l%C3%A9ment-progress%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <p>L'élément HTML5 &#171;&#160;<code lang="en">progress</code>&#160;&#187; est utilisé pour fournir une barre de progression. Ce composant ajoute le soutien pour cet élément dans les navigateurs qui n'ont pas déjà la prise en charge native.</p>
 
 <section><h2>Exemples</h2>

--- a/demos/sessiontimeout/sessiontimeout-eng.html
+++ b/demos/sessiontimeout/sessiontimeout-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Session timeout</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Session-timeout" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <span class="wet-boew-sessiontimeout" data-wet-boew="{inactivity: 30000, logouturl: 'http://wet-boew.github.com/wet-boew/demos/index-eng.html'}"></span>
 
 <section><h2>Overview</h2>

--- a/demos/sessiontimeout/sessiontimeout-fra.html
+++ b/demos/sessiontimeout/sessiontimeout-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Expiration de la session</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Expiration-de-la-session" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <span class="wet-boew-sessiontimeout" data-wet-boew="{inactivity: 30000, logouturl: 'http://wet-boew.github.com/wet-boew/demos/index-fra.html'}"></span>
 
 <section><h2>Aperçu</h2>

--- a/demos/share/share-eng.html
+++ b/demos/share/share-eng.html
@@ -99,8 +99,14 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Share widget</h1>
 
+<div class="span-3">
+	<ul class="button-group">
+	<li><a href="https://github.com/wet-boew/wet-boew/wiki/Share-widget" class="button button-info">Documentation</a></li>
+	<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+	</ul>
+</div>
 <div class="wet-boew-share span-5 margin-bottom-none" data-wet-boew="{sites:[]}"></div>
-<div class="clear"></div><div class="clear"></div>
+<div class="clear"></div>
 
 <section><h2>Heading 2 (<code>h2</code>) default appearance</h2>
 	<section><h3>Heading 3 (<code>h3</code>) default appearance</h3>

--- a/demos/share/share-filtered-eng.html
+++ b/demos/share/share-filtered-eng.html
@@ -99,6 +99,12 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Share widget - Filtered sites</h1>
 
+<div class="span-3">
+	<ul class="button-group">
+	<li><a href="https://github.com/wet-boew/wet-boew/wiki/Share-widget" class="button button-info">Documentation</a></li>
+	<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+	</ul>
+</div>
 <div class="wet-boew-share span-4"></div>
 <div class="clear"></div>
 

--- a/demos/share/share-filtered-fra.html
+++ b/demos/share/share-filtered-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Gadget de partage - Sites filtrés</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Gadget-de-partage" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="wet-boew-share span-4"></div>
 <div class="clear"></div>
 

--- a/demos/share/share-fra.html
+++ b/demos/share/share-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Gadget de partage</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Gadget-de-partage" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="wet-boew-share span-5 margin-bottom-none" data-wet-boew="{sites:[]}"></div>
 <div>&#160;</div><div class="clear"></div><div class="clear"></div>
 

--- a/demos/slideout/slideout-eng.html
+++ b/demos/slideout/slideout-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Slide out tab</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Slide-out-Tab" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <div class="wet-boew-slideout">
 	<h2>Table of Contents</h2>
 	<ul>

--- a/demos/slideout/slideout-fra.html
+++ b/demos/slideout/slideout-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Onglet coulissant</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Onglet-coulissant" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="wet-boew-slideout">
 	<h2>Table des matières</h2>
 	<ul>

--- a/demos/slider/slider-eng.html
+++ b/demos/slider/slider-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Slider control (input type="range" polyfill)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Slider-control-%28input-type%3D%27range%27-polyfill%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <div>
 	<p>Use the following attributes to specify restrictions:</p>
 	<ul>

--- a/demos/slider/slider-fra.html
+++ b/demos/slider/slider-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Commande de barre coulissante (correctif pour <span lang="en">input type="range"</span>)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Commande-de-barre-coulissante-%28correctif-pour-l%27%C3%A9l%C3%A9ment-input-type%3D%27range%27%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div>
 	<p>Utilisez les attributs suivants pour spécifier les restrictions:</p>
 	<ul>

--- a/demos/ssi/index-eng.html
+++ b/demos/ssi/index-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">SSI variant</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Ssi-variant" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <div class="span-4">
 <section><h2 id="home">Home pages</h2>
 <ul>

--- a/demos/ssi/index-fra.html
+++ b/demos/ssi/index-fra.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Variant pour SSI</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Variant-pour-SSI" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="span-4">
 <section><h2 id="accueil">Pages d'accueil</h2>
 <ul>

--- a/demos/tabs/tabs-eng.html
+++ b/demos/tabs/tabs-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Tabbed interface</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Tabbed-interface" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section><div class="span-4 module-table-contents"><h2>Table of contents</h2>
 <ul>
 <li><a href="#features">Features</a></li>

--- a/demos/tabs/tabs-fra.html
+++ b/demos/tabs/tabs-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Interface à onglets</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Interface-%C3%A0-onglets" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section><div class="span-4 module-table-contents"><h2>Table des matières</h2>
 <ul>
 <li><a href="#cara">Caractéristiques</a></li>

--- a/demos/texthighlight/texthighlight-eng.html
+++ b/demos/texthighlight/texthighlight-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Text highlighting</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Text-highlighting" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <p>The Text highlighting sub project highlights any text within a pre-defined area that matches case-insensitive search criteria specified through the URL's query string. Supports multi-word strings, including spaces and basic punctuation.</p>
 <p><strong>Note:</strong> Search criteria using special regex characters such as <code>"</code>, <code>|</code>, <code>?</code>, <code>+</code>, <code>(</code> or <code>)</code> may be partially or fully excluded from the results.</p>
 

--- a/demos/texthighlight/texthighlight-fra.html
+++ b/demos/texthighlight/texthighlight-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Mise en surbrillance de texte</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Mise-en-surbrillance-de-texte" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <p>Le composant de mise en subrillance de texte met en surbrillance n'importe quel texte dans un secteur pré-défini qui satisfait des critères de recherche. Les critères de recherche sont insensibles à la casse et sont spécifiés par la chaîne d'interrogation d'une addresse URL. Les chaînes avec plusieurs mots sont supportées, y compris les espaces et la ponctuation fondamentale.</p>
 <p><strong>Nota&#160;:</strong> Les critères de recherche regroupant des caractères spéciaux d'expression régulière (&#171;&#160;regex&#160;&#187;, <abbr title="par exemple">p.ex.</abbr>, &#171;&#160;<code>"</code>&#160;&#187;, &#171;&#160;<code>|</code>&#160;&#187;, &#171;&#160;<code>?</code>&#160;&#187;, &#171;&#160;<code>+</code>&#160;&#187;, &#171;&#160;<code>(</code>&#160;&#187; ou &#171;&#160;<code>)</code>&#160;&#187;) peuvent être partiellement ou entièrement exclus des résultats.</p>
 

--- a/demos/theme-clf2-nsi2/index-eng.html
+++ b/demos/theme-clf2-nsi2/index-eng.html
@@ -85,6 +85,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont"><abbr title="Common Look and Feel">CLF</abbr> 2.0 theme</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/CLF-2.0-theme" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section><h2 id="content">Content pages</h2>
 <ul>
 <li><a href="1col-theme-clf2-nsi2-eng.html"><span class="wb-invisible">Content pages - </span>English example - 1 column layout</a></li>

--- a/demos/theme-clf2-nsi2/index-fra.html
+++ b/demos/theme-clf2-nsi2/index-fra.html
@@ -85,6 +85,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Thème de la <abbr title="Normalisation des sites Internet">NSI</abbr> 2.0</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Th%C3%A8me-de-la-NSI-2.0" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section><h2 id="contenu">Pages de contenu</h2>
 <ul>
 <li><a href="1col-theme-clf2-nsi2-eng.html"><span class="wb-invisible">Pages de contenu - </span>Exemple en anglais - 1 colonne</a></li>

--- a/demos/theme-gcwu-fegc/index-eng.html
+++ b/demos/theme-gcwu-fegc/index-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">GC Web Usability theme</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/GC-Web-Usability-theme" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <div class="span-4">
 <section><h2 id="home">Home pages</h2>
 <ul>

--- a/demos/theme-gcwu-fegc/index-fra.html
+++ b/demos/theme-gcwu-fegc/index-fra.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Thème de la facilité d'emploi Web GC</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Th%C3%A8me-de-la-facilit%C3%A9-d%27emploi-Web-GC" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="span-4">
 <section><h2 id="accueil">Pages d'accueil</h2>
 <ul>

--- a/demos/theme-gcwu-intranet/index-eng.html
+++ b/demos/theme-gcwu-intranet/index-eng.html
@@ -101,7 +101,10 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">GC Web Usability Intranet theme</h1>
 
-
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/GC-Web-Usability-Intranet-theme" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
 
 <div class="span-6 module-table-contents">
               <h2>Table of contents</h2>

--- a/demos/theme-gcwu-intranet/index-fra.html
+++ b/demos/theme-gcwu-intranet/index-fra.html
@@ -101,6 +101,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Thème d'intranet de la facilité d'emploi Web GC</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Th%C3%A8me-d%27intranet-de-la-facilit%C3%A9-d%27emploi-Web-GC" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="span-4">
 <section><h2 id="content">Pages de contenu</h2>
 <ul>

--- a/demos/wamethod/wamethod-AAA-eng.html
+++ b/demos/wamethod/wamethod-AAA-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Web Accessibility Assessment Methodology (AAA)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Web-accessibility-assessment-methodology" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section>
 <div class="wet-boew-slideout"><h2>Table of Contents</h2>
 <ul>

--- a/demos/wamethod/wamethod-AAA-fra.html
+++ b/demos/wamethod/wamethod-AAA-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Méthodologie d’évaluation sur l’accessibilité des sites Web (AAA)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/M%C3%A9thodologie-d%E2%80%99%C3%A9valuation-sur-l%E2%80%99accessibilit%C3%A9-des-sites-web" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section>
 <div class="wet-boew-slideout"><h2>Table des matières</h2>
 <ul>

--- a/demos/wamethod/wamethod-eng.html
+++ b/demos/wamethod/wamethod-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Web Accessibility Assessment Methodology</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Web-accessibility-assessment-methodology" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <section>
 <div class="wet-boew-slideout"><h2>Table of Contents</h2>
 <ul>

--- a/demos/wamethod/wamethod-fra.html
+++ b/demos/wamethod/wamethod-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Méthodologie d’évaluation sur l’accessibilité des sites Web</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/M%C3%A9thodologie-d%E2%80%99%C3%A9valuation-sur-l%E2%80%99accessibilit%C3%A9-des-sites-web" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <section>
 <div class="wet-boew-slideout"><h2>Table des matières</h2>
 <ul>

--- a/demos/webfeeds/webfeeds-eng.html
+++ b/demos/webfeeds/webfeeds-eng.html
@@ -98,6 +98,12 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
 <h1 id="wb-cont">Web feeds widget</h1>
+
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Web-feeds" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <p>This feature provides a widget for aggregating and displaying the entries from one or more Web feeds on a Web page. Supported Web feed formats are Atom, RSS, and Media RSS.</p>
 
 <section><h2>Benefits</h2>

--- a/demos/webfeeds/webfeeds-fra.html
+++ b/demos/webfeeds/webfeeds-fra.html
@@ -97,6 +97,12 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
 <h1 id="wb-cont">Gadget des fils de syndication</h1>
+
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Gadget-des-fils-de-syndication" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <p>Cette composante est un gadget logiciel permettant de regrouper et d’afficher des données d'un ou plusieurs fils de syndication. Les formats soutenus sont Atom, RSS et Media RSS.</p>
 
 <section><h2>Avantages</h2>

--- a/demos/webstorage/localstorage-eng.html
+++ b/demos/webstorage/localstorage-eng.html
@@ -99,6 +99,16 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Persistent storage (localStorage polyfill) - Web Storage (HTML5)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Persistent-storage-%28localStorage-polyfill%2C-Web-Storage-%28HTML5%29%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Archiving-content" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <div id="process-status"></div>
 
 <h2>Overview</h2>

--- a/demos/webstorage/localstorage-fra.html
+++ b/demos/webstorage/localstorage-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Mémoire persistante (correctif pour <span lang="en">localStorage</span>) - <span lang="en">Web Storage</span> (HTML5)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/M%C3%A9moire-persistente-%28correctif-pour-localStorage%2C-Web-Storage-%28HTML5%29%29" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div id="process-status"></div>
 
 <h2>Vue d'ensemble</h2>

--- a/demos/zebra/columnhightlight.html
+++ b/demos/zebra/columnhightlight.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Column Highlight Table - Zebra striping - Web Experience Toolkit (WET)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Zebra-striping" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <div class="module-note span-6">
 	<p><strong>Note:</strong></p>
 	<p>Id/headers was omited in the source example.</p>

--- a/demos/zebra/invoice.html
+++ b/demos/zebra/invoice.html
@@ -99,6 +99,10 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Invoice Table - Zebra striping - Web Experience Toolkit (WET)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Zebra-striping" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
 
 <h2>Without <code>colgroup</code> and Without <code>rowgroup</code></h2>
 <table class="wet-boew-zebra">

--- a/demos/zebra/rowlevelwithsummary.html
+++ b/demos/zebra/rowlevelwithsummary.html
@@ -99,6 +99,10 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Row level with summary Table - Zebra striping - Web Experience Toolkit (WET)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Zebra-striping" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
 
 <table class="wet-boew-zebra hassum">
 	<caption>

--- a/demos/zebra/simple.html
+++ b/demos/zebra/simple.html
@@ -99,10 +99,12 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Simple Table - Zebra striping - Web Experience Toolkit (WET)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Zebra-striping" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
 
 <h2>Row Stripping</h2>
-
-
 
 <table class="wet-boew-zebra">
 	<caption>Column Header</caption>

--- a/demos/zebra/simplegrouping.html
+++ b/demos/zebra/simplegrouping.html
@@ -99,6 +99,10 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Simple Grouping Table - Zebra striping - Web Experience Toolkit (WET)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Zebra-striping" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
 
 <h2>Example without any headers</h2>
 

--- a/demos/zebra/zebra-eng.html
+++ b/demos/zebra/zebra-eng.html
@@ -99,6 +99,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Zebra striping - Web Experience Toolkit (WET)</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Zebra-striping" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
 <div class="grid-12">
 <section><h2>Table examples</h2>
 <div class="span-4"><section><h3>Default table appearance</h3>

--- a/demos/zebra/zebra-fra.html
+++ b/demos/zebra/zebra-fra.html
@@ -98,6 +98,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!-- MainContentStart -->
 <h1 id="wb-cont">Rayage du zèbre</h1>
 
+<ul class="button-group">
+<li><a href="https://github.com/wet-boew/wet-boew/wiki/Zebra-striping" class="button button-info">Documentation</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
 <div class="grid-12">
 <section><h2>Exemples - Tableaux</h2>
 <div class="span-4"><section><h3>Apparence par défaut d'un tableau</h3>

--- a/src/grids/sass/includes/_icon.scss
+++ b/src/grids/sass/includes/_icon.scss
@@ -36,9 +36,7 @@
 	background-image: none;
 	padding-left: 0;
 	display: inline;
-	height: auto;
 	margin-right: 0;
-	width: auto;
 }
 
 .wb-icon-alarm {	background-position: 0 0;}

--- a/src/js/sass/includes/_menubar.scss
+++ b/src/js/sass/includes/_menubar.scss
@@ -64,6 +64,9 @@
 	}
 	.mb-has-sm {
 		padding-right: 0.79em;
+		&:hover {
+			text-decoration: none;
+		}
 	}
 	.nav-current {
 		background: #242;

--- a/src/js/workers/menubar.js
+++ b/src/js/workers/menubar.js
@@ -16,6 +16,7 @@
 	_pe.fn.menubar = {
 		type : 'plugin',
 		depends : (_pe.mobile ? [] : ['resize', 'equalheights', 'hoverintent', 'outside']),
+		ignoreMenuBarClicks : false,
 		_exec : function (elm) {
 			/*
 			@notes: the mega menu will use custom events to better manage its events.
@@ -168,13 +169,22 @@
 				} else {
 					event.cancelBubble = true;
 				}
-			}).parent().on('click vclick touchstart', '> :header a', function () {
-				if ($(this).closest('li').hasClass('mb-active')) {
-					hidesubmenu(this);
+			}).parent().on('click vclick touchstart mouseenter mouseleave', '> :header a', function (e) {
+				var type = e.type;
+				if (type === 'mouseenter') {
+					_pe.fn.menubar.ignoreMenuBarClicks = true;
+				} else if (type === 'mouseleave') {
+					_pe.fn.menubar.ignoreMenuBarClicks = false;
 				} else {
-					showsubmenu(this);
+					if ($(this).closest('li').hasClass('mb-active')) {
+						if (type !== 'click' || !_pe.fn.menubar.ignoreMenuBarClicks) { // Ignore clicks on the menu bar if menu opened by hover
+							hidesubmenu(this);
+						}
+					} else {
+						showsubmenu(this);
+					}
+					return false;
 				}
-				return false;
 			});
 
 			/* bind all custom events and triggers to menu */


### PR DESCRIPTION
- Few more PRs that were accepted into parser-lib but not release with CSSLint yet
- Use development mode for Sass compilation by using a isDebugging flag in Ant

@LaurentGoderre: there are a few commits that now appear to be missing from v3.0 that I originally branched from. Only the last 2 commits where my changes.
