### PR TITLE
Sign In/Out CSS/HTML for #338

### DIFF
--- a/demos/theme-gcwu-fegc/application-signin-eng.html
+++ b/demos/theme-gcwu-fegc/application-signin-eng.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<!--[if IE 7]><html lang="en" class="no-js ie7"><![endif]-->
+<!--[if IE 8]><html lang="en" class="no-js ie8"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html lang="en" class="no-js">
+<!--<![endif]-->
+<head>
+<meta charset="utf-8" />
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+<title>Application Template - Sign In - GC Web Usability theme - Working examples - Web Experience Toolkit (WET)</title>
+
+<link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
+<meta name="description" content="English description / Description en anglais" />
+<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
+<meta name="dcterms.title" content="English title / Titre en anglais" />
+<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
+<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
+<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="dcterms.language" title="ISO639-2" content="eng" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!--[if lte IE 8]>
+<script src="../../dist/js/jquery-ie.min.js"></script>
+<script src="../../dist/js/polyfills/html5shiv-min.js"></script>
+<link rel="stylesheet" href="../../dist/grids/css/util-ie-min.css" />
+<link rel="stylesheet" href="../../dist/js/css/pe-ap-ie-min.css" />
+<link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ie-min.css" />
+<noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-ie-min.css" /></noscript>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../dist/js/jquery.min.js"></script>
+<link rel="stylesheet" href="../../dist/grids/css/util-min.css" />
+<link rel="stylesheet" href="../../dist/js/css/pe-ap-min.css" />
+<link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-min.css" />
+<noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
+<!--<![endif]-->
+
+<!-- CustomCSSStart -->
+<!-- CustomCSSEnd -->
+</head>
+
+<body><div id="wb-body">
+<div id="wb-skip">
+<ul id="wb-tphp">
+<li id="wb-skip1"><a href="#wb-cont">Skip to main content</a></li>
+<li id="wb-skip2"><a href="#wb-nav">Skip to footer</a></li>
+</ul>
+</div>
+
+<div id="wb-head"><div id="wb-head-in"><header>
+<!-- HeaderStart -->
+<nav role="navigation"><div id="gcwu-gcnb"><h2>Government of Canada navigation bar</h2><div id="gcwu-gcnb-in"><div id="gcwu-gcnb-fip">
+<div id="gcwu-sig"><div id="gcwu-sig-in"><object data="../../dist/theme-gcwu-fegc/images/sig-eng.svg" role="img" tabindex="-1" aria-label="Government of Canada" type="image/svg+xml"><img src="../../dist/theme-gcwu-fegc/images/sig-eng.png" alt="Government of Canada" /></object></div></div>
+<ul>
+<li id="gcwu-gcnb1"><a  target="_blank" rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
+<li id="gcwu-gcnb2"><a  target="_blank" rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
+<li id="gcwu-gcnb3"><a  target="_blank" rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
+<li id="gcwu-gcnb-lang"><a href="application-signin-fra.html" lang="fr">Français</a></li>
+</ul>
+</div></div></div></nav>
+
+<div id="gcwu-bnr" role="banner"><div id="gcwu-bnr-in">
+<div id="gcwu-wmms"><div id="gcwu-wmms-in"><object data="../../dist/theme-gcwu-fegc/images/wmms.svg" role="img" tabindex="-1" aria-label="Symbol of the Government of Canada" type="image/svg+xml"><img src="../../dist/theme-gcwu-fegc/images/wmms.png" alt="Symbol of the Government of Canada" /></object></div></div>
+<div id="gcwu-title"><p id="gcwu-title-in"><a target="_blank" href="../../index-eng.html">Web Experience Toolkit (WET)</a></p></div>
+
+<section role="search"><div id="gcwu-srchbx"><h2>Search</h2>
+<form action="#" method="post"><div id="gcwu-srchbx-in">
+<label for="gcwu-srch">Search website</label><input id="gcwu-srch" name="gcwu-srch" type="search" value="" size="27" maxlength="150" />
+<input id="gcwu-srch-submit" name="gcwu-srch-submit" type="submit" value="Search" />
+</div></form>
+</div></section>
+</div></div>
+
+<nav role="navigation">
+<div id="gcwu-psnb"><h2>Site menu</h2><div id="gcwu-psnb-in"><div class="wet-boew-menubar"><div>
+<ul class="mb-menu">
+<li><div><a target="_blank" class="first" href="#">Section 1</a></div></li>
+<li><div><a target="_blank" href="section2/index-eng.html">Section 2</a></div></li>
+<li><div><a target="_blank" href="#">Section 3</a></div></li>
+<li><div><a target="_blank" href="#">Section 4</a></div></li>
+<li><div><a target="_blank" href="#">Section 5</a></div></li>
+</ul>
+</div></div></div></div>
+
+<div id="gcwu-bc"><h2>Breadcrumb trail</h2><div id="gcwu-bc-in">
+<ol>
+<li><a target="_blank" href="../../index-eng.html">Home</a></li>
+<li><a target="_blank" href="../index-eng.html">Working examples</a></li>
+<li><a href="index-eng.html">GC Web Usability theme</a></li>
+<li>Application Template</li>
+</ol>
+</div></div>
+</nav>
+<!-- HeaderEnd -->
+</header></div></div>
+
+<div id="wb-core"><div id="wb-core-in" class="equalize">
+<div id="wb-main" role="main"><div id="wb-main-in">
+<!-- MainContentStart -->
+<h1 id="wb-cont">Application Template - GC Web Usability theme</h1>
+
+<div id="wb-session">
+<ul>
+<li class="session"><a href="#">Sign In</a></li>
+</ul>
+</div>
+
+<section><h2>Heading 2 (<code>h2</code>) default appearance</h2>
+	<section><h3>Heading 3 (<code>h3</code>) default appearance</h3>
+		<section><h4>Heading 4 (<code>h4</code>) default appearance</h4>
+			<section><h5>Heading 5 (<code>h5</code>) default appearance</h5>
+				<section><h6>Heading 6 (<code>h6</code>) default appearance</h6>
+					<p>Paragraph default appearance</p>
+				</section>
+			</section>
+		</section>
+	</section>
+</section>
+
+<p><a href="#">Link default appearance</a></p>
+<p><a href="mailto:"><code>mailto:</code> link default appearance</a></p>
+<p><a href="http://www." rel="external">Third party <code>http://www.</code> link default appearance</a></p>
+<p><a href=".doc">Link to file downloads based on file type <code>.doc</code>, <code>.psd</code>, <code>.zip</code>, <code>.pdf</code>, <code>.xls</code>, <code>.xlt</code>, <code>.rtf</code> and <code>.txt</code> default appearance</a></p>
+<p>Abbreviation default appearance: <abbr title="Treasury Board Secretariat">TBS</abbr>.</p>
+
+<ul>
+<li>unordered list (<code>ul</code>) first level default appearance
+	<ul>
+	<li>unordered list (<code>ul</code>) second level default appearance
+		<ul>
+		<li>unordered list (<code>ul</code>) third level default appearance</li>
+		</ul>
+	</li>
+	</ul>
+</li>
+</ul>
+
+<ol>
+<li>ordered list (<code>ol</code>) first level default appearance</li>
+<li>ordered list (<code>ol</code>) first level default appearance
+	<ol>
+	<li>ordered list (<code>ol</code>) second level default appearance</li>
+	<li>ordered list (<code>ol</code>) second level default appearance
+		<ol>
+		<li>ordered list (<code>ol</code>) third level default appearance</li>
+		<li>ordered list (<code>ol</code>) third level default appearance</li>
+		</ol>
+	</li>
+	</ol>
+</li>
+</ol>
+
+<table>
+<caption>Table caption default appearance</caption>
+<thead>
+<tr>
+<th scope="col">Table header (<code>th</code>) default appearance</th>
+<th scope="col">Table header (<code>th</code>) default appearance</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Table data (<code>td</code>) default appearance</td>
+<td>Table data (<code>td</code>) default appearance</td>
+</tr>
+</tbody>
+</table>
+
+<form action="#" method="post">
+<div><label for="data1">Form input default appearance:</label> <input name="data1" type="text" id="data1" /></div>
+<div><label for="data2">Form text area default appearance:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea></div>
+<div><label for="data4">Form <code>select</code> default appearance:</label>
+<select id="data4" name="data4">
+<option value="Option 1">Option 1</option>
+<option value="Option 2">Option 2</option>
+<option value="Option 3">Option 3</option>
+<option value="Option 4">Option 4</option>
+</select></div>
+<fieldset><legend>Form <code>legend</code>, <code>fieldset</code> and <code>checkbox</code> default appearance</legend>
+<div><input name="checkbox" type="checkbox" id="data5" value="checkbox" />&#160;<label for="data5">Option 1</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data6" value="checkbox" />&#160;<label for="data6">Option 2</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data7" value="checkbox" />&#160;<label for="data7">Option 3</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data8" value="checkbox" />&#160;<label for="data8">Option 4</label></div>
+</fieldset>
+<div><input name="submit" type="submit" id="submit" value="Submit default appearance" />
+<input name="reset" type="reset" id="reset" value="Reset default appearance" /></div>
+</form>
+
+<blockquote>
+<p>&quot;Blockquote default appearance&quot;.</p>
+</blockquote>
+
+<dl id="gcwu-date-mod" role="contentinfo">
+<dt>Version:</dt><dd>1.1b</dd>
+</dl>
+<div class="clear"></div>
+<!-- MainContentEnd -->
+</div></div>
+</div></div>
+
+<div id="wb-foot"><div id="wb-foot-in"><footer><h2 id="wb-nav">Footer</h2>
+<!-- FooterStart -->
+<nav role="navigation"><div id="gcwu-sft"><h3>Site footer</h3><div id="gcwu-sft-in">
+<div id="gcwu-tctr">
+<ul>
+<li class="gcwu-tc"><a href="#" target="_blank" rel="license">Terms and conditions</a></li>
+<li class="gcwu-tr"><a href="#" target="_blank">Transparency</a></li>
+</ul>
+</div>
+<div class="clear"></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">About us</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">News</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">Contact us</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">Stay connected</a></div></div>
+</div></div></nav>
+
+<nav role="navigation"><div id="gcwu-gcft"><h3>Government of Canada footer</h3><div id="gcwu-gcft-in"><div id="gcwu-gcft-fip">
+<ul>
+<li><a target="_blank" rel="external" href="http://healthycanadians.gc.ca/index-eng.php"><span>Health</span><br />healthycanadians.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.voyage.gc.ca/index-eng.asp"><span>Travel</span><br />travel.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.jobbank.gc.ca/intro-eng.aspx"><span>Jobs</span><br />jobbank.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://actionplan.gc.ca/en"><span>Economy</span><br />actionplan.gc.ca</a></li>
+<li id="gcwu-gcft-ca"><div><a target="_blank" rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></div></li>
+</ul>
+</div></div></div></nav>
+<!-- FooterEnd -->
+</footer>
+</div></div></div>
+
+<!-- ScriptsStart -->
+<script src="../../dist/js/settings.js"></script>
+<!--[if lte IE 8]>
+<script src="../../dist/theme-gcwu-fegc/js/theme-ie-min.js"></script>
+<script src="../../dist/js/pe-ap-ie-min.js"></script>
+<script src="../../dist/js/jquerymobile/jquery.mobile-ie.min.js"></script>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../dist/theme-gcwu-fegc/js/theme-min.js"></script>
+<script src="../../dist/js/pe-ap-min.js"></script>
+<script src="../../dist/js/jquerymobile/jquery.mobile.min.js"></script>
+<!--<![endif]-->
+<!-- ScriptsEnd -->
+
+<!-- CustomScriptsStart -->
+<!-- CustomScriptsEnd -->
+</body>
+</html>

