### PR TITLE
Kml getElementByNamTag error

### DIFF
--- a/src/js/workers/geomap.js
+++ b/src/js/workers/geomap.js
@@ -808,7 +808,9 @@
 										internalProjection: map.getProjectionObject(),
 										externalProjection: new OpenLayers.Projection('EPSG:4269'),
 										read: function(data) {
-											var items = this.getElementsByTagNameNS(data, '*', 'Placemark'),
+											var parser = new DOMParser(),
+												val = parser.parseFromString(data, "text/xml"),
+												items = this.getElementsByTagNameNS(val, '*', 'Placemark'),
 												row, $row, i, len, feature, atts, features = [],
 												layerAttributes = layer.attributes,
 												name;

--- a/src/js/workers/geomap.js
+++ b/src/js/workers/geomap.js
@@ -808,9 +808,14 @@
 										internalProjection: map.getProjectionObject(),
 										externalProjection: new OpenLayers.Projection('EPSG:4269'),
 										read: function(data) {
-											var parser = new DOMParser(),
-												val = parser.parseFromString(data, "text/xml"),
-												items = this.getElementsByTagNameNS(val, '*', 'Placemark'),
+											
+											// When read from server, data is string instead of #document
+											if (typeof data === 'string') {
+												var parser = new DOMParser(),
+													data = parser.parseFromString(data, "text/xml");
+											}
+
+											var	items = this.getElementsByTagNameNS(data, '*', 'Placemark'),
 												row, $row, i, len, feature, atts, features = [],
 												layerAttributes = layer.attributes,
 												name;


### PR DESCRIPTION
When the KML file is read from the server it is a string and the OpenLayer KML parser is not able to retrieve the geometry. When the file is read locally it is a "#document" element. I added a DOMParser to transform the string and it solve the problem.
