### PR TITLE
Made blockquotes appearance match

### DIFF
--- a/demos/grids/grid-text-eng.html
+++ b/demos/grids/grid-text-eng.html
@@ -365,12 +365,12 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 </blockquote>
 <blockquote class="float-right">
   <p><strong><code>blockquote.float-right</code></strong></p>
-	<p><em>Morbi massa odio, elementum eu accumsan eu, sagittis vitae odio. </em></p>
+	<p>Morbi massa odio, elementum eu accumsan eu, sagittis vitae odio.</p>
 </blockquote>
 <p>Vivamus suscipit dolor vel justo rutrum vitae luctus diam sollicitudin. Pellentesque auctor magna non justo elementum eget facilisis lacus gravida. Morbi massa odio, elementum eu accumsan eu, sagittis vitae odio. Sed sapien metus, commodo mollis tempor ac, pretium sed nulla. Vestibulum mauris leo, egestas et luctus ut, varius ornare nibh. Curabitur eu nunc sed mi adipiscing ultricies. Proin porta ipsum a ipsum auctor bibendum. Suspendisse adipiscing lacus sit amet erat mollis semper. Aliquam nec orci eu lectus vehicula fermentum. Quisque id nunc arcu, sit amet tincidunt arcu. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nulla at erat massa, eu sagittis est. Ut pulvinar vestibulum auctor. Nunc facilisis posuere libero at tincidunt. Ut vitae dui vel nisl volutpat ullamcorper. </p>
 <blockquote class="float-left">
 	<p><strong><code>blockquote.float-left</code></strong></p>
-	<p><em>Morbi massa odio, elementum eu accumsan eu, sagittis vitae odio.</em></p>
+	<p>Morbi massa odio, elementum eu accumsan eu, sagittis vitae odio.</p>
 </blockquote>
 <p>Etiam ut odio quis turpis tincidunt pharetra. Donec adipiscing luctus dui cursus molestie. Nullam vehicula sollicitudin justo, quis cursus quam feugiat ut. Ut et tincidunt enim. Nunc est massa, consectetur ut congue at, mattis sed sem. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Vestibulum dictum sem in nunc lacinia fermentum. Vivamus semper elementum risus ac gravida. Nullam a leo vel velit pretium tristique. In non quam id magna sagittis scelerisque non eu libero. Suspendisse quis risus lobortis leo tempor molestie et mollis massa. Donec auctor, elit in placerat dignissim, massa risus interdum est, ac interdum ipsum dolor id elit. Ut vitae est vel felis luctus rutrum. Quisque ut erat nisi, id rhoncus nibh. Donec sed enim felis, nec tincidunt odio.</p>
 <h2 id="wrap" class="margin-top-xlarge"><code>wrap-none</code> class</h2>

--- a/src/grids/sass/includes/_util-screen.scss
+++ b/src/grids/sass/includes/_util-screen.scss
@@ -174,7 +174,6 @@ blockquote {
 	&.float-right, &.float-left {
 		font: {
 			family: $serif;
-			style: normal;
 		}
 		border: {
 			left: none;


### PR DESCRIPTION
Blockquotes are have italic text but for some reason that was removed
when they were float-right or float-left.  Made it so all blockquotes
are italic.
