### PR TITLE
Added equalize plugin for IE7/8

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -209,12 +209,9 @@
 					}
 				}
 
+				// Load required plugins for IE
 				if (pe.ie > 0) {
-					if (pe.ie < 9) {
-						pe.wb_load({'plugins': {'css3ie': pe.main}}, 'css3ie-loaded');
-					} else {
-						pe.wb_load({'plugins': {'equalize': pe.main}}, 'equalize-loaded');
-					}
+					pe.wb_load({'plugins': (pe.ie < 9 ? {'equalize': pe.main, 'css3ie': pe.main} : {'equalize': pe.main})}, 'ie-plugins-loaded');
 				}
 			});
 


### PR DESCRIPTION
This adds the equalize plugin back to IE7/8 (it used to come from settings-ie.js).
