### PR TITLE
Util-screen and Slider: Fix some CSS3 gradient format issues

### DIFF
--- a/src/grids/sass/includes/_util-screen.scss
+++ b/src/grids/sass/includes/_util-screen.scss
@@ -388,7 +388,7 @@ table {
 	border: 1px solid $silver;
 	height: 55px;
 	width: 100%;
-	@include background(top, rgba(255, 255, 255, 1) 0, rgba(247, 247, 247, 1) 100%);
+	@include background-image(linear-gradient(top, rgba(255, 255, 255, 1) 0, rgba(247, 247, 247, 1) 100%));
 	@include border-bottom-radius($default-border-radius);
 	@include box-shadow(0 1px 0 0 $light, 0 2px 0 0 $silver, 0 3px 0 0 $light, 0 4px 0 0 $silver);
 	p {

--- a/src/grids/sass/includes/_util-screen.scss
+++ b/src/grids/sass/includes/_util-screen.scss
@@ -388,7 +388,7 @@ table {
 	border: 1px solid $silver;
 	height: 55px;
 	width: 100%;
-	@include background-image(linear-gradient(top, rgba(255, 255, 255, 1) 0, rgba(247, 247, 247, 1) 100%));
+	@include background-image(linear-gradient(rgba(255, 255, 255, 1), rgba(247, 247, 247, 1)));
 	@include border-bottom-radius($default-border-radius);
 	@include box-shadow(0 1px 0 0 $light, 0 2px 0 0 $silver, 0 3px 0 0 $light, 0 4px 0 0 $silver);
 	p {

--- a/src/js/sass/includes/_slider.scss
+++ b/src/js/sass/includes/_slider.scss
@@ -46,10 +46,10 @@
 	}
 	.fd-slider-disabled {
 		.fd-slider-bar {
-			@include background-image(linear-gradient(top, #333, #666));
+			@include background-image(linear-gradient(#333, #666));
 		}
 		.fd-slider-range {
-			@include background-image(linear-gradient(top, #000, #222));
+			@include background-image(linear-gradient(#000, #222));
 		}
 	}
 	.fd-slider-handle {
@@ -94,7 +94,7 @@
 	border-right: 1px solid rgba(170, 170, 170, .8);
 	line-height: 4px;
 	background-color: #ddd;
-	@include background-image(linear-gradient(top, #ececec, #ccc));
+	@include background-image(linear-gradient(#ececec, #ccc));
 	@include border-radius(2px);
 	@include background-clip(padding-box);
 }


### PR DESCRIPTION
As pointed out in gh-1158, some gradients aren't using the official CSS3 grammar because of an issue in the Compass mixin.
- Remove all "top" directions since top = to bottom, which is the default value.
- Correct invalid call in util.screen

There are still outstanding issues with calls using (left, right, and bottom)
