### PR TITLE
Fixed .no-js .example3 summary:hover rule

### DIFF
--- a/demos/details/details-eng.html
+++ b/demos/details/details-eng.html
@@ -56,7 +56,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 	background: #1A4D7C !important;
 }
 .no-js .example3 summary:hover, .no-js .example3 summary:focus, .no-js .example3 summary:active {
-	background: none !important;
+	background: #176CA7 !important;
 }
 .example3 summary:focus, .example3 summary:active {
 	outline: 1px dotted #000;

--- a/demos/details/details-fra.html
+++ b/demos/details/details-fra.html
@@ -56,7 +56,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 	background: #1A4D7C !important;
 }
 .no-js .example3 summary:hover, .no-js .example3 summary:focus, .no-js .example3 summary:active {
-	background: none !important;
+	background: #176CA7 !important;
 }
 .example3 summary:focus, .example3 summary:active {
 	outline: 1px dotted #000;


### PR DESCRIPTION
Fixes display of .example3 summary element when JavaScript is off (#1021)
