### PR TITLE
Grids placeholder links

### DIFF
--- a/demos/grids/grid-button-eng.html
+++ b/demos/grids/grid-button-eng.html
@@ -201,31 +201,31 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 
 <div class="span-3">
    <ul class="menu-horizontal">
-      <li><a href="#embedded" class="button button-small">button-small</a></li>
-      <li><a href="#embedded" class="button">default</a></li>
-      <li><a href="#embedded" class="button button-large">button-large</a></li>
-      <li><a href="#embedded" class="button button-xlarge">button-xlarge</a></li>
+      <li><a href="#" class="button button-small">button-small</a></li>
+      <li><a href="#" class="button">default</a></li>
+      <li><a href="#" class="button button-large">button-large</a></li>
+      <li><a href="#" class="button button-xlarge">button-xlarge</a></li>
    </ul>
    <ul class="menu-horizontal">
-      <li><a href="#embedded" class="button button-small button-dark">button-small</a></li>
-      <li><a href="#embedded" class="button button-dark">default</a></li>
-      <li><a href="#embedded" class="button button-large button-dark">button-large</a></li>
-      <li><a href="#embedded" class="button button-xlarge button-dark">button-xlarge</a></li>
+      <li><a href="#" class="button button-small button-dark">button-small</a></li>
+      <li><a href="#" class="button button-dark">default</a></li>
+      <li><a href="#" class="button button-large button-dark">button-large</a></li>
+      <li><a href="#" class="button button-xlarge button-dark">button-xlarge</a></li>
    </ul>
 </div>
 <details class="span-3">
 	<summary>View code</summary>
 	<pre>&lt;ul class=&quot;menu-horizontal&quot;&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-small&quot;&gt;button-small&lt;/a&gt;&lt;/li&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button&quot;&gt;default&lt;/a&gt;&lt;/li&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-large&quot;&gt;button-large&lt;/a&gt;&lt;/li&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-xlarge&quot;&gt;button-xlarge&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-small&quot;&gt;button-small&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button&quot;&gt;default&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-large&quot;&gt;button-large&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-xlarge&quot;&gt;button-xlarge&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;
 &lt;ul class=&quot;menu-horizontal&quot;&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-small button-dark&quot;&gt;button-small&lt;/a&gt;&lt;/li&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-dark&quot;&gt;default&lt;/a&gt;&lt;/li&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-large button-dark&quot;&gt;button-large&lt;/a&gt;&lt;/li&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-xlarge button-dark&quot;&gt;button-xlarge&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-small button-dark&quot;&gt;button-small&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-dark&quot;&gt;default&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-large button-dark&quot;&gt;button-large&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-xlarge button-dark&quot;&gt;button-xlarge&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;</pre>
 </details>
 <div class="clear"></div>
@@ -233,15 +233,15 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <p>Buttons have the attribute <code>display:inline;</code> by default.  Use the CSS <code>display-block</code> to make the button full width within the grid cell or container it is in.</p>
 <div class="span-3">
 <ul class="list-bullet-none margin-top-none indent-none">
-  <li class="margin-bottom-medium"><a href="#embedded" class="button">default</a></li>
-  <li><a href="#embedded" class="button display-block">display-block</a></li>
+  <li class="margin-bottom-medium"><a href="#" class="button">default</a></li>
+  <li><a href="#" class="button display-block">display-block</a></li>
 </ul>
 </div>
 <details class="span-3">
 	<summary>View code</summary>
 	<pre>&lt;ul class=&quot;list-bullet-none margin-top-none indent-none&quot;&gt;
-  &lt;li class=&quot;margin-bottom-medium&quot;&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button&quot;&gt;default&lt;/a&gt;&lt;/li&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button display-block&quot;&gt;display-block&lt;/a&gt;&lt;/li&gt;
+  &lt;li class=&quot;margin-bottom-medium&quot;&gt;&lt;a href=&quot;#&quot; class=&quot;button&quot;&gt;default&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button display-block&quot;&gt;display-block&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;</pre>
 </details>
 <div class="clear"></div>
@@ -250,15 +250,15 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <p>Remove the functionality of a button.</p>
 <div class="span-3">
 <ul class="menu-horizontal margin-top-none">
