### PR TITLE
Added check for sessionStorage to make sure defined before using in Tabbed interface

### DIFF
--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -531,11 +531,16 @@
 		 * Track the currently active tab for the user's session
 		 */
 		_set_active_panel : function(id, tabListIdx) {
-			window.sessionStorage.setItem('activePanel-' + tabListIdx, id);
+			if (typeof window.sessionStorage !== 'undefined') {
+				window.sessionStorage.setItem('activePanel-' + tabListIdx, id);
+			}
 		},
 
 		_get_active_panel : function(tabListIdx) {
-			return window.sessionStorage.getItem('activePanel-' + tabListIdx);
+			if (typeof window.sessionStorage !== 'undefined') {
+				return window.sessionStorage.getItem('activePanel-' + tabListIdx);
+			}
+			return null;
 		},
 
 		/**


### PR DESCRIPTION
Added check for sessionStorage to make sure defined before using in Tabbed interface (for using IE locally where the sessionStorage polyfill can't work).