--- a/demos/theme-gcwu-fegc/application-signin-fra.html
+++ b/demos/theme-gcwu-fegc/application-signin-fra.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<!--[if IE 7]><html lang="fr" class="no-js ie7"><![endif]-->
+<!--[if IE 8]><html lang="fr" class="no-js ie8"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html lang="fr" class="no-js">
+<!--<![endif]-->
+<head>
+<meta charset="utf-8" />
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+<title>Modèle pour applications - Ouvrir une session - Thème de la facilité d'emploi Web GC - Exemples pratiques - Boîte à outils de l'expérience Web (BOEW)</title>
+
+<link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
+<meta name="description" content="French description / Description en français" />
+<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
+<meta name="dcterms.title" content="French title / Titre en français" />
+<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
+<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
+<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="dcterms.language" title="ISO639-2" content="fra" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!--[if lte IE 8]>
+<script src="../../dist/js/jquery-ie.min.js"></script>
+<script src="../../dist/js/polyfills/html5shiv-min.js"></script>
+<link rel="stylesheet" href="../../dist/grids/css/util-ie-min.css" />
+<link rel="stylesheet" href="../../dist/js/css/pe-ap-ie-min.css" />
+<link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ie-min.css" />
+<noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-ie-min.css" /></noscript>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../dist/js/jquery.min.js"></script>
+<link rel="stylesheet" href="../../dist/grids/css/util-min.css" />
+<link rel="stylesheet" href="../../dist/js/css/pe-ap-min.css" />
+<link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-min.css" />
+<noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
+<!--<![endif]-->
+
+<!-- CustomCSSStart -->
+<!-- CustomCSSEnd -->
+</head>
+
+<body><div id="wb-body">
+<div id="wb-skip">
+<ul id="wb-tphp">
+<li id="wb-skip1"><a href="#wb-cont">Passer au contenu principal</a></li>
+<li id="wb-skip2"><a href="#wb-nav">Passer au pied de page</a></li>
+</ul>
+</div>
+
+<div id="wb-head"><div id="wb-head-in"><header>
+<!-- HeaderStart -->
+<nav role="navigation"><div id="gcwu-gcnb"><h2>Barre de navigation du gouvernement du Canada</h2><div id="gcwu-gcnb-in"><div id="gcwu-gcnb-fip">
+<div id="gcwu-sig"><div id="gcwu-sig-in"><object data="../../dist/theme-gcwu-fegc/images/sig-fra.svg" role="img" tabindex="-1" aria-label="Gouvernement du Canada" type="image/svg+xml"><img src="../../dist/theme-gcwu-fegc/images/sig-fra.png" alt="Gouvernement du Canada" /></object></div></div>
+<ul>
+<li id="gcwu-gcnb1"><a target="_blank" rel="external" href="http://www.canada.gc.ca/menu-fra.html">Canada.gc.ca</a></li>
+<li id="gcwu-gcnb2"><a target="_blank" rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml">Services</a></li>
+<li id="gcwu-gcnb3"><a target="_blank" rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-fra.html">Ministères</a></li>
+<li id="gcwu-gcnb-lang"><a href="application-signin-eng.html" lang="en">English</a></li>
+</ul>
+</div></div></div></nav>
+
+<div id="gcwu-bnr" role="banner"><div id="gcwu-bnr-in">
+<div id="gcwu-wmms"><div id="gcwu-wmms-in"><object data="../../dist/theme-gcwu-fegc/images/wmms.svg" role="img" tabindex="-1" aria-label="Symbole du gouvernement du Canada" type="image/svg+xml"><img src="../../dist/theme-gcwu-fegc/images/wmms.png" alt="Symbole du gouvernement du Canada" /></object></div></div>
+<div id="gcwu-title"><p id="gcwu-title-in"><a target="_blank" href="../../index-fra.html">Boîte à outils de l'expérience Web (BOEW</a></p></div>
+
+<section role="search"><div id="gcwu-srchbx"><h2>Recherche</h2>
+<form action="#" method="post"><div id="gcwu-srchbx-in">
+<label for="gcwu-srch">Recherchez le site Web</label><input id="gcwu-srch" name="gcwu-srch" type="search" value="" size="27" maxlength="150" />
+<input id="gcwu-srch-submit" name="gcwu-srch-submit" type="submit" value="Recherche" />
+</div></form>
+</div></section>
+</div></div>
+
+<nav role="navigation">
+<div id="gcwu-psnb"><h2>Menu du site</h2><div id="gcwu-psnb-in"><div class="wet-boew-menubar"><div>
+<ul class="mb-menu">
+<li><div><a target="_blank" class="first" href="#">Section 1</a></div></li>
+<li><div><a target="_blank" href="section2/index-fra.html">Section 2</a></div></li>
+<li><div><a target="_blank" href="#">Section 3</a></div></li>
+<li><div><a target="_blank" href="#">Section 4</a></div></li>
+<li><div><a target="_blank" href="#">Section 5</a></div></li>
+</ul>
+</div></div></div></div>
+
+<div id="gcwu-bc"><h2>Fil d'Ariane</h2><div id="gcwu-bc-in">
+<ol>
+<li><a target="_blank" href="../../index-fra.html">Accueil</a></li>
+<li><a target="_blank" href="../index-fra.html">Exemples pratiques</a></li>
+<li><a href="index-fra.html">Thème de la facilité d'emploi Web GC</a></li>
+<li>Modèle pour applications</li>
+</ol>
+</div></div>
+</nav>
+<!-- HeaderEnd -->
+</header></div></div>
+
+<div id="wb-core"><div id="wb-core-in" class="equalize">
+<div id="wb-main" role="main"><div id="wb-main-in">
+<!-- MainContentStart -->
+<h1 id="wb-cont">Modèle pour applications - Thème de la facilité d'emploi Web GC</h1>
+
+<div id="wb-session">
+<ul>
+<li class="session"><a href="#">Ouvrir une session</a></li>
+</ul>
+</div>
+
+<section><h2>En-tête 2 (<code>h2</code>) - apparence par défaut</h2>
+	<section><h3>En-tête 3 (<code>h3</code>) - apparence par défaut</h3>
+		<section><h4>En-tête 4 (<code>h4</code>) - apparence par défaut</h4>
+			<section><h5>En-tête 5 (<code>h5</code>) - apparence par défaut</h5>
+				<section><h6>En-tête 6 (<code>h6</code>) - apparence par défaut</h6>
+					<p>Paragraphe - apparence par défaut</p>
+				</section>
+			</section>
+		</section>
+	</section>
+</section>
+
+<p><a href="#">Lien - apparence par défaut</a></p>
+<p><a href="mailto:"><code>mailto:</code> lien - apparence par défaut</a></p>
+<p><a href="http://www." rel="external">Tiers <code>http://www.</code> lien - apparence par défaut</a></p>
+<p><a href=".doc">Lien aux téléchargements des fichiers fondés sur le type de fichier <code>.doc</code>, <code>.psd</code>, <code>.zip</code>, <code>.pdf</code>, <code>.xls</code>, <code>.xlt</code>, <code>.rtf</code> et <code>.txt</code> - apparence par défaut</a></p>
+<p>Abréviation - apparence par défaut: <abbr title="Secrétariat du Conseil de Trésor">SCT</abbr>.</p>
+
+<ul>
+<li>liste à puces (<code>ul</code>) premier niveau - apparence par défaut
+	<ul>
+	<li>liste à puces (<code>ul</code>) deuxième niveau - apparence par défaut
+		<ul>
+		<li>liste à puces (<code>ul</code>) troisième niveau - apparence par défaut</li>
+		</ul>
+	</li>
+	</ul>
+</li>
+</ul>
+
+<ol>
+<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
+	<ol>
+	<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
+	<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
+		<ol>
+		<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+		<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+		</ol>
+	</li>
+	</ol>
+</li>
+</ol>
+
+<table>
+<caption>Légende de table - apparence par défaut</caption>
+<thead>
+<tr>
+<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
+<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Données de table (<code>td</code>) - apparence par défaut</td>
+<td>Données de table (<code>td</code>) - apparence par défaut</td>
+</tr>
+</tbody>
+</table>
+
+<form action="#" method="post">
+<div><label for="data1">Formulaire - Entrée - apparence par défaut&#160;:</label> <input name="data1" type="text" id="data1" /></div>
+<div><label for="data2">Formulaire - Zone texte - apparence par défaut&#160;:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea></div>
+<div><label for="data4">Formulaire - Sélection - apparence par défaut&#160;:</label>
+<select id="data4" name="data4">
+<option value="Option 1">Option 1</option>
+<option value="Option 2">Option 2</option>
+<option value="Option 3">Option 3</option>
+<option value="Option 4">Option 4</option>
+</select></div>
+<fieldset><legend>Formulaire - <code lang="en">legend</code>, <code lang="en">fieldset</code> et case à cocher - apparence par défaut</legend>
+<div><input name="checkbox" type="checkbox" id="data5" value="checkbox" />&#160;<label for="data5">Option 1</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data6" value="checkbox" />&#160;<label for="data6">Option 2</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data7" value="checkbox" />&#160;<label for="data7">Option 3</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data8" value="checkbox" />&#160;<label for="data8">Option 4</label></div>
+</fieldset>
+<div><input name="submit" type="submit" id="submit" value="Soumettre - apparence par défaut" />
+<input name="reset" type="reset" id="reset" value="Réinitialiser - apparence par défaut" /></div>
+</form>
+
+<blockquote>
+<p>&quot;Blockquote - apparence par défaut&quot;.</p>
+</blockquote>
+
+<dl id="gcwu-date-mod" role="contentinfo">
+<dt>Version&#160;:</dt><dd>1.1b</dd>
+</dl>
+<div class="clear"></div>
+<!-- MainContentEnd -->
+</div></div>
+</div></div>
+
+<div id="wb-foot"><div id="wb-foot-in"><footer><h2 id="wb-nav">Pied de page</h2>
+<!-- FooterStart -->
+<nav role="navigation"><div id="gcwu-sft"><h3>Pied de page du site</h3><div id="gcwu-sft-in">
+<div id="gcwu-tctr">
+<ul>
+<li class="gcwu-tc"><a target="_blank" href="#" rel="license">Avis</a></li>
+<li class="gcwu-tr"><a target="_blank" href="#">Transparence</a></li>
+</ul>
+</div>
+<div class="clear"></div>
+<div class="span-2"><div class="gcwu-col-head"><a target="_blank" href="#">À propos de nous</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a target="_blank" href="#">Nouvelles</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a target="_blank" href="#">Contactez-nous</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a target="_blank" href="#">Restez branchés</a></div></div>
+</div></div></nav>
+
+<nav role="navigation"><div id="gcwu-gcft"><h3>Pied de page du gouvernement du Canada</h3><div id="gcwu-gcft-in"><div id="gcwu-gcft-fip">
+<ul>
+<li><a target="_blank" rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
+<li id="gcwu-gcft-ca"><div><a target="_blank" rel="external" href="http://www.canada.gc.ca/menu-fra.html">Canada.gc.ca</a></div></li>
+</ul>
+</div></div></div></nav>
+<!-- FooterEnd -->
+</footer>
+</div></div></div>
+
+<!-- ScriptsStart -->
+<script src="../../dist/js/settings.js"></script>
+<!--[if lte IE 8]>
+<script src="../../dist/theme-gcwu-fegc/js/theme-ie-min.js"></script>
+<script src="../../dist/js/pe-ap-ie-min.js"></script>
+<script src="../../dist/js/jquerymobile/jquery.mobile-ie.min.js"></script>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../dist/theme-gcwu-fegc/js/theme-min.js"></script>
+<script src="../../dist/js/pe-ap-min.js"></script>
+<script src="../../dist/js/jquerymobile/jquery.mobile.min.js"></script>
+<!--<![endif]-->
+<!-- ScriptsEnd -->
+
+<!-- CustomScriptsStart -->
+<!-- CustomScriptsEnd -->
+</body>
+</html>

