### PR TITLE
Use Sass placeholders for CLF2 theme

### DIFF
--- a/src/theme-clf2-nsi2/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-desktop-screen.scss
@@ -7,32 +7,66 @@
 html {
 	overflow-y: scroll;
 }
+
 body {
 	margin: 0;
 	padding: 0;
 }
-#wb-head-in, #wb-core-in, #wb-main, #wb-foot-in {
+
+%cfl2-default-desktop-screen-background-white {
 	background: #FFF;
 }
+
+#wb-main {
+	@extend %cfl2-default-desktop-screen-background-white;
+	@extend %cfl2-default-desktop-screen-box-model-centered;
+}
+
+#wb-foot-in {
+	@extend %cfl2-default-desktop-screen-background-white;
+	@extend %cfl2-default-desktop-screen-overflow-hidden;
+	@extend %cfl2-default-desktop-screen-white-side-borders;
+}
+
 #wb-head-in {
+	@extend %cfl2-default-desktop-screen-background-white;
+	@extend %cfl2-default-desktop-screen-white-side-borders;
+	@extend %cfl2-default-desktop-screen-overflow-hidden;
 	border-top: 10px solid #FFF;
 }
-#wb-head-in, #wb-core, #wb-foot-in {
-	border-left: 10px solid #FFF;
-	border-right: 10px solid #FFF;
+
+%cfl2-default-desktop-screen-white-side-borders {
+	border: {
+		left: 10px solid #FFF;
+		right: 10px solid #FFF;
+	}
+}
+
+#wb-core {
+	@extend %cfl2-default-desktop-screen-white-side-borders;
 }
 
 /** Box model - centered **/
-#wb-main, #wb-sec, #wb-sup {
+%cfl2-default-desktop-screen-box-model-centered {
 	z-index: 1;
 	display: inline;
 }
 
 /** Overflow restrict for background paintability control **/
-#wb-head, #wb-head-in, #wb-foot, #wb-foot-in {
+%cfl2-default-desktop-screen-overflow-hidden {
 	overflow: hidden;
 }
+
+#wb-head {
+	@extend %cfl2-default-desktop-screen-overflow-hidden;
+}
+
+#wb-foot {
+	@extend %cfl2-default-desktop-screen-overflow-hidden;
+}
+
 #wb-core-in {
+	@extend %cfl2-default-desktop-screen-background-white;
 	overflow: visible !important;
 	position: relative;
 	&:after {
@@ -52,6 +86,7 @@ body {
 		margin-top: 0;
 	}
 }
+
 #wb-body {
 	#wb-main {
 		float: left;
@@ -66,6 +101,7 @@ body {
 		padding-left: 5px;
 	}
 }
+
 #wb-body-sec-sup {
 	#wb-main {
 		position: relative;
@@ -77,12 +113,14 @@ body {
 
 /** Left column **/
 #wb-sec {
+	@extend %cfl2-default-desktop-screen-box-model-centered;
 	float: left;
 	background-color: #CC9;
 }
 
 /** Right column **/
 #wb-sup {
+	@extend %cfl2-default-desktop-screen-box-model-centered;
 	float: right;
 	position: relative;
 }
@@ -94,22 +132,28 @@ body {
 		}
 	}
 }
+
 #cn-sig {
+	@extend %cfl2-default-desktop-screen-img-no-bottom-margin;
 	float: left;
 	width: 50%;
 	min-width: 300px;
 }
+
 #cn-wmms {
+	@extend %cfl2-default-desktop-screen-img-no-bottom-margin;
 	float: right;
 	text-align: right;
 	width: 49.8%;
 	min-width: 100px;
 }
-#cn-sig, #cn-wmms {
+
+%cfl2-default-desktop-screen-img-no-bottom-margin {
 	img {
 		margin-bottom: 0;
 	}
 }
+
 #cn-leaf {
 	position: relative;
 	z-index: 2;
@@ -125,7 +169,8 @@ body {
 	}
 	margin-top: 2px;
 }
-#cn-banner, #cn-banner-eng, #cn-banner-fra {
+
+%cfl2-default-desktop-screen-all-banners {
 	float: left;
 	width: 100%;
 	min-height: 80px;
@@ -137,21 +182,37 @@ body {
 		margin: 0;
 		padding: 29px 0 0 0;
 		color: #FFF;
-		font-weight: bold;
-		font-size: 180%;
-		font-family: "times new roman", serif;
+		font: {
+			weight: bold;
+			size: 180%;
+			family: "times new roman", serif;
+		}
 	}
 	p {
 		width: 100%;
 		margin: 0;
 		padding: 0 0 4px 0;
 		color: #FFF;
-		font-size: 120%;
-		font-family: Arial, Helvetica, sans-serif;
+		font: {
+			size: 120%;
+			family: Arial, Helvetica, sans-serif;
+		}
 	}
 }
 
