### PR TITLE
Fixes display size of svg FIP and Wordmark in Safari on Windows

### DIFF
--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
@@ -273,6 +273,9 @@ a {
 		@extend %gcwu-default-desktop-screen-margin-left-0;
 		@extend %gcwu-default-desktop-screen-width-234-height-22;
 	}
+  object {
+    @extend %gcwu-default-desktop-screen-width-234-height-22;
+  }
 }
 
 #gcwu-sig-in {
@@ -418,6 +421,9 @@ a {
 		@extend %gcwu-default-desktop-screen-width-139-height-33;
 		margin: 0;
 	}
+  object {
+    @extend %gcwu-default-desktop-screen-width-139-height-33;
+  }
 }
 
 #gcwu-wmms-in {
@@ -539,7 +545,7 @@ a {
 			}
 		}
 	}
-	
+
 	#gcwu-title {
 		a {
 			@extend %gcwu-default-desktop-screen-margin-left-auto;

--- a/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen.scss
@@ -214,6 +214,9 @@
 		@extend %gcwu-intranet-default-desktop-screen-height-30-width-126;
 		@extend %gcwu-intranet-default-desktop-screen-right-0;
 	}
+  object {
+    @extend %gcwu-intranet-default-desktop-screen-height-30-width-126;
+  }
 }
 
 #gcwu-wmms-in {


### PR DESCRIPTION
FIP and Wordmark on Safari are oversized without an explicit size on the object:

![oversized](https://f.cloud.github.com/assets/2110107/301122/3935a1b6-95bf-11e2-8e72-0e1033cb543e.png)
