### PR TITLE
Fixed recursion error for vclick and touchstart events

### DIFF
--- a/src/js/workers/lightbox.js
+++ b/src/js/workers/lightbox.js
@@ -74,8 +74,11 @@
 			// Extend the defaults with settings passed through settings.js (wet_boew_lightbox), class-based overrides and the data-wet-boew attribute
 			$.extend(opts, (typeof wet_boew_lightbox !== 'undefined' ? wet_boew_lightbox : {}), overrides, _pe.data.getData(elm, 'wet-boew'));
 
+			// Find the lightbox links and galleries
+			$lb = elm.find('.lb-item, .lb-item-gal, .lb-gallery, .lb-hidden-gallery');
+
 			// Add touchscreen support for launching the lightbox
-			$lb = elm.find('.lb-item, .lb-gallery, .lb-hidden-gallery').on('vclick touchstart', function () {
+			$lb.filter('.lb-item, .lb-item-gal').on('vclick touchstart', function () {
 				$.fn.colorbox.load();
 			});
 

--- a/src/js/workers/lightbox.js
+++ b/src/js/workers/lightbox.js
@@ -75,13 +75,8 @@
 			$.extend(opts, (typeof wet_boew_lightbox !== 'undefined' ? wet_boew_lightbox : {}), overrides, _pe.data.getData(elm, 'wet-boew'));
 
 			// Add touchscreen support for launching the lightbox
-			$lb = elm.find('.lb-item, .lb-gallery, .lb-hidden-gallery').on('vclick touchstart', function (e) {
-				if (e.stopPropagation) {
-					e.stopPropagation();
-				} else {
-					e.cancelBubble = true;
-				}
-				$(this).trigger('click');
+			$lb = elm.find('.lb-item, .lb-gallery, .lb-hidden-gallery').on('vclick touchstart', function () {
+				$.fn.colorbox.load();
 			});
 
 			// Build single images, inline content and AJAXed content


### PR DESCRIPTION
Calling trigger('click') was overflowing the callstack when vclick and touchstart events were active.  This bug is more noticeable in v3.1 with jQM loaded by default.
