### PR TITLE
Mobile Favicon: fixes #1504 BlackBerry support

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -126,7 +126,7 @@
 				$this,
 				target,
 				validTarget = false,
-				classes,
+				classes = '',
 				test,
 				test_elms,
 				silentscroll_fired = false,
@@ -170,7 +170,14 @@
 			pe.mobile = pe.mobilecheck();
 			pe.medium = pe.mediumcheck();
 			pe.print = (pe.mobile ? false : pe.printcheck());
-			classes = wet_boew_theme !== null ? (wet_boew_theme.theme + (pe.mobile ? (' mobile-view' + (pe.medium ? ' medium-screen' : ' small-screen')) : (pe.print ? ' print-view' : ' desktop-view large-screen'))) : '';
+
+			// Add theme specific CSS classes and favicon
+			if(wet_boew_theme !== null) {
+				classes += wet_boew_theme.theme + (pe.mobile ? (' mobile-view' + (pe.medium ? ' medium-screen' : ' small-screen')) : (pe.print ? ' print-view' : ' desktop-view large-screen'));
+				if(typeof wet_boew_theme.favicon !== 'undefined') {
+					pe.add.favicon(pe.add.themecsslocation.replace(/css\/$/, wet_boew_theme.favicon.href), wet_boew_theme.favicon.rel, wet_boew_theme.favicon.sizes);
+				}
+			}
 			classes += (pe.touchscreen ? ' touchscreen' : '');
 			classes += (pe.svg ? ' svg' : ' no-svg');
 			classes += (pe.ie > 8 ? ' ie' + parseInt(pe.ie, 10) : (pe.ie < 1 ? ' no-ie' : ''));
@@ -1214,7 +1221,7 @@
 										}
 									}
 								}
-								
+
 								// The original menu item was not in a menu bar and is a top level section, all sections are to be collapsed (collapseTopOnly = false) or collapsible content is forced (collapsible = true)
 								if (!menubar && hlink.length > 0 && (toplevel || collapsible || !collapseTopOnly)) {
 									menu += link + hlinkDOM.href + '">' + hlinkDOM.innerHTML + ' - ' + mainText + '</a>';

--- a/src/theme-base/js/theme.js
+++ b/src/theme-base/js/theme.js
@@ -30,6 +30,11 @@
 		fullft: null,
 		gridsmenu: null,
 		menu: null,
+		favicon: {
+			href: 'images/favicon-mobile.png',
+			rel: 'apple-touch-icon',
+			sizes: '57x57 72x72 114x114 144x144 150x150'
+		},
 		init: function () {
 			wet_boew_theme.fullhd = pe.header.find('#base-fullhd');
 			wet_boew_theme.psnb = pe.header.find('#base-psnb');
@@ -248,9 +253,6 @@
 				// Append all the popups to the body
 				pe.bodydiv.append(bodyAppend + settings_popup);
 			}
-
-			// Load the mobile favicon
-			pe.add.favicon(pe.add.themecsslocation.replace(/css\/$/, 'images/favicon-mobile.png'), 'apple-touch-icon', '57x57 72x72 114x114 144x144 150x150');
 
 			// jQuery mobile has loaded
 			$document.on('pagecreate', function () {

--- a/src/theme-gcwu-fegc/js/theme.js
+++ b/src/theme-gcwu-fegc/js/theme.js
@@ -30,6 +30,11 @@
 		gcft: null,
 		gridsmenu: null,
 		menu: null,
+		favicon: {
+			href: 'images/favicon-mobile.png',
+			rel: 'apple-touch-icon',
+			sizes: '57x57 72x72 114x114 144x144 150x150'
+		},
 		init: function () {
 			wet_boew_theme.gcnb = pe.header.find('#gcwu-gcnb');
 			wet_boew_theme.psnb = pe.header.find('#gcwu-psnb');
@@ -330,9 +335,6 @@
 					wmms.parentNode.removeChild(wmms);
 				}
 			}
-
-			// Load the mobile favicon
-			pe.add.favicon(pe.add.themecsslocation.replace(/css\/$/, 'images/favicon-mobile.png'), 'apple-touch-icon', '57x57 72x72 114x114 144x144 150x150');
 
 			// jQuery mobile has loaded
 			$document.on('pagecreate', function () {

--- a/src/theme-gcwu-intranet/js/theme.js
+++ b/src/theme-gcwu-intranet/js/theme.js
@@ -30,6 +30,11 @@
 		gcft: null,
 		gridsmenu: null,
 		menu: null,
+		favicon: {
+			href: 'images/favicon-mobile.png',
+			rel: 'apple-touch-icon',
+			sizes: '57x57 72x72 114x114 144x144 150x150'
+		},
 		init: function () {
 			wet_boew_theme.gcnb = pe.header.find('#gcwu-gcnb');
 			wet_boew_theme.psnb = pe.header.find('#gcwu-psnb');
@@ -322,9 +327,6 @@
 					wmms.parentNode.removeChild(wmms);
 				}
 			}
-
-			// Load the mobile favicon
-			pe.add.favicon(pe.add.themecsslocation.replace(/css\/$/, 'images/favicon-mobile.png'), 'apple-touch-icon', '57x57 72x72 114x114 144x144 150x150');
 
 			// jQuery mobile has loaded
 			$document.on('pagecreate', function () {

--- a/src/theme-wet-boew/js/theme.js
+++ b/src/theme-wet-boew/js/theme.js
@@ -30,6 +30,11 @@
 		fullft: null,
 		gridsmenu: null,
 		menu: null,
+		favicon: {
+			href: 'images/favicon-mobile.png',
+			rel: 'apple-touch-icon',
+			sizes: '57x57 72x72 114x114 144x144 150x150'
+		},
 		init: function () {
 			wet_boew_theme.fullhd = pe.header.find('#wet-fullhd');
 			wet_boew_theme.psnb = pe.header.find('#wet-psnb');
@@ -278,9 +283,6 @@
 				// Append all the popups to the body
 				pe.bodydiv.append(bodyAppend + settings_popup);
 			}
-
-			// Load the mobile favicon
-			pe.add.favicon(pe.add.themecsslocation.replace(/css\/$/, 'images/favicon-mobile.png'), 'apple-touch-icon', '57x57 72x72 114x114 144x144 150x150');
 
 			// jQuery mobile has loaded
 			$document.on('pagecreate', function () {


### PR DESCRIPTION
This fixes BlackBerry OS 6.0+ support for the large mobile favicon.  
