### PR TITLE
Cleaned up Safari, no-js and pe-disable support for the FIP SVG images

### DIFF
--- a/src/grids/sass/util.scss
+++ b/src/grids/sass/util.scss
@@ -24,7 +24,7 @@
 }
 
 /* Mobile view (including Tablet view) */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import 'includes/util-mobile';
 /* -----Build Include Section End----- */

--- a/src/theme-base/sass/theme-ns.scss
+++ b/src/theme-base/sass/theme-ns.scss
@@ -18,7 +18,7 @@
 /* -----Build Include Section End----- */
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import 'includes/default-mobile-ns';
 /* -----Build Include Section End----- */

--- a/src/theme-base/sass/theme-ns.scss
+++ b/src/theme-base/sass/theme-ns.scss
@@ -18,7 +18,7 @@
 /* -----Build Include Section End----- */
 
 /* Mobile view */
-@media screen and (max-width: 767px), screen and (max-device-width: 767px) {
+@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
 /* -----Build Include Section Start----- */
 @import 'includes/default-mobile-ns';
 /* -----Build Include Section End----- */

--- a/src/theme-base/sass/theme.scss
+++ b/src/theme-base/sass/theme.scss
@@ -51,7 +51,7 @@
 }
 
 /* Mobile view (including Tablet view) */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-mobile';
 @import 'includes/default-mobile';

--- a/src/theme-gcwu-fegc/images/sig-eng-r.svg
+++ b/src/theme-gcwu-fegc/images/sig-eng-r.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 www.tbs.gc.ca/ws-nw/wet-boew/terms / www.sct.gc.ca/ws-nw/wet-boew/conditions -->
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="213px" height="20px" viewBox="0 0 213 20" preserveAspectRatio="xMinYMin meet">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 213 20" preserveAspectRatio="xMinYMin meet">
 	<defs>
 		<style type="text/css">
 			.fip_text {fill:#000;}.fip_flag {fill:#ED1F24;}

--- a/src/theme-gcwu-fegc/images/sig-eng.svg
+++ b/src/theme-gcwu-fegc/images/sig-eng.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 www.tbs.gc.ca/ws-nw/wet-boew/terms / www.sct.gc.ca/ws-nw/wet-boew/conditions -->
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="213px" height="20px" viewBox="0 0 213 20" preserveAspectRatio="xMinYMin meet">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 213 20" preserveAspectRatio="xMinYMin meet">
 	<defs>
 		<style type="text/css">
 			.fip_text {fill:#000;}.fip_flag {fill:#ED1F24;}

--- a/src/theme-gcwu-fegc/images/sig-fra-r.svg
+++ b/src/theme-gcwu-fegc/images/sig-fra-r.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 www.tbs.gc.ca/ws-nw/wet-boew/terms / www.sct.gc.ca/ws-nw/wet-boew/conditions -->
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="213px" height="20px" viewBox="0 0 213 20" preserveAspectRatio="xMinYMin meet">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 213 20" preserveAspectRatio="xMinYMin meet">
 	<defs>
 		<style type="text/css">
 			.fip_text {fill:#000;}.fip_flag {fill:#ED1F24;}

--- a/src/theme-gcwu-fegc/images/sig-fra.svg
+++ b/src/theme-gcwu-fegc/images/sig-fra.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 www.tbs.gc.ca/ws-nw/wet-boew/terms / www.sct.gc.ca/ws-nw/wet-boew/conditions -->
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="213px" height="20px" viewBox="0 0 213 20" preserveAspectRatio="xMinYMin meet">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 213 20" preserveAspectRatio="xMinYMin meet">
 	<defs>
 		<style type="text/css">
 			.fip_text {fill:#000;}.fip_flag {fill:#ED1F24;}

--- a/src/theme-gcwu-fegc/images/wmms-r.svg
+++ b/src/theme-gcwu-fegc/images/wmms-r.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 www.tbs.gc.ca/ws-nw/wet-boew/terms / www.sct.gc.ca/ws-nw/wet-boew/conditions -->
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="90px" height="22px" viewBox="0 0 146 35" preserveAspectRatio="xMinYMin meet">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 146 35" preserveAspectRatio="xMinYMin meet">
 	<defs>
 		<style type="text/css">
 			.fip_text {fill:#000;}.fip_flag {fill:#ED1F24;}

--- a/src/theme-gcwu-fegc/images/wmms.svg
+++ b/src/theme-gcwu-fegc/images/wmms.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 www.tbs.gc.ca/ws-nw/wet-boew/terms / www.sct.gc.ca/ws-nw/wet-boew/conditions -->
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="90px" height="22px" viewBox="0 0 146 35" preserveAspectRatio="xMinYMin meet">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 146 35" preserveAspectRatio="xMinYMin meet">
 	<defs>
 		<style type="text/css">
 			.fip_text {fill:#000;}.fip_flag {fill:#ED1F24;}

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-images-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-images-ie.scss
@@ -4,6 +4,26 @@
  */
 
 .ie7, .ie8 {
+	@mixin gcwu-sig($iso639_2) {
+		height: 100%;
+		width: 100%;
+		background: url(../images/sig-#{$iso639_2}-w.png) no-repeat 0 0 transparent;
+	}
+
+	#gcwu-sig-eng {
+		@include gcwu-sig("eng");
+	}
+
+	#gcwu-sig-fra {
+		@include gcwu-sig("fra");
+	}
+
+	#gcwu-wmms-fip {
+		height: 100%;
+		width: 100%;
+		background: url(../images/wmms-w.png) no-repeat 4px 0 transparent;
+	}
+
 	#gcwu-bc {
 		li {
 			background: url(../images/bcrumb.gif) left center no-repeat;

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen-images.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen-images.scss
@@ -22,20 +22,6 @@
 	background-color: #406C93;
 }
 
-@mixin gcwu-sig($iso639_2) {
-	height: 100%;
-	width: 100%;
-	background: url(../images/sig-#{$iso639_2}-w.png) no-repeat 0 0 transparent;
-}
-
-#gcwu-sig-eng {
-	@include gcwu-sig("eng");
-}
-
-#gcwu-sig-fra {
-	@include gcwu-sig("fra");
-}
-
 #gcwu-srch-submit {
 	background: #ccc url(../images/search-button.gif) 0 0 repeat-x;
 	@include pseudo-focus {
@@ -58,12 +44,6 @@
 
 #gcwu-bc-in {
 	@extend %gcwu-default-desktop-screen-images-deco-side;
-}
-
-#gcwu-wmms-fip {
-	height: 100%;
-	width: 100%;
-	background: url(../images/wmms-w.png) no-repeat 4px 0 transparent;
 }
 
 #gcwu-psnb {

--- a/src/theme-gcwu-fegc/sass/includes/_default-mobile-ns.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-mobile-ns.scss
@@ -7,48 +7,52 @@
 		width: 100% !important;
 		float: none;
 	}
-	%gcwu-default-mobile-ns-display-block {
+	%gcwu-default-mobile-ns-display-block-z-index-100 {
 		display: block;
-		width: 100%;
 		z-index: 100;
 	}
-	%gcwu-default-mobile-ns-display-block {
-		display: block;
+	%gcwu-default-mobile-ns-width-100 {
+		width: 100%;
 	}
 	#gcwu-gcnb {
 		ul {
-			@extend %gcwu-default-mobile-ns-display-block;
+			@extend %gcwu-default-mobile-ns-display-block-z-index-100;
 		}
 	}
 	#gcwu-wmms {
-		@extend %gcwu-default-mobile-ns-display-block;
+		@extend %gcwu-default-mobile-ns-display-block-z-index-100;
 	}
 	#gcwu-bc {
-		@extend %gcwu-default-mobile-ns-display-block;
+		@extend %gcwu-default-mobile-ns-display-block-z-index-100;
+		@extend %gcwu-default-mobile-ns-width-100;
 	}
 	#wb-sec {
-		@extend %gcwu-default-mobile-ns-display-block;
+		@extend %gcwu-default-mobile-ns-display-block-z-index-100;
+		@extend %gcwu-default-mobile-ns-width-100;
 	}
 	#wb-foot {
