### PR TITLE
Replace inline vendor prefixed CSS3 with Compass mixins in master

### DIFF
--- a/src/theme-base/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-base/sass/includes/_default-desktop-screen.scss
@@ -2,6 +2,9 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
+@import "compass/css3/border-radius";
+@import "compass/css3/box-shadow";
+
 html{
 	overflow-y:scroll;
 }
@@ -209,14 +212,10 @@ a {
 	#base-srch{
 		color:#444;
 		border:1px solid #ccc;
-		border-radius:2px;
-		-moz-border-radius:2px;
-		-webkit-border-radius:2px;
+		@include border-radius(2px);
 		margin-left:0;
 		width:218px;
-		box-shadow:none;
-		-moz-box-shadow:none;
-		-webkit-box-shadow:none;
+		@include box-shadow(none);
 		background:#fff;
 		padding:2px 0;
 		&:focus,&:active{
@@ -240,24 +239,18 @@ a {
 		right:1px solid #999;
 		top:1px solid #fff;
 		left:1px solid #fff;
-		radius:2px;
 	}
+	@include border-radius(2px);
 	color:#333;
-	-moz-border-radius:2px;
-	-webkit-border-radius:2px;
 	text-shadow:0 1px 0 #eee;
 	font-weight:400;
-	box-shadow:none;
-	-moz-box-shadow:none;
-	-webkit-box-shadow:none;
+	@include box-shadow(none);
 	padding:2px 6px;
 	display:inline;
 	&:focus,&:hover{
 		background:#ddd url(../images/search-button-focus.gif) 0 0 repeat-x;
 		text-shadow:0 1px 0 #ddd;
-		box-shadow:none;
-		-moz-box-shadow:none;
-		-webkit-box-shadow:none;
+		@include box-shadow(none);
 		border:{
 			bottom:1px solid #999;
 			right:1px solid #999;
@@ -266,9 +259,7 @@ a {
 		}
 	}
 	&:active{
-		-moz-box-shadow:inset 0 0 5px 2px #999, 0 0 0 0 #eee;
-		-webkit-box-shadow:inset 0 0 5px 2px #999, 0 0 0 0 #eee;
-		box-shadow:inset 0 0 5px 2px #999, 0 0 0 0 #eee;
+		@include box-shadow(inset 0 0 5px 2px #999, 0 0 0 0 #eee);
 		border:1px solid #999;
 	}
 }

--- a/src/theme-base/sass/includes/_default-mobile.scss
+++ b/src/theme-base/sass/includes/_default-mobile.scss
@@ -2,6 +2,10 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
+@import "compass/css3/images";
+@import "compass/css3/border-radius";
+@import "compass/css3/box-shadow";
+
 body{
 	-webkit-text-size-adjust:none;
 	font-family:Verdana, Arial, Helvetica, sans-serif;
@@ -89,7 +93,7 @@ a {
 
 .ui-mobile {
 	#base-srch{
-		box-shadow:none;
+		@include box-shadow(none);
 	}
 	#wb-sec{
 		display:none;
@@ -188,7 +192,7 @@ img{
 		text-decoration:none;
 		background:#eee;
 		border:1px solid #ddd;
-		border-radius:2px;
+		@include border-radius(2px);
 		float:right;
 		font-weight:400;
 		padding:3px;
@@ -209,20 +213,10 @@ img{
 	h2 {
 		text-shadow:0 1px 0 #FFF;
 		background-color:#EEEEEE;
-		background-image:-webkit-gradient(linear,left top,left bottom,from(#FFFFFF),to(#F1F1F1));
-		background-image:-webkit-linear-gradient(#FFFFFF,#F1F1F1);
-		background-image:-moz-linear-gradient(#FFFFFF,#F1F1F1);
-		background-image:-ms-linear-gradient(#FFFFFF,#F1F1F1);
-		background-image:-o-linear-gradient(#FFFFFF,#F1F1F1);
-		background-image:linear-gradient(#FFFFFF,#F1F1F1);
+		@include background-image(linear-gradient(#FFFFFF,#F1F1F1));
 		&:hover, &:focus, &:active {
 			background-color:#DFDFDF;
-			background-image:-webkit-gradient(linear,left top,left bottom,from(#F6F6F6),to(#E0E0E0));
-			background-image:-webkit-linear-gradient(#F6F6F6,#E0E0E0);
-			background-image:-moz-linear-gradient(#F6F6F6,#E0E0E0);
-			background-image:-ms-linear-gradient(#F6F6F6,#E0E0E0);
-			background-image:-o-linear-gradient(#F6F6F6,#E0E0E0);
-			background-image:linear-gradient(#F6F6F6,#E0E0E0);
+			@include background-image(linear-gradient(#F6F6F6,#E0E0E0));
 		}
 		color:#222;
 		text-align:center;
@@ -241,12 +235,7 @@ img{
 
 #base-bnr .ui-navbar a.ui-btn-active {
 	background-color:#DFDFDF;
-	background-image:-webkit-gradient(linear,left top,left bottom,from(#F6F6F6),to(#E0E0E0));
-	background-image:-webkit-linear-gradient(#F6F6F6,#E0E0E0);
-	background-image:-moz-linear-gradient(#F6F6F6,#E0E0E0);
-	background-image:-ms-linear-gradient(#F6F6F6,#E0E0E0);
-	background-image:-o-linear-gradient(#F6F6F6,#E0E0E0);
-	background-image:linear-gradient(#F6F6F6,#E0E0E0);
+	@include background-image(linear-gradient(#F6F6F6,#E0E0E0));
 	border:1px solid #CCC;
 	border-right:none;
 	color:#222;
@@ -406,12 +395,8 @@ img{
 		border-right-width: 1px;
 	}
 	.ui-collapsible-heading:not(.ui-collapsible-heading-collapsed) a {
-		-webkit-border-bottom-right-radius: 0;
-		-webkit-border-bottom-left-radius: 0;
-		-moz-border-radius-bottomright: 0;
-		-moz-border-radius-bottomleft: 0;
-		border-bottom-left-radius: 0;
-		border-bottom-right-radius: 0;
+		@include border-bottom-left-radius(0);
+		@include border-bottom-right-radius(0);
 	}
 	.wb-nested-menu {
 		padding: 0;
@@ -487,34 +472,23 @@ img{
 	}
 	.top-section a{
 		margin:0 0 5px;
-		border-radius:0;
-		-moz-border-radius:0;
-		-webkit-border-radius:0;
+		@include border-radius(0);
 	}
 	.top-level.ui-btn-corner-all {
-		border-radius:0.6em;
+		@include border-radius(0.6em);//TODO: Rest of the border-radius declarations are px, why is this in ems
 	}
 	#base-bc-in {
 		background:#DFDFDD;
-		background-image:-webkit-gradient(linear,left top,left bottom,from(#F0EFEF),to(#DFDFDD));
-		background-image:-webkit-linear-gradient(#F0EFEF,#DFDFDD);
-		background-image:-moz-linear-gradient(#F0EFEF,#DFDFDD);
-		background-image:-ms-linear-gradient(#F0EFEF,#DFDFDD);
-		background-image:-o-linear-gradient(#F0EFEF,#DFDFDD);
-		background-image:linear-gradient(#F0EFEF,#DFDFDD);
+		@include background-image(linear-gradient(#F0EFEF,#DFDFDD));
 		color: #555;
-		border-radius:0;
-		-moz-border-radius:0;
-		-webkit-border-radius:0;
+		@include border-radius(0);
 		text-shadow:0 1px 1px #fff;
 		border-bottom:1px solid #ccc;
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+		@include box-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
 		a {
 			color: #326CA6;
 			text-decoration: none;
-			border-radius:0;
-			-moz-border-radius:0;
-			-webkit-border-radius:0;
+			@include border-radius(0);
 			&:hover,&:active{
 				text-decoration:underline;
 			}
@@ -525,9 +499,7 @@ img{
 			float: left;
 			margin: 0;
 			padding: 5px 12px 5px 5px;
-			border-radius:0;
-			-moz-border-radius:0;
-			-webkit-border-radius:0;
+			@include border-radius(0);
 			&:last-child {
 				background-image: none;
 				padding-left:5px;

--- a/src/theme-base/sass/includes/_default-screen.scss
+++ b/src/theme-base/sass/includes/_default-screen.scss
@@ -3,6 +3,8 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/text-shadow";
+@import "compass/css3/border-radius";
+@import "compass/css3/box-shadow";
 
 body{
 	margin:0;
@@ -33,9 +35,7 @@ body{
 	h3, h4, .top-level {
 		font-size: 100%;
 		border-bottom: none;
-		border-radius: 2px;
-		-moz-border-radius: 2px;
-		-webkit-border-radius: 2px;
+		@include border-radius(2px);
 		margin: 0 0 3px;
 		a {
 			&, &.ui-link {
@@ -62,9 +62,7 @@ body{
 	}
 	a.nav-current {
 		border:1px solid #777;
-		border-radius:2px;
-		-moz-border-radius:2px;
-		-webkit-border-radius:2px;
+		@include border-radius(2px);
 	}
 	h3, h4, .top-level, li {
 		a {

--- a/src/theme-wet-boew/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-wet-boew/sass/includes/_default-desktop-screen.scss
@@ -3,6 +3,8 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/border-radius";
+@import "compass/css3/box-shadow";
+@import "compass/css3/images";
 
 html{
 	overflow-y:scroll;
@@ -228,9 +230,7 @@ a {
 		@include border-radius(3px);
 		margin:0 0 0 3px;
 		width:218px;
-		box-shadow:none;
-		-moz-box-shadow:none;
-		-webkit-box-shadow:none;
+		@include box-shadow(none);
 		background:#FFF;
 		padding:4px;
 		&:focus,&:active{
@@ -263,12 +263,8 @@ a {
 	border-top:1px solid #0B3048;
 	.mb-menu {
 		.mb-sm-open {
-			box-shadow: 0 5px 5px -4px rgba(0, 0, 0, 0.5), 5px 5px 5px -4px rgba(0, 0, 0, 0.5), -5px 5px 5px -4px rgba(0, 0, 0, 0.5);
-			background-image:-webkit-gradient(linear,50% 100%,50% 0,color-stop(0%,#EEE),color-stop(100%,#CCC));
-			background-image:-webkit-linear-gradient(bottom,#EEE,#CCC);
-			background-image:-moz-linear-gradient(bottom,#EEE,#CCC);
-			background-image:-o-linear-gradient(bottom,#EEE,#CCC);
-			background-image:linear-gradient(bottom,#EEE,#CCC);
+			@include box-shadow(0 5px 5px -4px rgba(0, 0, 0, 0.5), 5px 5px 5px -4px rgba(0, 0, 0, 0.5), -5px 5px 5px -4px rgba(0, 0, 0, 0.5));
+			@include background-image(linear-gradient(bottom,#EEE,#CCC));
 			@include border-radius(0);
 			li, .nav-current{
 				background:none;

--- a/src/theme-wet-boew/sass/includes/_default-mobile.scss
+++ b/src/theme-wet-boew/sass/includes/_default-mobile.scss
@@ -4,6 +4,8 @@
  */
 
 @import "compass/css3/border-radius";
+@import "compass/css3/images";
+@import "compass/css3/box-shadow";
 
 body{
 	-webkit-text-size-adjust:none;
@@ -92,7 +94,7 @@ a {
 
 .ui-mobile {
 	#wet-srch{
-		box-shadow:none;
+		@include box-shadow(none);
 	}
 	#wb-sec{
 		display:none;
@@ -214,20 +216,10 @@ img{
 	h2 {
 		text-shadow:0 1px 0 #FFF;
 		background-color:#EEEEEE;
-		background-image:-webkit-gradient(linear,left top,left bottom,from(#FFFFFF),to(#F1F1F1));
-		background-image:-webkit-linear-gradient(#FFFFFF,#F1F1F1);
-		background-image:-moz-linear-gradient(#FFFFFF,#F1F1F1);
-		background-image:-ms-linear-gradient(#FFFFFF,#F1F1F1);
-		background-image:-o-linear-gradient(#FFFFFF,#F1F1F1);
-		background-image:linear-gradient(#FFFFFF,#F1F1F1);
+		@include background-image(linear-gradient(#FFFFFF,#F1F1F1));
 		&:hover, &:focus, &:active {
 			background-color:#DFDFDF;
-			background-image:-webkit-gradient(linear,left top,left bottom,from(#F6F6F6),to(#E0E0E0));
-			background-image:-webkit-linear-gradient(#F6F6F6,#E0E0E0);
-			background-image:-moz-linear-gradient(#F6F6F6,#E0E0E0);
-			background-image:-ms-linear-gradient(#F6F6F6,#E0E0E0);
-			background-image:-o-linear-gradient(#F6F6F6,#E0E0E0);
-			background-image:linear-gradient(#F6F6F6,#E0E0E0);
+			@include background-image(linear-gradient(#F6F6F6,#E0E0E0));
 		}
 		color:#222;
 		text-align:center;
@@ -246,12 +238,7 @@ img{
 
 #wet-bnr .ui-navbar a.ui-btn-active {
 	background-color:#DFDFDF;
-	background-image:-webkit-gradient(linear,left top,left bottom,from(#F6F6F6),to(#E0E0E0));
-	background-image:-webkit-linear-gradient(#F6F6F6,#E0E0E0);
-	background-image:-moz-linear-gradient(#F6F6F6,#E0E0E0);
-	background-image:-ms-linear-gradient(#F6F6F6,#E0E0E0);
-	background-image:-o-linear-gradient(#F6F6F6,#E0E0E0);
-	background-image:linear-gradient(#F6F6F6,#E0E0E0);
+	@include background-image(linear-gradient(#F6F6F6,#E0E0E0));
 	border:1px solid #CCC;
 	border-right:none;
 	color:#222;
@@ -411,12 +398,8 @@ img{
 		border-right-width: 1px;
 	}
 	.ui-collapsible-heading:not(.ui-collapsible-heading-collapsed) a {
-		-webkit-border-bottom-right-radius: 0;
-		-webkit-border-bottom-left-radius: 0;
-		-moz-border-radius-bottomright: 0;
-		-moz-border-radius-bottomleft: 0;
-		border-bottom-left-radius: 0;
-		border-bottom-right-radius: 0;
+		@include border-bottom-left-radius(0);
+		@include border-bottom-right-radius(0);
 	}
 	.wb-nested-menu {
 		padding: 0;
@@ -499,17 +482,12 @@ img{
 	}
 	#wet-bc-in {
 		background:#DFDFDD;
-		background-image:-webkit-gradient(linear,left top,left bottom,from(#F0EFEF),to(#DFDFDD));
-		background-image:-webkit-linear-gradient(#F0EFEF,#DFDFDD);
-		background-image:-moz-linear-gradient(#F0EFEF,#DFDFDD);
-		background-image:-ms-linear-gradient(#F0EFEF,#DFDFDD);
-		background-image:-o-linear-gradient(#F0EFEF,#DFDFDD);
-		background-image:linear-gradient(#F0EFEF,#DFDFDD);
+		@include background-image(linear-gradient(#F0EFEF,#DFDFDD));
 		color: #555;
 		@include border-radius(0);
 		text-shadow:0 1px 1px #fff;
 		border-bottom:1px solid #ccc;
-		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+		@include box-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
 		a {
 			color: #326CA6;
 			text-decoration: none;


### PR DESCRIPTION
These where missed in the v3.0 cleanup since they were only introduced
in master
- Linear gradients
- box-shadows
- border-radius
- Few native elements that were missing the vendors
  Furter changes required
