### PR TITLE
Zebra: Rebrace selectors

### DIFF
--- a/src/js/sass/includes/_calendar-theme.scss
+++ b/src/js/sass/includes/_calendar-theme.scss
@@ -63,7 +63,6 @@
 		a {
 			color: #111;
 			@include pseudo-focus {
-				/* active is for IE, focus is for Firefox | active est pour IE, focus est pour Firefox */
 				@extend %cal-background-333;
 				@extend %cal-color-fff-important;
 			}

--- a/src/js/sass/includes/_zebra-ie.scss
+++ b/src/js/sass/includes/_zebra-ie.scss
@@ -15,7 +15,7 @@
 	background-color: #f0fcff;
 }
 
-/* IE7 hacks - should be in an IE7 only .css */
+// IE7 hacks - should be in an IE7 only .css
 .ie7 {
     ol.wet-boew-zebra {
 		> {
@@ -38,9 +38,9 @@
 }
 
 
-/* In separate CSS because IE have conflit when it's combined with the CSS3 nthChild instruction */
+// In separate CSS because IE have conflit when it's combined with the CSS3 nthChild instruction
 .wet-boew-zebra {
-	/* List Zebra */
+	// List Zebra
 	li, dt, dd {
 		&.list-even {
 			@extend %zebra-ie-background-color-ddd;
@@ -51,10 +51,9 @@
 		&.list-hover {
 			@extend %zebra-ie-list-background-color-f0fcff;
 		}
-
 	}
-	
-	/* Style Alterwg (Alternate White and Gray stripe) */
+
+	// Style Alterwg (Alternate White and Gray stripe)
 	&.alterwg {
 		li, dt, dd {
 			&.list-even {
@@ -66,14 +65,43 @@
 		}
 	}
 
-	/* Summary Group Styling */
-	tr.table-summary, tbody.table-summary tr, 
-	colgroup col.table-summary, colgroup.table-summary, 
-	tfoot tr, td.table-summary {
-		@extend %zebra-ie-background-color-eee; /* Summary Row/Col highligth */
+	// Summary Group Styling
+	tr {
+		&.table-summary {
+			@extend %zebra-ie-background-color-eee;
+		}
 	}
-	
-	/* Traditionel Table Zebra Stripping */
+
+	tbody {
+		&.table-summary {
+			tr {
+				@extend %zebra-ie-background-color-eee;
+			}
+		}
+	}
+	 
+	colgroup {
+		col.table-summary {
+			@extend %zebra-ie-background-color-eee;
+		}
+		&.table-summary {
+			@extend %zebra-ie-background-color-eee;
+		}
+	}
+	 
+	tfoot {
+		tr {
+			@extend %zebra-ie-background-color-eee;
+		}
+	}
+
+	td {
+		&.table-summary {
+			@extend %zebra-ie-background-color-eee;
+		}
+	}
+
+	// Traditionel Table Zebra Stripping
 	&.colzebra {
 		colgroup {
 			col {
@@ -105,25 +133,51 @@
 
 	&.rowhover, &.rowtdhover {
 		tbody, tfoot {
-			tr.table-hover,
-			tr.table-hover td.table-keycell, 
-			tr.table-hover td.table-desccell,
-			tr.table-hover td.table-layoutCell,
-			tr.table-hover th.table-layoutCell  {
-				@extend %zebra-ie-background-color-eee;
+			tr {
+				&.table-hover {
+					@extend %zebra-ie-background-color-eee;
+					th {
+						&.table-layoutCell {
+							@extend %zebra-ie-background-color-eee;
+						}
+					}
+					td {
+						&.table-keycell {
+							@extend %zebra-ie-background-color-eee;
+						}
+						&.table-desccell {
+							@extend %zebra-ie-background-color-eee;
+						}
+						&.table-layoutCell {
+							@extend %zebra-ie-background-color-eee;
+						}
+					}
+				}
+
+				// Hover for summary rows
+				&.table-summary {
+					&.table-hover {
+						@extend %zebra-ie-table-background-color-f0fcff;
+						th {
+							&.table-layoutCell {
+								@extend %zebra-ie-table-background-color-f0fcff;
+							}
+						}
+						td {
+							@extend %zebra-background-color-eee;
+							&.table-keycell {
+								@extend %zebra-ie-table-background-color-f0fcff;
+							}
+							&.table-desccell {
+								@extend %zebra-ie-table-background-color-f0fcff;
+							}
+							&.table-layoutCell {
+								@extend %zebra-ie-table-background-color-f0fcff;
+							}
+						}
+					}
+				}
 			}
-			
-			/* Hover for summary rows */
-			tr.table-summary.table-hover,
-			tr.table-summary.table-hover td.table-keycell, 
-			tr.table-summary.table-hover td.table-desccell,
-			tr.table-summary.table-hover td.table-layoutCell,
-			tr.table-summary.table-hover th.table-layoutCell  {
-				@extend %zebra-ie-table-background-color-f0fcff;
-			}
-			
 		}
-		
 	}
-	
 }

--- a/src/js/sass/includes/_zebra.scss
+++ b/src/js/sass/includes/_zebra.scss
@@ -50,10 +50,13 @@
 %zebra-background-color-transparent {
 	background-color: transparent;
 }
-
+%zebra-margin-5-0-10-0 {
+	margin: 5px 0 10px 0;
+}
 
 ul {
 	&.wet-boew-zebra {
+		@extend %zebra-margin-5-0-10-0;
 		li {
 			@extend %zebra-list-style-type-none;
 			li {
@@ -65,7 +68,6 @@ ul {
 
 ol, ul {
 	&.wet-boew-zebra {
-		margin: 5px 0 10px 0;
 		li {
 			@extend %zebra-padding-10;
 			margin-bottom: 2px;
@@ -76,18 +78,19 @@ ol, ul {
 
 ol {
 	&.wet-boew-zebra {
-	   padding: 0;
-	   list-style-type: decimal;
-	   counter-reset: li;
+		@extend %zebra-margin-5-0-10-0;
+		padding: 0;
+		list-style-type: decimal;
+		counter-reset: li;
 
 		> {
 			li {
-				/* Make room for the number you add with :before */
+				// Make room for the number you add with :before
 				padding-left: 2em;
 				position: relative;
 				list-style: none;
 				&:before {
-					/* Add the number using the counter and increment */
+					// Add the number using the counter and increment
 					content: counter(li) '. ';
 					counter-increment: li;
 					position: absolute;
@@ -104,9 +107,26 @@ ol {
 				}
 			}
 		}
+		&.module-comment {
+			@extend %zebra-child-li-before;
+			ol {
+				li {
+					@extend %zebra-list-style-type-none;
+				}
+				ol {
+					li {
+						@extend %zebra-list-style-type-none;
+					} 
+				}
+			}
+		}
+		&.list-bullet-none {
+			@extend %zebra-child-li-before;
+		}
 	}
 }
-.module-comment ol.wet-boew-zebra, ol.wet-boew-zebra.module-comment, ol.wet-boew-zebra.list-bullet-none {
+
+%zebra-child-li-before {
 	> {
 		li {
 			&:before {
@@ -119,15 +139,20 @@ ol {
 	}
 }
 
-.module-comment ol.wet-boew-zebra, ol.wet-boew-zebra.module-comment {
-	ol {
-		li {
-			@extend %zebra-list-style-type-none;
-		}
-		ol {
-			li {
-				@extend %zebra-list-style-type-none;
-			} 
+.module-comment {
+	ol { 
+		&.wet-boew-zebra {
+			@extend %zebra-child-li-before;
+			ol {
+				li {
+					@extend %zebra-list-style-type-none;
+				}
+				ol {
+					li {
+						@extend %zebra-list-style-type-none;
+					} 
+				}
+			}
 		}
 	}
 }
@@ -139,21 +164,12 @@ dl {
 }
 
 .wet-boew-zebra {
-	
-	/* Definition list */
+
+	// Definition list
 	dd {
 		@extend %zebra-no-margin-left;
 		@extend %zebra-padding-10;
 		@extend %zebra-border-1-solid-ccc;
-	}
-	dt {
-		@extend %zebra-padding-10;
-		@extend %zebra-border-1-solid-ccc;
-		font-weight: 700;
-		margin-top: 2px;
-	}
-
-	dt, dd {
 		&.list-even {
 			@extend %zebra-background-color-ddd;
 		}
@@ -164,37 +180,55 @@ dl {
 			@extend %zebra-list-background-color-f0fcff;
 		}
 	}
-	
-	
-	/* Ordered and Unordered list */
-	> li {
+
+	dt {
+		@extend %zebra-padding-10;
 		@extend %zebra-border-1-solid-ccc;
-		&:nth-child(2n) {
+		font-weight: 700;
+		margin-top: 2px;
+		&.list-even {
 			@extend %zebra-background-color-ddd;
 		}
-		&:nth-child(2n + 1) {
+		&.list-odd {
 			@extend %zebra-background-color-eee;
 		}
-		&:hover {
+		&.list-hover {
 			@extend %zebra-list-background-color-f0fcff;
 		}
 	}
-	
-	/* Style Alterwg (Alternate White and Gray stripe) */
-	&.alterwg {
-		dt, dd, > li {
-			@extend %zebra-border-none;
-		}
-		> li {
+
+	// Ordered and Unordered list
+	> {
+		li {
+			@extend %zebra-border-1-solid-ccc;
 			&:nth-child(2n) {
 				@extend %zebra-background-color-ddd;
 			}
 			&:nth-child(2n + 1) {
-				@extend %zebra-background-color-fff;
+				@extend %zebra-background-color-eee;
+			}
+			&:hover {
+				@extend %zebra-list-background-color-f0fcff;
 			}
 		}
-		
-		dt, dd {
+	}
+
+	// Style Alterwg (Alternate White and Gray stripe)
+	&.alterwg {
+		> {
+			li {
+				@extend %zebra-border-none;
+				&:nth-child(2n) {
+					@extend %zebra-background-color-ddd;
+				}
+				&:nth-child(2n + 1) {
+					@extend %zebra-background-color-fff;
+				}
+			}
+		}
+
+		dd {
+			@extend %zebra-border-none;
 			&.list-even {
 				@extend %zebra-background-color-ddd;
 			}
@@ -202,7 +236,17 @@ dl {
 				@extend %zebra-background-color-fff;
 			}
 		}
-		
+
+		dt {
+			@extend %zebra-border-none;
+			&.list-even {
+				@extend %zebra-background-color-ddd;
+			}
+			&.list-odd {
+				@extend %zebra-background-color-fff;
+			}
+		}
+
 		&.zebra-hover {
 			li, dt, dd {
 				&.list-hover, &:hover {
@@ -211,19 +255,15 @@ dl {
 			}
 		}
 	}
-	
-	/* Option about to apply no Margin on a Zebra list  */
+
+	// Option about to apply no Margin on a Zebra list
 	&.nomargin {
 		margin: 0;
 	}
-	
-	/* 
-	 * 
-	 * Table Zebra Stripping 
-	 * 
-	 * */
+
+	// Table Zebra Stripping 
 	 
-	/* Scope of cells */
+	// Scope of cells
 	td {
 		&.table-keycell {
 			padding: 8px;
@@ -232,14 +272,20 @@ dl {
 			font-style: italic;
 			padding: 8px;
 		}
+		&.table-summary {
+			@extend %zebra-background-color-eee;
+		}
+		&.table-layoutCell {
+			@extend %zebra-background-color-fff;
+		}
 	}
-	td, th {
+	th {
 		&.table-layoutCell {
 			@extend %zebra-background-color-fff;
 		}
 	}
 
-	/* Summary Group Styling */
+	// Summary Group Styling
 	tr {
 		&.table-summary {
 			@extend %zebra-background-color-eee;
@@ -258,8 +304,6 @@ dl {
 				@extend %zebra-background-color-eee;
 			}
 		}
-	} 
-	colgroup {
 		&.table-summary {
 			@extend %zebra-background-color-eee;
 		}
@@ -269,14 +313,8 @@ dl {
 			@extend %zebra-background-color-eee;
 		}
 	}
-	td {
-		&.table-summary {
-			@extend %zebra-background-color-eee;
-		}
-	}
-	
-	
-	/* Delimiter between table group */
+
+	// Delimiter between table group
 	tbody, tfoot {
 		&.table-rowgroupmarker {
 			border-top: solid black 2px;
@@ -287,9 +325,9 @@ dl {
 			border-left: solid black 2px;
 		}
 	}
-	
-	
-	/* Traditionel Table Zebra Stripping */
+
+
+	// Traditionel Table Zebra Stripping
 	&.colzebra {
 		colgroup {
 			col {
@@ -308,9 +346,9 @@ dl {
 			}
 		}
     }
-	
-	
-	/* Column Effect */
+
+
+	// Column Effect
 	&.columnhighlight {
 		colgroup {
 			col {
@@ -326,93 +364,186 @@ dl {
 				}
 			}
 		}
-		
-		
-		th.table-hover {
-			@extend %zebra-background-color-ccc;
-		}
-		&.table-accent th.table-hover {
-			@extend %zebra-background-color-555;
-		}
-		&.table-medium th.table-hover {
-			@extend %zebra-background-color-222;
-		}
-		&.table-dark th.table-hover {
-			@extend %zebra-background-color-666;
-		}
-		&.table-simplify th.table-hover {
-			@extend %zebra-background-color-transparent;
-		}
-	}
-	
-	/* Row Effect */
-	&.rowtdhover {
-		tbody, tfoot {
-			tr:hover, /*tr.table-hover,*/ tr.table-hover td,
-			tr:hover td.table-keycell, tr.table-hover td.table-keycell, 
-			tr:hover td.table-desccell, tr.table-hover td.table-desccell,
-			tr:hover td.table-layoutCell, tr.table-hover td.table-layoutCell,
-			tr:hover th.table-layoutCell, tr.table-hover th.table-layoutCell  {
-				@extend %zebra-background-color-eee;
-			}
-			
-			/* Hover for summary rows */
-			tr.table-summary:hover, tr.table-summary.table-hover td,
-			tr.table-summary:hover td.table-keycell, tr.table-summary.table-hover td.table-keycell, 
-			tr.table-summary:hover td.table-desccell, tr.table-summary.table-hover td.table-desccell,
-			tr.table-summary:hover td.table-layoutCell, tr.table-summary.table-hover td.table-layoutCell,
-			tr.table-summary:hover th.table-layoutCell, tr.table-summary.table-hover th.table-layoutCell  {
-				@extend %zebra-table-background-color-f0fcff;
-			}
-		}
-	}
-	&.rowhover {
-		tbody, tfoot {
-			tr:hover, /*tr.table-hover,*/ tr.table-hover td,
-			tr:hover td.table-keycell, tr.table-hover td.table-keycell, 
-			tr:hover td.table-desccell, tr.table-hover td.table-desccell,
-			tr:hover td.table-layoutCell, tr.table-hover td.table-layoutCell,
-			tr:hover th.table-layoutCell, tr.table-hover th.table-layoutCell  {
-				@extend %zebra-background-color-eee;
-			}
 
-			/* Hover for summary rows */
-			tr.table-summary:hover, tr.table-summary.table-hover td,
-			tr.table-summary:hover td.table-keycell, tr.table-summary.table-hover td.table-keycell, 
-			tr.table-summary:hover td.table-desccell, tr.table-summary.table-hover td.table-desccell,
-			tr.table-summary:hover td.table-layoutCell, tr.table-summary.table-hover td.table-layoutCell,
-			tr.table-summary:hover th.table-layoutCell, tr.table-summary.table-hover th.table-layoutCell  {
-				@extend %zebra-table-background-color-f0fcff;
-			}
 
-			
-			tr:hover th, tr.table-hover th {
+		th {
+			&.table-hover {
 				@extend %zebra-background-color-ccc;
 			}
-			/*
-			 * Uncomment to have white cell at the mouse intersection
-			tr:hover td:hover {
-				background-color: #fff;
-			}
-			*/
 		}
-		&.table-accent tbody, &.table-accent tfoot {
-			tr:hover th, tr.table-hover th  {
-				@extend %zebra-background-color-555;
+		&.table-accent {
+			th {
+				&.table-hover {
+					@extend %zebra-background-color-555;
+				}
 			}
 		}
-		&.table-medium tbody, &.table-medium tfoot {
-			tr:hover th, tr.table-hover th {
-				@extend %zebra-background-color-222;
+		&.table-medium {
+			th {
+				&.table-hover {
+					@extend %zebra-background-color-222;
+				}
 			}
 		}
-		&.table-dark tbody, &.table-dark tfoot {
-			tr:hover th, tr.table-hover th {
-				@extend %zebra-background-color-666;
+		&.table-dark {
+			th {
+				&.table-hover {
+					@extend %zebra-background-color-666;
+				}
 			}
 		}
-		&.table-simplify tbody tr th, &.table-simplify tfoot tr th {
-			@extend %zebra-background-color-transparent;
+		&.table-simplify {
+			th {
+				&.table-hover {
+					@extend %zebra-background-color-transparent;
+				}
+			}
+		}
+	}
+
+	// Row Effect
+	&.rowtdhover {
+		@extend %zebra-tfoot-theader-hover;
+	}
+	&.rowhover {
+		@extend %zebra-tfoot-theader-hover;
+		tbody, tfoot {
+			tr {
+				&:hover, &.table-hover {
+					th {
+						@extend %zebra-background-color-ccc;
+					}
+				}
+			}
+		}
+		&.table-accent {
+			tbody, tfoot {
+				tr {
+					&:hover, &.table-hover {
+						th {
+							@extend %zebra-background-color-555;
+						}
+					}
+				}
+			}
+		}
+		&.table-medium {
+			tbody, tfoot {
+				tr {
+					&:hover, &.table-hover {
+						th {
+							@extend %zebra-background-color-222;
+						}
+					}
+				}
+			}
+		}
+		&.table-dark {
+			tbody, tfoot {
+				tr {
+					&:hover, &.table-hover {
+						th {
+							@extend %zebra-background-color-666;
+						}
+					}
+				}
+			}
+		}
+		&.table-simplify {
+			tbody, tfoot {
+				tr {
+					th {
+						@extend %zebra-background-color-transparent;
+					}
+				}
+			}
+		}
+	}
+}
+
+%zebra-tfoot-theader-hover {
+	tbody, tfoot {
+		tr {
+			&:hover {
+				@extend %zebra-background-color-eee;
+				th {
+					&.table-layoutCell {
+						@extend %zebra-background-color-eee;
+					}
+				}
+				td {
+					&.table-keycell {
+						@extend %zebra-background-color-eee;
+					}
+					&.table-desccell {
+						@extend %zebra-background-color-eee;
+					}
+					&.table-layoutCell {
+						@extend %zebra-background-color-eee;
+					}
+				}
+			}
+			&.table-hover {
+				th {
+					&.table-layoutCell {
+						@extend %zebra-background-color-eee;
+					}
+				}
+				td {
+					@extend %zebra-background-color-eee;
+					&.table-keycell {
+						@extend %zebra-background-color-eee;
+					}
+					&.table-desccell {
+						@extend %zebra-background-color-eee;
+					}
+					&.table-layoutCell {
+						@extend %zebra-background-color-eee;
+					}
+				}
+			}
+
+			// Hover for summary rows
+			&.table-summary {
+				&:hover {
+					@extend %zebra-table-background-color-f0fcff;
+					th {
+						&.table-layoutCell {
+							@extend %zebra-table-background-color-f0fcff;
+						}
+					}
+					td {
+						&.table-keycell {
+							@extend %zebra-table-background-color-f0fcff;
+						}
+						&.table-desccell {
+							@extend %zebra-table-background-color-f0fcff;
+						}
+						&.table-layoutCell {
+							@extend %zebra-table-background-color-f0fcff;
+						}
+					}
+				}
+				&.table-hover {
+					th {
+						&.table-layoutCell {
+							@extend %zebra-table-background-color-f0fcff;
+						}
+					}
+					td {
+						@extend %zebra-table-background-color-f0fcff;
+						&.table-keycell {
+							@extend %zebra-table-background-color-f0fcff;
+						}
+						&.table-desccell {
+							@extend %zebra-table-background-color-f0fcff;
+						}
+						&.table-layoutCell {
+							@extend %zebra-table-background-color-f0fcff;
+						}
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
These classes were already extended, but are now expanded out for
readablity.
One unrelated comment change in calendar to remove an empty rule warning
in the test task.
