### PR TITLE
Column count CSS changed to match naming conventions

### DIFF
--- a/demos/grids/grid-base-eng.html
+++ b/demos/grids/grid-base-eng.html
@@ -105,7 +105,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div class="clear"></div>
 <div class="span-6 module-table-contents">
 <h2>Table of contents</h2>
-<ul class="column-three">
+<ul class="column-3">
 	<li><a href="#overview">Grid overview</a></li>
         <li><a href="#structure">Grid structure</a>
 		<ul>

--- a/demos/grids/grid-icon-eng.html
+++ b/demos/grids/grid-icon-eng.html
@@ -157,7 +157,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 
 
  
-<ul class="list-bullet-none indent-medium column-three">
+<ul class="list-bullet-none indent-medium column-3">
 <li><span class="wb-icon-alarm"></span>wb-icon-alarm</li>
 <li><span class="wb-icon-bank"></span>wb-icon-bank</li>
 <li><span class="wb-icon-book"></span>wb-icon-book</li>

--- a/demos/grids/grid-module-eng.html
+++ b/demos/grids/grid-module-eng.html
@@ -345,7 +345,7 @@ of Excellence&lt;/a&gt;&lt;/li&gt;
     <p>The ability to spread the list over multiple columns is achieved using the CSS3 <code>column-count</code> attribute.  IE9 and lower will display the list in a single column, as these browsers do not support column-count.  However, from an accessibility stance, this is a better approach as the table of contents  should be represented by a single list and not carved up over serveral lists for display purposes.  This ensures that the list is symantcially correct and inline with accessibility. </p>
 	<div class="span-4 module-table-contents">
 		<h2>Table of contents</h2>
-		<ul class="column-two">
+		<ul class="column-2">
 			<li><a href="#toc">Fake link</a></li>
 			<li><a href="#toc">Fake link</a></li>
 			<li><a href="#toc">Fake link</a></li>
@@ -362,7 +362,7 @@ of Excellence&lt;/a&gt;&lt;/li&gt;
 <pre>
 &lt;div class=&quot;span-4 module-table-contents&quot;&gt;
 	&lt;h2&gt;Table of contents&lt;/h2&gt;
-	&lt;ul class=&quot;column-two&quot;&gt;
+	&lt;ul class=&quot;column-2&quot;&gt;
 		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
@@ -379,7 +379,7 @@ of Excellence&lt;/a&gt;&lt;/li&gt;
 
     <div class="span-6 module-table-contents">
 		<h2>Table of contents</h2>
-		<ul class="column-three">
+		<ul class="column-3">
 			<li><a href="#toc">Fake link</a></li>
 			<li><a href="#toc">Fake link</a></li>
 			<li><a href="#toc">Fake link</a></li>
@@ -397,7 +397,7 @@ of Excellence&lt;/a&gt;&lt;/li&gt;
 <pre>
 &lt;div class=&quot;span-6 module-table-contents&quot;&gt;
 	&lt;h2&gt;Table of contents&lt;/h2&gt;
-	&lt;ul class=&quot;column-three&quot;&gt;
+	&lt;ul class=&quot;column-3&quot;&gt;
 		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;

--- a/demos/grids/grid-other-eng.html
+++ b/demos/grids/grid-other-eng.html
@@ -350,11 +350,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
   </pre></details>
   <div class="clear"></div>
   <h2 id="columns">Columns</h2>
-   <p>The ability to spread content over multiple columns is achieved using the CSS3 <code>column-count</code> attribute.  IE9 and lower will display the content in a single column, as these browsers do not support column-count. The options are <code>column-two</code>, <code>column-three</code> and <code>column-four</code>.</p>
+   <p>The ability to spread content over multiple columns is achieved using the CSS3 <code>column-count</code> attribute.  IE9 and lower will display the content in a single column, as these browsers do not support column-count. The options are <code>column-2</code>, <code>column-3</code> and <code>column-4</code>.</p>
 <p>	For example, the list in the below table of contents is split into two columns.  From an accessibility stance, this is a better approach as the table of contents  should be represented by a single list and not carved up over serveral lists for display purposes.  This ensures that the list is symantcially correct and inline with accessibility. As previously mentioned, this is column feature is only visible in modern browsers:</p>
 	<div class="span-4 module-table-contents">
 		<h2>Table of contents</h2>
-		<ul class="column-two">
+		<ul class="column-2">
 			<li><a href="#toc">Fake link</a></li>
 			<li><a href="#toc">Fake link</a></li>
 			<li><a href="#toc">Fake link</a></li>
@@ -371,7 +371,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <pre>
 &lt;div class=&quot;span-4 module-table-contents&quot;&gt;
 	&lt;h2&gt;Table of contents&lt;/h2&gt;
-	&lt;ul class=&quot;column-two&quot;&gt;
+	&lt;ul class=&quot;column-2&quot;&gt;
 		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
 		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;

--- a/src/grids/sass/includes/_util-desktop-screen.scss
+++ b/src/grids/sass/includes/_util-desktop-screen.scss
@@ -5,13 +5,13 @@
 @import "compass/css3/columns";
 
 /*	 columns	 */
-.column-two {
+.column-2 {
 	@include column-count(2);
 }
-.column-three {
+.column-3 {
 	@include column-count(3);
 }
-.column-four {
+.column-4 {
 	@include column-count(4);
 }
 


### PR DESCRIPTION
column-two, column-three and column-four change to column-2, column-3
and column-4 to match CSS naming conventions.  As this is not a popular
feature and only works in IE9+, there isn't much uptake on it yet so old
CSS names removed.   No legacy support provided as it's new as of WET 3
anyhow.
