### PR TITLE
Use mixin for clip properties

### DIFF
--- a/src/base/sass/_default-ie.scss
+++ b/src/base/sass/_default-ie.scss
@@ -3,33 +3,15 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 .ie7 {
-	%base-ie7-clip-rect-1
-	{
-		clip: rect(1px 1px 1px 1px);
-	}
 	#wb-skip {
 		a {
-			@extend .wb-show-onfocus;
-			&:link, &:visited {
-				@extend %base-ie7-clip-rect-1;
-			}
-		}
-	}
-	#wb-sec {
-		h2 {
-			@extend %base-ie7-clip-rect-1;
-		}
-	}
-	#wb-sup {
-		h2 {
-			@extend %base-ie7-clip-rect-1;
+			@extend .wb-show-onfocus; //TODO: Move to placeholder
 		}
 	}
 	.wb-invisible {
 		position: relative;
 		float: left;
 		margin-bottom: -1px !important;
-		@extend %base-ie7-clip-rect-1;
 	}
 	.wb-show-onfocus {
 		@extend .wb-invisible;

--- a/src/base/sass/_default-screen.scss
+++ b/src/base/sass/_default-screen.scss
@@ -48,7 +48,7 @@ a.wb-linkdesc {
 	span {
 		span {
 			position: absolute;
-			clip: rect(1px, 1px, 1px, 1px);
+			@include clip-rect;
 			height: 1px !important;
 			width: 1px !important;
 			overflow: hidden !important;

--- a/src/base/sass/_default.scss
+++ b/src/base/sass/_default.scss
@@ -2,7 +2,8 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-@import "compass/css3/opacity";
+@import 'compass/css3/opacity';
+@import '../../grids/sass/includes/mixins';
 
 body {
 	font-size: 80%;
@@ -96,7 +97,7 @@ h6 {
 
 %base-clip-hidden {
 	position: absolute;
-	clip: rect(1px, 1px, 1px, 1px);
+	@include clip-rect;
 	height: 1px !important;
 	width: 1px !important;
 	overflow: hidden !important;

--- a/src/grids/sass/includes/_mixins.scss
+++ b/src/grids/sass/includes/_mixins.scss
@@ -152,3 +152,11 @@ $default-box-shadow-v-offset: 0;
   }
   @return $value;
 }
+
+@mixin clip-rect($top: 1px, $right: 1px, $bottom: 1px, $left: 1px) {
+	@if $legacy-support-for-ie {
+		clip: rect($top $right $bottom $left);
+	} @else {
+		clip: rect($top, $right, $bottom, $left);
+	}
+}

--- a/src/js/sass/includes/_footnotes.scss
+++ b/src/js/sass/includes/_footnotes.scss
@@ -3,6 +3,7 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/inline-block";
+@import '../../grids/sass/includes/mixins';
 
 /*SCSS Variables*/
 $spacing: .375em;
@@ -73,7 +74,7 @@ table {
 		margin: 0;
 		dt {
 			position: absolute;
-			clip: rect(1px, 1px, 1px, 1px);
+			@include clip-rect;
 			height: 1px;
 			width: 1px;
 			overflow: hidden;

--- a/src/theme-clf2-nsi2/sass/includes/_default-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-ie.scss
@@ -3,28 +3,7 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
  .ie7 {
- 	%clf2-default-ie7-clip-1px {
-		clip: rect(1px 1px 1px 1px);
-	}
-	#cn-psnb {
-		h2 {
-			@extend %clf2-default-ie7-clip-1px;
-		}
-	}
-	#cn-psnb-2 {
-		h2 {
-			@extend %clf2-default-ie7-clip-1px;
-		}
-	}
-	#cn-in-pd {
-		h3 {
-			@extend %clf2-default-ie7-clip-1px;
-		}
-	}
 	%clf2-default-ie7-bc-all {
-		h2 {
-			@extend %clf2-default-ie7-clip-1px;
-		}
 		ol {
 			margin: 1px 0 3px 0;
 			clear: left;
@@ -34,11 +13,7 @@
 			padding-bottom: 3px;
 		}
 	}
-	#cn-bc {
-		@extend %clf2-default-ie7-bc-all;
-	}
 	#cn-bc2 {
-		@extend %clf2-default-ie7-bc-all;
 		ol {
 			margin-top: -3px;
 		}

--- a/src/theme-clf2-nsi2/sass/includes/_default.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default.scss
@@ -2,6 +2,9 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
+
+@import '../../grids/sass/includes/mixins';
+
 .wb-sec-def {
 	h3 {
 		margin: {
@@ -16,7 +19,7 @@
 
 %clf2-default-hidden {
 	position: absolute;
-	clip: rect(1px, 1px, 1px, 1px);
+	@include clip-rect;
 	height: 1px !important;
 	width: 1px !important;
 	overflow: hidden !important;

--- a/src/theme-clf2-nsi2/sass/includes/_serv-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-ie.scss
@@ -2,21 +2,3 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
-.ie8 {
- 	%clf2-serv-ie8-clip {
-		clip: rect(1px 1px 1px 1px);
-		height: 1px !important;
-		width: 1px !important;
-		overflow: hidden !important;
-	}
-	#wb-body {
-		h1 {
-			@extend %clf2-serv-ie8-clip;
-		}
-	}
-	#cn-in-pd {
-		h3 {
-			@extend %clf2-serv-ie8-clip;
-		}
-	}
-}

--- a/src/theme-clf2-nsi2/sass/includes/_serv.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv.scss
@@ -4,7 +4,7 @@
  */
 %clf2-serv-clip {
 	position: absolute;
-	clip: rect(1px, 1px, 1px, 1px);
+	@include clip-rect;
 	height: 1px !important;
 	width: 1px !important;
 	overflow: hidden !important;

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-ie.scss
@@ -3,19 +3,6 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 .ie7 {
- 	%clf2-sp-pe-ie7-clip {
-		clip: rect(1px 1px 1px 1px);
-	}
-	#wb-main-in {
-		h1 {
-			@extend %clf2-sp-pe-ie7-clip;
-		}
-	}
-	#cn-in-pd {
-		h3 {
-			@extend %clf2-sp-pe-ie7-clip;
-		}
-	}
 	#cn-lower-msg {
 		p {
 			margin-top: 18px;

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe.scss
@@ -74,7 +74,7 @@ body {
 
 %clf2-sp-pe-clip {
 	position: absolute;
-	clip: rect(1px, 1px, 1px, 1px);
+	@include clip-rect;
 	height: 1px !important;
 	width: 1px !important;
 	overflow: hidden !important;

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
@@ -39,7 +39,7 @@ a {
 %gcwu-default-desktop-screen-hidden-img {
 	img {
 		position: absolute;
-		clip: rect(1px, 1px, 1px, 1px);
+		@include clip-rect;
 		height: 0 !important;
 		width: 0 !important;
 		overflow: hidden !important;
@@ -295,7 +295,7 @@ a {
 	}
 	label {
 		position: absolute;
-		clip: rect(1px, 1px, 1px, 1px);
+		@include clip-rect;
 		height: 1px;
 		width: 1px;
 		overflow: hidden;

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop.scss
@@ -5,7 +5,7 @@
 %gcwu-default-desktop-hidden-h2 {
 	h2 {
 		position: absolute;
-		clip: rect(1px, 1px, 1px, 1px);
+		@include clip-rect;
 		height: 0 !important;
 		width: 0 !important;
 		overflow: hidden !important;

--- a/src/theme-gcwu-fegc/sass/includes/_default-mobile.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-mobile.scss
@@ -87,7 +87,7 @@ table {
 #wb-head {
 	@extend %period-after-pseudo;
 	#gcwu-wmms {
-		clip: rect(1px, 1px, 1px, 1px);
+		@include clip-rect;
 		height: 0 !important;
 		overflow: hidden !important;
 		position: absolute;
@@ -511,7 +511,7 @@ table {
 #jqm-wb-search {
 	@extend %gcwu-default-mobile-ui-bar-a-h1-white;
 	label {
-		clip: rect(1px, 1px, 1px, 1px);
+		@include clip-rect;
 		height: 1px;
 		overflow: hidden;
 		position: absolute;

--- a/src/theme-gcwu-fegc/sass/includes/_default.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default.scss
@@ -21,7 +21,7 @@
 }
 
 %gcwu-default-hidden {
-	clip: rect(1px, 1px, 1px, 1px);
+	@include clip-rect;
 	height: 0 !important;
 	overflow: hidden !important;
 	position: absolute;

--- a/src/theme-gcwu-fegc/sass/includes/_serv-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-ie.scss
@@ -5,7 +5,7 @@
 .ie7 {
 	h1 {
 		position: absolute;
-		clip: rect(1px 1px 1px 1px);
+		@include clip-rect;
 		height: 1px !important;
 		width: 1px !important;
 		overflow: hidden !important;

--- a/src/theme-gcwu-fegc/sass/includes/_serv.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv.scss
@@ -5,7 +5,7 @@
 
 h1 {
 	position: absolute;
-	clip: rect(1px, 1px, 1px, 1px);
+	@include clip-rect;
 	height: 0 !important;
 	width: 0 !important;
 	overflow: hidden !important;

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-ie.scss
@@ -4,11 +4,7 @@
  */
 .ie7 {
 	h2 {
-		position: absolute;
-		clip: rect(1px 1px 1px 1px);
 		height: 1px !important;
 		width: 1px !important;
-		overflow: hidden !important;
-		margin: 0 !important;
 	}
 }

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe.scss
@@ -17,7 +17,7 @@ h1 {
 
 h2 {
 	position: absolute;
-	clip: rect(1px, 1px, 1px, 1px);
+	@include clip-rect;
 	height: 0 !important;
 	width: 0 !important;
 	overflow: hidden !important;

--- a/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen.scss
@@ -132,7 +132,7 @@
 %intranet-default-desktop-screen-clip-auto {
 	img {
 		position: absolute;
-		clip: rect(auto, auto, auto, auto);
+		@include clip-rect(auto, auto, auto, auto);
 		width: auto !important;
 	}
 }


### PR DESCRIPTION
Since the IE requires that clip properties be comma free, this mixin uses the compiler conditional to emit the correct format. This meant several IE overrides could be removed
