### PR TITLE
Remove text-shadow mixin calls

### DIFF
--- a/src/grids/sass/includes/_button.scss
+++ b/src/grids/sass/includes/_button.scss
@@ -2,7 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 @import "compass/css3/box-shadow";
 @import "compass/css3/border-radius";
 @import "compass/css3/images";
@@ -26,7 +25,7 @@
 			@include box-shadow(none);
 			cursor: default;
 			font-style: italic;
-			@include text-shadow(none);
+			text-shadow: none;
 		}
 		
 		&:disabled {  //TODO: merge the disabled items together as they are apart for now for IE8
@@ -34,7 +33,7 @@
 			@include box-shadow(none);
 			cursor: default;
 			font-style: italic;
-			@include text-shadow(none);
+			text-shadow: none;
 		}
 	}
 
@@ -70,7 +69,7 @@
 				@include box-shadow(none);
 				outline-color: transparent;
 				text-decoration: underline;
-				@include text-shadow(none);
+				text-shadow: none;
 			}
 			&:hover, &:focus, &:active {
 				color: $attention !important;
@@ -209,7 +208,7 @@
 
 	$text: contrast-color($color, $dark, $white, 55%);
 	color: $text !important;
-	@include text-shadow(contrast-color($text, $dark, $white, 50%) 0 1px 1px);
+	text-shadow: 0 1px 1px contrast-color($text, $dark, $white, 50%);
 
 	@include background-image(linear-gradient($color, darken($color, 10%)));
 	&:hover, &:focus, &:active {

--- a/src/grids/sass/includes/_mixins.scss
+++ b/src/grids/sass/includes/_mixins.scss
@@ -2,7 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 @import "compass/utilities/color";
 
 $sans-serif:		Verdana, Arial, Helvetica, sans-serif;
@@ -122,7 +121,7 @@ $default-box-shadow-v-offset: 0;
 
 	// add text shadow
 	@if $shadow == true {
-		@include text-shadow(contrast-color($text, $dark, $white, 50%) 0 1px 1px);
+		text-shadow: 0 1px 1px contrast-color($text, $dark, $white, 50%);
 	}
 
 	// add gradient

--- a/src/grids/sass/includes/_module.scss
+++ b/src/grids/sass/includes/_module.scss
@@ -2,7 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 @import "compass/css3/box-sizing";
 @import "compass/typography/lists/bullets";
 @import "compass/css3/border-radius";
@@ -74,7 +73,7 @@
 						text-decoration: none;
 						background-repeat: no-repeat;
 						background-position: 100% 0; //top right;
-						@include text-shadow(-1px -1px 0 #333, 1px -1px 0 #333, -1px 1px 0 #555, 1px 1px 0 #000);
+						text-shadow: -1px -1px 0 #333, 1px -1px 0 #333, -1px 1px 0 #555, 1px 1px 0 #000;
 						font-weight: 700;
 						@include colorize-base($accent);
 					}

--- a/src/grids/sass/includes/_table.scss
+++ b/src/grids/sass/includes/_table.scss
@@ -2,7 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 
 @mixin tables {
 
@@ -178,7 +177,7 @@
 	th {
 		background-color: $color;
 		color: $text;
-		@include text-shadow($shadow 0 1px 1px);
+		text-shadow: 0 1px 1px $shadow;
 	}
 
 }

--- a/src/grids/sass/includes/_util-screen.scss
+++ b/src/grids/sass/includes/_util-screen.scss
@@ -194,7 +194,7 @@ code {	font: {
 		weight: $font-weight-normal;
 	}
 	padding: 0 2px !important;
-	@include text-shadow(none);
+	text-shadow: none;
 
 	@include colorize-base($light);
 	@include colorize-border($light);
@@ -384,7 +384,7 @@ table {
 		text-align: center;
 		color: #fff;
 		font-size: 85%;
-		@include text-shadow(0 1px 0 #111);
+		text-shadow: 0 1px 0 #111;
 		margin: 5px 0 0 0;
 		margin: 0 8px;
 		padding: 0 0 1px 0;
@@ -410,7 +410,7 @@ table {
 		color: $dark;
 		letter-spacing: -0.1em;
 		line-height: 55px;
-		@include text-shadow(1px 1px 0 $white);
+		text-shadow: 1px 1px 0 $white;
 		margin: 0 !important;
 		width: 100%;
 	}

--- a/src/js/sass/includes/_archived.scss
+++ b/src/js/sass/includes/_archived.scss
@@ -2,7 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 
 #archived {
 	background-color: #FFFFCC;
@@ -35,7 +34,7 @@
 		color: #333333;
 		padding: 0 0 2px 0;
 		position: relative;
-		@include text-shadow(none);
+		text-shadow: none;
 		&[href] {
 			&:link, &:hover, &:focus, &:active {
 				color: #FFFFFF;

--- a/src/js/sass/includes/_footnotes-ie7.scss
+++ b/src/js/sass/includes/_footnotes-ie7.scss
@@ -2,7 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 @import "compass/css3/inline-block";
 
 /*SCSS Variables*/
@@ -38,7 +37,6 @@ $clrDark: #555;
 								color: $clrWhite !important;
 								background-color: $clrDark;
 								border-color: $clrDark;
-								@include text-shadow(none !important);
 							}
 						}
 					}

--- a/src/js/sass/includes/_footnotes.scss
+++ b/src/js/sass/includes/_footnotes.scss
@@ -2,7 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 @import "compass/css3/inline-block";
 
 /*SCSS Variables*/
@@ -18,7 +17,7 @@ $clrDark: #555;
 	color: $clrWhite !important;
 	background-color: $clrDark;
 	border-color: $clrDark;
-	@include text-shadow(none !important);
+	text-shadow: none !important;
 }
 %footnote-link-background-white {
 	background-color: $clrWhite;
@@ -50,7 +49,7 @@ table {
 			a {
 				&.footnote-link {
 					@extend %footnote-link-background-white;
-					@include text-shadow(none);
+					text-shadow: none;
 				}
 			}
 		}

--- a/src/js/sass/includes/_prettify.scss
+++ b/src/js/sass/includes/_prettify.scss
@@ -2,7 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 
 /* Pretty printing styles. Used with prettify.js. */
 
@@ -92,7 +91,7 @@ ol {
 		margin: 0 0 0 32px !important;
 		li {
 			padding-left: 10px;
-			@include text-shadow(0 1px 0 #fff);
+			text-shadow: 0 1px 0 #fff;
 		}
 	}
 }

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
@@ -2,7 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 @import "compass/css3/border-radius";
 @import "compass/css3/box-shadow";
 @import "compass/css3/appearance";
@@ -262,7 +261,7 @@ a {
 		color: #fff;
 		font-size: 1.52em;
 		font-family: Arial, Helvetica, sans-serif;
-		@include text-shadow(#333 1px 1px 1px);
+		text-shadow: 1px 1px 1px #333;
 	}
 }
 
@@ -335,13 +334,13 @@ a {
 	}
 	color: #333;
 	@include border-radius(2px);
-	@include text-shadow(0 1px 0 #eee);
+	text-shadow: 0 1px 0 #eee;
 	font-weight: 400;
 	@include box-shadow(none);
 	padding: 2px 6px;
 	display: inline;
 	&:focus, &:hover {
-		@include text-shadow(0 1px 0 #ddd);
+		text-shadow: 0 1px 0 #ddd;
 		@include box-shadow(none);
 		border: {
 			bottom: 1px solid #999;

--- a/src/theme-gcwu-fegc/sass/includes/_default-mobile.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-mobile.scss
@@ -2,7 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 @import "compass/css3/box-shadow";
 @import "compass/css3/border-radius";
 @import "compass/css3/images";
@@ -31,7 +30,7 @@ blockquote {
 %no-margin-no-shadow {
 	margin-left: 0;
 	margin-right: 0;
-	@include text-shadow(none);
+	text-shadow: none;
 }
 
 form {
@@ -108,7 +107,7 @@ table {
 	a {
 		font-size: 1.5em;
 		color: #fff !important;
-		@include text-shadow(0 1px 1px #044062);
+		text-shadow: 0 1px 1px #044062;
 		text-decoration: none;
 	}
 }
@@ -320,7 +319,7 @@ table {
 	float: right;
 	border-top: 1px solid #044062;
 	h2 {
-		@include text-shadow(0 1px 1px #044062);
+		text-shadow: 0 1px 1px #044062;
 		background-color: #333333;
 		@include background-image(linear-gradient(#444444, #2D2D2D));
 		&:hover, &:focus, &:active {
@@ -420,7 +419,7 @@ table {
 	}
 	li {
 		color: #333;
-		@include text-shadow(0 1px 0 #fff);
+		text-shadow: 0 1px 0 #fff;
 		position: relative;
 		z-index: 1;
 		h3 {
@@ -676,7 +675,7 @@ table {
 		@include background-image(linear-gradient(#F0EFEF, #DFDFDD));
 		color: #555;
 		@include border-radius(0);
-		@include text-shadow(0 1px 1px #fff);
+		text-shadow: 0 1px 1px #fff;
 		border-bottom: 1px solid #ccc;
 		@include box-shadow(0 1px 2px rgba(0, 0, 0, 0.3));
 		a {

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe.scss
@@ -5,7 +5,6 @@
 @import "compass/css3/inline-block";
 @import "compass/css3/appearance";
 @import "compass/css3/border-radius";
-@import "compass/css3/text-shadow";
 @import "compass/css3/box-shadow";
 
 h1 {
@@ -89,7 +88,7 @@ h2 {
 			color: #333;
 			padding: 10px 0;
 			@include border-radius(2px);
-			@include text-shadow(0 1px 0 #eee);
+			text-shadow: 0 1px 0 #eee;
 			font: {
 				weight: 700;
 				size: 120%;
@@ -99,7 +98,7 @@ h2 {
 			text-decoration: none;
 			text-transform: capitalize;
 			&:hover, &:focus, &:active {
-				@include text-shadow(0 1px 0 #ddd);
+				text-shadow: 0 1px 0 #ddd;
 				@include box-shadow(none);
 				border: 1px solid #999;
 			}

--- a/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen.scss
@@ -17,7 +17,7 @@
 	h3 {
 		&.top-section {
 			margin: 0 0 2px -10px;
-			@include text-shadow(1px 1px 1px #fff);
+			text-shadow: 1px 1px 1px #fff;
 			background: #bbb url(../images/core/top-section.png) repeat-x 0 0 !important;
 			@include border-radius(0 2px 2px 0);
 			border: medium none;
@@ -86,7 +86,7 @@
 		repeat: repeat-x;
 		position: 0 -170px;
 	}
-	@include text-shadow(1px 1px 1px #333);
+	text-shadow: 1px 1px 1px #333;
 	a {
 		&:hover, &:focus {
 			text-decoration: underline;

--- a/src/theme-gcwu-intranet/sass/includes/_default-mobile.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-mobile.scss
@@ -7,7 +7,7 @@
 		border-top: 1px solid #CCC;
 		clear: both;
 		font-size: 130%;
-		@include text-shadow(1px 1px 1px #333);
+		text-shadow: 1px 1px 1px #333;
 		background: url(../images/gcwu-subsite-1.gif) repeat-x scroll 0 top #618000;
 		p {
 			margin: 0;
@@ -54,7 +54,7 @@
 
 #gcwu-subsite {
 	font-size: 130%;
-	@include text-shadow(1px 1px 1px #333);
+	text-shadow: 1px 1px 1px #333;
 	p {
 		margin: {
 			top: 0;

--- a/src/theme-gcwu-intranet/sass/includes/_default.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default.scss
@@ -2,14 +2,13 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/text-shadow";
 
 /** From branding.css **/
 .gcwu-subsite-1 {
 	background: #618000 url(../images/gcwu-subsite-1.gif) repeat-x 0 top;
 	a {
 		color: #fff !important;
-		@include text-shadow(1px 1px 1px #333 !important);
+		text-shadow: 1px 1px 1px #333 !important;
 	}
 }
 
@@ -50,7 +49,7 @@
 	border-top: 1px solid #ccc;
 	clear: left;
 	font-size: 130%;
-	@include text-shadow(1px 1px 1px #333);
+	text-shadow: 1px 1px 1px #333;
 	p {
 		margin: 0 auto;
 		padding: {
@@ -62,7 +61,7 @@
 		color: #fff;
 		text-decoration: none;
 		padding: 0 5px 0 10px;
-		@include text-shadow(1px 1px 1px #333);
+		text-shadow: 1px 1px 1px #333;
 		border-left: 1px solid #ccc;
 		font-size: 75%;
 		&:first-child {


### PR DESCRIPTION
After further research, this mixin doesn't add any value http://compass-style.org/reference/compass/css3/text-shadow/
- Removed the call in footer-ie since the property is only supported
  IE10+
- Standardize all calls to use the colour last format

Since the property is only supported in IE9, a custom mixin may be
desired to polyfill with the MS filter version
