### PR TITLE
Fixed the Zebra IE7 CSS overloading for an ordered list. 

### DIFF
--- a/src/js/sass/includes/_zebra-ie7.scss
+++ b/src/js/sass/includes/_zebra-ie7.scss
@@ -5,7 +5,7 @@
 
 /* IE7 hacks - should be in an IE7 only .css */
 .ie7 {
-    ol {
+    ol.wet-boew-zebra {
 		> {
 			li {
 				padding-left: 10px;


### PR DESCRIPTION
Related to #1125