--- a/demos/theme-gcwu-fegc/application-signout-eng.html
+++ b/demos/theme-gcwu-fegc/application-signout-eng.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<!--[if IE 7]><html lang="en" class="no-js ie7"><![endif]-->
+<!--[if IE 8]><html lang="en" class="no-js ie8"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html lang="en" class="no-js">
+<!--<![endif]-->
+<head>
+<meta charset="utf-8" />
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+<title>Application Template - Sign Out - GC Web Usability theme - Working examples - Web Experience Toolkit (WET)</title>
+
+<link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
+<meta name="description" content="English description / Description en anglais" />
+<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
+<meta name="dcterms.title" content="English title / Titre en anglais" />
+<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
+<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
+<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="dcterms.language" title="ISO639-2" content="eng" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!--[if lte IE 8]>
+<script src="../../dist/js/jquery-ie.min.js"></script>
+<script src="../../dist/js/polyfills/html5shiv-min.js"></script>
+<link rel="stylesheet" href="../../dist/grids/css/util-ie-min.css" />
+<link rel="stylesheet" href="../../dist/js/css/pe-ap-ie-min.css" />
+<link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ie-min.css" />
+<noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-ie-min.css" /></noscript>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../dist/js/jquery.min.js"></script>
+<link rel="stylesheet" href="../../dist/grids/css/util-min.css" />
+<link rel="stylesheet" href="../../dist/js/css/pe-ap-min.css" />
+<link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-min.css" />
+<noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
+<!--<![endif]-->
+
+<!-- CustomCSSStart -->
+<!-- CustomCSSEnd -->
+</head>
+
+<body><div id="wb-body">
+<div id="wb-skip">
+<ul id="wb-tphp">
+<li id="wb-skip1"><a href="#wb-cont">Skip to main content</a></li>
+<li id="wb-skip2"><a href="#wb-nav">Skip to footer</a></li>
+</ul>
+</div>
+
+<div id="wb-head"><div id="wb-head-in"><header>
+<!-- HeaderStart -->
+<nav role="navigation"><div id="gcwu-gcnb"><h2>Government of Canada navigation bar</h2><div id="gcwu-gcnb-in"><div id="gcwu-gcnb-fip">
+<div id="gcwu-sig"><div id="gcwu-sig-in"><object data="../../dist/theme-gcwu-fegc/images/sig-eng.svg" role="img" tabindex="-1" aria-label="Government of Canada" type="image/svg+xml"><img src="../../dist/theme-gcwu-fegc/images/sig-eng.png" alt="Government of Canada" /></object></div></div>
+<ul>
+<li id="gcwu-gcnb1"><a  target="_blank" rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></li>
+<li id="gcwu-gcnb2"><a  target="_blank" rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml">Services</a></li>
+<li id="gcwu-gcnb3"><a  target="_blank" rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-eng.html">Departments</a></li>
+<li id="gcwu-gcnb-lang"><a href="application-signout-fra.html" lang="fr">Français</a></li>
+</ul>
+</div></div></div></nav>
+
+<div id="gcwu-bnr" role="banner"><div id="gcwu-bnr-in">
+<div id="gcwu-wmms"><div id="gcwu-wmms-in"><object data="../../dist/theme-gcwu-fegc/images/wmms.svg" role="img" tabindex="-1" aria-label="Symbol of the Government of Canada" type="image/svg+xml"><img src="../../dist/theme-gcwu-fegc/images/wmms.png" alt="Symbol of the Government of Canada" /></object></div></div>
+<div id="gcwu-title"><p id="gcwu-title-in"><a target="_blank" href="../../index-eng.html">Web Experience Toolkit (WET)</a></p></div>
+
+<section role="search"><div id="gcwu-srchbx"><h2>Search</h2>
+<form action="#" method="post"><div id="gcwu-srchbx-in">
+<label for="gcwu-srch">Search website</label><input id="gcwu-srch" name="gcwu-srch" type="search" value="" size="27" maxlength="150" />
+<input id="gcwu-srch-submit" name="gcwu-srch-submit" type="submit" value="Search" />
+</div></form>
+</div></section>
+</div></div>
+
+<nav role="navigation">
+<div id="gcwu-psnb"><h2>Site menu</h2><div id="gcwu-psnb-in"><div class="wet-boew-menubar"><div>
+<ul class="mb-menu">
+<li><div><a target="_blank" class="first" href="#">Section 1</a></div></li>
+<li><div><a target="_blank" href="section2/index-eng.html">Section 2</a></div></li>
+<li><div><a target="_blank" href="#">Section 3</a></div></li>
+<li><div><a target="_blank" href="#">Section 4</a></div></li>
+<li><div><a target="_blank" href="#">Section 5</a></div></li>
+</ul>
+</div></div></div></div>
+
+<div id="gcwu-bc"><h2>Breadcrumb trail</h2><div id="gcwu-bc-in">
+<ol>
+<li><a target="_blank" href="../../index-eng.html">Home</a></li>
+<li><a target="_blank" href="../index-eng.html">Working examples</a></li>
+<li><a href="index-eng.html">GC Web Usability theme</a></li>
+<li>Application Template</li>
+</ol>
+</div></div>
+</nav>
+<!-- HeaderEnd -->
+</header></div></div>
+
+<div id="wb-core"><div id="wb-core-in" class="equalize">
+<div id="wb-main" role="main"><div id="wb-main-in">
+<!-- MainContentStart -->
+<h1 id="wb-cont">Application Template - GC Web Usability theme</h1>
+
+<div id="wb-session">
+<ul>
+<li class="settings"><a href="#">Your account</a></li>
+<li class="session"><a href="#">Sign Out</a></li>
+</ul>
+</div>
+
+<section><h2>Heading 2 (<code>h2</code>) default appearance</h2>
+	<section><h3>Heading 3 (<code>h3</code>) default appearance</h3>
+		<section><h4>Heading 4 (<code>h4</code>) default appearance</h4>
+			<section><h5>Heading 5 (<code>h5</code>) default appearance</h5>
+				<section><h6>Heading 6 (<code>h6</code>) default appearance</h6>
+					<p>Paragraph default appearance</p>
+				</section>
+			</section>
+		</section>
+	</section>
+</section>
+
+<p><a href="#">Link default appearance</a></p>
+<p><a href="mailto:"><code>mailto:</code> link default appearance</a></p>
+<p><a href="http://www." rel="external">Third party <code>http://www.</code> link default appearance</a></p>
+<p><a href=".doc">Link to file downloads based on file type <code>.doc</code>, <code>.psd</code>, <code>.zip</code>, <code>.pdf</code>, <code>.xls</code>, <code>.xlt</code>, <code>.rtf</code> and <code>.txt</code> default appearance</a></p>
+<p>Abbreviation default appearance: <abbr title="Treasury Board Secretariat">TBS</abbr>.</p>
+
+<ul>
+<li>unordered list (<code>ul</code>) first level default appearance
+	<ul>
+	<li>unordered list (<code>ul</code>) second level default appearance
+		<ul>
+		<li>unordered list (<code>ul</code>) third level default appearance</li>
+		</ul>
+	</li>
+	</ul>
+</li>
+</ul>
+
+<ol>
+<li>ordered list (<code>ol</code>) first level default appearance</li>
+<li>ordered list (<code>ol</code>) first level default appearance
+	<ol>
+	<li>ordered list (<code>ol</code>) second level default appearance</li>
+	<li>ordered list (<code>ol</code>) second level default appearance
+		<ol>
+		<li>ordered list (<code>ol</code>) third level default appearance</li>
+		<li>ordered list (<code>ol</code>) third level default appearance</li>
+		</ol>
+	</li>
+	</ol>
+</li>
+</ol>
+
+<table>
+<caption>Table caption default appearance</caption>
+<thead>
+<tr>
+<th scope="col">Table header (<code>th</code>) default appearance</th>
+<th scope="col">Table header (<code>th</code>) default appearance</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Table data (<code>td</code>) default appearance</td>
+<td>Table data (<code>td</code>) default appearance</td>
+</tr>
+</tbody>
+</table>
+
+<form action="#" method="post">
+<div><label for="data1">Form input default appearance:</label> <input name="data1" type="text" id="data1" /></div>
+<div><label for="data2">Form text area default appearance:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea></div>
+<div><label for="data4">Form <code>select</code> default appearance:</label>
+<select id="data4" name="data4">
+<option value="Option 1">Option 1</option>
+<option value="Option 2">Option 2</option>
+<option value="Option 3">Option 3</option>
+<option value="Option 4">Option 4</option>
+</select></div>
+<fieldset><legend>Form <code>legend</code>, <code>fieldset</code> and <code>checkbox</code> default appearance</legend>
+<div><input name="checkbox" type="checkbox" id="data5" value="checkbox" />&#160;<label for="data5">Option 1</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data6" value="checkbox" />&#160;<label for="data6">Option 2</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data7" value="checkbox" />&#160;<label for="data7">Option 3</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data8" value="checkbox" />&#160;<label for="data8">Option 4</label></div>
+</fieldset>
+<div><input name="submit" type="submit" id="submit" value="Submit default appearance" />
+<input name="reset" type="reset" id="reset" value="Reset default appearance" /></div>
+</form>
+
+<blockquote>
+<p>&quot;Blockquote default appearance&quot;.</p>
+</blockquote>
+
+<dl id="gcwu-date-mod" role="contentinfo">
+<dt>Version:</dt><dd>1.1b</dd>
+</dl>
+<div class="clear"></div>
+<!-- MainContentEnd -->
+</div></div>
+</div></div>
+
+<div id="wb-foot"><div id="wb-foot-in"><footer><h2 id="wb-nav">Footer</h2>
+<!-- FooterStart -->
+<nav role="navigation"><div id="gcwu-sft"><h3>Site footer</h3><div id="gcwu-sft-in">
+<div id="gcwu-tctr">
+<ul>
+<li class="gcwu-tc"><a href="#" target="_blank" rel="license">Terms and conditions</a></li>
+<li class="gcwu-tr"><a href="#" target="_blank">Transparency</a></li>
+</ul>
+</div>
+<div class="clear"></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">About us</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">News</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">Contact us</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">Stay connected</a></div></div>
+</div></div></nav>
+
+<nav role="navigation"><div id="gcwu-gcft"><h3>Government of Canada footer</h3><div id="gcwu-gcft-in"><div id="gcwu-gcft-fip">
+<ul>
+<li><a target="_blank" rel="external" href="http://healthycanadians.gc.ca/index-eng.php"><span>Health</span><br />healthycanadians.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.voyage.gc.ca/index-eng.asp"><span>Travel</span><br />travel.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.jobbank.gc.ca/intro-eng.aspx"><span>Jobs</span><br />jobbank.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://actionplan.gc.ca/en"><span>Economy</span><br />actionplan.gc.ca</a></li>
+<li id="gcwu-gcft-ca"><div><a target="_blank" rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></div></li>
+</ul>
+</div></div></div></nav>
+<!-- FooterEnd -->
+</footer>
+</div></div></div>
+
+<!-- ScriptsStart -->
+<script src="../../dist/js/settings.js"></script>
+<!--[if lte IE 8]>
+<script src="../../dist/theme-gcwu-fegc/js/theme-ie-min.js"></script>
+<script src="../../dist/js/pe-ap-ie-min.js"></script>
+<script src="../../dist/js/jquerymobile/jquery.mobile-ie.min.js"></script>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../dist/theme-gcwu-fegc/js/theme-min.js"></script>
+<script src="../../dist/js/pe-ap-min.js"></script>
+<script src="../../dist/js/jquerymobile/jquery.mobile.min.js"></script>
+<!--<![endif]-->
+<!-- ScriptsEnd -->
+
+<!-- CustomScriptsStart -->
+<!-- CustomScriptsEnd -->
+</body>
+</html>

