### PR TITLE
Fixed :visited link style for content links (#wb-main-in)

### DIFF
--- a/src/theme-base/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-base/sass/includes/_default-desktop-screen.scss
@@ -47,6 +47,9 @@ body{
 #wb-main-in{
 	padding-top:1px;
 	padding-bottom:2.5em;
+	a {
+		@extend %base-default-link;
+	}
 }
 
 #wb-body-sec #wb-main{
@@ -99,13 +102,19 @@ h1{
 	position:relative;
 }
 
-a{
-	&:link{
-		color:#295376;
+%base-default-link {
+	&, &.ui-link {
+		&:link {
+			color: #295376;
+		}
+		&:visited {
+			color: #5a306b;
+		}
 	}
-	&:visited{
-		color:#5a306b;
-	}	
+}
+
+a {
+	@extend %base-default-link;
 }
 
 #base-fullhd{

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
@@ -29,13 +29,19 @@ h1 {
 	margin-top: 0;
 }
 
+%gcwu-default-link {
+	&, &.ui-link {
+		&:link {
+			color: #295376;
+		}
+		&:visited {
+			color: #5a306b;
+		}
+	}
+}
+
 a {
-	&:link {
-		color: #295376;
-	}
-	&:visited {
-		color: #5a306b;
-	}
+	@extend %gcwu-default-link;
 }
 
 %gcwu-default-desktop-screen-hidden-img {
@@ -139,6 +145,9 @@ a {
 #wb-main-in {
 	padding-top: 1px;
 	padding-bottom: 2.5em;
+	a {
+		@extend %gcwu-default-link;
+	}
 }
 
 #wb-body-sec {

--- a/src/theme-wet-boew/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-wet-boew/sass/includes/_default-desktop-screen.scss
@@ -43,6 +43,9 @@ body{
 #wb-main-in{
 	padding-top:1px;
 	padding-bottom:2.5em;
+	a {
+		@extend %wet-default-link;
+	}
 }
 
 #wb-body-sec #wb-main{
@@ -95,13 +98,19 @@ h1{
 	position:relative;
 }
 
-a{
-	&:link{
-		color:#295376;
+%wet-default-link {
+	&, &.ui-link {
+		&:link {
+			color: #295376;
+		}
+		&:visited {
+			color: #5a306b;
+		}
 	}
-	&:visited{
-		color:#5A306B;
-	}	
+}
+
+a {
+	@extend %wet-default-link;
 }
 
 #wet-fullhd{


### PR DESCRIPTION
Stops jQuery Mobile `.ui-body-c .ui-link:visited` rule from overriding visited links style of links in the #wb-main-in content section (related to #1074 bug).