-#cn-psnb, #cn-psnb-2 {
+#cn-banner {
+	@extend %cfl2-default-desktop-screen-all-banners;
+}
+
+#cn-banner-eng {
+	@extend %cfl2-default-desktop-screen-all-banners;
+}
+
+#cn-banner-fra {
+	@extend %cfl2-default-desktop-screen-all-banners;
+}
+
+%cfl2-default-desktop-screen-psnb-and-2 {
 	width: 100%;
 	float: left;
 	&, ul li {
@@ -194,7 +255,15 @@ body {
 	}
 }
 
-#cn-psnb6, #cn-psnb6-2 {
+#cn-psnb {
+	@extend %cfl2-default-desktop-screen-psnb-and-2;
+}
+
+#cn-psnb-2 {
+	@extend %cfl2-default-desktop-screen-psnb-and-2;
+}
+
+%cfl2-default-desktop-screen-a-pseudo-width120pct {
 	a {
 		&:hover, &:active, &:focus {
 			width: 120%;
@@ -202,12 +271,25 @@ body {
 	}
 }
 
+#cn-psnb6 {
+	@extend %cfl2-default-desktop-screen-a-pseudo-width120pct;
+}
+
+#cn-psnb6-2 {
+	@extend %cfl2-default-desktop-screen-a-pseudo-width120pct;
+}
+
 .wb-sec-def {
+	form {
+		margin-bottom: 0;
+	}
 	h3 {
 		padding: 2px 5px;
 		background-color: #363;
-		margin-top: 0;
-		margin-bottom: 0;
+		margin: {
+			top: 0;
+			bottom: 0;
+		}
 		font-size: 110%;
 		&, a:link, a:visited {
 			color: #FFF;
@@ -218,25 +300,22 @@ body {
 			margin: -2px -5px;
 			padding: 2px 5px;
 			width: 100%;
+			&:hover, active, focus {
+				@extend %cfl2-default-desktop-screen-display-block-padding3-5-3-10px;
+			}
 		}
 		label {
 			font-weight: 700
 		}
 	}
-	ul {
-		list-style-type: none;
-		margin: 0 0 0;
-		margin-top: 0;
-		margin-bottom: 0;
-		ul {
-			list-style-type: disc;
-			margin-left: 25px;
-		}
-	}
 	li {
+		@extend %cfl2-default-desktop-screen-a-psuedo-styling;
 		border-top: 1px solid #363;
 		&:first-child {
 			border: none;
+		}
+		a {
+			@extend %cfl2-default-desktop-screen-display-block-padding3-5-3-10px;
 		}
 		li {
 			margin-left: 0;
@@ -248,33 +327,70 @@ body {
 			}
 		}
 	}
-	form {
+	ul {
+		list-style-type: none;
+		margin: 0 0 0;
+		margin-top: 0; //TODO: Is these zero values still needed with the line above?
 		margin-bottom: 0;
+		ul {
+			list-style-type: disc;
+			margin-left: 25px;
+		}
+	}
+	#cn-search-box {
+		@extend %cfl2-default-desktop-screen-cn-search-box;
+		#cn-search-submit {
+			@extend %cfl2-default-desktop-screen-cn-search-box-child-cn-search-submit;
+		}
+		#cn-search {
+			@extend %cfl2-default-desktop-screen-cn-search-box-child-cn-search;
+		}
 	}
 }
 
-.wb-sec-def #cn-search-box, .cn-search-box {
+%cfl2-default-desktop-screen-cn-search-box {
 	padding: 4px;
 	a {
 		padding-left: 5px;
 	}
 }
-.wb-sec-def #cn-search-box #cn-search, .cn-search-box .cn-search {
+
+.cn-search-box {
+	@extend %cfl2-default-desktop-screen-cn-search-box;
+	.cn-search {
+		@extend %cfl2-default-desktop-screen-cn-search-box-child-cn-search;
+	}
+	.cn-search-submit {
+		@extend %cfl2-default-desktop-screen-cn-search-box-child-cn-search-submit;
+	}
+}
+
+%cfl2-default-desktop-screen-cn-search-box-child-cn-search {
 	border: 1px solid #363;
 	margin-right: 5px;
 	width: 92%;
 }
-.wb-sec-def #cn-search-box #cn-search-submit, .cn-search-box .cn-search-submit {
+
+%cfl2-default-desktop-screen-cn-search-box-child-cn-search-submit {
 	background-color: #363;
 	color: #FFF;
 	font-weight: bold;
 	margin: 0;
 }
-.wb-sec-def h3 a:hover, .wb-sec-def h3 a:active, .wb-sec-def h3 a:focus, .wb-sec-def li a, #cn-search-box a {
+
+%cfl2-default-desktop-screen-display-block-padding3-5-3-10px {
 	display: block;
 	padding: 3px 5px 3px 10px;
 }
