### PR TITLE
Removed $.browser references for #907

### DIFF
--- a/src/js/dependencies/bookmark.js
+++ b/src/js/dependencies/bookmark.js
@@ -263,7 +263,7 @@ $('div selector').bookmark({sites: ['delicious', 'digg']});
 	$.extend(Bookmark.prototype, {
 		/* Class name added to elements to indicate already configured with bookmarking. */
 		markerClassName : 'hasBookmark',
-		
+
 		/* Override the default settings for all bookmarking instances.
 		@param	settings  (object) the new settings to use as defaults
 		@return void */
@@ -467,18 +467,9 @@ $('div selector').bookmark({sites: ['delicious', 'digg']});
 						'style="' + (settings.iconsStyle ? 'background-position: ' :
 								'background: transparent url(' + settings.icons + ') no-repeat ') + '-' +
 						((icon % settings.iconCols) * settings.iconSize) + 'px -' +
-						(Math.floor(icon / settings.iconCols) * settings.iconSize) + 'px;' +
-						($.browser.mozilla && $.browser.version < '1.9' ?
-								' padding-left: ' + settings.iconSize + 'px; padding-bottom: ' +
-								(Math.max(0, settings.iconSize - 16)) + 'px;' : '') + '"></span>';
+						(Math.floor(icon / settings.iconCols) * settings.iconSize) + 'px;"></span>';
 				} else {
-					html += '<img src="' + icon + '" alt="' + title + '" title="' +
-								title + '"' + (($.browser.mozilla && $.browser.version < '1.9') ||
-									($.browser.msie && $.browser.version < '7.0') ?
-										' style="vertical-align: bottom;"' :
-											($.browser.msie ? ' style="vertical-align: middle;"' :
-												($.browser.opera || $.browser.safari ?
-													' style="vertical-align: baseline;"' : ''))) + '/>';
+					html += '<img src="' + icon + '" alt="' + title + '" title="' + title + '"/>';
 				}
 				html += (settings.compact ? '' : '&#xa0;');
 			}
@@ -513,8 +504,8 @@ $('div selector').bookmark({sites: ['delicious', 'digg']});
 		@param	url    (string) the URL to bookmark
 		@param	title  (string) the title to bookmark */
 		_addFavourite : function (url, title) {
-			if ($.browser.msie) {
-				window.external.addFavorite(url, title);
+			if (typeof window.external.AddFavorite !== 'undefined') {
+				window.external.AddFavorite(url, title);
 			} else {
 				alert(this._defaults.manualBookmark);
 			}

--- a/src/js/dependencies/equalheights.js
+++ b/src/js/dependencies/equalheights.js
@@ -23,8 +23,6 @@ Optional: to set min-height in px, pass a true argument: $(element).equalHeights
 				if ($(this).height() > currentTallest) { currentTallest = $(this).height(); }
 			});
 			if (!px && typeof Number.prototype.pxToEm !== 'undefined') { currentTallest = currentTallest.pxToEm(); } //use ems unless px is specified
-			// for ie6, set height since min-height isn't supported
-			if ($.browser.msie && $.browser.version === '6.0') { $(this).children().css({ 'height': currentTallest }); }
 			$(this).children().css({ 'min-height': currentTallest });
 		});
 		return this;

--- a/src/js/sass/includes/_share-ie7.scss
+++ b/src/js/sass/includes/_share-ie7.scss
@@ -11,5 +11,12 @@
 			right: 0;
 			top: 1.5em;
 		}
+		.bookmark_list {
+			a {
+				img {
+					vertical-align: middle;
+				}
+			}
+		}
 	}
 }

--- a/src/js/sass/includes/_share.scss
+++ b/src/js/sass/includes/_share.scss
@@ -101,6 +101,11 @@ div {
 				background: 0 !important;
 				padding-left: 0 !important;
 			}
+			img {
+				width: auto;
+				margin-bottom: 0;
+				vertical-align: text-top;
+			}
 		}
 		span {
 			@include inline-block;


### PR DESCRIPTION
1. **equalheights.js**: removed IE6 support.
2. **bookmarks.js**: replaced with feature detection, CSS changes and removed pre FF 1.9 support.

If you'd like, I can submit a pull to the [bookmark repo](https://github.com/kbwood/bookmark), but I'm not sure if it'll get merged.  @nschonni's from 3 months ago is still open .
