### PR TITLE
IE7 rtl fixes for top bar, megamenu and date modified

### DIFF
--- a/src/js/sass/includes/_menubar-ie7.scss
+++ b/src/js/sass/includes/_menubar-ie7.scss
@@ -6,4 +6,19 @@
 	.mb-menu {
 		position: relative;
 	}
+	
+	&[dir="rtl"] {	
+	
+		.mb-sm-open {
+			left: auto;
+			right: 0;
+					
+			div[class*="span-"] {
+				zoom: 1;
+				vertical-align: top;
+				float: none !important;
+				display: inline !important;
+			}
+		}
+	}
 }

--- a/src/js/sass/includes/_menubar-ie7.scss
+++ b/src/js/sass/includes/_menubar-ie7.scss
@@ -6,9 +6,9 @@
 	.mb-menu {
 		position: relative;
 	}
-	
-	&[dir="rtl"] {	
-	
+
+	&[dir="rtl"] {
+
 		.mb-sm-open {
 			left: auto;
 			right: 0;

--- a/src/js/sass/includes/_menubar-ie7.scss
+++ b/src/js/sass/includes/_menubar-ie7.scss
@@ -12,8 +12,7 @@
 		.mb-sm-open {
 			left: auto;
 			right: 0;
-					
-			div[class*="span-"] {
+			[class*="span-"] {
 				zoom: 1;
 				vertical-align: top;
 				float: none !important;

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen-ie.scss
@@ -70,13 +70,13 @@
 	}
 
 	// Right to left (RTL) CSS
-	&[dir="rtl"] {		
+	&[dir="rtl"] {
 		%gcwu-default-screen-ie7-rtl-float-fix {
 			zoom: 1;
 			float: none;
-			display: inline;		
-		}	
-		
+			display: inline;
+		}
+
 		#gcwu-gcnb {
 			ul {
 				li {
@@ -84,16 +84,16 @@
 				}
 			}
 		}
-			
+
 		#gcwu-wmms-in {
 			float: left;
 		}
-		
+
 		#gcwu-date-mod {
-			float: left;			
+			float: left;
 			dt, dd {
 				@extend %gcwu-default-screen-ie7-rtl-float-fix;
-			}					
+			}
 		}
 
 		#gcwu-tctr {

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen-ie.scss
@@ -70,13 +70,30 @@
 	}
 
 	// Right to left (RTL) CSS
-	&[dir="rtl"] {
+	&[dir="rtl"] {		
+		%gcwu-default-screen-ie7-rtl-float-fix {
+			zoom: 1;
+			float: none;
+			display: inline;		
+		}	
+		
+		#gcwu-gcnb {
+			ul {
+				li {
+					@extend %gcwu-default-screen-ie7-rtl-float-fix;
+				}
+			}
+		}
+			
 		#gcwu-wmms-in {
 			float: left;
 		}
-
+		
 		#gcwu-date-mod {
-			float: left;
+			float: left;			
+			dt, dd {
+				@extend %gcwu-default-screen-ie7-rtl-float-fix;
+			}					
 		}
 
 		#gcwu-tctr {


### PR DESCRIPTION
This takes care of the following issues in #1052:
1. GC nav bar links position
2. Date modified position
3. Top menu not working