-  <li><a href="#embedded" class="button">default</a></li>
-  <li><a href="#embedded" class="button button-disabled ui-disabled">disabled</a></li>
+  <li><a href="#" class="button">default</a></li>
+  <li><a href="#" class="button button-disabled ui-disabled">disabled</a></li>
 </ul>
 </div>
 <details class="span-3">
 	<summary>View code</summary>
 <pre>&lt;ul class=&quot;menu-horizontal margin-top-none&quot;&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button&quot;&gt;default&lt;/a&gt;&lt;/li&gt;
-  &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-disabled ui-disabled&quot;&gt;disabled&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button&quot;&gt;default&lt;/a&gt;&lt;/li&gt;
+  &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-disabled ui-disabled&quot;&gt;disabled&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;</pre>
 </details>
 <div class="clear"></div>
@@ -269,16 +269,16 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <h4>Unordered list using <code>menu-horizontal</code></h4>
 <div class="span-3">
 	<ul class="menu-horizontal margin-top-none">
-		<li><a href="#embedded" class="button button-accent">Primary Action</a></li>
-		<li><a href="#embedded" class="button">Action</a></li>
+		<li><a href="#" class="button button-accent">Primary Action</a></li>
+		<li><a href="#" class="button">Action</a></li>
 	</ul>
 
 </div>
 <details class="span-3">
 	<summary>View code</summary>
 	<pre>&lt;ul class=&quot;menu-horizontal margin-top-none&quot;&gt;
-   &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-accent&quot;&gt;Primary Action&lt;/a&gt;&lt;/li&gt;
-   &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
+   &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-accent&quot;&gt;Primary Action&lt;/a&gt;&lt;/li&gt;
+   &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;</pre>
 </details>
 
@@ -287,16 +287,16 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <h4>Unordered list using <code>button-group</code></h4>
 <div class="span-3">
 	<ul class="button-group margin-top-none">
-		<li><a href="#embedded" class="button button-accent">Primary Action</a></li>
-		<li><a href="#embedded" class="button">Action</a></li>
+		<li><a href="#" class="button button-accent">Primary Action</a></li>
+		<li><a href="#" class="button">Action</a></li>
 	</ul>	
 </div>
 
 <details class="span-3">
 	<summary>View code</summary>
 	<pre>&lt;ul class=&quot;button-group margin-top-none&quot;&gt;
-   &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-accent&quot;&gt;Primary Action&lt;/a&gt;&lt;/li&gt;
-   &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
+   &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-accent&quot;&gt;Primary Action&lt;/a&gt;&lt;/li&gt;
+   &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
 &lt;/ul&gt;</pre>
 </details>
 
@@ -306,15 +306,15 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div class="span-3">
 	<div class="button-toolbar margin-top-none">
 	<ul class="button-group">
-		<li><a href="#embedded" class="button button-accent">Primary Action</a></li>
-		<li><a href="#embedded" class="button">Action</a></li>
+		<li><a href="#" class="button button-accent">Primary Action</a></li>
+		<li><a href="#" class="button">Action</a></li>
 	</ul>
 	<ul class="button-group">
-		<li><a href="#embedded" class="button">Action</a></li>
-		<li><a href="#embedded" class="button">Action</a></li>
+		<li><a href="#" class="button">Action</a></li>
+		<li><a href="#" class="button">Action</a></li>
 	</ul>
 	<p class="button-group">
-		<a href="#embedded" class="button">Help</a>
+		<a href="#" class="button">Help</a>
 	</p>
 	</div>	
 </div>
@@ -323,15 +323,15 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 	<summary>View code</summary>
 	<pre>&lt;div class=&quot;button-toolbar margin-top-none&quot;&gt;
    &lt;ul class=&quot;button-group&quot;&gt;
-      &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button button-accent&quot;&gt;Primary Action&lt;/a&gt;&lt;/li&gt;
-      &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
+      &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button button-accent&quot;&gt;Primary Action&lt;/a&gt;&lt;/li&gt;
+      &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
    &lt;/ul&gt;
    &lt;ul class=&quot;button-group&quot;&gt;
