### PR TITLE
Add colours for charts.

### DIFF
--- a/src/grids/sass/includes/_mixins.scss
+++ b/src/grids/sass/includes/_mixins.scss
@@ -66,7 +66,19 @@ $default-color-gradient: true;
 $default-color-shadow: true;
 $default-color-border: false;
 
-
+$accent-1: #8d201c;
+$accent-2: #EE8310;
+$accent-3: #2a7da6;
+$accent-4: #5a306b;
+$accent-5: #285228;
+$accent-6: #154055;
+$accent-7: #555555;
+$accent-8: #f6d200;
+$accent-9: #d73d38;
+$accent-10: #418541;
+$accent-11: #87aec9;
+$accent-12: #23447e;
+$accent-13: #999999;
 
 @mixin colorize-base($color: $default-color, $important: false) {
 


### PR DESCRIPTION
as per issue #842 I've added the colours specified by
@cfarquharson to the /grids/sass/_mixins.scss for want of a
better place to put it.

And I've named them Accent-1 through Accent-N since I couldn't find any names for the 
hex colours.
