### PR TITLE
Clear the demos and dist folders in *-dist to avoid residual files

### DIFF
--- a/build/post_build.sh
+++ b/build/post_build.sh
@@ -54,6 +54,8 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] &&  [ "$TRAVIS_REPO_SLUG" == "wet-boew/
 		git checkout -f "$build_branch"
 
 		#Replace the new dist and demo folders and root files with the new ones
+		rm -Rf dist/*
+		rm -Rf demos/*
 		cp -Rf $HOME/temp_wet-boew/* .
 
 		#Commit the result


### PR DESCRIPTION
Renamed, moved or deetefiles remained in the *-dist banch
