### PR TITLE
Restricted mobile css to mobile view, fixed legend overlap in Chrome

### DIFF
--- a/src/js/sass/includes/_formvalid.scss
+++ b/src/js/sass/includes/_formvalid.scss
@@ -33,7 +33,7 @@
 	}
 }
 
-.ui-mobile {
+.mobile-view {
 	.wet-boew-formvalid {
 		input {
 			&[type=checkbox] {
@@ -51,7 +51,7 @@
 			@extend %formvalid-margin-top-1em;
 		}
 		legend {
-			margin-bottom: -1em;
+			margin-bottom: -0.5em;
 		}
 		.buttons {
 			margin-top: 2em;


### PR DESCRIPTION
Mobile CSS was being applied to desktop view as a result of v3.1 change to load jQM for all views.
1. Restricted load of mobile only CSS.
2. Fixed overlap of legend in Chrome for mobile view:

![chrome-mobile-label](https://f.cloud.github.com/assets/2110107/277246/59822aec-90c0-11e2-9bea-1b93e321ed7e.png)
