### PR TITLE
Fix mobile initialization bug

### DIFF
--- a/src/theme-base/js/theme.js
+++ b/src/theme-base/js/theme.js
@@ -210,7 +210,7 @@
 					i = len;
 					while (i--) {
 						node = nodes[i];
-						link = node.childNodes[0];
+						link = $(node).children('a:first')[0];
 						settings_popup += '<li' + (i === 0 ? ' class="ui-corner-bottom"' : '');
 						if (node.id.indexOf('-lang-current') !== -1) {
 							settings_popup += '><a href="javascript:;" class="ui-disabled">' + node.innerHTML + ' <span class="current">' + pe.dic.get('%current') + '</span></a></li>';

--- a/src/theme-gcwu-fegc/js/theme.js
+++ b/src/theme-gcwu-fegc/js/theme.js
@@ -242,7 +242,7 @@
 					i = len;
 					while (i--) {
 						node = nodes[i];
-						link = node.childNodes[0];
+						link = $(node).children('a:first')[0];
 						settings_popup += '<li' + (i === 0 ? ' class="ui-corner-bottom"' : '');
 						if (node.id.indexOf('-lang-current') !== -1) {
 							settings_popup += '><a href="javascript:;" class="ui-disabled">' + node.innerHTML + ' <span class="current">' + pe.dic.get('%current') + '</span></a></li>';

--- a/src/theme-gcwu-intranet/js/theme.js
+++ b/src/theme-gcwu-intranet/js/theme.js
@@ -236,7 +236,7 @@
 					i = len;
 					while (i--) {
 						node = nodes[i];
-						link = node.childNodes[0];
+						link = $(node).children('a:first')[0];
 						settings_popup += '<li' + (i === 0 ? ' class="ui-corner-bottom"' : '');
 						if (node.id.indexOf('-lang-current') !== -1) {
 							settings_popup += '><a href="javascript:;" class="ui-disabled">' + node.innerHTML + ' <span class="current">' + pe.dic.get('%current') + '</span></a></li>';

--- a/src/theme-wet-boew/js/theme.js
+++ b/src/theme-wet-boew/js/theme.js
@@ -240,7 +240,7 @@
 					i = len;
 					while (i--) {
 						node = nodes[i];
-						link = node.childNodes[0];
+						link = $(node).children('a:first')[0];
 						settings_popup += '<li' + (i === 0 ? ' class="ui-corner-bottom"' : '');
 						if (node.id.indexOf('-lang-current') !== -1) {
 							settings_popup += '><a href="javascript:;" class="ui-disabled">' + node.innerHTML + ' <span class="current">' + pe.dic.get('%current') + '</span></a></li>';


### PR DESCRIPTION
Where any empty text node or any non-anchor node inside the language
selector list will break mobile initialization. Empty text nodes
(whitespace) in the
HTML should not have any effect on WET.

Example test code:

``` html
<li id="base-fullhd-lang">
Some text here
  <a href="/fr/user/login" lang="fr">Français</a>
</li>
```

In the above, the 'Some text here' breaks initialization. One would
likely never put this there, but empty text with only carriage returns or
tabs will have the same effect. This commit fixes the issue.
