### PR TITLE
CSSLint: remove units from Compass box-shadow defaults

### DIFF
--- a/src/grids/sass/includes/_mixins.scss
+++ b/src/grids/sass/includes/_mixins.scss
@@ -69,7 +69,9 @@ $default-color-gradient: true;
 $default-color-shadow: true;
 $default-color-border: false;
 
-
+//override the compass zero values with unitless values
+$default-box-shadow-h-offset: 0;
+$default-box-shadow-v-offset: 0;
 
 @mixin colorize-base($color: $default-color, $important: false) {
 


### PR DESCRIPTION
Leaves the same values, but as pointed out here https://github.com/chriseppstein/compass/issues/1157 care must be taken if math operations are then applied to them.
