### PR TITLE
Set default table background colour to white in Grids SCSS. Prevents out...

### DIFF
--- a/src/grids/sass/includes/_table.scss
+++ b/src/grids/sass/includes/_table.scss
@@ -132,6 +132,7 @@
 
 @mixin table {
 
+	background-color: $white;
 	border-collapse: collapse;
 	border-spacing: 0;
 	max-width: 100%;


### PR DESCRIPTION
...er visual properties from appearing behind cells in extremely wide tables.