--- a/demos/theme-gcwu-fegc/application-signout-fra.html
+++ b/demos/theme-gcwu-fegc/application-signout-fra.html
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<!--[if IE 7]><html lang="fr" class="no-js ie7"><![endif]-->
+<!--[if IE 8]><html lang="fr" class="no-js ie8"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html lang="fr" class="no-js">
+<!--<![endif]-->
+<head>
+<meta charset="utf-8" />
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+<title>Modèle pour applications - Fermer la session - Thème de la facilité d'emploi Web GC - Exemples pratiques - Boîte à outils de l'expérience Web (BOEW)</title>
+
+<link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
+<meta name="description" content="French description / Description en français" />
+<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
+<meta name="dcterms.title" content="French title / Titre en français" />
+<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
+<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
+<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="dcterms.language" title="ISO639-2" content="fra" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!--[if lte IE 8]>
+<script src="../../dist/js/jquery-ie.min.js"></script>
+<script src="../../dist/js/polyfills/html5shiv-min.js"></script>
+<link rel="stylesheet" href="../../dist/grids/css/util-ie-min.css" />
+<link rel="stylesheet" href="../../dist/js/css/pe-ap-ie-min.css" />
+<link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ie-min.css" />
+<noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-ie-min.css" /></noscript>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../dist/js/jquery.min.js"></script>
+<link rel="stylesheet" href="../../dist/grids/css/util-min.css" />
+<link rel="stylesheet" href="../../dist/js/css/pe-ap-min.css" />
+<link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-min.css" />
+<noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
+<!--<![endif]-->
+
+<!-- CustomCSSStart -->
+<!-- CustomCSSEnd -->
+</head>
+
+<body><div id="wb-body">
+<div id="wb-skip">
+<ul id="wb-tphp">
+<li id="wb-skip1"><a href="#wb-cont">Passer au contenu principal</a></li>
+<li id="wb-skip2"><a href="#wb-nav">Passer au pied de page</a></li>
+</ul>
+</div>
+
+<div id="wb-head"><div id="wb-head-in"><header>
+<!-- HeaderStart -->
+<nav role="navigation"><div id="gcwu-gcnb"><h2>Barre de navigation du gouvernement du Canada</h2><div id="gcwu-gcnb-in"><div id="gcwu-gcnb-fip">
+<div id="gcwu-sig"><div id="gcwu-sig-in"><object data="../../dist/theme-gcwu-fegc/images/sig-fra.svg" role="img" tabindex="-1" aria-label="Gouvernement du Canada" type="image/svg+xml"><img src="../../dist/theme-gcwu-fegc/images/sig-fra.png" alt="Gouvernement du Canada" /></object></div></div>
+<ul>
+<li id="gcwu-gcnb1"><a target="_blank" rel="external" href="http://www.canada.gc.ca/menu-fra.html">Canada.gc.ca</a></li>
+<li id="gcwu-gcnb2"><a target="_blank" rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml">Services</a></li>
+<li id="gcwu-gcnb3"><a target="_blank" rel="external" href="http://www.canada.gc.ca/aboutgov-ausujetgouv/depts/menu-fra.html">Ministères</a></li>
+<li id="gcwu-gcnb-lang"><a href="application-signout-eng.html" lang="en">English</a></li>
+</ul>
+</div></div></div></nav>
+
+<div id="gcwu-bnr" role="banner"><div id="gcwu-bnr-in">
+<div id="gcwu-wmms"><div id="gcwu-wmms-in"><object data="../../dist/theme-gcwu-fegc/images/wmms.svg" role="img" tabindex="-1" aria-label="Symbole du gouvernement du Canada" type="image/svg+xml"><img src="../../dist/theme-gcwu-fegc/images/wmms.png" alt="Symbole du gouvernement du Canada" /></object></div></div>
+<div id="gcwu-title"><p id="gcwu-title-in"><a target="_blank" href="../../index-fra.html">Boîte à outils de l'expérience Web (BOEW</a></p></div>
+
+<section role="search"><div id="gcwu-srchbx"><h2>Recherche</h2>
+<form action="#" method="post"><div id="gcwu-srchbx-in">
+<label for="gcwu-srch">Recherchez le site Web</label><input id="gcwu-srch" name="gcwu-srch" type="search" value="" size="27" maxlength="150" />
+<input id="gcwu-srch-submit" name="gcwu-srch-submit" type="submit" value="Recherche" />
+</div></form>
+</div></section>
+</div></div>
+
+<nav role="navigation">
+<div id="gcwu-psnb"><h2>Menu du site</h2><div id="gcwu-psnb-in"><div class="wet-boew-menubar"><div>
+<ul class="mb-menu">
+<li><div><a target="_blank" class="first" href="#">Section 1</a></div></li>
+<li><div><a target="_blank" href="section2/index-fra.html">Section 2</a></div></li>
+<li><div><a target="_blank" href="#">Section 3</a></div></li>
+<li><div><a target="_blank" href="#">Section 4</a></div></li>
+<li><div><a target="_blank" href="#">Section 5</a></div></li>
+</ul>
+</div></div></div></div>
+
+<div id="gcwu-bc"><h2>Fil d'Ariane</h2><div id="gcwu-bc-in">
+<ol>
+<li><a target="_blank" href="../../index-fra.html">Accueil</a></li>
+<li><a target="_blank" href="../index-fra.html">Exemples pratiques</a></li>
+<li><a href="index-fra.html">Thème de la facilité d'emploi Web GC</a></li>
+<li>Modèle pour applications</li>
+</ol>
+</div></div>
+</nav>
+<!-- HeaderEnd -->
+</header></div></div>
+
+<div id="wb-core"><div id="wb-core-in" class="equalize">
+<div id="wb-main" role="main"><div id="wb-main-in">
+<!-- MainContentStart -->
+<h1 id="wb-cont">Modèle pour applications - Thème de la facilité d'emploi Web GC</h1>
+
+<div id="wb-session">
+<ul>
+<li class="settings"><a href="#">Votre compte</a></li>
+<li class="session"><a href="#">Fermer la session</a></li>
+</ul>
+</div>
+
+<section><h2>En-tête 2 (<code>h2</code>) - apparence par défaut</h2>
+	<section><h3>En-tête 3 (<code>h3</code>) - apparence par défaut</h3>
+		<section><h4>En-tête 4 (<code>h4</code>) - apparence par défaut</h4>
+			<section><h5>En-tête 5 (<code>h5</code>) - apparence par défaut</h5>
+				<section><h6>En-tête 6 (<code>h6</code>) - apparence par défaut</h6>
+					<p>Paragraphe - apparence par défaut</p>
+				</section>
+			</section>
+		</section>
+	</section>
+</section>
+
+<p><a href="#">Lien - apparence par défaut</a></p>
+<p><a href="mailto:"><code>mailto:</code> lien - apparence par défaut</a></p>
+<p><a href="http://www." rel="external">Tiers <code>http://www.</code> lien - apparence par défaut</a></p>
+<p><a href=".doc">Lien aux téléchargements des fichiers fondés sur le type de fichier <code>.doc</code>, <code>.psd</code>, <code>.zip</code>, <code>.pdf</code>, <code>.xls</code>, <code>.xlt</code>, <code>.rtf</code> et <code>.txt</code> - apparence par défaut</a></p>
+<p>Abréviation - apparence par défaut: <abbr title="Secrétariat du Conseil de Trésor">SCT</abbr>.</p>
+
+<ul>
+<li>liste à puces (<code>ul</code>) premier niveau - apparence par défaut
+	<ul>
+	<li>liste à puces (<code>ul</code>) deuxième niveau - apparence par défaut
+		<ul>
+		<li>liste à puces (<code>ul</code>) troisième niveau - apparence par défaut</li>
+		</ul>
+	</li>
+	</ul>
+</li>
+</ul>
+
+<ol>
+<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
+	<ol>
+	<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
+	<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
+		<ol>
+		<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+		<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+		</ol>
+	</li>
+	</ol>
+</li>
+</ol>
+
+<table>
+<caption>Légende de table - apparence par défaut</caption>
+<thead>
+<tr>
+<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
+<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Données de table (<code>td</code>) - apparence par défaut</td>
+<td>Données de table (<code>td</code>) - apparence par défaut</td>
+</tr>
+</tbody>
+</table>
+
+<form action="#" method="post">
+<div><label for="data1">Formulaire - Entrée - apparence par défaut&#160;:</label> <input name="data1" type="text" id="data1" /></div>
+<div><label for="data2">Formulaire - Zone texte - apparence par défaut&#160;:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea></div>
+<div><label for="data4">Formulaire - Sélection - apparence par défaut&#160;:</label>
+<select id="data4" name="data4">
+<option value="Option 1">Option 1</option>
+<option value="Option 2">Option 2</option>
+<option value="Option 3">Option 3</option>
+<option value="Option 4">Option 4</option>
+</select></div>
+<fieldset><legend>Formulaire - <code lang="en">legend</code>, <code lang="en">fieldset</code> et case à cocher - apparence par défaut</legend>
+<div><input name="checkbox" type="checkbox" id="data5" value="checkbox" />&#160;<label for="data5">Option 1</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data6" value="checkbox" />&#160;<label for="data6">Option 2</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data7" value="checkbox" />&#160;<label for="data7">Option 3</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data8" value="checkbox" />&#160;<label for="data8">Option 4</label></div>
+</fieldset>
+<div><input name="submit" type="submit" id="submit" value="Soumettre - apparence par défaut" />
+<input name="reset" type="reset" id="reset" value="Réinitialiser - apparence par défaut" /></div>
+</form>
+
+<blockquote>
+<p>&quot;Blockquote - apparence par défaut&quot;.</p>
+</blockquote>
+
+<dl id="gcwu-date-mod" role="contentinfo">
+<dt>Version&#160;:</dt><dd>1.1b</dd>
+</dl>
+<div class="clear"></div>
+<!-- MainContentEnd -->
+</div></div>
+</div></div>
+
+<div id="wb-foot"><div id="wb-foot-in"><footer><h2 id="wb-nav">Pied de page</h2>
+<!-- FooterStart -->
+<nav role="navigation"><div id="gcwu-sft"><h3>Pied de page du site</h3><div id="gcwu-sft-in">
+<div id="gcwu-tctr">
+<ul>
+<li class="gcwu-tc"><a target="_blank" href="#" rel="license">Avis</a></li>
+<li class="gcwu-tr"><a target="_blank" href="#">Transparence</a></li>
+</ul>
+</div>
+<div class="clear"></div>
+<div class="span-2"><div class="gcwu-col-head"><a target="_blank" href="#">À propos de nous</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a target="_blank" href="#">Nouvelles</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a target="_blank" href="#">Contactez-nous</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a target="_blank" href="#">Restez branchés</a></div></div>
+</div></div></nav>
+
+<nav role="navigation"><div id="gcwu-gcft"><h3>Pied de page du gouvernement du Canada</h3><div id="gcwu-gcft-in"><div id="gcwu-gcft-fip">
+<ul>
+<li><a target="_blank" rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
+<li><a target="_blank" rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
+<li id="gcwu-gcft-ca"><div><a target="_blank" rel="external" href="http://www.canada.gc.ca/menu-fra.html">Canada.gc.ca</a></div></li>
+</ul>
+</div></div></div></nav>
+<!-- FooterEnd -->
+</footer>
+</div></div></div>
+
+<!-- ScriptsStart -->
+<script src="../../dist/js/settings.js"></script>
+<!--[if lte IE 8]>
+<script src="../../dist/theme-gcwu-fegc/js/theme-ie-min.js"></script>
+<script src="../../dist/js/pe-ap-ie-min.js"></script>
+<script src="../../dist/js/jquerymobile/jquery.mobile-ie.min.js"></script>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../dist/theme-gcwu-fegc/js/theme-min.js"></script>
+<script src="../../dist/js/pe-ap-min.js"></script>
+<script src="../../dist/js/jquerymobile/jquery.mobile.min.js"></script>
+<!--<![endif]-->
+<!-- ScriptsEnd -->
+
+<!-- CustomScriptsStart -->
+<!-- CustomScriptsEnd -->
+</body>
+</html>