-.wb-sec-def li, #cn-search-box {
+
+#cn-search-box {
+	@extend %cfl2-default-desktop-screen-a-psuedo-styling;
+	a {
+		@extend %cfl2-default-desktop-screen-display-block-padding3-5-3-10px;
+	}
+}
+
+%cfl2-default-desktop-screen-a-psuedo-styling {
 	a {
 		&:link {
 			color: #000;
@@ -301,27 +417,34 @@ body {
 }
 
 #cn-toppage-foot {
+	@extend %cfl2-default-desktop-screen-all-toppage;
 	float: left;
 	text-align: center;
 	margin-left: 5px;
 	min-width: 4em;
 }
+
 #cn-in-pd-links {
 	float: right;
 	text-align: right;
 	min-width: 4em;
 }
-.cn-toppage, #cn-toppage-foot {
+
+%cfl2-default-desktop-screen-all-toppage {
 	text-align: center;
-	background-image: url(../images/tphp.gif);
-	background-repeat: no-repeat;
-	background-position: 50% 0;//top center
+	background: {
+		image: url(../images/tphp.gif);
+		repeat: no-repeat;
+		position: 50% 0;//top center
+	}
 	a {
 		@include inline-block;
 		padding-top: 13px;
 	}
 }
+
 .cn-toppage {
+	@extend %cfl2-default-desktop-screen-all-toppage;
 	float: right;
 }
 
@@ -333,8 +456,10 @@ body {
 	h3 {
 		padding: 2px 5px;
 		background-color: #363;
-		margin-top: 0;
-		margin-bottom: 0;
+		margin: {
+			top: 0;
+			bottom: 0;
+		}
 		font-size: 110%;
 		&, a:link, a:visited {
 			color: #FFF;
@@ -353,18 +478,22 @@ body {
 		+ {
 			div {
 				border: 1px solid #000;
-				padding-left: 8px;
-				padding-right: 5px;
+				padding: {
+					left: 8px;
+					right: 5px;
+				}
 				margin-bottom: 10px;
 				ul {
 					a {
-						margin-left: -8px;
-						margin-right: -5px;
+						margin: {
+							left: -8px;
+							right: -5px;
+						}
 						padding-left: 8px;
 					}
 					ul {
 						a {
-							padding: 1px 5px 1px 5px;
+							padding: 1px 5px 1px 5px; //TODO:  Simplyfy to the 2 value version "1px 5px" as it is the same?
 							margin-left: -5px;
 						}
 					}
@@ -374,8 +503,10 @@ body {
 	}
 	ul {
 		list-style-type: none;
-		margin-top: 0;
-		margin-bottom: 5px;
+		margin: {
+			top: 0;
+			bottom: 5px;
+		}
 		ul {
 			list-style-type: disc;
 			margin-bottom: 0;
@@ -405,8 +536,10 @@ body {
 				outline: none;
 			}
 			img {
-				margin-top: -3px;
-				margin-left: -10px;
+				margin: {
+					top: -3px;
+					left: -10px;
+				}
 			}
 		}
 	}

--- a/src/theme-clf2-nsi2/sass/includes/_default-ie7.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-ie7.scss
@@ -3,10 +3,28 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
  .ie7 {
- 	#cn-bc h2, #cn-bc2 h2, #cn-psnb h2, #cn-psnb-2 h2, #cn-in-pd h3 {
+ 	%clf2-default-ie7-clip-1px {
 		clip: rect(1px 1px 1px 1px);
 	}
-	#cn-bc, #cn-bc2 {
+	#cn-psnb {
+		h2 {
+			@extend %clf2-default-ie7-clip-1px;
+		}
+	}
+	#cn-psnb-2 {
+		h2 {
+			@extend %clf2-default-ie7-clip-1px;
+		}
+	}
+	#cn-in-pd {
+		h3 {
+			@extend %clf2-default-ie7-clip-1px;
+		}
+	}
+	%clf2-default-ie7-bc-all {
+		h2 {
+			@extend %clf2-default-ie7-clip-1px;
+		}
 		ol {
 			margin: 1px 0 3px 0;
 			clear: left;
@@ -16,7 +34,11 @@
 			padding-bottom: 3px;
 		}
 	}
+	#cn-bc {
+		@extend %clf2-default-ie7-bc-all;
+	}
 	#cn-bc2 {
+		@extend %clf2-default-ie7-bc-all;
 		ol {
 			margin-top: -3px;
 		}

--- a/src/theme-clf2-nsi2/sass/includes/_default-print-ie7.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-print-ie7.scss
@@ -5,8 +5,10 @@
 .ie7 {
 	#cn-banner {
 		width: 100%;
-		margin-top: 20px;
-		margin-bottom: 20px;
+		margin: {
+			top: 20px;
+			bottom: 20px;
+		}
 	}
 	#cn-bc {
 		padding: 5px 0;

--- a/src/theme-clf2-nsi2/sass/includes/_default-print.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-print.scss
@@ -2,22 +2,74 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-#wb-sec, #wb-sup, #cn-leaf, .cn-toppage, #cn-banner p, #cn-banner-eng p, #cn-banner-fra p, #cn-psnb, #cn-psnb-2, #cn-toppage-foot, #cn-in-pd-links {
+%clf2-default-print-display-none {
 	display: none;
 }
+
+#wb-sec {
+	@extend %clf2-default-print-display-none;
+}
+
+#wb-sup {
+	@extend %clf2-default-print-display-none;
+}
+
+#cn-leaf {
+	@extend %clf2-default-print-display-none;
+}
+
+.cn-toppage {
+	@extend %clf2-default-print-display-none;
+}
+
+#cn-banner {
+	@extend %clf2-default-print-all-banners;
+}
+
+#cn-banner-eng {
+	@extend %clf2-default-print-all-banners;
+}
+
+#cn-banner-fra {
+	@extend %clf2-default-print-all-banners;
+}
+
+#cn-psnb {
+	@extend %clf2-default-print-display-none;
+}
+
+#cn-psnb-2 {
+	@extend %clf2-default-print-display-none;
+}
+
+#cn-toppage-foot {
+	@extend %clf2-default-print-display-none;
+}
+
+#cn-in-pd-links {
+	@extend %clf2-default-print-display-none;
+}
+
 #wb-head {
 	width: 100%;
 }
