### PR TITLE
Transparency Fixes (CLF2 Theme)

### DIFF
--- a/demos/theme-clf2-nsi2/3col-theme-clf2-nsi2-eng.html
+++ b/demos/theme-clf2-nsi2/3col-theme-clf2-nsi2-eng.html
@@ -136,7 +136,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 </ul>
 </section>
 
-<section><h3>Transparency</h3>
+<section><h3>Transpar&#173;ency</h3>
 <ul>
 <li><a href="#">Completed Access to Information Requests</a></li>
 <li><a href="#">Proactive Disclosure</a></li>

--- a/demos/theme-clf2-nsi2/3col-theme-clf2-nsi2-fra.html
+++ b/demos/theme-clf2-nsi2/3col-theme-clf2-nsi2-fra.html
@@ -135,6 +135,13 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li><a href="#">Article&#160;3a</a></li>
 </ul>
 </section>
+
+<section><h3>Transparence</h3>
+<ul>
+<li><a href="#">Demandes d'accès à l'information complétées</a></li>
+<li><a href="#">Divulgation proactive</a></li>
+</ul>
+</section>
 <!-- SideNavLeftEnd -->
 </div>
 </nav></div></div>

--- a/demos/theme-clf2-nsi2/3col-theme-clf2-nsi2-fra.html
+++ b/demos/theme-clf2-nsi2/3col-theme-clf2-nsi2-fra.html
@@ -136,7 +136,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 </ul>
 </section>
 
-<section><h3>Transparence</h3>
+<section><h3>Transpar&#173;ence</h3>
 <ul>
 <li><a href="#">Demandes d'accès à l'information complétées</a></li>
 <li><a href="#">Divulgation proactive</a></li>


### PR DESCRIPTION
Couldn't help but notice that the Transparency section in the left nav of the French 3 column CLF2 page template has been missing since WET 2.3 (possibly even longer). Figured I'd re-add it, as well as address a 200% text zooming issue.
