### PR TITLE
Fixes #1598: added IE9 targeted fixes to .tabs-style-2/3

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -153,8 +153,8 @@
 			pe.urlhash = pe.urlpage.hash;
 			pe.urlquery = pe.urlpage.params;
 
-			// Identify whether or not the device supports JavaScript and has a touchscreen
-			$html.removeClass('no-js').addClass(wet_boew_theme !== null ? wet_boew_theme.theme : '').addClass(pe.touchscreen ? 'touchscreen' : '');
+			// Identify whether or not the device supports JavaScript, has a touchscreen and is a modern version of IE
+			$html.removeClass('no-js').addClass(wet_boew_theme !== null ? wet_boew_theme.theme : '').addClass(pe.touchscreen ? 'touchscreen' : '').addClass(pe.ie > 8 ? 'ie' + parseInt(pe.ie, 10) : '');
 
 			hlinks = pe.bodydiv.find('#wb-main a, #wb-skip a').filter(function () {
 				return this.href.indexOf('#') !== -1;

--- a/src/js/sass/includes/_tabbedinterface.scss
+++ b/src/js/sass/includes/_tabbedinterface.scss
@@ -534,3 +534,24 @@
 		display: block;
 	}
 }
+
+.ie9 {
+	.tabs-style-2 {
+		.tabs {
+			li {
+				a {
+					display: inline;
+				}
+			}
+		}
+	}
+	.tabs-style-3 {
+		.tabs {
+			li {
+				&:not(.tabs-toggle) {
+					display: inline;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
When this gets merged with master, the pe-ap.js change doesn't need to go (v3.1 already has .ie9+ CSS classes added to the html element).
