### PR TITLE
Travis: call the testing in the script section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ branches:
     - v3.0-dist
     - master-dist
 
-before_script: 
-  - ant test -Djshint.failbuild=true
-
 script:
+  - ant test -Djshint.failbuild=true
   - ant
   - ./build/post_build.sh


### PR DESCRIPTION
That way failing tests cause the build to be marked failed instead of errored
