### PR TITLE
Fixed centre alignment of #gcwu-bnr-in for desktop view

### DIFF
--- a/src/theme-gcwu-fegc/sass/includes/_default-responsive.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-responsive.scss
@@ -142,6 +142,7 @@ li {
 }
 
 #gcwu-bnr-in {
+  @extend %gcwu-default-responsive-margin-auto;
 	@extend %gcwu-default-responsive-width-960;
 }
 


### PR DESCRIPTION
Added back margin: auto for the `#gcwu-bnr-in` element.
