### PR TITLE
CSS: fixed :visited style for #wb-main-in links

### DIFF
--- a/src/base/sass/_default-screen.scss
+++ b/src/base/sass/_default-screen.scss
@@ -138,7 +138,7 @@ a.wb-linkdesc {
 				padding: 2px 10px;
 				text-decoration: none;
 				text-shadow: none;
-				color: #fff;
+				color: #fff !important;
 				&:hover {
 					text-decoration: underline;
 				}

--- a/src/grids/sass/includes/_util-screen.scss
+++ b/src/grids/sass/includes/_util-screen.scss
@@ -507,6 +507,9 @@ table {
 		margin: 0 8px;
 		padding: 0 0 1px 0;
 	}
+  a {
+    color: #fff !important;
+  }
 	abbr, acronym {
 		border: none;
 	}

--- a/src/grids/sass/includes/_util-small-medium.scss
+++ b/src/grids/sass/includes/_util-small-medium.scss
@@ -42,12 +42,6 @@ ul {
 	}
 }
 
-.date-month {
-	a {
-		color: #fff !important;
-	}
-}
-
 %util-small-medium-bb-pre7-background-333-important-color-f9f9f9-important {
 	background: #333 !important;
 	color: #f9f9f9 !important;
@@ -55,7 +49,7 @@ ul {
 .bb-pre7 {
 	input, textarea, select {
 		// Can't use pseudo-focus since fix is needed for both focused and activated states
-		&:focus, &:active { 
+		&:focus, &:active {
 			@extend %util-small-medium-bb-pre7-background-333-important-color-f9f9f9-important;
 		}
 	}

--- a/src/theme-base/sass/includes/_default-large-screen.scss
+++ b/src/theme-base/sass/includes/_default-large-screen.scss
@@ -31,10 +31,6 @@ h1 {
 	}
 }
 
-a {
-	@extend %base-default-large-screen-link;
-}
-
 %base-default-large-screen-inline-z-index1 {
 	z-index: 1;
 	display: inline;
@@ -138,6 +134,9 @@ a {
 		top: 1px;
 		bottom: 2.5em; //TODO: mixed px and ems
 	}
+  a {
+    @extend %base-default-large-screen-link;
+  }
 }
 
 %base-default-large-screen-float-right {
@@ -296,7 +295,7 @@ a {
 
 #base-srch-submit {
 	background: #ccc;
-	@if $legacy-support-for-ie8 { 
+	@if $legacy-support-for-ie8 {
 		@include filter-gradient(#F0F0F0,#CCC);
 	} @else {
 		@include background-image(linear-gradient(#F0F0F0,#CCC));
@@ -318,7 +317,7 @@ a {
 	display: inline;
 	@include pseudo-focus {
 		background: #ddd;
-		@if $legacy-support-for-ie8 { 
+		@if $legacy-support-for-ie8 {
 			@include filter-gradient(#CCC,#DDD);
 		} @else {
 			@include background-image(linear-gradient(#CCC,#DDD));
@@ -391,7 +390,7 @@ a {
 			@extend %base-default-large-screen-float-left;
 		}
 	}
-	
+
 	#wb-body-sec {
 		#wb-main {
 			@extend %base-default-large-screen-float-left;
@@ -451,9 +450,9 @@ a {
 				}
 			}
 		}
-		
+
 	}
-	
+
 	#base-fullhd-in {
 		p {
 			@extend %base-default-large-screen-float-right;

--- a/src/theme-gcwu-fegc/sass/includes/_default-large-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-large-screen.scss
@@ -126,10 +126,6 @@ h1 {
 	margin-top: 0;
 }
 
-a {
-	@extend %gcwu-default-link;
-}
-
 #wb-sup {
 	@extend %gcwu-default-large-screen-inline-z1;
 	@extend %gcwu-default-large-screen-float-right-relative;
@@ -207,6 +203,9 @@ a {
 #wb-main-in {
 	padding-top: 1px;
 	padding-bottom: 2.5em;
+  a {
+    @extend %gcwu-default-link;
+  }
 }
 
 #wb-body-sec {
@@ -386,7 +385,7 @@ a {
 #gcwu-srch-submit {
 	@include appearance(none);
 	min-height: 24px;
-	@if $legacy-support-for-ie8 { 
+	@if $legacy-support-for-ie8 {
 		@include filter-gradient(#F0F0F0,#CCC);
 	} @else {
 		@include background-image(linear-gradient(#F0F0F0,#CCC));
@@ -404,7 +403,7 @@ a {
 	padding: 2px 6px;
 	display: inline;
 	@include pseudo-focus {
-		@if $legacy-support-for-ie8 { 
+		@if $legacy-support-for-ie8 {
 			@include filter-gradient(#CCC,#DDD);
 		} @else {
 			@include background-image(linear-gradient(#CCC,#DDD));
@@ -455,7 +454,7 @@ a {
 		&, li {
 			background: #23447e;
 			min-height: 2.15em;
-			@if $legacy-support-for-ie8 { 
+			@if $legacy-support-for-ie8 {
 				background: #23447e url(../images/menu-bg.gif) repeat-x;
 			} @else {
 				@include background-image(linear-gradient(#146094, #23447E));
@@ -487,7 +486,7 @@ a {
 		.mb-sm-open {
 			@include box-shadow(0 5px 5px -4px rgba(0, 0, 0, 0.5), 5px 5px 5px -4px rgba(0, 0, 0, 0.5), -5px 5px 5px -4px rgba(0, 0, 0, 0.5));
 			border-bottom: 4px solid #0F315B;
-			@if $legacy-support-for-ie8 { 
+			@if $legacy-support-for-ie8 {
 				@include filter-gradient(#CCC, #EEE);
 			} @else {
 				@include background-image(linear-gradient(#CCC, #EEE));

--- a/src/theme-wet-boew/sass/includes/_default-large-screen.scss
+++ b/src/theme-wet-boew/sass/includes/_default-large-screen.scss
@@ -170,6 +170,9 @@ body {
 #wb-main-in {
 	padding-top: 1px;
 	padding-bottom: 2.5em;
+  a {
+    @extend %wet-default-large-screen-link;
+  }
 }
 
 #wb-sec-in {
@@ -214,10 +217,6 @@ h1 {
 #wb-sup {
 	@extend %wet-default-large-screen-float-right;
 	@extend %wet-default-large-screen-position-relative;
-}
-
-a {
-	@extend %wet-default-large-screen-link;
 }
 
 #wet-fullhd {
@@ -334,7 +333,7 @@ a {
 			font-size: 80%;
 			padding: 2px;
 		}
-	}	
+	}
 }
 
 #wet-subsite {


### PR DESCRIPTION
The :visited link style was being overridden by jQuery Mobile.  This PR increases the specificity of the link's CSS rule so that `#wb-main-in` links get their :visited style back.