-      &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
-      &lt;li&gt;&lt;a href=&quot;#embedded&quot; class=&quot;button&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
+      &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
+      &lt;li&gt;&lt;a href=&quot;#&quot; class=&quot;button&quot;&gt;Action&lt;/a&gt;&lt;/li&gt;
    &lt;/ul&gt;
    &lt;p class=&quot;button-group&quot;&gt;
-      &lt;a href=&quot;#embedded&quot; class=&quot;button&quot;&gt;Help&lt;/a&gt;
+      &lt;a href=&quot;#&quot; class=&quot;button&quot;&gt;Help&lt;/a&gt;
    &lt;/p&gt;
 &lt;/div&gt;</pre>
 </details>
@@ -342,47 +342,47 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 	<h2 id="examples">Examples</h2>
 
     <ul class="menu-horizontal">
-      <li><a href="#embedded" class="button button-small">A<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">B<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">A<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">B<span class="wb-invisible"> topics</span></a></li>
       <li><a class="button button-small button-disabled ui-disabled">C<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">D<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">E<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">F<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">G<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small button-accent button-disabled ui-disabled">H<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">I<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">J<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">K<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">L<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">D<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">E<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">F<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">G<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small button-accent button-disabled ui-disabled">H<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">I<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">J<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">K<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">L<span class="wb-invisible"> topics</span></a></li>
       <li><a class="button button-small button-disabled ui-disabled">M<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">N<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">O<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">P<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">Q<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">R<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">S<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">T<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">U<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">V<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">N<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">O<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">P<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">Q<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">R<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">S<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">T<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">U<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">V<span class="wb-invisible"> topics</span></a></li>
       <li><a class="button button-small button-disabled ui-disabled">W<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">X<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">Y<span class="wb-invisible"> topics</span></a></li>
-      <li><a href="#embedded" class="button button-small">Z<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">X<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">Y<span class="wb-invisible"> topics</span></a></li>
+      <li><a href="#" class="button button-small">Z<span class="wb-invisible"> topics</span></a></li>
    </ul>
    
     <ul class="menu-horizontal">
-      <li><a href="#embedded" class="button button-small button-accent">Previous<span class="wb-invisible">page of search results</span></a></li>
-      <li><a href="#embedded" class="button button-small">1<span class="wb-invisible">: Page 1 of search results</span></a></li>
-     <li> <a href="#embedded" class="button button-small">2<span class="wb-invisible">: Page 2 of search results</span></a></li>
+      <li><a href="#" class="button button-small button-accent">Previous<span class="wb-invisible">page of search results</span></a></li>
+      <li><a href="#" class="button button-small">1<span class="wb-invisible">: Page 1 of search results</span></a></li>
+     <li> <a href="#" class="button button-small">2<span class="wb-invisible">: Page 2 of search results</span></a></li>
      <li> <span class="button button-small button-attention button-disabled ui-disabled">3<span class="wb-invisible">: Page 3 of search results</span></span></li>
-      <li><a href="#embedded" class="button button-small">4<span class="wb-invisible">: Page 4 of search results</span></a></li>
-      <li><a href="#embedded" class="button button-small">5<span class="wb-invisible">: Page 5 of search results</span></a></li>
-     <li> <a href="#embedded" class="button button-small">6<span class="wb-invisible">: Page 6 of search results</span></a></li>
-      <li><a href="#embedded" class="button button-small">7<span class="wb-invisible">: Page 7 of search results</span></a></li>
-      <li><a href="#embedded" class="button button-small">8<span class="wb-invisible">: Page 8 of search results</span></a></li>
-      <li><a href="#embedded" class="button button-small">9<span class="wb-invisible">: Page 9 of search results</span></a></li>
-      <li><a href="#embedded" class="button button-small">10<span class="wb-invisible">: Page 10 of search results</span></a></li>
-      <li><a href="#embedded" class="button button-small button-accent">Next<span class="wb-invisible">page of search results</span></a></li>
+      <li><a href="#" class="button button-small">4<span class="wb-invisible">: Page 4 of search results</span></a></li>
+      <li><a href="#" class="button button-small">5<span class="wb-invisible">: Page 5 of search results</span></a></li>
+     <li> <a href="#" class="button button-small">6<span class="wb-invisible">: Page 6 of search results</span></a></li>
+      <li><a href="#" class="button button-small">7<span class="wb-invisible">: Page 7 of search results</span></a></li>
+      <li><a href="#" class="button button-small">8<span class="wb-invisible">: Page 8 of search results</span></a></li>
+      <li><a href="#" class="button button-small">9<span class="wb-invisible">: Page 9 of search results</span></a></li>
+      <li><a href="#" class="button button-small">10<span class="wb-invisible">: Page 10 of search results</span></a></li>
+      <li><a href="#" class="button button-small button-accent">Next<span class="wb-invisible">page of search results</span></a></li>
    </ul>
    
    <ul class="button-group">

