### PR TITLE
EditorConfig: Add common settings for IDEs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+; See http://EditorConfig.org for supported IDEs
+
+root = true  ; top-most EditorConfig file
+
+[*]
+indent_style = tab
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
For editors supported by http://editorconfig.org/, it will understand the basic tabbing and encoding preferences for our files
