### PR TITLE
Remove support for Firefox 3.6 and below

### DIFF
--- a/src/base/sass/_modern-vendor-prefix.scss
+++ b/src/base/sass/_modern-vendor-prefix.scss
@@ -9,4 +9,4 @@ $experimental-support-for-webkit: true;
 $support-for-original-webkit-gradients: true;
 $experimental-support-for-opera:true;
 $experimental-support-for-microsoft: true;
-$legacy-support-for-mozilla:true;
+$legacy-support-for-mozilla:false;

--- a/src/grids/sass/includes/_util-screen.scss
+++ b/src/grids/sass/includes/_util-screen.scss
@@ -22,9 +22,6 @@ p, table {
 }
 
 pre {
-	@if $legacy-support-for-mozilla { //TODO: Do we still need to support this version when Mozilla no longer does
-		overflow-x: auto;  /* Use horizontal scroller if needed; for Firefox 2, not needed in Firefox 3 */
-	}
 	white-space: pre-wrap;
 }
 


### PR DESCRIPTION
- Remove inline hack
- Turn off hacks used by Compass

Fixes #1103 