--- a/demos/theme-gcwu-fegc/ar/application-signin-ar.html
+++ b/demos/theme-gcwu-fegc/ar/application-signin-ar.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<!--[if IE 7]><html dir="rtl" lang="ar" class="no-js ie7"><![endif]-->
+<!--[if IE 8]><html dir="rtl" lang="ar" class="no-js ie8"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html dir="rtl" lang="ar" class="no-js">
+<!--<![endif]-->
+<head>
+<meta charset="utf-8" />
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+<title>Application Template - Sign Out - GC Web Usability theme - Working examples - Web Experience Toolkit (WET)</title>
+
+<link rel="shortcut icon" href="../../../dist/theme-gcwu-fegc/images/favicon.ico" />
+<meta name="description" content="Arabic description / Description en arabe" />
+<meta name="dcterms.creator" content="Arabic name of the content author / Nom en arabe de l'auteur du contenu" />
+<meta name="dcterms.title" content="Arabic title / Titre en arabe" />
+<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
+<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
+<meta name="dcterms.subject" title="scheme" content="Arabic subject terms / Termes de sujet en arabe" />
+<meta name="dcterms.language" title="ISO639-2" content="eng" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!--[if lte IE 8]>
+<script src="../../../dist/js/jquery-ie.min.js"></script>
+<script src="../../../dist/js/polyfills/html5shiv-min.js"></script>
+<link rel="stylesheet" href="../../../dist/grids/css/util-ie-min.css" />
+<link rel="stylesheet" href="../../../dist/js/css/pe-ap-ie-min.css" />
+<link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-ie-min.css" />
+<noscript><link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-ns-ie-min.css" /></noscript>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../../dist/js/jquery.min.js"></script>
+<link rel="stylesheet" href="../../../dist/grids/css/util-min.css" />
+<link rel="stylesheet" href="../../../dist/js/css/pe-ap-min.css" />
+<link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-min.css" />
+<noscript><link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
+<!--<![endif]-->
+
+<!-- CustomCSSStart -->
+<!-- CustomCSSEnd -->
+</head>
+
+<body><div id="wb-body">
+<div id="wb-skip">
+<ul id="wb-tphp">
+<li id="wb-skip1"><a href="#wb-cont">Skip to main content</a></li>
+<li id="wb-skip2"><a href="#wb-nav">Skip to footer</a></li>
+</ul>
+</div>
+
+<div id="wb-head"><div id="wb-head-in"><header>
+<!-- HeaderStart -->
+<nav role="navigation"><div id="gcwu-gcnb"><h2>Government of Canada navigation bar</h2><div id="gcwu-gcnb-in"><div id="gcwu-gcnb-fip">
+<div id="gcwu-sig"><div id="gcwu-sig-in"><object data="../../../dist/theme-gcwu-fegc/images/sig-eng.svg" role="img" tabindex="-1" aria-label="Government of Canada" type="image/svg+xml"><img src="../../../dist/theme-gcwu-fegc/images/sig-eng.png" alt="Government of Canada" /></object></div></div>
+<ul>
+<li id="gcwu-gcnb-lang"><a href="../application-signin-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang-2"><a href="../application-signin-eng.html" lang="en">English</a></li>
+</ul>
+</div></div></div></nav>
+
+<div id="gcwu-bnr" role="banner"><div id="gcwu-bnr-in">
+<div id="gcwu-wmms"><div id="gcwu-wmms-in"><object data="../../../dist/theme-gcwu-fegc/images/wmms.svg" role="img" tabindex="-1" aria-label="Symbol of the Government of Canada" type="image/svg+xml"><img src="../../../dist/theme-gcwu-fegc/images/wmms.png" alt="Symbol of the Government of Canada" /></object></div></div>
+<div id="gcwu-title"><p id="gcwu-title-in"><a target="_blank" href="../../../index-eng.html">Web Experience Toolkit</a></p></div>
+
+<section role="search"><div id="gcwu-srchbx"><h2>Search</h2>
+<form action="#" method="post"><div id="gcwu-srchbx-in">
+<label for="gcwu-srch">Search website</label><input id="gcwu-srch" name="gcwu-srch" type="search" value="" size="27" maxlength="150" />
+<input id="gcwu-srch-submit" name="gcwu-srch-submit" type="submit" value="Search" />
+</div></form>
+</div></section>
+</div></div>
+
+<nav role="navigation">
+<div id="gcwu-psnb"><h2>Site menu</h2><div id="gcwu-psnb-in"><div class="wet-boew-menubar"><div>
+<ul class="mb-menu">
+<li><div><a target="_blank" class="first" href="#">Section 1</a></div></li>
+<li><div><a target="_blank" href="section2/index-eng.html">Section 2</a></div></li>
+<li><div><a target="_blank" href="#">Section 3</a></div></li>
+<li><div><a target="_blank" href="#">Section 4</a></div></li>
+<li><div><a target="_blank" href="#">Section 5</a></div></li>
+</ul>
+</div></div></div></div>
+
+<div id="gcwu-bc"><h2>Breadcrumb trail</h2><div id="gcwu-bc-in">
+<ol>
+<li><a target="_blank" href="../../../index-eng.html">Home</a></li>
+<li><a target="_blank" href="../../index-eng.html">Working examples</a></li>
+<li><a target="_blank" href="../index-eng.html">GC Web Usability theme</a></li>
+<li>Application Template</li>
+</ol>
+</div></div>
+</nav>
+<!-- HeaderEnd -->
+</header></div></div>
+
+<div id="wb-core"><div id="wb-core-in" class="equalize">
+<div id="wb-main" role="main"><div id="wb-main-in">
+<!-- MainContentStart -->
+<h1 id="wb-cont">Application Template - GC Web Usability theme</h1>
+
+<div id="wb-session">
+<ul>
+<li class="session"><a href="#">Sign In</a></li>
+</ul>
+</div>
+
+<section><h2>Heading 2 (<code>h2</code>) default appearance</h2>
+	<section><h3>Heading 3 (<code>h3</code>) default appearance</h3>
+		<section><h4>Heading 4 (<code>h4</code>) default appearance</h4>
+			<section><h5>Heading 5 (<code>h5</code>) default appearance</h5>
+				<section><h6>Heading 6 (<code>h6</code>) default appearance</h6>
+					<p>Paragraph default appearance</p>
+				</section>
+			</section>
+		</section>
+	</section>
+</section>
+
+<p><a href="#">Link default appearance</a></p>
+<p><a href="mailto:"><code>mailto:</code> link default appearance</a></p>
+<p><a href="http://www." rel="external">Third party <code>http://www.</code> link default appearance</a></p>
+<p><a href=".doc">Link to file downloads based on file type <code>.doc</code>, <code>.psd</code>, <code>.zip</code>, <code>.pdf</code>, <code>.xls</code>, <code>.xlt</code>, <code>.rtf</code> and <code>.txt</code> default appearance</a></p>
+<p>Abbreviation default appearance: <abbr title="Treasury Board Secretariat">TBS</abbr>.</p>
+
+<ul>
+<li>unordered list (<code>ul</code>) first level default appearance
+	<ul>
+	<li>unordered list (<code>ul</code>) second level default appearance
+		<ul>
+		<li>unordered list (<code>ul</code>) third level default appearance</li>
+		</ul>
+	</li>
+	</ul>
+</li>
+</ul>
+
+<ol>
+<li>ordered list (<code>ol</code>) first level default appearance</li>
+<li>ordered list (<code>ol</code>) first level default appearance
+	<ol>
+	<li>ordered list (<code>ol</code>) second level default appearance</li>
+	<li>ordered list (<code>ol</code>) second level default appearance
+		<ol>
+		<li>ordered list (<code>ol</code>) third level default appearance</li>
+		<li>ordered list (<code>ol</code>) third level default appearance</li>
+		</ol>
+	</li>
+	</ol>
+</li>
+</ol>
+
+<table>
+<caption>Table caption default appearance</caption>
+<thead>
+<tr>
+<th scope="col">Table header (<code>th</code>) default appearance</th>
+<th scope="col">Table header (<code>th</code>) default appearance</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Table data (<code>td</code>) default appearance</td>
+<td>Table data (<code>td</code>) default appearance</td>
+</tr>
+</tbody>
+</table>
+
+<form action="#" method="post">
+<div><label for="data1">Form input default appearance:</label> <input name="data1" type="text" id="data1" /></div>
+<div><label for="data2">Form text area default appearance:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea></div>
+<div><label for="data4">Form <code>select</code> default appearance:</label>
+<select id="data4" name="data4">
+<option value="Option 1">Option 1</option>
+<option value="Option 2">Option 2</option>
+<option value="Option 3">Option 3</option>
+<option value="Option 4">Option 4</option>
+</select></div>
+<fieldset><legend>Form <code>legend</code>, <code>fieldset</code> and <code>checkbox</code> default appearance</legend>
+<div><input name="checkbox" type="checkbox" id="data5" value="checkbox" />&#160;<label for="data5">Option 1</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data6" value="checkbox" />&#160;<label for="data6">Option 2</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data7" value="checkbox" />&#160;<label for="data7">Option 3</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data8" value="checkbox" />&#160;<label for="data8">Option 4</label></div>
+</fieldset>
+<div><input name="submit" type="submit" id="submit" value="Submit default appearance" />
+<input name="reset" type="reset" id="reset" value="Reset default appearance" /></div>
+</form>
+
+<blockquote>
+<p>&quot;Blockquote default appearance&quot;.</p>
+</blockquote>
+
+<dl id="gcwu-date-mod" role="contentinfo">
+<dt>Version:</dt><dd>1.1b</dd>
+</dl>
+<div class="clear"></div>
+<!-- MainContentEnd -->
+</div></div>
+</div></div>
+
+<div id="wb-foot"><div id="wb-foot-in"><footer><h2 id="wb-nav">Footer</h2>
+<!-- FooterStart -->
+<nav role="navigation"><div id="gcwu-sft"><h3>Site footer</h3><div id="gcwu-sft-in">
+<div id="gcwu-tctr">
+<ul>
+<li class="gcwu-tc"><a href="#" target="_blank" rel="license">Terms and conditions</a></li>
+<li class="gcwu-tr"><a href="#" target="_blank">Transparency</a></li>
+</ul>
+</div>
+<div class="clear"></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">About us</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">News</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">Contact us</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">Stay connected</a></div></div>
+</div></div></nav>
+
+<nav role="navigation"><div id="gcwu-gcft"><h3>Government of Canada footer</h3><div id="gcwu-gcft-in"><div id="gcwu-gcft-fip">
+<ul>
+<li id="gcwu-gcft-ca"><div><a target="_blank" rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></div></li>
+</ul>
+</div></div></div></nav>
+<!-- FooterEnd -->
+</footer>
+</div></div></div>
+
+<!-- ScriptsStart -->
+<script src="../../../dist/js/settings.js"></script>
+<!--[if lte IE 8]>
+<script src="../../../dist/theme-gcwu-fegc/js/theme-ie-min.js"></script>
+<script src="../../../dist/js/pe-ap-ie-min.js"></script>
+<script src="../../../dist/js/jquerymobile/jquery.mobile-ie.min.js"></script>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../../dist/theme-gcwu-fegc/js/theme-min.js"></script>
+<script src="../../../dist/js/pe-ap-min.js"></script>
+<script src="../../../dist/js/jquerymobile/jquery.mobile.min.js"></script>
+<!--<![endif]-->
+<!-- ScriptsEnd -->
+
+<!-- CustomScriptsStart -->
+<!-- CustomScriptsEnd -->
+</body>
+</html>

