### PR TITLE
Removed unused jQuery argument

### DIFF
--- a/src/js/workers/deselectradio.js
+++ b/src/js/workers/deselectradio.js
@@ -5,7 +5,6 @@
 /*
  * Deselectable radio buttons plugin
  */
-/*global jQuery: false*/
 (function () {
 	"use strict";
 	var _pe = window.pe || {
@@ -55,4 +54,4 @@
 	window.pe = _pe;
 	return _pe;
 }
-(jQuery));
+());


### PR DESCRIPTION
The jQuery argument is no longer required after removing the $ in #1655.
