### PR TITLE
Fixes #1653: prevents both click and vclick from firing

### DIFF
--- a/src/js/workers/deselectradio.js
+++ b/src/js/workers/deselectradio.js
@@ -27,6 +27,7 @@
 				}
 			}
 			_pe.document.on('click vclick', 'input[type="radio"].deselectable', function (e) {
+				e.stopPropagation();
 				if (this.className.indexOf(' checked') !== -1) { // Already selected so deselect and remember that it is no longer selected
 					this.checked = false;
 					this.className = this.className.replace(' checked', '');
@@ -47,7 +48,6 @@
 						this.className += ' checked';
 					}
 				}
-				e.stopPropagation();
 			});
 			return elm;
 		} // end of exec

--- a/src/js/workers/deselectradio.js
+++ b/src/js/workers/deselectradio.js
@@ -6,7 +6,7 @@
  * Deselectable radio buttons plugin
  */
 /*global jQuery: false*/
-(function ($) {
+(function () {
 	"use strict";
 	var _pe = window.pe || {
 		fn : {}
@@ -26,7 +26,7 @@
 					input.className += ' deselectable' + (input.checked ? ' checked' : '');
 				}
 			}
-			_pe.document.on('click vclick', 'input[type="radio"].deselectable', function () {
+			_pe.document.on('click vclick', 'input[type="radio"].deselectable', function (e) {
 				if (this.className.indexOf(' checked') !== -1) { // Already selected so deselect and remember that it is no longer selected
 					this.checked = false;
 					this.className = this.className.replace(' checked', '');
@@ -47,6 +47,7 @@
 						this.className += ' checked';
 					}
 				}
+				e.stopPropagation();
 			});
 			return elm;
 		} // end of exec


### PR DESCRIPTION
When both events fired, it prevented the radio button from being checked.