+
 #cn-sig {
 	position: absolute;
-	top: 0;left: 0;
+	top: 0;
+	left: 0;
 }
+
 #cn-wmms {
 	position: absolute;
 	top: 0;
 	right: 0;
 }
-#cn-banner, #cn-banner-eng, #cn-banner-fr {
+
+%clf2-default-print-all-banners {
+	p {
+		@extend %clf2-default-print-display-none;
+	}
 	#cn-banner-text {
 		display: block;
 		font-size: 14pt;
@@ -28,16 +80,27 @@
 		text-align: center;
 	}
 }
-#cn-bc, #cn-bc2 {
+
+%clf2-default-print-all-cn-bc-ol {
 	ol {
 		border-top: 1px solid #000;
 		padding-top: 5px;
 		margin-bottom: 5px;
 	}
 }
+
+#cn-bc {
+	@extend %clf2-default-print-all-cn-bc-ol;
+}
+
+#cn-bc2 {
+	@extend %clf2-default-print-all-cn-bc-ol;
+}
+
 #wb-foot {
 	border-top: 1px solid #000;
 }
+
 #cn-doc-dates {
 	width: 100%;
 }

--- a/src/theme-clf2-nsi2/sass/includes/_default-responsive.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-responsive.scss
@@ -6,49 +6,49 @@ body {
 	min-width: 780px;
 }
 
-%clf-default-responsive-fullwidth {
+%clf2-default-responsive-fullwidth {
 	width: 100%;
 }
 
-%clf-default-responsive-margin-auto {
+%clf2-default-responsive-margin-auto {
 	margin: auto;
 }
 
-%clf-default-responsive-width760 {
+%clf2-default-responsive-width760 {
 	width: 760px;
 }
 
 #wb-body {
 	#wb-main {
-		@extend %clf-default-responsive-width760;
+		@extend %clf2-default-responsive-width760;
 	}
 }
 
 #wb-core {
-	@extend %clf-default-responsive-margin-auto;
-	@extend %clf-default-responsive-width760;
+	@extend %clf2-default-responsive-margin-auto;
+	@extend %clf2-default-responsive-width760;
 }
 
 #wb-core-in {
-	@extend %clf-default-responsive-margin-auto;
-	@extend %clf-default-responsive-width760;
+	@extend %clf2-default-responsive-margin-auto;
+	@extend %clf2-default-responsive-width760;
 }
 
 #wb-head {
-	@extend %clf-default-responsive-fullwidth;
+	@extend %clf2-default-responsive-fullwidth;
 }
 
 #wb-head-in {
-	@extend %clf-default-responsive-margin-auto;
-	@extend %clf-default-responsive-width760;
+	@extend %clf2-default-responsive-margin-auto;
+	@extend %clf2-default-responsive-width760;
 }
 
 #wb-foot {
-	@extend %clf-default-responsive-fullwidth;
+	@extend %clf2-default-responsive-fullwidth;
 }
 #wb-foot-in {
-	@extend %clf-default-responsive-margin-auto;
-	@extend %clf-default-responsive-width760;
+	@extend %clf2-default-responsive-margin-auto;
+	@extend %clf2-default-responsive-width760;
 }
 
 #wb-body-sec {

--- a/src/theme-clf2-nsi2/sass/includes/_default-screen-ie7.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-screen-ie7.scss
@@ -9,7 +9,7 @@
 	#cn-leaf {
 		margin-top: 5px;
 	}
-	#cn-psnb, #cn-psnb-2 {
+	%clf2-default-screen-ie7-all-psnb {
 		ul {
 			height: auto;
 			overflow: hidden;
@@ -18,13 +18,19 @@
 			}
 		}
 	}
+	#cn-psnb {
+		@extend %clf2-default-screen-ie7-all-psnb;
+	}
+	#cn-psnb-2 {
+		@extend %clf2-default-screen-ie7-all-psnb;
+	}
 	#wb-main-in {
 		#{headings(all)}, p, blockquote, table, form, img, pre {
 			margin-left: 0;
 			margin-right: 0;
 		}
 	}