-		@extend %gcwu-default-mobile-ns-display-block;
+		@extend %gcwu-default-mobile-ns-display-block-z-index-100;
+		@extend %gcwu-default-mobile-ns-width-100;
 	}
 	#gcwu-psnb {
 		@extend %gcwu-default-mobile-ns-positioning;
-		@extend %gcwu-default-mobile-ns-display-block;
+		@extend %gcwu-default-mobile-ns-display-block-z-index-100;
 		#gcwu-psnb-in {
-			@extend %gcwu-default-mobile-ns-display-block;
+			@extend %gcwu-default-mobile-ns-display-block-z-index-100;
+			@extend %gcwu-default-mobile-ns-width-100;
 		}
 	}
 	#gcwu-srchbx {
 		@extend %gcwu-default-mobile-ns-positioning;
-		@extend %gcwu-default-mobile-ns-display-block;
+		@extend %gcwu-default-mobile-ns-display-block-z-index-100;
 		form {
 			border-bottom: 1px solid #999;
 			text-align: center;
 			background: #1A3D6C;
 			padding: 10px 0;
 			margin-bottom: 0;
-			@extend %gcwu-default-mobile-ns-display-block;
+			@extend %gcwu-default-mobile-ns-display-block-z-index-100;
+			@extend %gcwu-default-mobile-ns-width-100;
 		}
 	}
 }

--- a/src/theme-gcwu-fegc/sass/theme-ns.scss
+++ b/src/theme-gcwu-fegc/sass/theme-ns.scss
@@ -18,7 +18,7 @@
 /* -----Build Include Section End----- */
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import 'includes/default-mobile-ns';
 /* -----Build Include Section End----- */

--- a/src/theme-gcwu-fegc/sass/theme-ns.scss
+++ b/src/theme-gcwu-fegc/sass/theme-ns.scss
@@ -18,7 +18,7 @@
 /* -----Build Include Section End----- */
 
 /* Mobile view */
