### PR TITLE
Change /* comments inside SCSS selectors to //

### DIFF
--- a/src/base/sass/_base-ie7.scss
+++ b/src/base/sass/_base-ie7.scss
@@ -61,7 +61,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		.wb-invisible,.wb-show-onfocus,#wb-foot h2 {
 			float: right;

--- a/src/base/sass/_base-screen-ie7.scss
+++ b/src/base/sass/_base-screen-ie7.scss
@@ -28,7 +28,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		#wb-skip {
 			ul {

--- a/src/grids/sass/includes/_badge.scss
+++ b/src/grids/sass/includes/_badge.scss
@@ -52,7 +52,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	[dir="rtl"] {
 		.badge-intro {
 			margin-right: auto;

--- a/src/grids/sass/includes/_button.scss
+++ b/src/grids/sass/includes/_button.scss
@@ -168,7 +168,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	[dir="rtl"] {
 		.button-group {
 			.button {

--- a/src/grids/sass/includes/_form.scss
+++ b/src/grids/sass/includes/_form.scss
@@ -152,7 +152,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	[dir="rtl"] {
 		label {
 			.form-horizontal & {
@@ -256,7 +256,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	[dir="rtl"] {
 		.form-radio, .form-checkbox {
 			padding-left: 0;

--- a/src/grids/sass/includes/_list.scss
+++ b/src/grids/sass/includes/_list.scss
@@ -60,7 +60,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	[dir="rtl"] {
 		ul, dl, ol {
 			margin: $margin-medium 40px $margin-medium $margin-medium;

--- a/src/grids/sass/includes/_module.scss
+++ b/src/grids/sass/includes/_module.scss
@@ -318,7 +318,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	[dir="rtl"] {
 		.module-billboard, .module-related, .module-menu-section {
 			ul {

--- a/src/grids/sass/includes/_table.scss
+++ b/src/grids/sass/includes/_table.scss
@@ -129,7 +129,7 @@
 
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	[dir="rtl"] {
 		table {
 			&.table-simplify {			
@@ -216,7 +216,7 @@
 		margin-left: $spacing-large;
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	[dir="rtl"] {
 		ul, ol, dl {
 			margin-left: auto;

--- a/src/grids/sass/includes/_util-screen.scss
+++ b/src/grids/sass/includes/_util-screen.scss
@@ -538,7 +538,7 @@ table {
 		margin-right: 0;
 	}
 
-	/*	 indentation	 */
+	//	 indentation
 	.indent-none {
 		margin-left: 0 !important;
 		margin-right: 0 !important;

--- a/src/theme-base/sass/includes/_default-ie7.scss
+++ b/src/theme-base/sass/includes/_default-ie7.scss
@@ -9,7 +9,7 @@
 		border-left:expression(this.previousSibling == null ? 'none' : '-' );
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		#base-subsite a {
 			padding-left: 0;

--- a/src/theme-base/sass/includes/_default-print-ie7.scss
+++ b/src/theme-base/sass/includes/_default-print-ie7.scss
@@ -24,7 +24,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	[dir="rtl"] {
 		#base-bc {
 			li {

--- a/src/theme-base/sass/includes/_default-screen-ie7.scss
+++ b/src/theme-base/sass/includes/_default-screen-ie7.scss
@@ -47,7 +47,7 @@
 		float:left;
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		#base-date-mod {
 			float: left;

--- a/src/theme-gcwu-fegc/sass/includes/_default-print-ie7.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-print-ie7.scss
@@ -24,7 +24,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		#gcwu-bc {
 			li {

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen-ie7.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen-ie7.scss
@@ -69,7 +69,7 @@
 		float: left;
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		#gcwu-wmms-in {
 			float: left;

--- a/src/theme-gcwu-intranet/sass/includes/_default-ie7.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-ie7.scss
@@ -34,7 +34,7 @@
 		background: transparent url(../images/gcwu-sft-in.png) no-repeat right bottom;
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		#gcwu-subsite a {
 			padding-left: 0;

--- a/src/theme-gcwu-intranet/sass/includes/_default-screen-ie7.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-screen-ie7.scss
@@ -3,7 +3,7 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 .ie7 {
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 	}
 }

--- a/src/theme-gcwu-intranet/sass/includes/_default-screen-ie8.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-screen-ie8.scss
@@ -3,7 +3,7 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 .ie8 {
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		#gcwu-tctr {
 			li {

--- a/src/theme-wet-boew/sass/includes/_default-ie7.scss
+++ b/src/theme-wet-boew/sass/includes/_default-ie7.scss
@@ -9,7 +9,7 @@
 		border-left:expression(this.previousSibling == null ? 'none' : '-' );
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		#base-subsite a {
 			padding-left: 0;

--- a/src/theme-wet-boew/sass/includes/_default-print-ie7.scss
+++ b/src/theme-wet-boew/sass/includes/_default-print-ie7.scss
@@ -24,7 +24,7 @@
 		}
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		#base-bc {
 			li {

--- a/src/theme-wet-boew/sass/includes/_default-screen-ie7.scss
+++ b/src/theme-wet-boew/sass/includes/_default-screen-ie7.scss
@@ -46,7 +46,7 @@
 		float:left;
 	}
 
-	/* Right to left (RTL) CSS */
+	// Right to left (RTL) CSS
 	&[dir="rtl"] {
 		#base-date-mod {
 			float: left;


### PR DESCRIPTION
This type of comment can cause empty rules to be emitted
http://sass-lang.com/docs/yardoc/file.SASS_REFERENCE.html#comments
This classes should get removed by the compressor, but still get flagged
by CSSLint https://travis-ci.org/wet-boew/wet-boew/builds/4214129/#L86