-	.wb-sec-def, .wb-sup-def {
+	%clf2-default-screen-ie7-all-defs {
 		ul {
 			margin-left: 0;
 			ul {
@@ -42,18 +48,33 @@
 			}
 		}
 	}
-	.wb-sec-def #cn-search-box, .cn-search-box {
+	%clf2-default-screen-ie7-cn-search-box {
 		margin: -15px -10px 0 -10px;
 		a {
 			margin-bottom: -9px;
 		}
 	}
-	//TODO: cn-search-box is used as a class and an ID, which should it be
-	.wb-sec-def #cn-search-box #cn-search-submit, .cn-search-box .cn-search-submit {
+	.wb-sec-def {
+		@extend %clf2-default-screen-ie7-all-defs;
+		#cn-search-box {
+			@extend %clf2-default-screen-ie7-cn-search-box;
+			#cn-search-submit {
+				@extend %clf2-default-screen-ie7-cn-search-box-child-cn-search-submit;
+			}
+		}
+	}
+	.cn-search-box {
+		@extend %clf2-default-screen-ie7-cn-search-box;
+		.cn-search-submit {
+			@extend %clf2-default-screen-ie7-cn-search-box-child-cn-search-submit;
+		}
+	}
+	%clf2-default-screen-ie7-cn-search-box-child-cn-search-submit {
 		overflow: visible;
 		padding: 0 8px;
 	}
 	.wb-sup-def {
+		@extend %clf2-default-screen-ie7-all-defs;
 		margin-bottom: -10px;
 		h3 {
 			margin-left: 0;

--- a/src/theme-clf2-nsi2/sass/includes/_default.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default.scss
@@ -14,7 +14,7 @@
 	}
 }
 
-#cn-bc h2, #cn-bc2 h2, #cn-psnb h2, #cn-psnb-2 h2, #cn-in-pd h3 {
+%clf2-default-hidden {
 	position: absolute;
 	clip: rect(1px, 1px, 1px, 1px);
 	height: 1px !important;
@@ -22,7 +22,36 @@
 	overflow: hidden !important;
 }
 
-#cn-bc, #cn-bc2 {
+#cn-bc {
+	@extend %clf2-default-bc-all;
+}
+
+#cn-bc2 {
+	@extend %clf2-default-bc-all;
+}
+
+#cn-psnb {
+	h2 {
+		@extend %clf2-default-hidden;
+	}
+}
+
+#cn-psnb-2 {
+	h2 {
+		@extend %clf2-default-hidden;
+	}
+}
+
+#cn-in-pd {
+	h3 {
+		@extend %clf2-default-hidden;
+	}
+}
+
+%clf2-default-bc-all {
+	h2 {
+		@extend %clf2-default-hidden;
+	}
 	ol {
 		padding-top: 0;
 		line-height: 1.57em;
@@ -42,12 +71,21 @@
 	}
 }
 
-#cn-doc-dates, #cn-toppage-foot, #cn-in-pd-links {
+%clf2-default-width-33pct {
 	margin: 10px 0;
 	width: 33%;
 }
 
+#cn-toppage-foot {
+	@extend %clf2-default-width-33pct;
+}
+
+#cn-in-pd-links {
+	@extend %clf2-default-width-33pct;
+}
+
 #cn-doc-dates {
+	@extend %clf2-default-width-33pct;
 	float: left;
 	clear: left;
 	min-width: 6em;

--- a/src/theme-clf2-nsi2/sass/includes/_serv-desktop-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-desktop-screen.scss
@@ -2,13 +2,16 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
+
 html {
 	overflow-y: scroll;
 }
+
 body {
 	margin: 0;
 	padding: 0;
 }
+
 #wb-body {
 	border: 10px solid #FFF;
 }
@@ -20,9 +23,26 @@ body {
 }
 
 /** Overflow restrict for background paintability control **/
-#wb-head, #wb-head-in, #cn-foot, #wb-foot-in {
+%clf2-serv-desktop-screen-overflow-hidden {
 	overflow: hidden;
 }
+
+#wb-head {
+	@extend %clf2-serv-desktop-screen-overflow-hidden;
+}
+
+#wb-head-in {
+	@extend %clf2-serv-desktop-screen-overflow-hidden;
+}
+
+#cn-foot {
+	@extend %clf2-serv-desktop-screen-overflow-hidden;
+}
+
+#wb-foot-in {
+	@extend %clf2-serv-desktop-screen-overflow-hidden;
+}
+
 #wb-core-in {
 	overflow: visible !important;
 	position: relative;

--- a/src/theme-clf2-nsi2/sass/includes/_serv-ie8.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-ie8.scss
@@ -3,10 +3,20 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 .ie8 {
- 	#wb-body h1, #cn-in-pd h3 {
+ 	%clf2-serv-ie8-clip {
 		clip: rect(1px 1px 1px 1px);
 		height: 1px !important;
 		width: 1px !important;
 		overflow: hidden !important;
+	}
+	#wb-body {
+		h1 {
+			@extend %clf2-serv-ie8-clip;
+		}
+	}
+	#cn-in-pd {
+		h3 {
+			@extend %clf2-serv-ie8-clip;
+		}
 	}
 }

--- a/src/theme-clf2-nsi2/sass/includes/_serv-responsive.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-responsive.scss
@@ -7,10 +7,35 @@ body {
 }
 
 /** Box model - centered **/
-#wb-head, #cn-foot {
+%clf2-serv-responsive-width100pct {
 	width: 100%;
 }
