### PR TITLE
Move IE8 button disabled fix to mixin

### DIFF
--- a/src/grids/sass/includes/_button.scss
+++ b/src/grids/sass/includes/_button.scss
@@ -21,15 +21,7 @@
 			@include single-transition(background-position, 0.1s, linear);
 		}
 
-		&.button-disabled { //TODO: merge the disabled items together as they are apart for now for IE8
-			background: none;
-			@include box-shadow(none);
-			cursor: default;
-			font-style: italic;
-			@include text-shadow(none);
-		}
-		
-		&:disabled {  //TODO: merge the disabled items together as they are apart for now for IE8
+		@include button-disabled {
 			background: none;
 			@include box-shadow(none);
 			cursor: default;
@@ -76,14 +68,7 @@
 				color: $attention !important;
 			}
 
-			&.button-disabled {  //TODO: merge the disabled items together as they are apart for now for IE8
-				text-decoration: none !important;
-				&:hover, &:focus, &:active {
-					color: $dark !important;
-				}
-			}
-			
-			&:disabled {  //TODO: merge the disabled items together as they are apart for now for IE8
+			@include button-disabled {
 				text-decoration: none !important;
 				&:hover, &:focus, &:active {
 					color: $dark !important;
@@ -220,11 +205,7 @@
 			border-color: $text;
 		}
 	}
-	&.button-disabled { //TODO: merge the disabled items together as they are apart for now for IE8
-		background-color: $color;
-		border-color: darken($color, 5%);
-	}
-	&:disabled { //TODO: merge the disabled items together as they are apart for now for IE8
+	@include button-disabled {
 		background-color: $color;
 		border-color: darken($color, 5%);
 	}
@@ -234,4 +215,20 @@
 	font-size: $size;
 	line-height: $height;
 	padding: $padding;
+}
+
+@mixin button-disabled() {
+	@if $legacy-support-for-ie8 {
+		&.button-disabled {
+			@content;
+		}
+		
+		&:disabled {
+			@content;
+		}
+	} @else {
+		&.button-disabled, &:disabled {
+			@content;
+		}
+	}
 }


### PR DESCRIPTION
Modern browser CSS will keep it as a single rule, IE8 CSS duplicates the
rule for the :disabled bug
