### PR TITLE
Add offset and clean up Sass code in grid functionality.

### DIFF
--- a/src/grids/sass/_responsive-1200.scss
+++ b/src/grids/sass/_responsive-1200.scss
@@ -2,144 +2,44 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
+
+// Width for an 8 grid column
+$width-8: 130px;
+// Width for a standard 12 grid column
+$width-12: 80px;
+// Width for a smaller 12 grid column
+$width-12small: 50px;
+// Standard gutter width
+$gutter: 10px;
+
+
+@function -wet-boew-calculate-width($width, $columns) {
+	@return ($width * $columns) + (($gutter * 2) * ($columns - 1));		
+}
+
+@function -wet-boew-calculate-offset($width, $columns){
+	@return (($width + (2 * $gutter)) * $columns) + $gutter;
+}
+
+@mixin create_grid($width, $max){
+	@for $i from 1 through $max {
+		.span-#{$i} { width: -wet-boew-calculate-width($width, $i); }	
+		.offset-#{$i} {	margin-left: -wet-boew-calculate-offset($width, $i); }
+	}
+}
+
 [id|="wb-body-sec"] {
 	#wb-core {
 		.grid-12 {
-			.span-1 {
-				width: 55px;
-			}
-			.span-2 {
-				@extend %responsive1200-width130;
-			}
-			.span-3 {
-				width: 205px;
-			}
-			.span-4 {
-				@extend %responsive1200-width280;
-			}
-			.span-5 {
-				width: 355px;
-			}
-			.span-6 {
-				@extend %responsive1200-width430;
-			}
-			.span-7 {
-				width: 505px;
-			}
-			.span-8 {
-				@extend %responsive1200-width580;
-			}
-			.span-9 {
-				width: 655px;
-			}
-			.span-10 {
-				@extend %responsive1200-width730;
-			}
-			.span-11 {
-				width: 805px;
-			}
-			.span-12 {
-				@extend %responsive1200-width880;
-			}
+			@include create_grid($width-12small, 12);
 		}
 	}
 }
 
 .grid-12 {
-	.span-1 {
-		width: 80px;
-	}
-	.span-2 {
-		width: 180px;
-	}
-	.span-3 {
-		@extend %responsive1200-width280;
-	}
-	.span-4 {
-		width: 380px;
-	}
-	.span-5 {
-		width: 480px;
-	}
-	.span-6 {
-		@extend %responsive1200-width580;
-	}
-	.span-7 {
-		width: 680px;
-	}
-	.span-8 {
-		width: 780px;
-	}
-	.span-9 {
-		@extend %responsive1200-width880;
-	}
-	.span-10 {
-		width: 980px;
-	}
-	.span-11 {
-		width: 1080px;
-	}
-	.span-12 {
-		@extend %responsive1200-width1180;
-	}
+	@include create_grid($width-12, 12);
 }
 