-#wb-core, #wb-core-in, #wb-head-in, #wb-foot-in {
+
+#wb-head {
+	@extend %clf2-serv-responsive-width100pct;
+}
+
+#cn-foot {
+	@extend %clf2-serv-responsive-width100pct;
+}
+
+%clf2-serv-responsive-width760px {
 	width: 760px;
 	margin: auto;
+}
+
+#wb-core {
+	@extend %clf2-serv-responsive-width760px;
+}
+
+#wb-core-in {
+	@extend %clf2-serv-responsive-width760px;
+}
+
+#wb-head-in {
+	@extend %clf2-serv-responsive-width760px;
+}
+
+#wb-foot-in {
+	@extend %clf2-serv-responsive-width760px;
 }

--- a/src/theme-clf2-nsi2/sass/includes/_serv-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-screen.scss
@@ -2,14 +2,17 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
+
 html {
 	overflow-y: scroll;
 }
+
 body {
 	min-width: 780px;
 	margin: 0;
 	padding: 0;
 }
+
 #wb-body {
 	border: 10px solid #FFF;
 	#wb-main {
@@ -19,23 +22,51 @@ body {
 }
 
 /** Box model - centered **/
-#wb-head, #cn-foot {
+%clf2-serv-screen-width100pct {
 	width: 100%;
 }
-#wb-core, #wb-core-in, #wb-head-in, #wb-foot-in {
+
+#wb-head {
+	@extend %clf2-serv-screen-width100pct;
+	@extend %clf2-serv-screen-overflow-hidden;
+}
+
+#cn-foot {
+	@extend %clf2-serv-screen-width100pct;
+	@extend %clf2-serv-screen-overflow-hidden;
+}
+
+%clf2-serv-screen-width760px {
 	width: 760px;
 	margin: auto;
 }
+
+#wb-core {
+	@extend %clf2-serv-screen-width760px;
+}
+
+#wb-head-in {
+	@extend %clf2-serv-screen-width760px;
+	@extend %clf2-serv-screen-overflow-hidden;
+}
+
+#wb-foot-in {
+	@extend %clf2-serv-screen-width760px;
+	@extend %clf2-serv-screen-overflow-hidden;
+}
+
 #wb-main {
 	z-index: 1;
 	display: inline;
 }
 
 /** Overflow restrict for background paintability control **/
-#wb-head, #wb-head-in, #cn-foot, #wb-foot-in {
+%clf2-serv-screen-overflow-hidden {
 	overflow: hidden;
 }
+
 #wb-core-in {
+	@extend %clf2-serv-screen-width760px;
 	overflow: visible !important;
 	position: relative;
 	&:after {
@@ -49,8 +80,10 @@ body {
 
 /** Centre column **/
 #wb-main-in {
-	padding-top: 1px;
-	padding-bottom: 1px;
+	padding: {
+		top: 1px;
+		bottom: 1px;
+	}
 	h1 {
 		margin-top: 0;
 	}
@@ -74,6 +107,7 @@ body {
 	width: 50%;
 	min-width: 300px;
 }
+
 #cn-wmms {
 	float: right;
 	text-align: right;

--- a/src/theme-clf2-nsi2/sass/includes/_serv.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv.scss
@@ -2,29 +2,43 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-#wb-body h1, #cn-in-pd h3 {
+%clf2-serv-clip {
 	position: absolute;
 	clip: rect(1px, 1px, 1px, 1px);
 	height: 1px !important;
 	width: 1px !important;
 	overflow: hidden !important;
 }
+
+#wb-body {
+	h1 {
+		@extend %clf2-serv-clip;
+	}
+}
+
 #wb-skip {
 	display: none;
 	visibility: hidden;
 }
+
 %clf-serv-width49pct {
 	width: 49%;
 }
+
 #cn-left-msg {
 	float: left;
 	@extend %clf-serv-width49pct;
 }
+
 #cn-right-msg {
 	float: right;
 	@extend %clf-serv-width49pct;
 }
+
 #cn-in-pd {
+	h3 {
+		@extend %clf2-serv-clip;
+	}
 	ul {
 		list-style-type: none;
 		margin: -2px 0 0 0;
@@ -34,13 +48,16 @@
 		}
 	}
 }
+
 #cn-inotices-link-left {
 	float: left;
 }
+
 #cn-inotices-link-right {
 	float: right;
 	text-align: right;
 }
+
 .cn-doc-dates {
 	margin: 0;
 	width: 100%;

--- a/src/theme-clf2-nsi2/sass/includes/_serv.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv.scss
@@ -21,18 +21,18 @@
 	visibility: hidden;
 }
 
-%clf-serv-width49pct {
+%clf2-serv-width49pct {
 	width: 49%;
 }
 
 #cn-left-msg {
 	float: left;
-	@extend %clf-serv-width49pct;
+	@extend %clf2-serv-width49pct;
 }
 
 #cn-right-msg {
 	float: right;