--- a/demos/theme-gcwu-fegc/ar/application-signout-ar.html
+++ b/demos/theme-gcwu-fegc/ar/application-signout-ar.html
@@ -1,0 +1,243 @@
+<!DOCTYPE html>
+<!--[if IE 7]><html dir="rtl" lang="ar" class="no-js ie7"><![endif]-->
+<!--[if IE 8]><html dir="rtl" lang="ar" class="no-js ie8"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html dir="rtl" lang="ar" class="no-js">
+<!--<![endif]-->
+<head>
+<meta charset="utf-8" />
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+<title>Application Template - Sign In - GC Web Usability theme - Working examples - Web Experience Toolkit (WET)</title>
+
+<link rel="shortcut icon" href="../../../dist/theme-gcwu-fegc/images/favicon.ico" />
+<meta name="description" content="Arabic description / Description en arabe" />
+<meta name="dcterms.creator" content="Arabic name of the content author / Nom en arabe de l'auteur du contenu" />
+<meta name="dcterms.title" content="Arabic title / Titre en arabe" />
+<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
+<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
+<meta name="dcterms.subject" title="scheme" content="Arabic subject terms / Termes de sujet en arabe" />
+<meta name="dcterms.language" title="ISO639-2" content="eng" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<!--[if lte IE 8]>
+<script src="../../../dist/js/jquery-ie.min.js"></script>
+<script src="../../../dist/js/polyfills/html5shiv-min.js"></script>
+<link rel="stylesheet" href="../../../dist/grids/css/util-ie-min.css" />
+<link rel="stylesheet" href="../../../dist/js/css/pe-ap-ie-min.css" />
+<link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-ie-min.css" />
+<noscript><link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-ns-ie-min.css" /></noscript>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../../dist/js/jquery.min.js"></script>
+<link rel="stylesheet" href="../../../dist/grids/css/util-min.css" />
+<link rel="stylesheet" href="../../../dist/js/css/pe-ap-min.css" />
+<link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-min.css" />
+<noscript><link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
+<!--<![endif]-->
+
+<!-- CustomCSSStart -->
+<!-- CustomCSSEnd -->
+</head>
+
+<body><div id="wb-body">
+<div id="wb-skip">
+<ul id="wb-tphp">
+<li id="wb-skip1"><a href="#wb-cont">Skip to main content</a></li>
+<li id="wb-skip2"><a href="#wb-nav">Skip to footer</a></li>
+</ul>
+</div>
+
+<div id="wb-head"><div id="wb-head-in"><header>
+<!-- HeaderStart -->
+<nav role="navigation"><div id="gcwu-gcnb"><h2>Government of Canada navigation bar</h2><div id="gcwu-gcnb-in"><div id="gcwu-gcnb-fip">
+<div id="gcwu-sig"><div id="gcwu-sig-in"><object data="../../../dist/theme-gcwu-fegc/images/sig-eng.svg" role="img" tabindex="-1" aria-label="Government of Canada" type="image/svg+xml"><img src="../../../dist/theme-gcwu-fegc/images/sig-eng.png" alt="Government of Canada" /></object></div></div>
+<ul>
+<li id="gcwu-gcnb-lang"><a href="../application-signout-fra.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang-2"><a href="../application-signout-eng.html" lang="en">English</a></li>
+</ul>
+</div></div></div></nav>
+
+<div id="gcwu-bnr" role="banner"><div id="gcwu-bnr-in">
+<div id="gcwu-wmms"><div id="gcwu-wmms-in"><object data="../../../dist/theme-gcwu-fegc/images/wmms.svg" role="img" tabindex="-1" aria-label="Symbol of the Government of Canada" type="image/svg+xml"><img src="../../../dist/theme-gcwu-fegc/images/wmms.png" alt="Symbol of the Government of Canada" /></object></div></div>
+<div id="gcwu-title"><p id="gcwu-title-in"><a target="_blank" href="../../../index-eng.html">Web Experience Toolkit</a></p></div>
+
+<section role="search"><div id="gcwu-srchbx"><h2>Search</h2>
+<form action="#" method="post"><div id="gcwu-srchbx-in">
+<label for="gcwu-srch">Search website</label><input id="gcwu-srch" name="gcwu-srch" type="search" value="" size="27" maxlength="150" />
+<input id="gcwu-srch-submit" name="gcwu-srch-submit" type="submit" value="Search" />
+</div></form>
+</div></section>
+</div></div>
+
+<nav role="navigation">
+<div id="gcwu-psnb"><h2>Site menu</h2><div id="gcwu-psnb-in"><div class="wet-boew-menubar"><div>
+<ul class="mb-menu">
+<li><div><a target="_blank" class="first" href="#">Section 1</a></div></li>
+<li><div><a target="_blank" href="section2/index-eng.html">Section 2</a></div></li>
+<li><div><a target="_blank" href="#">Section 3</a></div></li>
+<li><div><a target="_blank" href="#">Section 4</a></div></li>
+<li><div><a target="_blank" href="#">Section 5</a></div></li>
+</ul>
+</div></div></div></div>
+
+<div id="gcwu-bc"><h2>Breadcrumb trail</h2><div id="gcwu-bc-in">
+<ol>
+<li><a target="_blank" href="../../../index-eng.html">Home</a></li>
+<li><a target="_blank" href="../../index-eng.html">Working examples</a></li>
+<li><a target="_blank" href="../index-eng.html">GC Web Usability theme</a></li>
+<li>Application Template</li>
+</ol>
+</div></div>
+</nav>
+<!-- HeaderEnd -->
+</header></div></div>
+
+<div id="wb-core"><div id="wb-core-in" class="equalize">
+<div id="wb-main" role="main"><div id="wb-main-in">
+<!-- MainContentStart -->
+<h1 id="wb-cont">Application Template - GC Web Usability theme</h1>
+
+<div id="wb-session">
+<ul>
+<li class="settings"><a href="#">Your Account</a></li>
+<li class="session"><a href="#">Sign Out</a></li>
+</ul>
+</div>
+
+<section><h2>Heading 2 (<code>h2</code>) default appearance</h2>
+	<section><h3>Heading 3 (<code>h3</code>) default appearance</h3>
+		<section><h4>Heading 4 (<code>h4</code>) default appearance</h4>
+			<section><h5>Heading 5 (<code>h5</code>) default appearance</h5>
+				<section><h6>Heading 6 (<code>h6</code>) default appearance</h6>
+					<p>Paragraph default appearance</p>
+				</section>
+			</section>
+		</section>
+	</section>
+</section>
+
+<p><a href="#">Link default appearance</a></p>
+<p><a href="mailto:"><code>mailto:</code> link default appearance</a></p>
+<p><a href="http://www." rel="external">Third party <code>http://www.</code> link default appearance</a></p>
+<p><a href=".doc">Link to file downloads based on file type <code>.doc</code>, <code>.psd</code>, <code>.zip</code>, <code>.pdf</code>, <code>.xls</code>, <code>.xlt</code>, <code>.rtf</code> and <code>.txt</code> default appearance</a></p>
+<p>Abbreviation default appearance: <abbr title="Treasury Board Secretariat">TBS</abbr>.</p>
+
+<ul>
+<li>unordered list (<code>ul</code>) first level default appearance
+	<ul>
+	<li>unordered list (<code>ul</code>) second level default appearance
+		<ul>
+		<li>unordered list (<code>ul</code>) third level default appearance</li>
+		</ul>
+	</li>
+	</ul>
+</li>
+</ul>
+
+<ol>
+<li>ordered list (<code>ol</code>) first level default appearance</li>
+<li>ordered list (<code>ol</code>) first level default appearance
+	<ol>
+	<li>ordered list (<code>ol</code>) second level default appearance</li>
+	<li>ordered list (<code>ol</code>) second level default appearance
+		<ol>
+		<li>ordered list (<code>ol</code>) third level default appearance</li>
+		<li>ordered list (<code>ol</code>) third level default appearance</li>
+		</ol>
+	</li>
+	</ol>
+</li>
+</ol>
+
+<table>
+<caption>Table caption default appearance</caption>
+<thead>
+<tr>
+<th scope="col">Table header (<code>th</code>) default appearance</th>
+<th scope="col">Table header (<code>th</code>) default appearance</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Table data (<code>td</code>) default appearance</td>
+<td>Table data (<code>td</code>) default appearance</td>
+</tr>
+</tbody>
+</table>
+
+<form action="#" method="post">
+<div><label for="data1">Form input default appearance:</label> <input name="data1" type="text" id="data1" /></div>
+<div><label for="data2">Form text area default appearance:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea></div>
+<div><label for="data4">Form <code>select</code> default appearance:</label>
+<select id="data4" name="data4">
+<option value="Option 1">Option 1</option>
+<option value="Option 2">Option 2</option>
+<option value="Option 3">Option 3</option>
+<option value="Option 4">Option 4</option>
+</select></div>
+<fieldset><legend>Form <code>legend</code>, <code>fieldset</code> and <code>checkbox</code> default appearance</legend>
+<div><input name="checkbox" type="checkbox" id="data5" value="checkbox" />&#160;<label for="data5">Option 1</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data6" value="checkbox" />&#160;<label for="data6">Option 2</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data7" value="checkbox" />&#160;<label for="data7">Option 3</label>&#160;&#160;
+<input name="checkbox" type="checkbox" id="data8" value="checkbox" />&#160;<label for="data8">Option 4</label></div>
+</fieldset>
+<div><input name="submit" type="submit" id="submit" value="Submit default appearance" />
+<input name="reset" type="reset" id="reset" value="Reset default appearance" /></div>
+</form>
+
+<blockquote>
+<p>&quot;Blockquote default appearance&quot;.</p>
+</blockquote>
+
+<dl id="gcwu-date-mod" role="contentinfo">
+<dt>Version:</dt><dd>1.1b</dd>
+</dl>
+<div class="clear"></div>
+<!-- MainContentEnd -->
+</div></div>
+</div></div>
+
+<div id="wb-foot"><div id="wb-foot-in"><footer><h2 id="wb-nav">Footer</h2>
+<!-- FooterStart -->
+<nav role="navigation"><div id="gcwu-sft"><h3>Site footer</h3><div id="gcwu-sft-in">
+<div id="gcwu-tctr">
+<ul>
+<li class="gcwu-tc"><a href="#" target="_blank" rel="license">Terms and conditions</a></li>
+<li class="gcwu-tr"><a href="#" target="_blank">Transparency</a></li>
+</ul>
+</div>
+<div class="clear"></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">About us</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">News</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">Contact us</a></div></div>
+<div class="span-2"><div class="gcwu-col-head"><a href="#" target="_blank">Stay connected</a></div></div>
+</div></div></nav>
+
+<nav role="navigation"><div id="gcwu-gcft"><h3>Government of Canada footer</h3><div id="gcwu-gcft-in"><div id="gcwu-gcft-fip">
+<ul>
+<li id="gcwu-gcft-ca"><div><a target="_blank" rel="external" href="http://www.canada.gc.ca/menu-eng.html">Canada.gc.ca</a></div></li>
+</ul>
+</div></div></div></nav>
+<!-- FooterEnd -->
+</footer>
+</div></div></div>
+
+<!-- ScriptsStart -->
+<script src="../../../dist/js/settings.js"></script>
+<!--[if lte IE 8]>
+<script src="../../../dist/theme-gcwu-fegc/js/theme-ie-min.js"></script>
+<script src="../../../dist/js/pe-ap-ie-min.js"></script>
+<script src="../../../dist/js/jquerymobile/jquery.mobile-ie.min.js"></script>
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<script src="../../../dist/theme-gcwu-fegc/js/theme-min.js"></script>
+<script src="../../../dist/js/pe-ap-min.js"></script>
+<script src="../../../dist/js/jquerymobile/jquery.mobile.min.js"></script>
+<!--<![endif]-->
+<!-- ScriptsEnd -->
+
+<!-- CustomScriptsStart -->
+<!-- CustomScriptsEnd -->
+</body>
+</html>

