### PR TITLE
Fixed enabling/disabling of keyboard and mouse support and fixed focus outlines of map buttons

### DIFF
--- a/src/js/sass/includes/_geomap.scss
+++ b/src/js/sass/includes/_geomap.scss
@@ -627,16 +627,8 @@ a {
 .wet-boew-geomap {
 	width: 100%;
 	position: relative;
-	border-style: solid;
-  border-width: 1px;
-  border-color: #CCC;
-  &:hover {
-    border-color: #07F;
-  }
-  &:focus {
-    border-color: #07F;
-  }
-  &:blur {
-    border-color: #CCC;
-  }
+	border: 1px solid #CCC;
+	&.active {
+		border-color: #07F;
+	}
 }

--- a/src/js/sass/includes/_geomap.scss
+++ b/src/js/sass/includes/_geomap.scss
@@ -18,98 +18,67 @@
 /**
  *   Openlayer pan zoom bar button
  */
+.olButton {
+	height: 18px;
+	width: 18px;
+	img {
+		left: 0;
+		top: 0;
+		float: left;
+		margin: 0;
+	}
+}
+
 .olControlpanup {
-  height: 18px;
-  width: 18px;
-  left: 15px;
-  top: 4px;
-  img {
-    left: 0px;
-    top: 0px;
-  }
+	left: 15px;
+	top: 4px;
 }
 
 .olControlpanleft {
-  height: 18px;
-  width: 18px;
-  left: 1px;
-  top: 22px;
-  img {
-    left: 0px;
-    top: 0px;
-  }
+	left: 1px;
+	top: 22px;
 }
 
 .olControlpandown {
-  height: 18px;
-  width: 18px;
-  left: 15px;
-  top: 40px;
-  img {
-    left: 0px;
-    top: 0px;
-  }
+	left: 15px;
+	top: 40px;
 }
 
 .olControlpanright {
-  height: 18px;
-  width: 18px;
-  left: 29px;
-  top: 22px;
-  img {
-    left: 0px;
-    top: 0px;
-  }
+	left: 29px;
+	top: 22px;
 }
 
 .olControlzoomin {
-  height: 18px;
-  width: 18px;
-  left: 15px;
-  top: 63px;
-  img {
-    left: 0px;
-    top: 0px;
-  }
+	left: 15px;
+	top: 63px;
 }
 
 .olControlzoomout {
-  height: 18px;
-  width: 18px;
-  left: 15px;
-  top: 213px;
-  img {
-    left: 0px;
-    top: 0px;
-  }
+	left: 15px;
+	top: 213px;
 }
 
 .olControlzoomworld {
-  height: 18px;
-  width: 18px;
-  left: 15px;
-  top: 234px;
-  img {
-    left: 0px;
-    top: 0px;
-  }
+	left: 15px;
+	top: 234px;
 }
 
 .olControlSlider {
-  height: 9px;
-  width: 18px;
-  img {
-    height: 9px;
-    width: 18px;
-  }
+	height: 9px;
+	width: 18px;
+	img {
+		height: 9px;
+		width: 18px;
+	}
 }
 
 .olControlBar {
-  background-image: url("../images/geomap/zoombar.png") !important;
-  height: 18px;
-  width: 132px;
-  left: 15px !important;
-  top: 81px !important;
+	background-image: url("../images/geomap/zoombar.png") !important;
+	height: 18px;
+	width: 132px;
+	left: 15px !important;
+	top: 81px !important;
 }
 
 div {

--- a/src/js/workers/geomap.js
+++ b/src/js/workers/geomap.js
@@ -1276,20 +1276,19 @@
 			// enable the keyboard navigation when map div has focus. Disable when blur
 			// Enable the wheel zoom only on hover
 			$geomap.attr('tabindex', '0').on('mouseenter mouseleave focusin focusout', function(e) {
-				var type = e.type;
-				if (type === 'mouseenter') {
-					map.getControlsByClass('OpenLayers.Control.Navigation')[0].activate();
-				} else if (type === 'mouseleave') {
-					map.getControlsByClass('OpenLayers.Control.Navigation')[0].deactivate();					
-				} else if (type === 'focusin') {
-					if (!keyboardActive) {
+				var type = e.type,
+					$this = $(this);
+				if (type === 'mouseenter' || type === 'focusin') {
+					if (!$this.hasClass('active')) {
 						map.getControlsByClass('OpenLayers.Control.KeyboardDefaults')[0].activate();
-						keyboardActive = true;
+						map.getControlsByClass('OpenLayers.Control.Navigation')[0].activate();
+						$this.addClass('active');
 					}
-				} else {
-					if (keyboardActive) {
+				} else if (type === 'mouseleave' || type === 'focusout') {
+					if ($this.hasClass('active')) {
+						map.getControlsByClass('OpenLayers.Control.Navigation')[0].deactivate();
 						map.getControlsByClass('OpenLayers.Control.KeyboardDefaults')[0].deactivate();
-						keyboardActive = false;
+						$this.removeClass('active');
 					}
 				}
 			});


### PR DESCRIPTION
- Enabled/disabled keyboard and mouse support for mouseenter or focusin and mouseleave or focusout. Ensures that both are active at the same time versus being input dependent.
- Fixed focus outline of div elements to improve appearance of change in #1690.