--- a/demos/grids/grid-module-eng.html
+++ b/demos/grids/grid-module-eng.html
@@ -113,7 +113,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
     <li><a href="#related">module-related</a></li>
     <li><a href="#billboard">module-billboard</a></li>
         <li><a href="#menu">module-menu-section</a></li>
-    <li><a href="#toc">module-table-contents</a></li>
+    <li><a href="#">module-table-contents</a></li>
     <li><a href="#poster">module-poster</a></li>
      <li><a href="#contact">module-contact</a></li>
     <li><a href="#news">module-news and module-spotlight</a></li>
@@ -319,10 +319,10 @@ of Excellence&lt;/a&gt;&lt;/li&gt;
 <div class="span-4 module-table-contents">
 		<h2>Table of contents</h2>
 		<ul>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
 		</ul>
 	</div>
     <div class="clear"></div>
@@ -332,10 +332,10 @@ of Excellence&lt;/a&gt;&lt;/li&gt;
 &lt;div class=&quot;span-4 module-table-contents&quot;&gt;
 	&lt;h2&gt;Table of contents&lt;/h2&gt;
 	&lt;ul&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;
 </pre>
@@ -346,14 +346,14 @@ of Excellence&lt;/a&gt;&lt;/li&gt;
 	<div class="span-4 module-table-contents">
 		<h2>Table of contents</h2>
 		<ul class="column-two">
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
 		</ul>
 	</div>
     <div class="clear"></div>
@@ -363,14 +363,14 @@ of Excellence&lt;/a&gt;&lt;/li&gt;
 &lt;div class=&quot;span-4 module-table-contents&quot;&gt;
 	&lt;h2&gt;Table of contents&lt;/h2&gt;
 	&lt;ul class=&quot;column-two&quot;&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;
 </pre>
@@ -380,14 +380,14 @@ of Excellence&lt;/a&gt;&lt;/li&gt;
     <div class="span-6 module-table-contents">
 		<h2>Table of contents</h2>
 		<ul class="column-three">
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
-			<li><a href="#toc">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
+			<li><a href="#">Fake link</a></li>
 		</ul>
 	</div>
 
@@ -398,14 +398,14 @@ of Excellence&lt;/a&gt;&lt;/li&gt;
 &lt;div class=&quot;span-6 module-table-contents&quot;&gt;
 	&lt;h2&gt;Table of contents&lt;/h2&gt;
 	&lt;ul class=&quot;column-three&quot;&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
-		&lt;li&gt;&lt;a href=&quot;#toc&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#&quot;&gt;Fake link&lt;/a&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/div&gt;
 </pre>

--- a/demos/grids/grid-module-eng.html
+++ b/demos/grids/grid-module-eng.html
@@ -113,7 +113,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
     <li><a href="#related">module-related</a></li>
     <li><a href="#billboard">module-billboard</a></li>
         <li><a href="#menu">module-menu-section</a></li>
-    <li><a href="#">module-table-contents</a></li>
+    <li><a href="#toc">module-table-contents</a></li>
     <li><a href="#poster">module-poster</a></li>
      <li><a href="#contact">module-contact</a></li>
     <li><a href="#news">module-news and module-spotlight</a></li>


### PR DESCRIPTION
Since the Grid system's example links to #toc and #embedded regularly appear in broken link crawls, I figured there'd be value in outright replacing them with placeholder link destinations (#). Should completely eliminate the risk of them turning up as broken in future crawls.
