### PR TITLE
Cleanup: Remove CSS refrences in root HTML files

### DIFF
--- a/index-eng.html
+++ b/index-eng.html
@@ -23,7 +23,6 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!--[if lte IE 8]>
 <script src="dist/js/jquery-ie.min.js"></script>
 <script src="dist/js/polyfills/html5shiv-min.js"></script>
-<link rel="stylesheet" href="dist/theme-gcwu-fegc/css/jquery.mobile-ie-min.css" />
 <link rel="stylesheet" href="dist/grids/css/util-ie-min.css" />
 <link rel="stylesheet" href="dist/js/css/pe-ap-ie-min.css" />
 <link rel="stylesheet" href="dist/theme-gcwu-fegc/css/theme-ie-min.css" />

--- a/index-fra.html
+++ b/index-fra.html
@@ -23,7 +23,6 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!--[if lte IE 8]>
 <script src="dist/js/jquery-ie.min.js"></script>
 <script src="dist/js/polyfills/html5shiv-min.js"></script>
-<link rel="stylesheet" href="dist/theme-gcwu-fegc/css/jquery.mobile-ie-min.css" />
 <link rel="stylesheet" href="dist/grids/css/util-ie-min.css" />
 <link rel="stylesheet" href="dist/js/css/pe-ap-ie-min.css" />
 <link rel="stylesheet" href="dist/theme-gcwu-fegc/css/theme-ie-min.css" />

--- a/index.html
+++ b/index.html
@@ -28,7 +28,6 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <!--[if lte IE 8]>
 <script src="dist/js/jquery-ie.min.js"></script>
 <script src="dist/js/polyfills/html5shiv-min.js"></script>
-<link rel="stylesheet" href="dist/theme-gcwu-fegc/css/jquery.mobile-ie-min.css" />
 <link rel="stylesheet" href="dist/grids/css/util-ie-min.css" />
 <link rel="stylesheet" href="dist/js/css/pe-ap-ie-min.css" />
 <link rel="stylesheet" href="dist/theme-gcwu-fegc/css/theme-sp-pe-ie-min.css" />


### PR DESCRIPTION
Was missed by the previous PR and only affected the IE copies.
