### PR TITLE
GCWU Theme: wb-invisilbe hide border in IE8

### DIFF
--- a/src/base/sass/_default-ie.scss
+++ b/src/base/sass/_default-ie.scss
@@ -50,6 +50,12 @@
 	}
 }
 
+.ie8 {
+	.wb-invisible {
+		border: none;
+	}
+}
+
 .ie7, .ie8 {
 	select, button {
 		font-size: 100%


### PR DESCRIPTION
Fixes #1347.
Only seems to affect IE8, IE7 did not show the same issue
