### PR TITLE
Add focus mixin

### DIFF
--- a/src/base/sass/_default-ie.scss
+++ b/src/base/sass/_default-ie.scss
@@ -5,36 +5,45 @@
 .ie7 {
 	#wb-skip {
 		a {
-			@extend .wb-show-onfocus; //TODO: Move to placeholder
+			@extend %base-default-ie7-relative-float-left;
+			@extend %base-default-ie7-show-focus;
 		}
 	}
-	.wb-invisible {
+	%base-default-ie7-relative-float-left {
 		position: relative;
 		float: left;
 		margin-bottom: -1px !important;
 	}
-	.wb-show-onfocus {
-		@extend .wb-invisible;
-		&:focus, &:active {
+	.wb-invisible {
+		@extend %base-default-ie7-relative-float-left;
+	}
+	%base-default-ie7-show-focus {
+		@include pseudo-focus(false) {
 			width: auto !important;
 			height: auto !important;
 			overflow: visible !important;
 			white-space: nowrap;
 		}
 	}
-
-	.wb-show-onhover {
+	.wb-show-onfocus {
+		@extend %base-default-ie7-relative-float-left;
+		@extend %base-default-ie7-show-focus;
+	}
+	%base-default-ie7-transparent {
 		@include transparent;
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			@include opaque;
 		}
+	}
+	.wb-show-onhover {
+		@extend %base-default-ie7-transparent;
 	}
 
 	a {
 		&.wb-linkdesc {
 			span {
 				span {
-					@extend .wb-show-onhover;
+					@extend %base-default-ie7-transparent;
 				}
 			}
 		}

--- a/src/base/sass/_default-screen-ie.scss
+++ b/src/base/sass/_default-screen-ie.scss
@@ -22,7 +22,7 @@
 					top: -9000em;
 				}
 			}
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				height: 1%;
 			}
 		}
@@ -32,7 +32,7 @@
 .ie8 {
 	.wb-show-onhover {
 		@include transparent;
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			@include opaque;
 		}
 	}

