### PR TITLE
Smoothed out loading of SVG FIP images and cleaned up top-level theme SCSS files

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -163,7 +163,7 @@
 				}
 			}
 
-			// Remove the "no-js" clas and add the identification classes to the HTML element.
+			// Remove the "no-js" class and add the identification classes to the HTML element.
 			$html.removeClass('no-js').addClass(classes);
 
 			hlinks = pe.bodydiv.find('#wb-main a, #wb-skip a').filter(function () {

--- a/src/theme-base/sass/theme-ns-ie.scss
+++ b/src/theme-base/sass/theme-ns-ie.scss
@@ -7,12 +7,6 @@
  * Version: @wet-boew-build.version@
  *
  */
-
-/* -----Include jQuery Mobile CSS Start----- */
-@import '../jquerymobile/jquery.mobile.theme-ie';
-@import '../../js/jquerymobile/jquery.mobile.structure-ie';
-/* -----Include jQuery Mobile CSS End----- */
-
 @import '../../base/sass/oldie-vendor-prefix';
 
 /* -----Build Include Section Start----- */

--- a/src/theme-base/sass/theme-ns-ie.scss
+++ b/src/theme-base/sass/theme-ns-ie.scss
@@ -16,10 +16,3 @@
 @import '../../js/sass/pe-ap-ns';
 @import 'includes/default-ns';
 /* -----Build Include Section End----- */
-
-/* Mobile view */
-@media screen and (max-width: 767px), screen and (max-device-width: 767px) {
-/* -----Build Include Section Start----- */
-@import 'includes/default-mobile-ns';
-/* -----Build Include Section End----- */
-}

--- a/src/theme-base/sass/theme-ns.scss
+++ b/src/theme-base/sass/theme-ns.scss
@@ -7,12 +7,6 @@
  * Version: @wet-boew-build.version@
  *
  */
-
-/* -----Include jQuery Mobile CSS Start----- */
-@import '../jquerymobile/jquery.mobile.theme';
-@import '../../js/jquerymobile/jquery.mobile.structure';
-/* -----Include jQuery Mobile CSS End----- */
-
 @import '../../base/sass/modern-vendor-prefix';
 
 /* -----Build Include Section Start----- */

--- a/src/theme-clf2-nsi2/sass/theme-ns-ie.scss
+++ b/src/theme-clf2-nsi2/sass/theme-ns-ie.scss
@@ -7,7 +7,7 @@
  * Version: @wet-boew-build.version@
  *
  */
-@import '../../base/sass/modern-vendor-prefix';
+@import '../../base/sass/oldie-vendor-prefix';
 
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-ns';

--- a/src/theme-gcwu-fegc/sass/includes/_default-ns.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-ns.scss
@@ -6,8 +6,8 @@
 	display: block;
 }
 #gcwu-wmms-in {
-	@extend %gcwu-default-ns-display-none;
+	@extend %gcwu-default-ns-display-block;
 }
 #gcwu-sig-in {
-	@extend %gcwu-default-ns-display-none;
+	@extend %gcwu-default-ns-display-block;
 }

--- a/src/theme-gcwu-fegc/sass/includes/_default-ns.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-ns.scss
@@ -2,3 +2,12 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
+%gcwu-default-ns-display-block {
+	display: block;
+}
+#gcwu-wmms-in {
+	@extend %gcwu-default-ns-display-none;
+}
+#gcwu-sig-in {
+	@extend %gcwu-default-ns-display-none;
+}

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
@@ -60,7 +60,7 @@ body {
 #gcwu-sig-in {
 	@extend %gcwu-default-screen-display-none;
 }