-	@extend %clf-serv-width49pct;
+	@extend %clf2-serv-width49pct;
 }
 
 #cn-in-pd {

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-ie7.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-ie7.scss
@@ -3,8 +3,18 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 .ie7 {
- 	#wb-main-in h1, #cn-in-pd h3 {
+ 	%clf2-sp-pe-ie7-clip {
 		clip: rect(1px 1px 1px 1px);
+	}
+	#wb-main-in {
+		h1 {
+			@extend %clf2-sp-pe-ie7-clip;
+		}
+	}
+	#cn-in-pd {
+		h3 {
+			@extend %clf2-sp-pe-ie7-clip;
+		}
 	}
 	#cn-lower-msg {
 		p {

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-responsive.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-responsive.scss
@@ -7,57 +7,57 @@ body {
 }
 
 /** Box model - centered **/
-%clf-sp-pe-responsive-width100pct {
+%clf2-sp-pe-responsive-width100pct {
 	width: 100%;
 }
 
 #wb-head {
-	@extend %clf-sp-pe-responsive-width100pct;
+	@extend %clf2-sp-pe-responsive-width100pct;
 }
 
 #wb-foot {
-	@extend %clf-sp-pe-responsive-width100pct;
+	@extend %clf2-sp-pe-responsive-width100pct;
 }
 
-%clf-sp-pe-responsive-margin-auto {
+%clf2-sp-pe-responsive-margin-auto {
 	margin: auto;
 }
 
-%clf-sp-pe-responsive-width600px {
+%clf2-sp-pe-responsive-width600px {
 	width: 600px;
 }
 
 #wb-core {
-	@extend %clf-sp-pe-responsive-width600px;
-	@extend %clf-sp-pe-responsive-margin-auto;
+	@extend %clf2-sp-pe-responsive-width600px;
+	@extend %clf2-sp-pe-responsive-margin-auto;
 }
 
 #wb-core-in {
-	@extend %clf-sp-pe-responsive-width600px;
-	@extend %clf-sp-pe-responsive-margin-auto;
+	@extend %clf2-sp-pe-responsive-width600px;
+	@extend %clf2-sp-pe-responsive-margin-auto;
 }
 
-%clf-sp-pe-responsive-width760px {
+%clf2-sp-pe-responsive-width760px {
 	width: 760px;
-	@extend %clf-sp-pe-responsive-margin-auto;
+	@extend %clf2-sp-pe-responsive-margin-auto;
 }
 
 #wb-head-in {
-	@extend %clf-sp-pe-responsive-width760px;
+	@extend %clf2-sp-pe-responsive-width760px;
 }
 
 #wb-foot-in {
-	@extend %clf-sp-pe-responsive-width760px;
+	@extend %clf2-sp-pe-responsive-width760px;
 }
 
 /** Centre column **/
 #wb-body {
-	@extend %clf-sp-pe-responsive-width600px;
+	@extend %clf2-sp-pe-responsive-width600px;
 	#wb-main {
 		//TODO: Is the nested ID selector important or can the above and below 600px rules be combined
-		@extend %clf-sp-pe-responsive-width600px;
+		@extend %clf2-sp-pe-responsive-width600px;
 	}
 }
 #cn-msg-space {
-	@extend %clf-sp-pe-responsive-width600px;
+	@extend %clf2-sp-pe-responsive-width600px;
 }

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-responsive.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-responsive.scss
@@ -7,29 +7,57 @@ body {
 }
 
 /** Box model - centered **/
-#wb-head, #wb-foot {
+%clf-sp-pe-responsive-width100pct {
 	width: 100%;
 }
+
+#wb-head {
+	@extend %clf-sp-pe-responsive-width100pct;
+}
+
+#wb-foot {
+	@extend %clf-sp-pe-responsive-width100pct;
+}
+
 %clf-sp-pe-responsive-margin-auto {
 	margin: auto;
 }
-#wb-core, #wb-core-in {
+
+%clf-sp-pe-responsive-width600px {
 	width: 600px;
+}
+
+#wb-core {
+	@extend %clf-sp-pe-responsive-width600px;
 	@extend %clf-sp-pe-responsive-margin-auto;
 }
-#wb-head-in, #wb-foot-in {
+
+#wb-core-in {
+	@extend %clf-sp-pe-responsive-width600px;
+	@extend %clf-sp-pe-responsive-margin-auto;
+}
+
+%clf-sp-pe-responsive-width760px {
 	width: 760px;
 	@extend %clf-sp-pe-responsive-margin-auto;
 }
 
+#wb-head-in {
+	@extend %clf-sp-pe-responsive-width760px;
+}
+
+#wb-foot-in {
+	@extend %clf-sp-pe-responsive-width760px;
+}
+
 /** Centre column **/
 #wb-body {
-	width: 600px;
+	@extend %clf-sp-pe-responsive-width600px;
 	#wb-main {
 		//TODO: Is the nested ID selector important or can the above and below 600px rules be combined
-		width: 600px;
+		@extend %clf-sp-pe-responsive-width600px;
 	}
 }
 #cn-msg-space {
-	width: 600px;
+	@extend %clf-sp-pe-responsive-width600px;
 }

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe.scss
@@ -2,16 +2,16 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
+
 html {
 	overflow-y: scroll;
 }
