### PR TITLE
Added 10px bottom margin to create horizontal gutter

### DIFF
--- a/src/base/sass/_default-screen.scss
+++ b/src/base/sass/_default-screen.scss
@@ -116,6 +116,7 @@ a.wb-linkdesc {
 
 /* Sign-in/out application links */
 #wb-session {
+  margin-bottom: 10px;
   &:before {
     @extend %wb-default-screen-clearfix;
   }


### PR DESCRIPTION
This stops elements with no top margin from bumping up against the bottom of `#wb-session`.
