### PR TITLE
Sped up display of SVG FIP images

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -150,6 +150,8 @@
 			// Identify IE9+ browser
 			if (pe.ie > 8) {
 				classes += ' ie' + parseInt(pe.ie, 10);
+			} else if (pe.ie < 1) {
+				classes += ' no-ie';
 			}
 
 			// Is this a mobile device?

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
@@ -22,6 +22,14 @@
 %gcwu-default-screen-display-block {
 	display: block;
 }
+%gcwu-default-screen-wmms-sig-display-block {
+	#gcwu-wmms-in {
+		@extend %gcwu-default-screen-display-block;
+	}
+	#gcwu-sig-in {
+		@extend %gcwu-default-screen-display-block;
+	}
+}
 
 body {
 	margin: 0;
@@ -60,13 +68,19 @@ body {
 #gcwu-sig-in {
 	@extend %gcwu-default-screen-display-none;
 }
-.ui-mobile, .pe-disable {
-	#gcwu-wmms-in {
-		@extend %gcwu-default-screen-display-block;
+.ui-mobile {
+	&:not(.ui-mobile-rendering) {
+		@extend %gcwu-default-screen-wmms-sig-display-block;
 	}
-	#gcwu-sig-in {
-		@extend %gcwu-default-screen-display-block;
+	&.no-ie:not(.no-svg) {
+		@extend %gcwu-default-screen-wmms-sig-display-block;
 	}
+	&[class*=ie1] {
+		@extend %gcwu-default-screen-wmms-sig-display-block;
+	}
+}
+.pe-disable {
+	@extend %gcwu-default-screen-wmms-sig-display-block;
 }
 
 .wb-sec-def {


### PR DESCRIPTION
 Sped up display of SVG FIP images on browsers that don't display a white box initially (delay only meant to hide the white box).