+
 body {
 	margin: 0;
 	padding: 0;
 }
-#wb-body {
-	border: 10px solid #FFF;
-}
+
 #wb-skip {
 	display: none;
 	visibility: hidden;
@@ -24,9 +24,22 @@ body {
 }
 
 /** Overflow restrict for background paintability control **/
-#wb-head, #wb-head-in, #wb-foot, #wb-foot-in {
+%clf2-sp-pe-overflow-hidden {
 	overflow: hidden;
 }
+
+#wb-head {
+	@extend %clf2-sp-pe-overflow-hidden;
+}
+
+#wb-head-in {
+	@extend %clf2-sp-pe-overflow-hidden;
+}
+
+#wb-foot-in {
+	@extend %clf2-sp-pe-overflow-hidden;
+}
+
 #wb-core-in {
 	overflow: visible !important;
 	position: relative;
@@ -41,17 +54,25 @@ body {
 
 /** Centre column **/
 #wb-main-in {
-	padding-top: 1px;
-	padding-bottom: 1px;
+	padding: {
+		top: 1px;
+		bottom: 1px;
+	}
+	h1, h2 {
+		@extend %clf2-sp-pe-clip;
+	}
 }
+
 #wb-body {
 	margin: 0 auto;
-	border-top: 20px solid #FFFFFF;
+	border: 10px solid #FFF;
+	border-top-width: 20px;
 	#wb-main {
 		float: left;
 	}
 }
-#wb-main-in h1, #wb-main-in h2, #cn-in-pd h3 {
+
+%clf2-sp-pe-clip {
 	position: absolute;
 	clip: rect(1px, 1px, 1px, 1px);
 	height: 1px !important;
@@ -59,19 +80,28 @@ body {
 	overflow: hidden !important;
 }
 
+#cn-in-pd {
+	h3 {
+		@extend %clf2-sp-pe-clip;
+	}
+}
+
 #cn-sig {
 	margin-bottom: 6px;
 }
+
 #cn-msg-space {
 	float: left;
 	margin-bottom: 30px;
 	min-height: 250px;
 	color: #000;
 }
+
 #cn-upper-msg {
 	height: 130px;
 	background: #363;
 }
+
 #cn-lower-msg {
 	min-height: 120px;
 	background: #CCC;
@@ -83,16 +113,21 @@ body {
 		padding: 0 5px;
 	}
 }
+
 #cn-left-msg {
 	float: left;
 }
+
 #cn-right-msg {
 	float: right;
 	text-align: right;
 }
+
 #wb-foot {
+	@extend %clf2-sp-pe-overflow-hidden;
 	height: 4.2em;
 }
+
 #cn-wmms {
 	float: right;
 	text-align: right;
@@ -100,36 +135,49 @@ body {
 		margin: 0;
 	}
 }
-#cn-ef-lang-links, #cn-other-lang-links {
+
+%clf2-sp-pe-all-lang-links {
 	list-style-type: none;
 	float: left;
 	margin: 0;
-	padding-left: 0;
-	padding-right: 30px;
+	padding: {
+		left: 0;
+		right: 30px;
+	}
 	clear: left;
 	li {
 		float: left;
-		font-size: 125%;
+		font: {
+			size: 125%;
+			weight: bold;
+		}
 		width: 7.5em;
 		height: 1.65em;
 		text-align: center;
-		font-weight: bold;
-		margin-bottom: 10px;
-		margin-right: 30px;
-		border-top: #CCC 2px solid;
-		border-left: #CCC 2px solid;
-		border-bottom: #666 2px solid;
-		border-right: #666 2px solid;
+		margin: {
+			bottom: 10px;
+			right: 30px;
+		}
+		border: {
+			top: #CCC 2px solid;
+			left: #CCC 2px solid;
+			bottom: #666 2px solid;
+			right: #666 2px solid;
+		}
 		a {
 			display: block;
 			height: 100%;
-			text-decoration: none;
+			text: {
+				decoration: none;
+				transform: capitalize;
+			}
 			line-height: 1.6em;
-			text-transform: capitalize;
 		}
 	}
 }
+
 #cn-other-lang-links {
+	@extend %clf2-sp-pe-all-lang-links;
 	width: 95%;
 	li {
 		background-color: #FFF;
@@ -146,7 +194,9 @@ body {
 		}
 	}
 }
+
 #cn-ef-lang-links {
+	@extend %clf2-sp-pe-all-lang-links;
 	li {
 		background-color: #000;
 		a {
@@ -163,14 +213,16 @@ body {
 }
 
 #cn-in-links {
+	list-style-type: none;
+	float: left;
+	margin: 0;
+	padding: {
+		left: 0;
+		right: 30px;
+	}
 	li {
 		float: left;
 		width: 9.7em;
 		margin-right: 30px;
 	}
-	list-style-type: none;
-	float: left;
-	margin: 0;
-	padding-left: 0;
-	padding-right: 30px;
 }


### PR DESCRIPTION
Use Sass placeholder classes and extends, so that each ID has only one root element.
- removed some answered TODOs and added a few more
- fix minor bug with #cn-banner-fra missing the a in one instance
