### PR TITLE
IE9: Turn on SVG support for gradients

### DIFF
--- a/src/base/sass/_modern-vendor-prefix.scss
+++ b/src/base/sass/_modern-vendor-prefix.scss
@@ -10,3 +10,4 @@ $support-for-original-webkit-gradients: true;
 $experimental-support-for-opera:true;
 $experimental-support-for-microsoft: true;
 $legacy-support-for-mozilla:true;
+$experimental-support-for-svg:true;


### PR DESCRIPTION
IE9 doesn't support gradients natively so the SVG fallback is required. IE10 is OK.

Does increase the non-IE grids CSS ~10KB and the js CSS, ~5KB
