### PR TITLE
Date highlight does not show white linked month

### DIFF
--- a/src/grids/sass/includes/_util-screen.scss
+++ b/src/grids/sass/includes/_util-screen.scss
@@ -555,6 +555,9 @@ table {
 		margin: 0 8px;
 		padding: 0 0 1px 0;
 	}
+	a {
+		color: #fff !important;
+	}
 	abbr, acronym {
 		border: none;
 	}


### PR DESCRIPTION
Comparing the two source CSS, the _util-mobile's date-month class has white colour precedence for the linked month but the _util-screen does not. Should it has one?

![date-month linked text does not have white precedence](https://f.cloud.github.com/assets/3224347/121539/50470432-6db3-11e2-91b6-7a3243fd637b.PNG)
![date-month linked has white precedence on mobile view](https://f.cloud.github.com/assets/3224347/121540/576b359e-6db3-11e2-8e05-3697f2a56950.PNG)
