### PR TITLE
CSS only .equalize for desktop view

### DIFF
--- a/demos/guide-design/guide-eng.html
+++ b/demos/guide-design/guide-eng.html
@@ -119,7 +119,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
   </div>
 </div>
 <div class="clear"></div>
-<div class="equalize">
+<div class="equalize module-gutter-bottom">
   <div class="span-3 module-info module-simplify">
     <h2>JavaScript add-ons</h2>
     <p>The JavaScript add-ons combine CSS and JavaScript to create complex design/features. </p>

--- a/src/grids/sass/_responsive-ie.scss
+++ b/src/grids/sass/_responsive-ie.scss
@@ -7,3 +7,9 @@
 		margin-bottom: 20px !important;
 	}
 }
+
+.ie8 {
+	.equalize {
+		margin-bottom: 0 !important;
+	}
+}

--- a/src/grids/sass/includes/_equalize.scss
+++ b/src/grids/sass/includes/_equalize.scss
@@ -15,51 +15,50 @@
 			margin-bottom: 0 !important;
 			display: table !important;
 			table-layout: fixed;
-			> * {
-				float: none !important;
-				display: table-cell !important;
-				vertical-align: top !important;
-			}
-			> [class*="span-"] {
-				border: 0 solid transparent;
-				border-width: 0 10px 20px 10px;
-				@include background-clip(padding-box);
-				@include background-origin(padding-box);
-				&.row-start {
-					border-left: 0;
+			> {
+				* {
+					float: none !important;
+					display: table-cell !important;
+					vertical-align: top !important;
 				}
-				&.row-end {
-					border-right: 0;
+				[class*="span-"] {
+					border: 0 solid transparent;
+					border-width: 0 10px 20px 10px;
+					@include background-clip(padding-box);
+					@include background-origin(padding-box);
+					&.row-start {
+						border-left: 0;
+					}
+					&.row-end {
+						border-right: 0;
+					}
 				}
-			}
-			> [class*="module-"] {
-				border: 10px solid transparent;
-				outline-offset: -10px;
-				@include box-sizing(content-box);
+				[class*="module-"] {
+					border: 10px solid transparent;
+					outline-offset: -10px;
+					@include box-sizing(content-box);
+				}
 			}
 			&.module-gutter-bottom {
 				border-bottom: 10px solid transparent;
 			}
 		}
 
-		.ie9, .ie10 {
-			.equalize {
-				> [class*="module-"] {
-					border: 0;
-					float: left !important;
-					display: block !important;
-				}
-				&.module-gutter-bottom {
-					border-bottom: 0;
-				}
-			}
+		.ie9 {
+		    @extend %grids-equalize-all-modern-ie;
+		}
+
+		.ie10 {
+		    @extend %grids-equalize-all-modern-ie;
 		}
 
 		#wb-core-in {
 			&.equalize {
 				direction: rtl;
-				> * {
-					direction: ltr;
+				> {
+					* {
+						direction: ltr;
+					}
 				}
 			}
 		}
@@ -67,28 +66,59 @@
 		/* Right to left (RTL) CSS */
 		[dir="rtl"] {
 			.equalize {
-				> [class*="span-"] {
-					&.row-start {
-						border-left-width: 10px;
-						border-right: 0;
-					}
-					&.row-end {
-						border-left: 0;
-						border-right-width: 10px;
+				> {
+					[class*="span-"] {
+						&.row-start {
+							border-left-width: 10px;
+							border-right: 0;
+						}
+						&.row-end {
+							border-left: 0;
+							border-right-width: 10px;
+						}
 					}
 				}
 			}
 			#wb-core-in {
 				&.equalize {
 					direction: ltr;
-					> * {
-						direction: rtl;
+					> {
+						* {
+							direction: rtl;
+						}
 					}
 				}
 			}
-			&.ie9, &.ie10 {
-				.equalize {
-					> [class*="module-"] {
+
+			&.ie9 {
+				@extend %grids-equalize-all-modern-ie-rtl;
+			}
+
+			&.ie10 {
+				@extend %grids-equalize-all-modern-ie-rtl;
+			}
+		}
+
+		// IE9/10 don't support outline-offset, so equalize.js provides the equal height
+		%grids-equalize-all-modern-ie {
+		    .equalize {
+		        > {
+		            [class*="module-"] {
+		                border: 0;
+		                float: left !important;
+		                display: block !important;
+		            }
+		        }
+		        &.module-gutter-bottom {
+		            border-bottom: 0;
+		        }
+		    }
+		}
+
+		%grids-equalize-all-modern-ie-rtl {
+			.equalize {
+				> {
+					[class*="module-"] {
 						float: right !important;
 					}
 				}

--- a/src/grids/sass/includes/_equalize.scss
+++ b/src/grids/sass/includes/_equalize.scss
@@ -1,0 +1,98 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ */
+
+@import "compass/css3/box-sizing";
+@import "compass/css3/background-clip";
+@import "compass/css3/background-origin";
+
+@mixin equalize {
+	@if not $legacy-support-for-ie {
+
+		// TODO: switch to 'display: flex' when support improves (see issue #907)
+		.equalize {
+			margin-bottom: 0 !important;
+			display: table !important;
+			table-layout: fixed;
+			> * {
+				float: none !important;
+				display: table-cell !important;
+				vertical-align: top !important;
+			}
+			> [class*="span-"] {
+				border: 0 solid transparent;
+				border-width: 0 10px 20px 10px;
+				@include background-clip(padding-box);
+				@include background-origin(padding-box);
+				&.row-start {
+					border-left: 0;
+				}
+				&.row-end {
+					border-right: 0;
+				}
+			}
+			> [class*="module-"] {
+				border: 10px solid transparent;
+				outline-offset: -10px;
+				@include box-sizing(content-box);
+			}
+			&.module-gutter-bottom {
+				border-bottom: 10px solid transparent;
+			}
+		}
+
+		.ie9, .ie10 {
+			.equalize {
+				> [class*="module-"] {
+					border: 0;
+					float: left !important;
+					display: block !important;
+				}
+				&.module-gutter-bottom {
+					border-bottom: 0;
+				}
+			}
+		}
+
+		#wb-core-in {
+			&.equalize {
+				direction: rtl;
+				> * {
+					direction: ltr;
+				}
+			}
+		}
+
+		/* Right to left (RTL) CSS */
+		[dir="rtl"] {
+			.equalize {
+				> [class*="span-"] {
+					&.row-start {
+						border-left-width: 10px;
+						border-right: 0;
+					}
+					&.row-end {
+						border-left: 0;
+						border-right-width: 10px;
+					}
+				}
+			}
+			#wb-core-in {
+				&.equalize {
+					direction: ltr;
+					> * {
+						direction: rtl;
+					}
+				}
+			}
+			&.ie9, &.ie10 {
+				.equalize {
+					> [class*="module-"] {
+						float: right !important;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/grids/sass/includes/_util-desktop-screen.scss
+++ b/src/grids/sass/includes/_util-desktop-screen.scss
@@ -4,6 +4,10 @@
  */
 @import "compass/css3/columns";
 
+@import "equalize";
+
+@include equalize;
+
 /*	 columns	 */
 .column-two {
 	@include column-count(2);

--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -143,6 +143,11 @@
 			// Identify whether or not the device supports JavaScript and has a touchscreen
 			$html.removeClass('no-js').addClass(wet_boew_theme !== null ? wet_boew_theme.theme : '').addClass(pe.touchscreen ? 'touchscreen' : '');
 
+			// Identify IE9+ browser
+			if (pe.ie > 8) {
+				$html.addClass('ie' + parseInt(pe.ie, 10));
+			}
+
 			hlinks = pe.bodydiv.find('#wb-main a, #wb-skip a').filter(function () {
 				return this.href.indexOf('#') !== -1;
 			});
@@ -202,8 +207,12 @@
 					}
 				}
 
-				if (pe.ie > 0 && pe.ie < 9) {
-					pe.wb_load({'plugins': {'css3ie': pe.main}}, 'css3ie-loaded');
+				if (pe.ie > 0) {
+					if (pe.id < 9) {
+						pe.wb_load({'plugins': {'css3ie': pe.main}}, 'css3ie-loaded');
+					} else {
+						pe.wb_load({'plugins': {'equalize': pe.main}}, 'equalize-loaded');
+					}
 				}
 			});
 

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -11,7 +11,7 @@ WET-BOEW-Settings
  */
 var wet_boew_properties = {
 	/** global plugins are called via a array of dependency names **/
-	globals : ['equalize', 'deselectradio', 'css3ie', 'datemodified']
+	globals : ['deselectradio', 'css3ie', 'datemodified']
 };
 
 /*


### PR DESCRIPTION
Replaces equalize.js with CSS only equal heights using display table and table-cell (#75, #907).  
1. FF, Opera, WebKit use CSS only equal heights.
2. IE9/10 use CSS only equal heights with fallback to equalize.js for [class^="module-"] elements (no support for outline-offset).
3. IE7/8 use equalize.js.