-.ui-mobile {
+.ui-mobile, .pe-disable {
 	#gcwu-wmms-in {
 		@extend %gcwu-default-screen-display-block;
 	}

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
@@ -16,6 +16,12 @@
 %gcwu-default-screen-text-decoration-none {
 	text-decoration: none;
 }
+%gcwu-default-screen-display-none {
+	display: none;
+}
+%gcwu-default-screen-display-block {
+	display: block;
+}
 
 body {
 	margin: 0;
@@ -45,6 +51,21 @@ body {
 	a {
 		@extend %gcwu-default-screen-color-fff;
 		@extend %gcwu-default-screen-text-decoration-none;
+	}
+}
+
+#gcwu-wmms-in {
+	@extend %gcwu-default-screen-display-none;
+}
+#gcwu-sig-in {
+	@extend %gcwu-default-screen-display-none;
+}
+.ui-mobile {
+	#gcwu-wmms-in {
+		@extend %gcwu-default-screen-display-block;
+	}
+	#gcwu-sig-in {
+		@extend %gcwu-default-screen-display-block;
 	}
 }
 
@@ -122,7 +143,7 @@ body {
 	%gcwu-default-screen-a-psuedo-underline {
 		a {
 			&, &.ui-link {
-				display: block;
+				@extend %gcwu-default-screen-display-block;
 				@extend %gcwu-default-screen-color-333;
 				@extend %gcwu-default-screen-text-decoration-none;
 				&:visited {

--- a/src/theme-gcwu-fegc/sass/theme-ns-ie.scss
+++ b/src/theme-gcwu-fegc/sass/theme-ns-ie.scss
@@ -7,12 +7,6 @@
  * Version: @wet-boew-build.version@
  *
  */
-
-/* -----Include jQuery Mobile CSS Start----- */
-@import '../jquerymobile/jquery.mobile.theme-ie';
-@import '../../js/jquerymobile/jquery.mobile.structure-ie';
-/* -----Include jQuery Mobile CSS End----- */
-
 @import '../../base/sass/modern-vendor-prefix';
 
 /* -----Build Include Section Start----- */

--- a/src/theme-gcwu-fegc/sass/theme-ns-ie.scss
+++ b/src/theme-gcwu-fegc/sass/theme-ns-ie.scss
@@ -7,7 +7,7 @@
  * Version: @wet-boew-build.version@
  *
  */
-@import '../../base/sass/modern-vendor-prefix';
+@import '../../base/sass/oldie-vendor-prefix';
 
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-ns';
@@ -16,10 +16,3 @@
 @import '../../js/sass/pe-ap-ns';
 @import 'includes/default-ns';
 /* -----Build Include Section End----- */
-
-/* Mobile view */
-@media screen and (max-width: 767px), screen and (max-device-width: 767px) {
-/* -----Build Include Section Start----- */
-@import 'includes/default-mobile-ns';
-/* -----Build Include Section End----- */
-}

--- a/src/theme-gcwu-fegc/sass/theme-ns.scss
+++ b/src/theme-gcwu-fegc/sass/theme-ns.scss
@@ -7,18 +7,6 @@
  * Version: @wet-boew-build.version@
  *
  */
-
-/* -----Include jQuery Mobile CSS Start----- */
-@import '../jquerymobile/jquery.mobile.theme';
-@import '../../js/jquerymobile/jquery.mobile.structure';
-/* -----Include jQuery Mobile CSS End----- */
-
-
-/* -----Include jQuery Mobile CSS Start----- */
-@import '../jquerymobile/jquery.mobile.theme';
-@import '../../js/jquerymobile/jquery.mobile.structure';
-/* -----Include jQuery Mobile CSS End----- */
-
 @import '../../base/sass/modern-vendor-prefix';
 
 /* -----Build Include Section Start----- */

--- a/src/theme-gcwu-intranet/sass/theme-ns-ie.scss
+++ b/src/theme-gcwu-intranet/sass/theme-ns-ie.scss
@@ -7,12 +7,6 @@
  * Version: @wet-boew-build.version@
  *
  */
-
-/* -----Include jQuery Mobile CSS Start----- */
-@import '../jquerymobile/jquery.mobile.theme';
-@import '../../js/jquerymobile/jquery.mobile.structure';
-/* -----Include jQuery Mobile CSS End----- */
-
 @import '../../base/sass/modern-vendor-prefix';
 
 /* -----Build Include Section Start----- */

--- a/src/theme-gcwu-intranet/sass/theme-ns-ie.scss
+++ b/src/theme-gcwu-intranet/sass/theme-ns-ie.scss
@@ -7,7 +7,7 @@
  * Version: @wet-boew-build.version@
  *
  */
-@import '../../base/sass/modern-vendor-prefix';
+@import '../../base/sass/oldie-vendor-prefix';
 
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-ns';
@@ -16,10 +16,3 @@
 @import '../../js/sass/pe-ap-ns';
 @import '../../theme-gcwu-fegc/sass/includes/default-ns';
 /* -----Build Include Section End----- */
-
-/* Mobile view */
-@media screen and (max-width: 767px), screen and (max-device-width: 767px) {
-/* -----Build Include Section Start----- */
-@import '../../theme-gcwu-fegc/sass/includes/default-mobile-ns';
-/* -----Build Include Section End----- */
-}

--- a/src/theme-gcwu-intranet/sass/theme-ns.scss
+++ b/src/theme-gcwu-intranet/sass/theme-ns.scss
@@ -7,12 +7,6 @@
  * Version: @wet-boew-build.version@
  *
  */
-
-/* -----Include jQuery Mobile CSS Start----- */
-@import '../jquerymobile/jquery.mobile.theme';
-@import '../../js/jquerymobile/jquery.mobile.structure';
-/* -----Include jQuery Mobile CSS End----- */
-
 @import '../../base/sass/modern-vendor-prefix';
 
 /* -----Build Include Section Start----- */

--- a/src/theme-wet-boew/sass/theme-ns-ie.scss
+++ b/src/theme-wet-boew/sass/theme-ns-ie.scss
@@ -7,12 +7,6 @@
  * Version: @wet-boew-build.version@
  *
  */
-
-/* -----Include jQuery Mobile CSS Start----- */
-@import '../jquerymobile/jquery.mobile.theme-ie';
-@import '../../js/jquerymobile/jquery.mobile.structure-ie';
-/* -----Include jQuery Mobile CSS End----- */
-
 @import '../../base/sass/oldie-vendor-prefix';
 
 /* -----Build Include Section Start----- */

--- a/src/theme-wet-boew/sass/theme-ns-ie.scss
+++ b/src/theme-wet-boew/sass/theme-ns-ie.scss
@@ -16,10 +16,3 @@
 @import '../../js/sass/pe-ap-ns';
 @import 'includes/default-ns';
 /* -----Build Include Section End----- */
-
-/* Mobile view */
-@media screen and (max-width:767px), screen and (max-device-width:767px) {
-/* -----Build Include Section Start----- */
-@import 'includes/default-mobile-ns';
-/* -----Build Include Section End----- */
-}

--- a/src/theme-wet-boew/sass/theme-ns.scss
+++ b/src/theme-wet-boew/sass/theme-ns.scss
@@ -7,12 +7,6 @@
  * Version: @wet-boew-build.version@
  *
  */
-
-/* -----Include jQuery Mobile CSS Start----- */
-@import '../jquerymobile/jquery.mobile.theme';
-@import '../../js/jquerymobile/jquery.mobile.structure';
-/* -----Include jQuery Mobile CSS End----- */
-
 @import '../../base/sass/modern-vendor-prefix';
 
 /* -----Build Include Section Start----- */


### PR DESCRIPTION
- Delayed display of SVG FIP images to avoid white box flicker.
- Removed jQuery Mobile CSS imports from non-JavaScript SCSS files. Only needed in regular theme SCSS files.
- Removed mobile view CSS and changed prefix to oldie for theme-ns-ie.scss in each of the themes.
- Changed prefix to oldie for theme-ns-ie.scss in the CLF 2.0 theme.
- Fixed no JS and pe-disable scenarios for loading of SVG FIP images.
- Fixed a minor comment in pe-ap.js