--- a/src/base/sass/_default-screen.scss
+++ b/src/base/sass/_default-screen.scss
@@ -3,7 +3,7 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 a {
-	&:active, &:focus {
+	@include pseudo-focus(false) {
 		cursor: auto;
 	}
 }
@@ -34,7 +34,7 @@ abbr, acronym {
 			background-color: transparent;
 			font-weight: 700;
 		}
-		&:focus, &:active {
+		@include pseudo-focus(false) {
 			background-color: #000;
 			text-decoration: none;
 			color: #FFF;
@@ -54,7 +54,7 @@ a.wb-linkdesc {
 			overflow: hidden !important;
 		}
 	}
-	&:hover, &:focus, &:active {
+	@include pseudo-focus {
 		z-index: 25;
 		outline: 0;
 		text-decoration: none;

--- a/src/base/sass/_default.scss
+++ b/src/base/sass/_default.scss
@@ -13,7 +13,7 @@ body {
 }
 
 a {
-	&:hover, &:focus, &:active {
+	@include pseudo-focus {
 		text-decoration: underline;
 	}
 }
@@ -116,7 +116,7 @@ h6 {
 
 %base-clip-focus-active {
 	@extend %base-clip-hidden;
-	&:focus, &:active {
+	@include pseudo-focus(false) {
 		position: static;
 		clip: auto;
 		height: inherit !important;
@@ -141,7 +141,7 @@ h6 {
 
 .wb-show-onhover {
 	@include transparent;
-	&:hover, &:focus, &:active {
+	@include pseudo-focus {
 		@include opaque;
 	}
 }

--- a/src/base/sass/_modern-vendor-prefix.scss
+++ b/src/base/sass/_modern-vendor-prefix.scss
@@ -4,6 +4,8 @@
  */
 /* turn off fixes for old IE */
 $legacy-support-for-ie: false;
+$legacy-support-for-ie7: false;
+$legacy-support-for-ie8: false;
 $experimental-support-for-mozilla:true;
 $experimental-support-for-webkit: true;
 $support-for-original-webkit-gradients: true;

--- a/src/grids/sass/includes/_button.scss
+++ b/src/grids/sass/includes/_button.scss
@@ -13,7 +13,7 @@
 		background-image: none;
 		@include button($light);
 
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			background-position: 0 -15px;
 			text-decoration: none;
 			outline-offset: -6px;
@@ -37,6 +37,14 @@
 		@extend %grid-button-color-button-accent;
 	}
 
+	%button-none-style {
+		background: none;
+		border-color: transparent !important;
+		@include box-shadow(none);
+		outline-color: transparent;
+		text-decoration: underline;
+		text-shadow: none;
+	}
 	/* without line 29 the buttons would not be coloured in IE, move to fixes? */
 	input, button, a, summary {
 		&.button-accent {
@@ -58,21 +66,17 @@
 			@include color-button($attention);
 		}
 		&.button-none {
-			&, &:hover, &:focus, &:active {
-				background: none;
-				border-color: transparent !important;
-				@include box-shadow(none);
-				outline-color: transparent;
-				text-decoration: underline;
-				text-shadow: none;
+			@extend %button-none-style;
+			@include pseudo-focus {
+				@extend %button-none-style;
 			}
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				color: $attention !important;
 			}
 
 			@include button-disabled {
 				text-decoration: none !important;
-				&:hover, &:focus, &:active {
+				@include pseudo-focus {
 					color: $dark !important;
 				}
 			}
@@ -107,7 +111,7 @@
 			margin-left: -1px;
 			@include border-radius(0);
 
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				z-index: 2;
 			}
 		}
@@ -199,7 +203,7 @@
 	text-shadow: 0 1px 1px contrast-color($text, $dark, $white, 50%);
 
 	@include background-image(linear-gradient($color, darken($color, 10%)));
-	&:hover, &:focus, &:active {
+	@include pseudo-focus {
 		background-color: darken($color, 10%);
 	}
 	@if $experimental-support-for-mozilla {

--- a/src/grids/sass/includes/_form.scss
+++ b/src/grids/sass/includes/_form.scss
@@ -197,7 +197,7 @@
 			position: relative;
 			vertical-align: middle;
 
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				z-index: 2;
 			}
 		}
@@ -274,7 +274,7 @@
 		border-color: darken($light, 15%);
 		@include box-shadow(inset 0 1px 1px rgba(0, 0, 0, 0.05));
 
-		&:focus, &:active {
+		@include pseudo-focus(false) {
 			border-color: $accent;
 
 			@include transition(border 0.2s linear 0s, box-shadow 0.2s linear 0s);
@@ -287,7 +287,7 @@
 			color: $medium;
 			cursor: not-allowed;
 
-			&:focus, &:active {
+			@include pseudo-focus(false) {
 				@include box-shadow(none);
 			}
 		}
@@ -299,19 +299,19 @@
 		// apply color to the form element
 		.form-confirm & {
 			border-color: $summary;
-			&:focus, &:active {
+			@include pseudo-focus(false) {
 				@include single-box-shadow($summary);
 			}
 		}
 		.form-attention & {
 			border-color: $attention;
-			&:focus, &:active {
+			@include pseudo-focus(false) {
 				@include single-box-shadow($attention);
 			}
 		}
 		.form-alert & {
 			border-color: darken($alert, 37%);
-			&:focus, &:active {
+			@include pseudo-focus(false) {
 				@include single-box-shadow(darken($alert, 37%));
 			}
 		}

--- a/src/grids/sass/includes/_mixins.scss
+++ b/src/grids/sass/includes/_mixins.scss
@@ -89,7 +89,7 @@ $default-box-shadow-v-offset: 0;
 			color: $text;
 		}
 
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			@if $text == white {
 				color: darken($text, 10%);
 			} @else {
@@ -159,4 +159,27 @@ $default-box-shadow-v-offset: 0;
 	} @else {
 		clip: rect($top, $right, $bottom, $left);
 	}
+}
+
+//Used to work around an IE7 bug with focus
+@mixin pseudo-focus($hover: true) {
+    @if $legacy-support-for-ie7 {
+        @if $hover {
+            &:hover, &:active {
+                @content;
+            }
+        } @else {
+            &:active {
+                @content;
+            }
+        }        
+    } @else if $hover {
+		&:hover, &:focus {
+			@content;
+		}
+	} @else {
+		&:focus {
+			@content;
+		}
+    }
 }

--- a/src/grids/sass/includes/_module.scss
+++ b/src/grids/sass/includes/_module.scss
@@ -24,7 +24,7 @@
 		}
 		a {
 			text-decoration: none;
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				text-decoration: underline;
 			}
 		}
@@ -77,7 +77,7 @@
 						font-weight: 700;
 						@include colorize-base($accent);
 					}
-					&:hover, &:focus, &:active {
+					@include pseudo-focus {
 						text-decoration: underline;
 					}
 				}
@@ -109,7 +109,7 @@
 				a {
 					display: block;
 					text-decoration: none;
-					&:hover, &:focus, &:active {
+					@include pseudo-focus {
 						background-color: darken($light, 3%);
 						text-decoration: underline;
 					}

--- a/src/js/sass/includes/_archived.scss
+++ b/src/js/sass/includes/_archived.scss
@@ -3,6 +3,8 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 
+@import '../../../grids/sass/includes/mixins';
+
 #archived {
 	background-color: #FFC;
 	border: 1px solid #C00;
@@ -16,6 +18,10 @@
 		margin-left: 10px !important;
 		margin-right: 10px !important;
 	}
+}
+
+%archived-color-FFF {
+	color: #FFF;
 }
 
 .archived {
@@ -36,8 +42,11 @@
 		position: relative;
 		text-shadow: none;
 		&[href] {
-			&:link, &:hover, &:focus, &:active {
-				color: #FFF;
+			&:link {
+				@extend %archived-color-FFF;
+			}
+			@include pseudo-focus {
+				@extend %archived-color-FFF;
 			}
 		}
 	}

--- a/src/js/sass/includes/_calendar-theme.scss
+++ b/src/js/sass/includes/_calendar-theme.scss
@@ -14,7 +14,7 @@
 			&:link, &:visited {
 				border: 1px solid #333;
 			}
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				color: #FFF;
 				border: 1px solid #FFF;
 			}
@@ -25,7 +25,7 @@
 			&:link, &:visited {
 				color: #FFF !important;
 			}
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				color: #36C !important;
 				background-color: #FFF;
 			}
@@ -49,7 +49,7 @@
 	}
 	.cal-day-list a {
 		color: #111;
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			/* active is for IE, focus is for Firefox | active est pour IE, focus est pour Firefox */
 			background: #333;
 			color: #FFF;

--- a/src/js/sass/includes/_charts.scss
+++ b/src/js/sass/includes/_charts.scss
@@ -36,7 +36,7 @@ figure {
 
 		/* Add focus styles (for keyboard accessibility) */
 		summary {
-			&:hover, &:focus {
+			@include pseudo-focus{
 				background: #ddd;
 			}
 		}

--- a/src/js/sass/includes/_datalist.scss
+++ b/src/js/sass/includes/_datalist.scss
@@ -40,7 +40,7 @@ ul {
 				color: #000;
 				display: block;
 				padding: 0 5px;
-				&:hover, &:focus, &:active {
+				@include pseudo-focus {
 					background: #406C93;
 					color: #fff;
 				}

--- a/src/js/sass/includes/_details.scss
+++ b/src/js/sass/includes/_details.scss
@@ -13,7 +13,7 @@
 summary {
 	@extend %pe-details-display-block;
 	cursor: pointer; /* Apply a pointer cursor upon hover to indicate it’s a clickable element. These styles can be applied regardless of whether the fallback is needed */
-	&:hover, &:focus, &:active { /* Add focus styles (for keyboard accessibility) */
+	@include pseudo-focus { /* Add focus styles (for keyboard accessibility) */
 		background: #ddd;
 	}
 }
@@ -70,7 +70,7 @@ details {
 	}
 	summary {
 		cursor: auto;
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			background: none;
 		}
 	}

--- a/src/js/sass/includes/_events-calendar.scss
+++ b/src/js/sass/includes/_events-calendar.scss
@@ -34,7 +34,7 @@ div {
 									color: #000 !important;
 									width: auto;
 								}
-								&:hover, &:focus, &:active {
+								@include pseudo-focus {
 									color: #FFF !important;
 								}
 							}

--- a/src/js/sass/includes/_footnotes.scss
+++ b/src/js/sass/includes/_footnotes.scss
@@ -28,7 +28,7 @@ sup a.footnote-link, .wet-boew-footnotes dl dd p.footnote-return a {
 	border: 1px solid $clrMedium;
 	padding: 0 4px 1px;
 	white-space: nowrap;
-	&:hover, &:focus, &:active {
+	@include pseudo-focus {
 		@extend %footnote-link-highlight;
 	}
 }
@@ -37,7 +37,7 @@ sup a.footnote-link, .wet-boew-footnotes dl dd p.footnote-return a {
 		a {
 			&.footnote-link {
 				@extend %footnote-link-background-white;
-				&:hover, &:focus, &:active {
+				@include pseudo-focus {
 					@extend %footnote-link-highlight;
 				}
 			}
@@ -84,7 +84,7 @@ table {
 			position: relative;
 			margin: $spacing 0;
 			border: 1px solid transparent;
-			&:focus {
+			@include pseudo-focus(false) {
 				background-color: $clrLight;
 				border-color: $clrDark;
 				p {

--- a/src/js/sass/includes/_lightbox.scss
+++ b/src/js/sass/includes/_lightbox.scss
@@ -85,7 +85,7 @@
 }
 
 %wb-lightbox-focus-active-outline-0-border-1-dotted-000 {
-	&:focus, &:active {
+	@include pseudo-focus(false) {
 		outline: 0;
 		border: 1px dotted #000;
 	}
@@ -231,7 +231,7 @@
 	@extend %wb-lightbox-focus-active-outline-0-border-1-dotted-000;
 	left: -28px;
 	background-position: 100% 0;
-	&:hover, &:focus, &:active {
+	@include pseudo-focus {
 		background-position: 100% 100%; //bottom right
 	}
 }
@@ -245,7 +245,7 @@
 	@extend %wb-lightbox-focus-active-outline-0-border-1-dotted-000;
 	right: -28px;
 	background-position: 0 0;
-	&:hover, &:focus, &:active {
+	@include pseudo-focus {
 		background-position: 0 100%;
 	}
 }
@@ -261,7 +261,7 @@
 	background-position: 50% 0;
 	width: 38px;
 	height: 19px;
-	&:hover, &:focus, &:active {
+	@include pseudo-focus {
 		background-position: 50% 100%;
 	}
 }

--- a/src/js/sass/includes/_menubar.scss
+++ b/src/js/sass/includes/_menubar.scss
@@ -58,7 +58,7 @@
 			text-decoration: none;
 			color: #fff;
 		}
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			text-decoration: underline;
 		}
 	}

--- a/src/js/sass/includes/_tabbedinterface.scss
+++ b/src/js/sass/includes/_tabbedinterface.scss
@@ -3,16 +3,14 @@
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
 
-//TODO: Use extend for the gradient
+
 /* Gradient (avoid encoding duplication) */
-.tabs li a, .tabs-style-1 .tabs, .tabs-style-1 .tabs li a:hover, .tabs-style-1 .tabs li a:focus, .tabs-style-1 .tabs li a:active, .tabs-style-2 .tabs li.tabs-toggle, .tabs-style-3 .tabs-panel, .tabs-style-4 .tabs li a:hover,  .tabs-style-4 .tabs li a:focus,  .tabs-style-4 .tabs li a:active {
+%tabbedinterface-gradient-background {
 	background: url(../images/tabs/gradient.png) repeat-x 0 0 #eee;
 }
 
-.tabs.started a.active {
-	&,&:hover,&:focus,&:active {
-		cursor: pointer;
-	}
+%tabbedinterface-cursor-pointer {
+	cursor: pointer;
 }
 
 %tabbedinterface-tabs-active {
@@ -33,6 +31,7 @@
 		border-bottom: none;
 		@include border-radius(2px 2px 0 0);
 		a {
+			@extend %tabbedinterface-gradient-background;
 			display: block;
 			text-decoration: none;
 			color: #333;
@@ -89,6 +88,16 @@
 	.tabs-toggle {
 		border: none;
 		background: none;
+	}
+	&.started {
+		a {
+			&.active {
+				@extend %tabbedinterface-cursor-pointer;
+				@include pseudo-focus {
+					@extend %tabbedinterface-cursor-pointer;
+				}
+			}
+		}
 	}
 }
 
@@ -164,11 +173,19 @@
 	border-top: none;
 	padding: 4px;
 }
+
+%tabbedinterface-no-repeat-border999 {
+	background-repeat: no-repeat;
+	background-position: -1px 0;
+	border: 1px solid #999;
+}
+
 /* style 1 */
 .tabs-style-1 {
     border: solid 1px #ccc;
     padding: 2px;
 	.tabs {
+		@extend %tabbedinterface-gradient-background;
 		border: 1px solid silver;
 		color: #222;
 		font-weight: 700;
@@ -180,6 +197,7 @@
 				color: #fff;
 				padding: 3px 4px 4px;
 				@include pseudo-focus {
+					@extend %tabbedinterface-gradient-background;
 					color: #000;
 					border-top: 1px solid #fff;
 					padding-top: 1px;
@@ -199,12 +217,9 @@
 			&.tabs-toggle {
 				a {
 					color: #000;
-					&, &:active, &:hover, &:active {
-						background-repeat: no-repeat;
-						background-position: -1px 0;
-						border: 1px solid #999;
-					}
-					&:active, &:hover, &:active {
+					@extend %tabbedinterface-no-repeat-border999;
+					@include pseudo-focus {
+						@extend %tabbedinterface-no-repeat-border999;
 						color: #c00;
 					}
 					&.tabs-prev, &.tabs-next {
@@ -266,6 +281,7 @@
 				color: #fff;
 			}
 			&.tabs-toggle {
+				@extend %tabbedinterface-gradient-background;
 				margin-left: 6px;
 				margin-right: -6px;
 				a {
@@ -360,6 +376,7 @@
 		}
 	}
 	.tabs-panel {
+		@extend %tabbedinterface-gradient-background;
 		width: 66%;
 		z-index: 1;
 		border: none;
@@ -404,6 +421,7 @@
 				margin: 0;
 				padding: 2px;
 				@include pseudo-focus {
+					@extend %tabbedinterface-gradient-background;
 					color: #000;
 				}
 				&.active {

--- a/src/js/sass/includes/_tabbedinterface.scss
+++ b/src/js/sass/includes/_tabbedinterface.scss
@@ -15,6 +15,13 @@
 	}
 }
 
+%tabbedinterface-tabs-active {
+	color: #333;
+	padding-top: 5px;
+	background: #fff;
+	cursor: text;
+}
+
 .tabs {
     border-bottom: solid 1px #ccc;
     margin: 0;
@@ -35,11 +42,9 @@
 			top: 1px;
 			margin-top: -1px;
 			&.active {
-				&, &:hover, &:focus, &:active {
-					color: #333;
-					padding-top: 5px;
-					background: #fff;
-					cursor: text;
+				@extend %tabbedinterface-tabs-active;
+				@include pseudo-focus {
+					@extend %tabbedinterface-tabs-active;
 				}
 			}
 		}
@@ -53,7 +58,7 @@
 				@include border-radius(2px);
 				border: 1px solid #999;
 				margin-right: 2px;
-				&:hover, &:focus, &:active {
+				@include pseudo-focus {
 					text-decoration: underline;
 					color: #000;
 				}
@@ -153,6 +158,12 @@
 	}
 }
 
+%tabbedinterface-tab-style-1-active {
+	color: #000;
+	background: #fff;
+	border-top: none;
+	padding: 4px;
+}
 /* style 1 */
 .tabs-style-1 {
     border: solid 1px #ccc;
@@ -168,17 +179,15 @@
 				border-top: none;
 				color: #fff;
 				padding: 3px 4px 4px;
-				&:hover, &:focus, &:active {
+				@include pseudo-focus {
 					color: #000;
 					border-top: 1px solid #fff;
 					padding-top: 1px;
 				}
 				&.active {
-					&, &:hover, &:focus, &:active {
-						color: #000;
-						background: #fff;
-						border-top: none;
-						padding: 4px;
+					@extend %tabbedinterface-tab-style-1-active;
+					@include pseudo-focus {
+						@extend %tabbedinterface-tab-style-1-active;
 					}
 				}
 				&.tabs-start, &.tabs-stop {
@@ -210,6 +219,12 @@
 	}
 }
 
+%tabbedinterface-tab-style-2-active {
+	background: #333;
+	color: #fff;
+	outline-color: #000;
+	padding-top: 2px;
+}
 
 /* style 2 */
 .tabs-style-2 {
@@ -238,11 +253,11 @@
 				border: 1px solid #999;
 				padding: 2px 5px;
 				@include border-radius(2px);
-				&.active, &:hover, &:focus, &:active {
-					background: #333;
-					color: #fff;
-					outline-color: #000;
-					padding-top: 2px;
+				&.active {
+					@extend %tabbedinterface-tab-style-2-active;
+					@include pseudo-focus {
+						@extend %tabbedinterface-tab-style-2-active;
+					}
 				}
 			}
 			&.active {
@@ -255,7 +270,7 @@
 				margin-right: -6px;
 				a {
 					background-color: transparent !important;
-					&:hover, &:focus, &:active {
+					@include pseudo-focus {
 						color: #000;
 					}
 				}
@@ -282,6 +297,15 @@
 	}
 }
 
+%tabbedinterface-tab-style-3-active {
+	background: #000;
+	color: #fff;
+	outline-color: #000;
+	margin-right: 0;
+	padding: 5px 5px 5px 25px;
+	@include opacity(0.75);
+	@include border-radius(3px 0 0 3px);
+}
 
 /* style 3 */
 .tabs-style-3 {
@@ -309,14 +333,11 @@
 				text-decoration: none;
 				background: transparent;
 				padding: 5px 5px 5px 25px;
-				&.active, &:hover, &:focus, &:active {
-					background: #000;
-					color: #fff;
-					outline-color: #000;
-					margin-right: 0;
-					padding: 5px 5px 5px 25px;
-					@include opacity(0.75);
-					@include border-radius(3px 0 0 3px);
+				&.active {
+					@extend %tabbedinterface-tab-style-3-active;
+					@include pseudo-focus {
+						@extend %tabbedinterface-tab-style-3-active;
+					}
 				}
 			}
 			&.active {
@@ -329,7 +350,7 @@
 					float: right;
 					margin-top: 10px;
 					border: 1px solid #ccc;
-					&:hover, &:focus, &:active {
+					@include pseudo-focus {
 						@include opaque;
 						color: #000;
 						margin-right: 2px;
@@ -382,7 +403,7 @@
 				font-size: 80%;
 				margin: 0;
 				padding: 2px;
-				&:hover, &:focus, &:active {
+				@include pseudo-focus {
 					color: #000;
 				}
 				&.active {

--- a/src/theme-clf2-nsi2/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-desktop-screen.scss
@@ -127,7 +127,7 @@ body {
 
 #wb-skip {
 	a {
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			background-color: #363;
 		}
 	}
@@ -241,7 +241,7 @@ body {
 					color: #FFF;
 					text-decoration: none;
 				}
-				&:hover, &:active, &:focus {
+				@include pseudo-focus {
 					color: #000;
 					background-color: #CCC;
 				}
@@ -265,7 +265,7 @@ body {
 
 %cfl2-default-desktop-screen-a-pseudo-width120pct {
 	a {
-		&:hover, &:active, &:focus {
+		@include pseudo-focus {
 			width: 120%;
 		}
 	}
@@ -400,7 +400,7 @@ body {
 			color: #636;
 			text-decoration: none;
 		}
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			color: #CC9;
 			background-color: #030;
 			outline: none;
@@ -470,7 +470,7 @@ body {
 			margin: -2px -5px;
 			padding: 2px 5px;
 			width: 100%;
-			&:hover, &:active, &:focus {
+			@include pseudo-focus {
 				background-color: #030;
 				color: #CC9;
 			}
@@ -530,7 +530,7 @@ body {
 				color: #636;
 				text-decoration: none;
 			}
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				color: #CC9;
 				background-color: #030;
 				outline: none;

--- a/src/theme-clf2-nsi2/sass/includes/_default-screen-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-screen-ie.scss
@@ -42,7 +42,7 @@
 		}
 		h3 {
 			a {
-				&:hover, &:focus, &:active {
+				@include pseudo-focus {
 					zoom: 1;
 				}
 			}

--- a/src/theme-clf2-nsi2/sass/includes/_serv-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-screen.scss
@@ -96,7 +96,7 @@ body {
 		}
 	}
 	a {
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			background-color: #363;
 		}
 	}

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-desktop-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-desktop-screen.scss
@@ -9,7 +9,7 @@
 		}
 	}
 	a {
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			background-color: #363;
 		}
 	}

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe.scss
@@ -187,7 +187,7 @@ body {
 				color: #000;
 				background-color: #FFF;
 			}
-			&:active, &:focus, &:hover {
+			@include pseudo-focus {
 				color: #FFF;
 				background-color: #000;
 			}
@@ -204,7 +204,7 @@ body {
 				color: #FFF;
 				background-color: #000;
 			}
-			&:active, &:focus, &:hover {
+			@include pseudo-focus {
 				color: #000;
 				background-color: #FFF;
 			}

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen-images.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen-images.scss
@@ -38,7 +38,7 @@
 
 #gcwu-srch-submit {
 	background: #ccc url(../images/search-button.gif) 0 0 repeat-x;
-	&:focus, &:hover {
+	@include pseudo-focus {
 		background: #ddd url(../images/search-button-focus.gif) 0 0 repeat-x;
 	}
 }

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
@@ -253,7 +253,7 @@ a {
 	a {
 		display: inline-block;
 		margin-left: 10px;
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			text-decoration: underline;
 		}
 	}
@@ -309,7 +309,7 @@ a {
 		@include box-shadow(none);
 		background: #fff;
 		padding: 2px 0;
-		&:focus, &:active {
+		@include pseudo-focus(false) {
 			background: #f0fcff;
 		}
 	}
@@ -339,7 +339,7 @@ a {
 	@include box-shadow(none);
 	padding: 2px 6px;
 	display: inline;
-	&:focus, &:hover {
+	@include pseudo-focus {
 		text-shadow: 0 1px 0 #ddd;
 		@include box-shadow(none);
 		border: {
@@ -404,7 +404,7 @@ a {
 
 %text-decoration-underline-a-psuedos {
 	a {
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			text-decoration: underline;
 		}
 	}

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop.scss
@@ -44,7 +44,7 @@
 	a {
 		color: #295376;
 		text-decoration: none;
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			color: #295376;
 			text-decoration: underline;
 		}

--- a/src/theme-gcwu-fegc/sass/includes/_default-mobile.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-mobile.scss
@@ -326,7 +326,7 @@ table {
 		text-shadow: 0 1px 1px #044062;
 		background-color: #333;
 		@include background-image(linear-gradient(#444, #2D2D2D));
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			background-color: #444;
 			@extend %gcwu-default-linear-gradient-606060-333;
 		}

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
@@ -18,7 +18,7 @@ body {
 				padding-top: 5px;
 				padding-bottom: 5px;
 				font-size: 1.1em;
-				&:hover, &:focus, &:active {
+				@include pseudo-focus {
 					color: #FFF;
 					text-decoration: underline;
 				}
@@ -78,7 +78,7 @@ body {
 			display: block;
 			color: #333;
 			text-decoration: none;
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				color: #333;
 				text-decoration: underline;
 			}

--- a/src/theme-gcwu-fegc/sass/includes/_default.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default.scss
@@ -97,7 +97,7 @@
 	li {
 		padding-bottom: 8px;
 		a {
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				text-decoration: none;
 			}
 		}

--- a/src/theme-gcwu-fegc/sass/includes/_serv-mobile.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-mobile.scss
@@ -38,11 +38,12 @@
 
 #gcwu-title {
 	a {
-		&, &:visited, &:hover, &:focus, &:active { //TODO: Conflicting text-decorations for hover, focus and active with next rule
+		&, &:visited {
 			color: #295376;
 			text-decoration: none;
 		}
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
+			color: #295376;
 			text-decoration: underline;
 		}
 	}

--- a/src/theme-gcwu-fegc/sass/includes/_serv-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-screen.scss
@@ -131,7 +131,7 @@ h1 {
 		a {
 			text-decoration: none;
 			font-size: 0.9em;
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				text-decoration: underline;
 			}
 		}

--- a/src/theme-gcwu-fegc/sass/includes/_serv.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv.scss
@@ -51,11 +51,12 @@ h1 {
 #gcwu-title {
 	border-bottom: 1px solid #666;
 	a {
-		&, &:visited, &:hover, &:focus, &:active { //TODO: Conflicting text-decorations for hover, focus and active with next rule
+		&, &:visited {
 			color: #295376;
 			text-decoration: none;
 		}
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
+			color: #295376;
 			text-decoration: underline;
 		}
 	}
@@ -107,7 +108,7 @@ h1 {
 	li {
 		a {
 			text-decoration: none;
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				text-decoration: underline;
 			}
 		}

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-desktop-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-desktop-screen.scss
@@ -18,7 +18,7 @@
 
 #wb-main {
 	a[href] {
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			color: #000;
 		}
 	}

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-images.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-images.scss
@@ -7,7 +7,7 @@
 	li {
 		a {
 			background: #ccc url(../images/sp-pe-button.gif) 0 0 repeat-x; //TODO: Use gradients with fallback
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				background: #ddd url(../images/sp-pe-button-focus.gif) 0 0 repeat-x; //TODO: Use gradients with fallback
 			}
 		}

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-mobile.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-mobile.scss
@@ -80,7 +80,7 @@ h1 {
 #gcwu-lang {
 	@extend %gcwu-sp-pe-mobile-lang-foot;
 	a[href]{
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			color: #FFF;
 		}
 	}
@@ -149,7 +149,7 @@ h1 {
 	#gcwu-lang {
 		@extend %gcwu-sp-pe-mobile-no-js-block-li;
 		a {
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				color: #000;
 			}
 		}

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe.scss
@@ -97,7 +97,7 @@ h2 {
 			display: block;
 			text-decoration: none;
 			text-transform: capitalize;
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				text-shadow: 0 1px 0 #ddd;
 				@include box-shadow(none);
 				border: 1px solid #999;
@@ -145,7 +145,7 @@ h2 {
 			display: block;
 			text-decoration: none;
 			font-size: 0.9em;
-			&:hover, &:focus, &:active {
+			@include pseudo-focus {
 				text-decoration: underline;
 			}
 		}

--- a/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen-images.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen-images.scss
@@ -6,7 +6,7 @@
 
 #gcwu-srch-submit {
 	background: #ccc url(../images/search-button.gif) 0 0 repeat-x;
-	&:focus, &:hover {
+	@include pseudo-focus {
 		background: #ddd url(../images/search-button-focus.gif) 0 0 repeat-x;
 	}
 }

--- a/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen.scss
@@ -68,7 +68,7 @@
 	background: none;
 	padding-right: 0;
 	#gcwu-srch {
-		&:focus, &:active {
+		@include pseudo-focus(false) {
 			background: #f0fcff;
 		}
 	}
@@ -88,7 +88,7 @@
 	}
 	text-shadow: 1px 1px 1px #333;
 	a {
-		&:hover, &:focus {
+		@include pseudo-focus {
 			text-decoration: underline;
 		}
 	}
@@ -312,7 +312,7 @@
 
 %intranet-default-desktop-screen-a-psuedo-underline {
 	a {
-		&:hover, &:focus, &:active {
+		@include pseudo-focus {
 			text-decoration: underline;
 		}
 	}


### PR DESCRIPTION
Add mixin for use in active/focus/hover pseudo events that emits correct selectors depending on the target browser.
Fixes gh-1293
