### PR TITLE
Add a startOpen option to the SlideOut Tab so tab will start open.

### DIFF
--- a/src/js/workers/slideout.js
+++ b/src/js/workers/slideout.js
@@ -16,7 +16,6 @@
 		type: 'plugin',
 		depends: ['resize', 'metadata'],
 		opened: false,
-		defaultOpen: false,
 		_exec: function (elm) {
 			var borderWidth = 10,
 				tocText = pe.dic.get('%table-contents'),
@@ -40,9 +39,10 @@
 				opts,
 				ie7 = pe.ie > 0 && pe.ie < 8,
 				$wbcorein = $('#wb-core-in'),
+				defaultOpen = false,
 				imagesDir = pe.add.liblocation + 'images/slideout/';
 				
-			defaultOpen = $(elm).hasClass('wet-boew-slideout-open');
+			defaultOpen = elm.hasClass('wb-slideout-open');
 			$.metadata.setType('attr', 'data-wet-boew');
 			opts = {
 				imgShow: {

--- a/src/js/workers/slideout.js
+++ b/src/js/workers/slideout.js
@@ -54,7 +54,7 @@
 					height: 147,
 					width: 30,
 					alt: hideText + tocText
-				}
+				}, startOpen: false
 			};
 			$.extend(opts, elm.metadata());
 
@@ -342,6 +342,11 @@
 			// Fix scrolling issue in some versions of IE (#4051)
 			if (ie7) {
 				$('html').css('overflowY', 'auto');
+			}
+
+			//If start Open is turned on then slide out the sidebar
+			if (opts.startOpen){
+				toggle();
 			}
 		} // end of exec
 	};

--- a/src/js/workers/slideout.js
+++ b/src/js/workers/slideout.js
@@ -16,6 +16,7 @@
 		type: 'plugin',
 		depends: ['resize', 'metadata'],
 		opened: false,
+		defaultOpen: false,
 		_exec: function (elm) {
 			var borderWidth = 10,
 				tocText = pe.dic.get('%table-contents'),
@@ -40,7 +41,8 @@
 				ie7 = pe.ie > 0 && pe.ie < 8,
 				$wbcorein = $('#wb-core-in'),
 				imagesDir = pe.add.liblocation + 'images/slideout/';
-
+				
+			defaultOpen = $(elm).hasClass('wet-boew-slideout-open');
 			$.metadata.setType('attr', 'data-wet-boew');
 			opts = {
 				imgShow: {
@@ -54,7 +56,7 @@
 					height: 147,
 					width: 30,
 					alt: hideText + tocText
-				}, startOpen: false
+				}
 			};
 			$.extend(opts, elm.metadata());
 
@@ -345,7 +347,7 @@
 			}
 
 			//If start Open is turned on then slide out the sidebar
-			if (opts.startOpen){
+			if (defaultOpen){
 				toggle();
 			}
 		} // end of exec

--- a/src/js/workers/slideout.js
+++ b/src/js/workers/slideout.js
@@ -347,7 +347,7 @@
 			}
 
 			//If start Open is turned on then slide out the sidebar
-			if (defaultOpen){
+			if (defaultOpen) {
 				toggle();
 			}
 		} // end of exec


### PR DESCRIPTION
Setting startOpen: true in the data-wet-boew will have the slide out tab default to open when the page loads. 
Basically it runs the toggle function once the tab is finished loading. Having it slide open reinforces to the user that this they can toggle this functionality.

To add this functionality add the following to the data-wet-boew attribute

```
data-wet-boew='{startOpen: true}'
```

It defaults to closed if no attribute is set.

This is for issue #1064

/cc @berubs @pierreliz
