### PR TITLE
Fixes width of legend underline in IE9

### DIFF
--- a/src/grids/sass/includes/_form.scss
+++ b/src/grids/sass/includes/_form.scss
@@ -265,6 +265,7 @@
 			border-top: 1px solid $silver;
 			content: "";
 			display: block;
+			width: 100%;
 			height: $margin-medium;
 			clear: both;
 		}


### PR DESCRIPTION
In IE9, the legend:after pseudo-element that creates the legend's bottom border was expanding too far to the right.
