### PR TITLE
Build: Bump jRuby version for security patch

### DIFF
--- a/build/build-tasks.properties
+++ b/build/build-tasks.properties
@@ -16,14 +16,14 @@ wet-boew-anttasks.jar=${lib.dir}/wet-boew-anttasks.jar
 opencsv.jar=${lib.dir}/opencsv-2.3.jar
 
 #jRuby Properties
-jruby.version=1.7.2
+jruby.version=1.7.3
 jruby.jar=jruby-complete-${jruby.version}.jar
 
 #Gems
 gem.dir=${lib.dir}/jruby-compiled
-sass.gem=sass-3.2.5.gem
-chunky_png.gem=chunky_png-1.2.6.gem
-fssm.gem=fssm-0.2.9.gem
+sass.gem=sass-3.2.6.gem
+chunky_png.gem=chunky_png-1.2.7.gem
+fssm.gem=fssm-0.2.10.gem
 compass.gem=compass-0.12.2.gem
 
 #JSLint


### PR DESCRIPTION
Bump gems as editing the properties file will already trigger a rebuild
of the vendors directory.
