### PR TITLE
Corrected typo error in the footer's CSS

### DIFF
--- a/src/theme-wet-boew/sass/includes/_default-screen.scss
+++ b/src/theme-wet-boew/sass/includes/_default-screen.scss
@@ -116,7 +116,7 @@ body{
 	.span-1,.span-2,.span-3,.span-4,.span-5,.span-6,.span-7,.span-8,.span-9,.span-10,.span-11,.span-12{
 		margin-bottom:0;
 	}
-	.base-col-head {
+	.wet-col-head {
 		.ui-link {
 			font-weight: 700;
 		}


### PR DESCRIPTION
Cherry-picked from #1126 by @vpnguyen
- was using "base" prefix in wet theme
