### PR TITLE
Suppress jquery mobile csslint warnings gh 1468

### DIFF
--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -146,7 +146,9 @@
 		</jshint>
 	</target>
 
-	<property name="csslint.ignores" value="ids,important,qualified-headings,universal-selector,unqualified-attributes,star-property-hack,unique-headings,adjoining-classes,floats,overqualified-elements,font-sizes,regex-selectors,duplicate-properties,box-sizing"/>
+	<!-- Zero units can be removed after JQM 1.3.1 as PR fixed these -->
+	<property name="csslint.ignores.jquery.mobile" value="import,compatible-vendor-prefixes,vendor-prefix,adjoining-classes,unique-headings,qualified-headings,duplicate-properties,box-sizing,zero-units,outline-none,known-properties,box-model,text-indent,unqualified-attributes,universal-selector,display-property-grouping,overqualified-elements"/>
+	<property name="csslint.ignores" value="ids,important,qualified-headings,universal-selector,unqualified-attributes,star-property-hack,unique-headings,adjoining-classes,floats,overqualified-elements,font-sizes,regex-selectors,duplicate-properties,box-sizing,duplicate-background-images,fallback-colors"/>
 	<property name="csslint.errors" value="outline-none"/>
 
 	<target name="csslint" description="Runs CSSLint on CSS produced by the project's Sass files and outputs results to the console" depends="usedebugging, prepare-files">
@@ -162,7 +164,7 @@
 
 			<!-- your customized arguments go here -->
 			<arg value="--format=compact"/>
-			<arg value="--ignore=${csslint.ignores}"/>
+			<arg value="--ignore=${csslint.ignores},${csslint.ignores.jquery.mobile}"/>
 			<arg value="--error=${csslint.errors}"/>
 			<srcfile/>
 		</apply>

--- a/src/grids/sass/includes/_util-mobile.scss
+++ b/src/grids/sass/includes/_util-mobile.scss
@@ -47,7 +47,8 @@ table {
 }
 .bb-pre7 {
 	input, textarea, select {
-		&:focus, &:active { /* Can't use pseudo-focus since fix is needed for both focused and activated states */
+		// Can't use pseudo-focus since fix is needed for both focused and activated states
+		&:focus, &:active { 
 			@extend %util-mobile-bb-pre7-background-333-important-color-f9f9f9-important;
 		}
 	}


### PR DESCRIPTION
There were a bunch of warnings introduced after the inclusion of the jQuery mobile CSS.
Some options should be re-evaluated at a later time, but for now this fixes gh-1468.
The only outstanding errors now, are around the @-moz-document parser issues that have already been filed with the other project.
