### PR TITLE
formvalid: fixes working example margins

### DIFF
--- a/demos/formvalid/formvalid-eng.html
+++ b/demos/formvalid/formvalid-eng.html
@@ -106,8 +106,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 
 <div class="wet-boew-formvalid">
 <form action="#" method="get" id="validation-example">
-<div class="span-8">
-<fieldset><legend>Contact information</legend>
+
+<fieldset class="margin-top-large"><legend>Contact information</legend>
 <label for="title1"><span class="field-name">Title</span> <strong>(required)</strong></label>
 <select id="title1" name="title1" required="required">
 <option></option>
@@ -122,9 +122,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <label for="email1"><span class="field-name">Email Address</span></label><input id="email1" name="email1" type="email" />
 <label for="url1"><span class="field-name">Website URL (http://www.url.com)</span></label><input id="url1" name="url1" type="url" />
 </fieldset>
-</div>
-<div class="span-8">
-<fieldset><legend>Other examples</legend>
+
+<fieldset class="margin-top-large"><legend>Other examples</legend>
 <label for="date1"><span class="field-name">Date</span> (YYYY-MM-DD)</label><input id="date1" name="date1" type="date" data-rule-dateISO="true" />
 <label for="time1"><span class="field-name">Time</span> (hh:mm)</label><input id="time1" name="time1" type="time" />
 <label for="an1"><span class="field-name">Alphanumeric</span> (at least 4 characters)</label><input id="an1" name="an1" type="text" pattern="[A-Za-z0-9\s]{4,}" data-rule-alphanumeric="true" data-rule-minlength="4" />
@@ -134,24 +133,22 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <label for="text1"><span class="field-name">Letters and punctuation only</span> (allowed punctuation: [. , ( ) "])</label><input id="text1" name="text1" type="text" pattern="[A-Za-z-.,()'&quot;\s]" data-rule-letterswithbasicpunc="true" />
 <label for="password1"><span class="field-name">Password</span> (between 5 and 10 characters)</label><input id="password1" name="password1" type="password" maxlength="10" size="10" pattern="{5,10}" data-rule-rangelength="[5,10]" />
 </fieldset>
-</div>
-<div class="span-8">
-<fieldset><legend><span class="field-name">Favourite pet</span> (select at least one of the following options)</legend>
+
+<fieldset class="margin-top-large"><legend><span class="field-name">Favourite pet</span> (select at least one of the following options)</legend>
 <label for="animal1"><input type="checkbox" name="animal" value="1" id="animal1" required="required" />&#160;&#160;Dog</label>
 <label for="animal2"><input type="checkbox" name="animal" value="2" id="animal2" />&#160;&#160;Cat</label>
 <label for="animal3"><input type="checkbox" name="animal" value="3" id="animal3" />&#160;&#160;Fish</label>
 <label for="animal4"><input type="checkbox" name="animal" value="4" id="animal4" />&#160;&#160;Other</label>
-</fieldset> 
-</div>
-<div class="span-8">
-<fieldset><legend><span class="field-name">Citizenship status</span></legend>
+</fieldset>
+
+<fieldset class="margin-top-large"><legend><span class="field-name">Citizenship status</span></legend>
 <label for="status1"><input type="radio" name="status" value="1" id="status1" required="required" />&#160;&#160;Canadian citizen</label>
 <label for="status2"><input type="radio" name="status" value="2" id="status2" />&#160;&#160;Permanent resident</label>
 <label for="status3"><input type="radio" name="status" value="3" id="status3" />&#160;&#160;Work permit</label>
 <label for="status4"><input type="radio" name="status" value="4" id="status4" />&#160;&#160;Other</label>
 </fieldset>
-</div>
-<div class="form-inline">
+
+<div class="form-inline margin-top-large">
 <input type="submit" value="Submit" class="button button-accent"/> <input type="reset" value="Reset" class="button" />
 </div>
 </form>

--- a/demos/formvalid/formvalid-fra.html
+++ b/demos/formvalid/formvalid-fra.html
@@ -105,8 +105,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 
 <div class="wet-boew-formvalid">
 <form action="#" method="get" id="validation-example">
-<div class="span-8">
-<fieldset><legend>Coordonnées</legend>
+
+<fieldset class="margin-top-large"><legend>Coordonnées</legend>
 <label for="title1"><span class="field-name">Titre</span> <strong>(obligatoire)</strong></label>
 <select id="title1" name="title1" required="required">
 <option></option>
@@ -121,9 +121,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <label for="email1"><span class="field-name">Adresse électronique</span></label><input id="email1" name="email1" type="email" />
 <label for="url1"><span class="field-name">URL du site Web (http://www.url.com)</span></label><input id="url1" name="url1" type="url" />
 </fieldset>
-</div>
-<div class="span-8">
-<fieldset><legend>Autres exemples</legend>
+
+<fieldset class="margin-top-large"><legend>Autres exemples</legend>
 <label for="date1"><span class="field-name">Date</span> (AAAA-MM-JJ)</label><input id="date1" name="date1" type="date" data-rule-dateISO="true" />
 <label for="time1"><span class="field-name">Heure</span> (hh:mm)</label><input id="time1" name="time1" type="time" />
 <label for="an1"><span class="field-name">Alphanumérique</span> (4 caractères minimum)</label><input id="an1" name="an1" type="text" pattern="[A-Za-z0-9\s]{4,}" data-rule-alphanumeric="true" data-rule-minlength="4" />
@@ -133,24 +132,22 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <label for="text1"><span class="field-name">Lettres et des signes de ponctuation seulement</span> (ponctuation qui est permis&#160;: [. , ( ) "])</label><input id="text1" name="text1" type="text" pattern="[A-Za-z-.,()'&quot;\s]" data-rule-letterswithbasicpunc="true" />
 <label for="password1"><span class="field-name">Mot de passe</span> (entre 5 et 10 characters)</label><input id="password1" name="password1" type="password" maxlength="10" size="10" pattern="{5,10}" data-rule-rangelength="[5,10]" />
 </fieldset>
-</div>
-<div class="span-8">
-<fieldset><legend><span class="field-name">Animal favori</span> (sélectionner au moins une des options ci-dessous)</legend>
+
+<fieldset class="margin-top-large"><legend><span class="field-name">Animal favori</span> (sélectionner au moins une des options ci-dessous)</legend>
 <label for="animal1"><input type="checkbox" name="animal" value="1" id="animal1" required="required" />&#160;&#160;Chien</label>
 <label for="animal2"><input type="checkbox" name="animal" value="2" id="animal2" />&#160;&#160;Chat</label>
 <label for="animal3"><input type="checkbox" name="animal" value="3" id="animal3" />&#160;&#160;Poisson</label>
 <label for="animal4"><input type="checkbox" name="animal" value="4" id="animal4" />&#160;&#160;Autre</label>
-</fieldset> 
-</div>
-<div class="span-8">
-<fieldset><legend><span class="field-name">Statut de citoyen</span></legend>
+</fieldset>
+
+<fieldset class="margin-top-large"><legend><span class="field-name">Statut de citoyen</span></legend>
 <label for="status1"><input type="radio" name="status" value="1" id="status1" required="required" />&#160;&#160;Citoyen canadien</label>
 <label for="status2"><input type="radio" name="status" value="2" id="status2" />&#160;&#160;Résident permanent</label>
 <label for="status3"><input type="radio" name="status" value="3" id="status3" />&#160;&#160;Permis de travail</label>
 <label for="status4"><input type="radio" name="status" value="4" id="status4" />&#160;&#160;Autre</label>
 </fieldset>
-</div>
-<div class="form-inline"><input type="submit" value="Soumettre" class="button button-accent" /> <input type="reset" value="Réinitialiser" class="button" /></div>
+
+<div class="form-inline margin-top-large"><input type="submit" value="Soumettre" class="button button-accent" /> <input type="reset" value="Réinitialiser" class="button" /></div>
 </form>
 </div>
 <div class="clear"></div>


### PR DESCRIPTION
1. Fixes the left/right margins of the working examples by removing the `<div class="span-8>` grid elements.
2. Adds vertical margins between the fieldsets using `margin-top-large`.