-@media screen and (max-width: 767px), screen and (max-device-width: 767px) {
+@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
 /* -----Build Include Section Start----- */
 @import 'includes/default-mobile-ns';
 /* -----Build Include Section End----- */

--- a/src/theme-gcwu-fegc/sass/theme-serv.scss
+++ b/src/theme-gcwu-fegc/sass/theme-serv.scss
@@ -50,7 +50,7 @@
 }
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-mobile';
 @import 'includes/serv-mobile';

--- a/src/theme-gcwu-fegc/sass/theme-sp-pe.scss
+++ b/src/theme-gcwu-fegc/sass/theme-sp-pe.scss
@@ -52,7 +52,7 @@
 }
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-mobile';
 @import 'includes/sp-pe-mobile';

--- a/src/theme-gcwu-fegc/sass/theme.scss
+++ b/src/theme-gcwu-fegc/sass/theme.scss
@@ -53,7 +53,7 @@
 }
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-mobile';
 @import 'includes/default-mobile';

--- a/src/theme-gcwu-intranet/sass/includes/_default-mobile-ns.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-mobile-ns.scss
@@ -1,0 +1,14 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ */
+.no-js {
+	#gcwu-wmms {
+		object {
+			&[data*="wmms.svg"] {
+				display: block;
+			}
+		}
+		background: #fff;
+	}
+}

--- a/src/theme-gcwu-intranet/sass/includes/_default-mobile.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-mobile.scss
@@ -23,13 +23,20 @@
 
 #gcwu-wmms {
 	object {
-		display: none;
+		&[data*="wmms.svg"] {
+			display: none;
+		}
 	}
 }
 
-.ui-mobile {
-	#gcwu-wmms-in {
-		display: block;
+.pe-disable {
+	#gcwu-wmms {
+		object {
+			&[data*="wmms.svg"] {
+				display: block;
+			}
+		}
+		background: #fff;
 	}
 }
 

--- a/src/theme-gcwu-intranet/sass/theme-ns.scss
+++ b/src/theme-gcwu-intranet/sass/theme-ns.scss
@@ -18,8 +18,9 @@
 /* -----Build Include Section End----- */
 
 /* Mobile view */
-@media screen and (max-width: 767px), screen and (max-device-width: 767px) {
+@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
 /* -----Build Include Section Start----- */
 @import '../../theme-gcwu-fegc/sass/includes/default-mobile-ns';
+@import 'includes/default-mobile-ns';
 /* -----Build Include Section End----- */
 }

--- a/src/theme-gcwu-intranet/sass/theme-ns.scss
+++ b/src/theme-gcwu-intranet/sass/theme-ns.scss
@@ -18,7 +18,7 @@
 /* -----Build Include Section End----- */
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import '../../theme-gcwu-fegc/sass/includes/default-mobile-ns';
 @import 'includes/default-mobile-ns';

--- a/src/theme-gcwu-intranet/sass/theme-serv.scss
+++ b/src/theme-gcwu-intranet/sass/theme-serv.scss
@@ -51,7 +51,7 @@
 }
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-mobile';
 @import '../../theme-gcwu-fegc/sass/includes/serv-mobile';

--- a/src/theme-gcwu-intranet/sass/theme-sp-pe.scss
+++ b/src/theme-gcwu-intranet/sass/theme-sp-pe.scss
@@ -52,7 +52,7 @@
 }
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-mobile';
 @import '../../theme-gcwu-fegc/sass/includes/sp-pe-mobile';

--- a/src/theme-gcwu-intranet/sass/theme.scss
+++ b/src/theme-gcwu-intranet/sass/theme.scss
@@ -56,7 +56,7 @@
 }
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-mobile';
 @import '../../theme-gcwu-fegc/sass/includes/default-mobile';

--- a/src/theme-wet-boew/sass/theme-ns.scss
+++ b/src/theme-wet-boew/sass/theme-ns.scss
@@ -18,7 +18,7 @@
 /* -----Build Include Section End----- */
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import 'includes/default-mobile-ns';
 /* -----Build Include Section End----- */

--- a/src/theme-wet-boew/sass/theme-ns.scss
+++ b/src/theme-wet-boew/sass/theme-ns.scss
@@ -18,7 +18,7 @@
 /* -----Build Include Section End----- */
 
 /* Mobile view */
-@media screen and (max-width:767px), screen and (max-device-width:767px) {
+@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
 /* -----Build Include Section Start----- */
 @import 'includes/default-mobile-ns';
 /* -----Build Include Section End----- */

--- a/src/theme-wet-boew/sass/theme.scss
+++ b/src/theme-wet-boew/sass/theme.scss
@@ -51,7 +51,7 @@
 }
 
 /* Mobile view */
-@media screen and (max-width: 959px), screen and (max-device-width:1023px) {
+@media screen and (max-width: 959px), screen and (max-device-width: 1023px) {
 /* -----Build Include Section Start----- */
 @import '../../base/sass/default-mobile';
 @import 'includes/default-mobile';


### PR DESCRIPTION
Cleaned up Safari, no-js and pe-disable support for the FIP SVG images in both the GCWU and GCWU Intranet themes.
