### PR TITLE
Charts: Concat Flot and plugins during build

### DIFF
--- a/src/js/build.xml
+++ b/src/js/build.xml
@@ -16,7 +16,7 @@
 
 	<target name="default" depends="clean,build" description="Performs a clean and build when calling ant without any target"/>
 
-	<target name="copy-all" extensionOf="prepare-files" depends="-copy-css,-copy-images,-copy-js,-copy-depends,-build-pe,-copy-binaries"/>
+	<target name="copy-all" extensionOf="prepare-files" depends="-copy-css,-copy-images,-copy-js,-copy-depends,-build-flot,-build-pe,-copy-binaries"/>
 	
 	<target name="-copy-binaries">
 		<copy todir="${dist.dir}">  
@@ -31,6 +31,7 @@
 		<exclude name="workers/**"/>
 		<exclude name="pe-ap.js"/>
 		<exclude name="i18n/base.js"/>
+		<exclude name="dependencies/flot*.js"/>
 	</fileset>
 
 	<!-- Build JS Tasks -->
@@ -48,6 +49,12 @@
 		</concat>
 		<!-- Temporary fix - to be replaced by modern and old IE targeted output -->
 		<copy file="${dist.dir}/pe-ap.js" tofile="${dist.dir}/pe-ap-ie.js"/>
+	</target>
+	
+	<target name="-build-flot" description="Concat flot and any plugins into single file. Done for gh-1276">
+		<concat dest="${dist.dir}/dependencies/flot.js" fixlastline="yes">
+			<fileset dir="${src.dir}/dependencies" includes="flot*.js" />
+		</concat>
 	</target>
 	
 	<target name="-build-i18n" depends="-get-validation-languages">

--- a/src/js/workers/charts.js
+++ b/src/js/workers/charts.js
@@ -5,7 +5,7 @@
 /*
  * Charts and graphs
  */
-/*global jQuery: false, pe:false, wet_boew_charts: false, Raphael: false*/
+/*global jQuery: false, pe:false*/
 (function ($) {
 	"use strict";
 	var _pe = window.pe || {
@@ -13,7 +13,7 @@
 	}; /* local reference */
 	_pe.fn.charts = {
 		type: 'plugin',
-		depends: ['parserTable', 'excanvas', 'flot', 'flotPie', 'charts'],
+		depends: ['parserTable', 'excanvas', 'flot', 'charts'],
 		polyfills: ['detailssummary'],
 		_exec: function (elm) {
 			_pe.fn.chartsGraph.generate(elm);


### PR DESCRIPTION
Fixes gh-1276
- Cleaned up JSHint globals at top
- Removed additional flotPie depends since it is no longer a descrete
  file
- Any future plugins will be included in this output file as long as
  they keep the flot\* naming
