### PR TITLE
Implemented RTL workarounds for jQuery Mobile and Lightbox

### DIFF
--- a/src/base/sass/_default.scss
+++ b/src/base/sass/_default.scss
@@ -5,6 +5,11 @@
 @import 'compass/css3/opacity';
 @import '../../grids/sass/includes/mixins';
 
+%wb-default-left-auto-right--9999 {
+	right: auto;
+	left: -9999px;
+}
+
 body {
 	font-size: 80%;
 	margin: 0;
@@ -155,8 +160,80 @@ h6 {
 }
 
 [dir="rtl"] {
-  .ui-popup-hidden {
-    left: auto;
-    right: -9999px;
-  }
+	/* Start of RTL fixes for jQuery Mobile's way of hiding stuff
+	 * TODO: Fix in jQuery Mobile rather than here
+	 */
+	/* left: -9999px */
+	.ui-nojs {
+		@extend %wb-default-left-auto-right--9999;
+	}
+	.ui-popup-hidden {
+		@extend %wb-default-left-auto-right--9999;
+	}
+	.ui-hide-label {
+		label {
+			&.ui-input-text {
+				@extend %wb-default-left-auto-right--9999;
+			}
+			&.ui-select {
+				@extend %wb-default-left-auto-right--9999;
+			}
+			&.ui-slider {
+				@extend %wb-default-left-auto-right--9999;
+			}
+			&.ui-submit {
+				@extend %wb-default-left-auto-right--9999;
+			}
+			&.ui-controlgroup-label {
+				@extend %wb-default-left-auto-right--9999;
+			}
+		}
+	}
+	.ui-hidden-accessible {
+		@extend %wb-default-left-auto-right--9999;
+	}
+	.ui-page-header-fullscreen {
+		.ui-fixed-hidden {
+			@extend %wb-default-left-auto-right--9999;
+		}
+	}
+	.ui-page-footer-fullscreen {
+		.ui-fixed-hidden {
+			@extend %wb-default-left-auto-right--9999;
+		}
+	}
+	.ui-btn-icon-notext {
+		.ui-btn-text {
+			@extend %wb-default-left-auto-right--9999;
+		}
+	}
+	.ui-controlgroup-controls {
+		label {
+			&.ui-select {
+				@extend %wb-default-left-auto-right--9999;
+			}
+			&.ui-submit {
+				@extend %wb-default-left-auto-right--9999;
+			}
+		}
+	}
+	.ui-select {
+		select {
+			@extend %wb-default-left-auto-right--9999;
+		}
+	}
+	/* text-indent: -9999px */
+	.ui-btn-hidden {
+		text-indent: 9999px;
+	}
+	.ui-collapsible-heading {
+		.ui-btn {
+			span {
+				&.ui-btn {
+					text-indent: 9999px;
+				}
+			}
+		}
+	}
+	/* End of RTL fixes for jQuery Mobile's way of hiding stuff */
 }

--- a/src/base/sass/_default.scss
+++ b/src/base/sass/_default.scss
@@ -9,6 +9,9 @@
 	right: auto;
 	left: -9999px;
 }
+%wb-default-text-indent-9999 {
+	text-indent: 9999px;
+}
 
 body {
 	font-size: 80%;
@@ -163,7 +166,7 @@ h6 {
 	/* Start of RTL fixes for jQuery Mobile's way of hiding stuff
 	 * TODO: Fix in jQuery Mobile rather than here
 	 */
-	/* left: -9999px */
+	/* Fixes left: -9999px */
 	.ui-nojs {
 		@extend %wb-default-left-auto-right--9999;
 	}
@@ -222,15 +225,15 @@ h6 {
 			@extend %wb-default-left-auto-right--9999;
 		}
 	}
-	/* text-indent: -9999px */
+	/* Fixes text-indent: -9999px */
 	.ui-btn-hidden {
-		text-indent: 9999px;
+		@extend %wb-default-text-indent-9999;
 	}
 	.ui-collapsible-heading {
 		.ui-btn {
 			span {
 				&.ui-btn {
-					text-indent: 9999px;
+					@extend %wb-default-text-indent-9999;
 				}
 			}
 		}

--- a/src/js/sass/includes/_lightbox.scss
+++ b/src/js/sass/includes/_lightbox.scss
@@ -8,6 +8,9 @@
 %wb-lightbox-position-absolute {
 	position: absolute;
 }
+%wb-lightbox-text-indent-9999 {
+	text-indent: 9999px;
+}
 
 %wb-lightbox-top-0 {
 	top: 0;
@@ -316,5 +319,17 @@
 			@extend %wb-lightbox-display-block;
 			@extend %wb-lightbox-visibility-visible;
 		}
+	}
+}
+
+[dir="rtl"] {
+	#cboxPrevious {
+		@extend %wb-lightbox-text-indent-9999;
+	}
+	#cboxNext {
+		@extend %wb-lightbox-text-indent-9999;
+	}
+	#cboxClose {
+		@extend %wb-lightbox-text-indent-9999;
 	}
 }


### PR DESCRIPTION
- Fixed display issues when printing RTL pages that are in mobile view.
- Fixed potential RTL issues in Lightbox because of use of text-indent: -9999px.