--- a/demos/theme-gcwu-fegc/index-eng.html
+++ b/demos/theme-gcwu-fegc/index-eng.html
@@ -133,6 +133,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li><a href="application-eng.html"><span class="wb-invisible">English examples - Web applications - </span>Content page</a></li>
 <li><a href="application-secnav1-eng.html"><span class="wb-invisible">English examples - Web applications - </span>Content page - Secondary menu 1</a></li>
 <li><a href="application-secnav2-eng.html"><span class="wb-invisible">English examples - Web applications - </span>Content page - Secondary menu 2</a></li>
+<li><a href="application-signin-eng.html"><span class="wb-invisible">English examples - Web applications - </span>Content page - Sign In</a></li>
+<li><a href="application-signout-eng.html"><span class="wb-invisible">English examples - Web applications - </span>Content page - Sign Out</a></li>
 <li><a href="application-nosearchlang-eng.html"><span class="wb-invisible">English examples - Web applications - </span>Content page - No search or language selection link</a></li>
 <li><a href="application-nositemenubc-eng.html"><span class="wb-invisible">English examples - Web applications - </span>Content page - No site menu or breadcrumb trail</a></li>
 <li><a href="application-nosearchlangsitemenubc-eng.html"><span class="wb-invisible">English examples - Web applications - </span>Content page - No search, language selection link, site menu or breadcrumb trail</a></li>
@@ -159,6 +161,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li><a href="application-fra.html"><span class="wb-invisible">French examples - Web applications - </span>Content page</a></li>
 <li><a href="application-secnav1-fra.html"><span class="wb-invisible">French examples - Web applications - </span>Content page - Secondary menu 1</a></li>
 <li><a href="application-secnav2-fra.html"><span class="wb-invisible">French examples - Web applications - </span>Content page - Secondary menu 2</a></li>
+<li><a href="application-signin-fra.html"><span class="wb-invisible">French examples - Web applications - </span>Content page - Sign In</a></li>
+<li><a href="application-signout-fra.html"><span class="wb-invisible">French examples - Web applications - </span>Content page - Sign Out</a></li>
 <li><a href="application-nosearchlang-fra.html"><span class="wb-invisible">French examples - Web applications - </span>Content page - No search or language selection link</a></li>
 <li><a href="application-nositemenubc-fra.html"><span class="wb-invisible">French examples - Web applications - </span>Content page - No site menu or breadcrumb trail</a></li>
 <li><a href="application-nosearchlangsitemenubc-fra.html"><span class="wb-invisible">French examples - Web applications - </span>Content page - No search, language selection link, site menu or breadcrumb trail</a></li>
@@ -203,6 +207,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li><a href="ar/application-ar.html"><span class="wb-invisible">Arabic examples - Web applications - </span>Content page</a></li>
 <li><a href="ar/application-secnav1-ar.html"><span class="wb-invisible">Arabic examples - Web applications - </span>Content page - Secondary menu 1</a></li>
 <li><a href="ar/application-secnav2-ar.html"><span class="wb-invisible">Arabic examples - Web applications - </span>Content page - Secondary menu 2</a></li>