-%responsive1200-width130 {
-	width: 130px;
-}
-
-.span-1 {
-	@extend %responsive1200-width130;
-}
-
-%responsive1200-width280 {
-	width: 280px;
-}
-
-.span-2 {
-	@extend %responsive1200-width280;
-}
-
-%responsive1200-width430 {
-	width: 430px;
-}
-
-.span-3 {
-	@extend %responsive1200-width430;
-}
-
-%responsive1200-width580 {
-	width: 580px;
-}
-
-.span-4 {
-	@extend %responsive1200-width580;
-}
-
-%responsive1200-width730 {
-	width: 730px;
-}
-
-.span-5 {
-	@extend %responsive1200-width730;
-}
-
-%responsive1200-width880 {
-	width: 880px;
-}
-
-.span-6 {
-	@extend %responsive1200-width880;
-}
-
-.span-7 {
-	width: 1030px;
-}
-
-%responsive1200-width1180 {
-	width: 1180px;
-}
-
-.span-8 {
-	@extend %responsive1200-width1180;
+@for $i from 1 through 8 {
+	@include create_grid($width-8, 8);
 }

--- a/src/grids/sass/_responsive-1200.scss
+++ b/src/grids/sass/_responsive-1200.scss
@@ -3,30 +3,14 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 
+@import 'includes/_grid-mixins.scss';
+
 // Width for an 8 grid column
 $width-8: 130px;
 // Width for a standard 12 grid column
 $width-12: 80px;
 // Width for a smaller 12 grid column
 $width-12small: 50px;
-// Standard gutter width
-$gutter: 10px;
-
-
-@function -wet-boew-calculate-width($width, $columns) {
-	@return ($width * $columns) + (($gutter * 2) * ($columns - 1));		
-}
-
-@function -wet-boew-calculate-offset($width, $columns){
-	@return (($width + (2 * $gutter)) * $columns) + $gutter;
-}
-
-@mixin create_grid($width, $max){
-	@for $i from 1 through $max {
-		.span-#{$i} { width: -wet-boew-calculate-width($width, $i); }	
-		.offset-#{$i} {	margin-left: -wet-boew-calculate-offset($width, $i); }
-	}
-}
 
 [id|="wb-body-sec"] {
 	#wb-core {

--- a/src/grids/sass/_responsive-768.scss
+++ b/src/grids/sass/_responsive-768.scss
@@ -12,7 +12,6 @@ $width-12: 44px;
 // Width for a smaller 12 grid column
 $width-12small: 28px;
 
-
 [id|="wb-body-sec"] {
 	#wb-core {
 		.grid-12 {

--- a/src/grids/sass/_responsive-768.scss
+++ b/src/grids/sass/_responsive-768.scss
@@ -2,144 +2,29 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
+
+@import 'includes/_grid-mixins.scss';
+
+// Width for an 8 grid column
+$width-8: 76px;
+// Width for a standard 12 grid column
+$width-12: 44px;
+// Width for a smaller 12 grid column
+$width-12small: 28px;
+
+
 [id|="wb-body-sec"] {
 	#wb-core {
 		.grid-12 {
-			.span-1 {
-				width: 28px;
-			}
-			.span-2 {
-				@extend %responsive768-width76;
-			}
-			.span-3 {
-				width: 124px;
-			}
-			.span-4 {
-				@extend %responsive768-width172;
-			}
-			.span-5 {
-				width: 220px;
-			}
-			.span-6 {
-				@extend %responsive768-width268;
-			}
-			.span-7 {
-				width: 316px;
-			}
-			.span-8 {
-				@extend %responsive768-width364;
-			}
-			.span-9 {
-				width: 412px;
-			}
-			.span-10 {
-				@extend %responsive768-width460;
-			}
-			.span-11 {
-				width: 508px;
-			}
-			.span-12 {
-				@extend %responsive768-width556;
-			}
+			@include create_grid($width-12small, 12);
 		}
 	}
 }
 
 .grid-12 {
-	.span-1 {
-		width: 44px;
-	}
-	.span-2 {
-		width: 108px;
-	}
-	.span-3 {
-		@extend %responsive768-width172;
-	}
-	.span-4 {
-		width: 236px;
-	}
-	.span-5 {
-		width: 300px;
-	}
-	.span-6 {
-		@extend %responsive768-width364;
-	}
-	.span-7 {
-		width: 428px;
-	}
-	.span-8 {
-		width: 492px;
-	}
-	.span-9 {
-		@extend %responsive768-width556;
-	}
-	.span-10 {
-		width: 620px;
-	}
-	.span-11 {
-		width: 684px;
-	}
-	.span-12 {
-		@extend %responsive768-width748;
-	}
+	@include create_grid($width-12, 12);
 }
 
-%responsive768-width76 {
-	width: 76px;
-}
-
-.span-1 {
-	@extend %responsive768-width76;
-}
-
-%responsive768-width172 {
-	width: 172px;
-}
-
-.span-2 {
-	@extend %responsive768-width172;
-}
-
-%responsive768-width268 {
-	width: 268px;
-}
-
-.span-3 {
-	@extend %responsive768-width268;
-}
-
-%responsive768-width364 {
-	width: 364px;
-}
-
-.span-4 {
-	@extend %responsive768-width364;
-}
-
-%responsive768-width460 {
-	width: 460px;
-}
-
-.span-5 {
-	@extend %responsive768-width460;
-}
-
-%responsive768-width556 {
-	width: 556px;
-}
-
-.span-6 {
-	@extend %responsive768-width556;
-}
-
-.span-7 {
-	width: 652px;
-}
-
-%responsive768-width748 {
-	width: 748px;
-}
-
-.span-8 {
-	@extend %responsive768-width748;
+@for $i from 1 through 8 {
+	@include create_grid($width-8, 8);
 }

--- a/src/grids/sass/includes/_grid-mixins.scss
+++ b/src/grids/sass/includes/_grid-mixins.scss
@@ -1,0 +1,18 @@
+// Standard gutter width
+$gutter: 10px;
+
+//Functions and mixins for grids
+@function -wet-boew-calculate-width($width, $columns) {
+	@return ($width * $columns) + (($gutter * 2) * ($columns - 1));		
+}
+
+@function -wet-boew-calculate-offset($width, $columns){
+	@return (($width + (2 * $gutter)) * $columns) + $gutter;
+}
+
+@mixin create_grid($width, $max){
+	@for $i from 1 through $max {
+		.span-#{$i} { width: -wet-boew-calculate-width($width, $i); }	
+		.offset-#{$i} {	margin-left: -wet-boew-calculate-offset($width, $i); }
+	}
+}

--- a/src/grids/sass/includes/_grid-mixins.scss
+++ b/src/grids/sass/includes/_grid-mixins.scss
@@ -1,3 +1,7 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ */
 // Standard gutter width
 $gutter: 10px;
 

--- a/src/grids/sass/includes/_mixins.scss
+++ b/src/grids/sass/includes/_mixins.scss
@@ -68,6 +68,7 @@ $default-color-border: false;
 
 
 
+
 @mixin colorize-base($color: $default-color, $important: false) {
 
 	// set default colors


### PR DESCRIPTION
I added offsets to the grid system to bring our system in line
with other modern grid systems like bootstrap.js, blueprint.css,
960grid.css, etc. This also has the added benefit of preventing
web developers from having to clutter up their HTML with empty divs to
handle positioning.

I decided to go with a single offset method as opposed to a push
and pull system as I personally think it is a much simpler way to
implement an offset system.

Spans and Offsets are generated using SASS functions to
cut down on the amount of code in the SASS Files and make it
more readable for developers.

We lose the ability to use @ extend but that is not as important
as we minimize the css anyways.

I moved the common grid functions and mixins to _include/_grid_mixins.scss_
to make it easier to implement future grids for different screen sizes.

-Calvin Rodo
calvin.rodo@hrsdc-rhdcc.gc.ca
