### PR TITLE
Fixes #1333 by consolidating multiple wb_load calls into one

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -213,14 +213,6 @@
 						}, 200);
 					}
 				}
-
-				if (pe.ie > 0) {
-					if (pe.ie < 9) {
-						pe.wb_load({'plugins': {'css3ie': pe.main}}, 'css3ie-loaded');
-					} else {
-						pe.wb_load({'plugins': {'equalize': pe.main}}, 'equalize-loaded');
-					}
-				}
 			});
 
 			// Load ajax content
@@ -1762,7 +1754,8 @@
 		* @todo pass an element as the context for the recursion.
 		*/
 		dance: function () {
-			var loading_finished = 'wb-init-loaded';
+			var loading_finished = 'wb-init-loaded',
+				plugins = {};
 			pe.document.one(loading_finished, function () {
 				if (!(pe.ie > 0 && pe.ie < 9)) {
 					pe.resize(function () {
@@ -1781,7 +1774,15 @@
 					});
 				}
 			});
-			pe.wb_load({'dep': ['resize', 'equalheights'], 'checkdom': true, 'polycheckdom': true}, loading_finished);
+
+			// Figure out if we need to load plugins for IE
+			if (pe.ie > 0 && pe.ie < 11) {
+				plugins.equalize = pe.main;
+				if (pe.ie < 9) {
+					plugins.css3ie = pe.main;
+				}
+			}
+			pe.wb_load({'plugins': plugins, 'dep': ['resize', 'equalheights'], 'checkdom': true, 'polycheckdom': true}, loading_finished);
 		}
 	};
 	/* window binding */

--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -1776,7 +1776,7 @@
 			});
 
 			// Figure out if we need to load plugins for IE
-			if (pe.ie > 0 && pe.ie < 11) {
+			if (pe.ie > 0) {
 				plugins.equalize = pe.main;
 				if (pe.ie < 9) {
 					plugins.css3ie = pe.main;

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -11,7 +11,7 @@ WET-BOEW-Settings
  */
 var wet_boew_properties = {
 	/** global plugins are called via a array of dependency names **/
-	globals : ['deselectradio', 'css3ie', 'datemodified']
+	globals : ['deselectradio', 'datemodified']
 };
 
 /*


### PR DESCRIPTION
1. Removes css3ie from settings.js.
2. Merges all wb_load calls in pe-ap.js into one in pe.dance().  This fixes #1333.
3. Loads equalize plugin for IE7/8/9/10.
4. Loads css3ie for IE7/8.