+<li><a href="ar/application-signin-ar.html"><span class="wb-invisible">Arabic examples - Web applications - </span>Content page - Sign In</a></li>
+<li><a href="ar/application-signout-ar.html"><span class="wb-invisible">Arabic examples - Web applications - </span>Content page - Sign Out</a></li>
 <li><a href="ar/application-nosearchlang-ar.html"><span class="wb-invisible">Arabic examples - Web applications - </span>Content page - No search or language selection link</a></li>
 <li><a href="ar/application-nositemenubc-ar.html"><span class="wb-invisible">Arabic examples - Web applications - </span>Content page - No site menu or breadcrumb trail</a></li>
 <li><a href="ar/application-nosearchlangsitemenubc-ar.html"><span class="wb-invisible">Arabic examples - Web applications - </span>Content page - No search, language selection link, site menu or breadcrumb trail</a></li>

--- a/demos/theme-gcwu-fegc/index-fra.html
+++ b/demos/theme-gcwu-fegc/index-fra.html
@@ -133,6 +133,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li><a href="application-eng.html"><span class="wb-invisible">Exemples an anglais - Applications Web - </span>Page de contenu</a></li>
 <li><a href="application-secnav1-eng.html"><span class="wb-invisible">Exemples an anglais - Applications Web - </span>Page de contenu - Menu secondaire 1</a></li>
 <li><a href="application-secnav2-eng.html"><span class="wb-invisible">Exemples an anglais - Applications Web - </span>Page de contenu - Menu secondaire 2</a></li>
+<li><a href="application-signin-eng.html"><span class="wb-invisible">Exemples an anglais - Applications Web - </span>Page de contenu - Ouvrir une session</a></li>
+<li><a href="application-signout-eng.html"><span class="wb-invisible">Exemples an anglais - Applications Web - </span>Page de contenu - Fermer la session</a></li>
 <li><a href="application-nosearchlang-eng.html"><span class="wb-invisible">Exemples an anglais - Applications Web - </span>Page de contenu - Sans recherche ou lien de sélection de la langue</a></li>
 <li><a href="application-nositemenubc-eng.html"><span class="wb-invisible">Exemples an anglais - Applications Web - </span>Page de contenu - Sans menu du site our fil d'Ariane</a></li>
 <li><a href="application-nosearchlangsitemenubc-eng.html"><span class="wb-invisible">Exemples an anglais - Applications Web - </span>Page de contenu - Sans recherche, lien de sélection de la langue, menu du site ou fil d'Ariane</a></li>
@@ -159,6 +161,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li><a href="application-fra.html"><span class="wb-invisible">Exemples an français - Applications Web - </span>Page de contenu</a></li>
 <li><a href="application-secnav1-fra.html"><span class="wb-invisible">Exemples an français - Applications Web - </span>Page de contenu - Menu secondaire 1</a></li>
 <li><a href="application-secnav2-fra.html"><span class="wb-invisible">Exemples an français - Applications Web - </span>Page de contenu - Menu secondaire 2</a></li>
+<li><a href="application-signin-fra.html"><span class="wb-invisible">Exemples an anglais - Applications Web - </span>Page de contenu - Ouvrir une session</a></li>
+<li><a href="application-signout-fra.html"><span class="wb-invisible">Exemples an anglais - Applications Web - </span>Page de contenu - Fermer la session</a></li>
 <li><a href="application-nosearchlang-fra.html"><span class="wb-invisible">Exemples an français - Applications Web - </span>Page de contenu - Sans recherche ou lien de sélection de la langue</a></li>
 <li><a href="application-nositemenubc-fra.html"><span class="wb-invisible">Exemples an français - Applications Web - </span>Page de contenu - Sans menu du site ou fil d'Ariane</a></li>
 <li><a href="application-nosearchlangsitemenubc-fra.html"><span class="wb-invisible">Exemples an français - Applications Web - </span>Page de contenu - Sans recherche, lien de sélection de la langue, menu du site our fil d'Ariane</a></li>
@@ -179,7 +183,6 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 
 <section><h3>Applications Web</h3>
 <ul>
-<<<<<<< HEAD
 <li><a href="es/application-es.html"><span class="wb-invisible">Exemples en espagnol - Applications Web - </span>Page de contenu</a></li>
 <li><a href="es/application-secnav1-es.html"><span class="wb-invisible">Exemples en espagnol - Applications Web - </span>Page de contenu - Menu secondaire 1</a></li>
 <li><a href="es/application-secnav2-es.html"><span class="wb-invisible">Exemples en espagnol - Applications Web - </span>Page de contenu - Menu secondaire 2</a></li>
@@ -204,17 +207,11 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li><a href="ar/application-ar.html"><span class="wb-invisible">Exemples en arabe - Applications Web - </span>Page de contenu</a></li>
 <li><a href="ar/application-secnav1-ar.html"><span class="wb-invisible">Exemples en arabe - Applications Web - </span>Page de contenu - Menu secondaire 1</a></li>
 <li><a href="ar/application-secnav2-ar.html"><span class="wb-invisible">Exemples en arabe - Applications Web - </span>Page de contenu - Menu secondaire 2</a></li>
+<li><a href="ar/application-signin-ar.html"><span class="wb-invisible">Exemples en arabe - Applications Web - </span>Page de contenu - Ouvrir une session</a></li>
+<li><a href="ar/application-signout-ar.html"><span class="wb-invisible">Exemples en arabe - Applications Web - </span>Page de contenu - Fermer la session</a></li>
 <li><a href="ar/application-nosearchlang-ar.html"><span class="wb-invisible">Exemples en arabe - Applications Web - </span>Page de contenu - Sans recherche ou lien de sélection de la langue</a></li>
 <li><a href="ar/application-nositemenubc-ar.html"><span class="wb-invisible">Exemples en arabe - Applications Web - </span>Page de contenu - Sans menu du site ou fil d'Ariane</a></li>
 <li><a href="ar/application-nosearchlangsitemenubc-ar.html"><span class="wb-invisible">Exemples en arabe - Applications Web - </span>Page de contenu - Sans recherche, lien de sélection de la langue, menu du site ou fil d'Ariane</a></li>
-=======
-<li><a href="application-fra.html"><span class="wb-invisible">Examples en français - Applications Web - </span>Page de contenu</a></li>
-<li><a href="application-secnav1-fra.html"><span class="wb-invisible">Examples en français - Applications Web - </span>Page de contenu - Menu secondaire 1</a></li>
-<li><a href="application-secnav2-fra.html"><span class="wb-invisible">Examples en français - Applications Web - </span>Page de contenu- Menu secondaire 2</a></li>
-<li><a href="application-nosearchlang-fra.html"><span class="wb-invisible">Examples en français - Applications Web - </span>Page de contenu - Sans recherche ou lien de sélection de la langue</a></li>
-<li><a href="application-nositemenubc-fra.html"><span class="wb-invisible">Examples en français - Applications Web - </span>Page de contenu - Sans menu du site ou fil d'Ariane</a></li>
-<li><a href="application-nosearchlangsitemenubc-fra.html"><span class="wb-invisible">Examples en français - Applications Web - </span>Page de contenu - Sans recherche, lien de sélection de la langue, menu du site ou fil d'Ariane</a></li>
->>>>>>> v3.0
 </ul>
 </section>
 </section>

--- a/src/base/sass/_default-mobile.scss
+++ b/src/base/sass/_default-mobile.scss
@@ -5,7 +5,7 @@
 %wb-mobile-display-none-important {
 	display: none !important;
 }
- 
+
 .mobile-hide {
 	@extend %wb-mobile-display-none-important;
 }
@@ -23,4 +23,8 @@
 }
 #wb-core-in {
 	width: 100%;
+}
+
+#wb-session {
+  @extend %wb-mobile-display-none-important;
 }

--- a/src/base/sass/_default-screen-ie.scss
+++ b/src/base/sass/_default-screen-ie.scss
@@ -16,6 +16,11 @@
 			left: 44%;
 		}
 	}
+
+  #wb-session {
+    zoom: 1;
+  }
+
 	a {
 		&.wb-linkdesc {
 			span {
@@ -38,6 +43,20 @@
 				float: right;
 			}
 		}
+
+    #wb-session {
+      ul {
+        li {
+          float: left;
+          direction: ltr;
+          &.settings {
+            a {
+              border: 0;
+            }
+          }
+        }
+      }
+    }
 	}
 }
 

--- a/src/base/sass/_default-screen.scss
+++ b/src/base/sass/_default-screen.scss
@@ -2,9 +2,18 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
  */
+
+@import "compass/css3/border-radius";
+
 %wb-default-screen-verdana-font {
 	font-family: Verdana, Arial, Helvetica, sans-serif;
 }
+
+%wb-default-screen-clearfix {
+  content:"";
+  display:table;
+}
+
 
 body {
 	@extend %wb-default-screen-verdana-font;
@@ -105,6 +114,50 @@ a.wb-linkdesc {
 	}
 }
 
+/* Sign-in/out application links */
+#wb-session {
+  &:before {
+    @extend %wb-default-screen-clearfix;
+  }
+  &:after {
+    @extend %wb-default-screen-clearfix;
+    clear: both;
+  }
+  ul {
+    float: right;
+    list-style: none;
+    margin: -10px 10px 0 10px;
+    padding: 0 2px 1px 2px;
+    background: #1E4C85;
+    @include border-radius(0 0 2px 2px);
+    li {
+      float: left;
+      margin: 0;
+      padding: 6px 0;
+      a {
+        padding: 2px 10px;
+        text-decoration: none;
+        text-shadow: none;
+        color: #fff;
+        &:hover {
+           text-decoration: underline;
+        }
+      }
+      &.session {
+        a {
+          font-weight: 700;
+          text-decoration: underline;
+        }
+      }
+      &.settings {
+        a {
+          border-right: 1px solid #5679A4;
+        }
+      }
+    }
+  }
+}
+
 /* Right to left (RTL) CSS */
 [dir="rtl"] {
 	#wb-skip {
@@ -140,5 +193,20 @@ a.wb-linkdesc {
 
 	#gcwu-bnr + nav {
 		margin-left: -1px;
+	}
+
+	#wb-session {
+	  ul {
+	    float: left;
+	    li {
+	      float: right;
+        &.settings {
+          a {
+            border-left: 1px solid #5679A4;
+            border-right: 0;
+          }
+        }
+	    }
+	  }
 	}
 }


### PR DESCRIPTION
1. Includes the CSS and HTML markup for the [v4 sign in/out mockup](http://fullahead.org/work/wet-boew/3.1.0/sign-in-out/v4/content-signin_v4.png).
2. Hides #wb-session element for mobile view.
3. Doesn't include Spanish working examples (translations are needed).
4. Doesn't update mobile settings menu with new links but does include the following two CSS classes that can be used by the .js to build the mobile menu:
- `#wb-session .session`: sign in/out link.
- `#wb-session .settings`: 1 to many account setting links.

Let me know if you want me to tackle the mobile menu later in the week.
