### PR TITLE
Changed all references to wet-boew.github.com to wet-boew-github.io to align with the new GitHub change.

### DIFF
--- a/demos/langselect/langselect/lang
+++ b/demos/langselect/langselect/lang
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
 # Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-# wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+# wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
 $q = $ENV{'QUERY_STRING'};
 if ($q =~ s/_e\./_f./gism) {
 } elsif ($q =~ s/-eng\./-fra./gism) {

--- a/demos/langselect/langselect/lang-inc.php
+++ b/demos/langselect/langselect/lang-inc.php
@@ -1,7 +1,7 @@
 <?php
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 $_PAGE['altlangurl'] = $_SERVER["REQUEST_URI"];
 $_PAGE['altlangurl'] = preg_replace('/#(.*)$/', '', $_PAGE['altlangurl']);

--- a/demos/langselect/langselect/lang-inc.shtm
+++ b/demos/langselect/langselect/lang-inc.shtm
@@ -1,5 +1,5 @@
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt -->
 <!--#if expr="${REQUEST_URI} = /^(.*)-eng.([A-Za-z]*)$/"-->
 <!--#set var="pg-altlangurl" value="${1}-fra.${2}"-->
 <!--#elif expr="${REQUEST_URI} = /^(.*)_e.([A-Za-z]*)$/"-->

--- a/demos/langselect/langselect/lang.asp
+++ b/demos/langselect/langselect/lang.asp
@@ -1,7 +1,7 @@
 ﻿<%@ LANGUAGE="VBSCRIPT" %>
 <%
 ' Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-' wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+' wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
 sString = Request.ServerVariables("HTTP_REFERER")
 sFullFileName = Mid (sString, Instr (sString, ".asp"))
 iLen = Instr (sString, ".asp")-4

--- a/demos/langselect/langselect/lang.php
+++ b/demos/langselect/langselect/lang.php
@@ -1,7 +1,7 @@
 <?php
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 if ($_SERVER['HTTP_REFERER'] != "") {
 	$q = $_SERVER['HTTP_REFERER'];

--- a/demos/tableparser/js/sel-cell.js
+++ b/demos/tableparser/js/sel-cell.js
@@ -1,6 +1,6 @@
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
  * row Selector - Table usability - Core plugin

--- a/demos/tableparser/js/sel-cell.js
+++ b/demos/tableparser/js/sel-cell.js
@@ -1,5 +1,5 @@
 /*!
- * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * Web Experience Toolkit (WET) / BoÃ®te Ã  outils de l'expÃ©rience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**

--- a/demos/tableparser/js/sel-col.js
+++ b/demos/tableparser/js/sel-col.js
@@ -1,6 +1,6 @@
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
  * col Selector - Table usability - Core plugin

--- a/demos/tableparser/js/sel-col.js
+++ b/demos/tableparser/js/sel-col.js
@@ -1,5 +1,5 @@
 /*!
- * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * Web Experience Toolkit (WET) / BoÃ®te Ã  outils de l'expÃ©rience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**

--- a/demos/tableparser/js/sel-collevel.js
+++ b/demos/tableparser/js/sel-collevel.js
@@ -1,6 +1,6 @@
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
  * Summary Cell Selector - Table usability - Core plugin

--- a/demos/tableparser/js/sel-collevel.js
+++ b/demos/tableparser/js/sel-collevel.js
@@ -1,5 +1,5 @@
 /*!
- * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * Web Experience Toolkit (WET) / BoÃ®te Ã  outils de l'expÃ©rience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**

--- a/demos/tableparser/js/sel-data.js
+++ b/demos/tableparser/js/sel-data.js
@@ -1,6 +1,6 @@
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
  * Summary Cell Selector - Table usability - Core plugin

--- a/demos/tableparser/js/sel-data.js
+++ b/demos/tableparser/js/sel-data.js
@@ -1,5 +1,5 @@
 /*!
- * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * Web Experience Toolkit (WET) / BoÃ®te Ã  outils de l'expÃ©rience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**

--- a/demos/tableparser/js/sel-description.js
+++ b/demos/tableparser/js/sel-description.js
@@ -1,6 +1,6 @@
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
  * Description Cell Selector - Table usability - Core plugin

--- a/demos/tableparser/js/sel-description.js
+++ b/demos/tableparser/js/sel-description.js
@@ -1,5 +1,5 @@
 /*!
- * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * Web Experience Toolkit (WET) / BoÃ®te Ã  outils de l'expÃ©rience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**

--- a/demos/tableparser/js/sel-keycell.js
+++ b/demos/tableparser/js/sel-keycell.js
@@ -1,6 +1,6 @@
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
  * Key Cell Selector - Table usability - Core plugin

--- a/demos/tableparser/js/sel-keycell.js
+++ b/demos/tableparser/js/sel-keycell.js
@@ -1,5 +1,5 @@
 /*!
- * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * Web Experience Toolkit (WET) / BoÃ®te Ã  outils de l'expÃ©rience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
@@ -194,7 +194,7 @@ The perpective for the computation/query search
  
 Parameterised Custom Selectors
 
-You’ll notice that some Pseudo-Class selectors accept a parameter, for example :has(selector). So how do we get some of that good stuff? We are going to build a lengthBetween selector that will filter out items whose length is greater than two specified parameters, in this case, four and eight. The calling code will look like:
+Youâ€™ll notice that some Pseudo-Class selectors accept a parameter, for example :has(selector). So how do we get some of that good stuff? We are going to build a lengthBetween selector that will filter out items whose length is greater than two specified parameters, in this case, four and eight. The calling code will look like:
 view plaincopy to clipboardprint?
 
     alert($("input:lengthBetween(4,8)").length);  
@@ -218,12 +218,12 @@ view plaincopy to clipboardprint?
 
     alert($("input:lengthBetween(4,8)").length);  
 
-    match[0] – contains the full pseudo-class selector call. In this example :lengthBetween(4,8)
-    match[1] – contains the selector name only. In this example lengthBetween
-    match[2] – denotes which, if any, type of quotes are used in the parameter expression. i.e. single (‘)  or double (“). In this example it will be empty.
-    match[3] – gives us the parameters, i.e. what is contained in the brackets. In this example 4,8
+    match[0] â€“ contains the full pseudo-class selector call. In this example :lengthBetween(4,8)
+    match[1] â€“ contains the selector name only. In this example lengthBetween
+    match[2] â€“ denotes which, if any, type of quotes are used in the parameter expression. i.e. single (â€˜)  or double (â€œ). In this example it will be empty.
+    match[3] â€“ gives us the parameters, i.e. what is contained in the brackets. In this example 4,8
 
-So, if we just want the parameters, then match[3] is the way forward. This is a simple string value and it’s really up to you how you handle it. You can String.Split() it to get multiple parameters, and you can consider validating the parameters somehow. Again, we are drifting away somewhat from the scope of this discussion, so I’ll refer to the jQuery core once more:
+So, if we just want the parameters, then match[3] is the way forward. This is a simple string value and itâ€™s really up to you how you handle it. You can String.Split() it to get multiple parameters, and you can consider validating the parameters somehow. Again, we are drifting away somewhat from the scope of this discussion, so Iâ€™ll refer to the jQuery core once more:
 view plaincopy to clipboardprint?
 
     gt: function (elem, i, match) {  

--- a/demos/tableparser/js/sel-row.js
+++ b/demos/tableparser/js/sel-row.js
@@ -1,6 +1,6 @@
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
  * row Selector - Table usability - Core plugin

--- a/demos/tableparser/js/sel-row.js
+++ b/demos/tableparser/js/sel-row.js
@@ -1,5 +1,5 @@
 /*!
- * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * Web Experience Toolkit (WET) / BoÃ®te Ã  outils de l'expÃ©rience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**

--- a/demos/tableparser/js/sel-rowlevel.js
+++ b/demos/tableparser/js/sel-rowlevel.js
@@ -1,6 +1,6 @@
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
  * Summary Cell Selector - Table usability - Core plugin

--- a/demos/tableparser/js/sel-rowlevel.js
+++ b/demos/tableparser/js/sel-rowlevel.js
@@ -1,5 +1,5 @@
 /*!
- * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * Web Experience Toolkit (WET) / BoÃ®te Ã  outils de l'expÃ©rience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**

--- a/demos/tableparser/js/sel-summary.js
+++ b/demos/tableparser/js/sel-summary.js
@@ -1,6 +1,6 @@
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
  * Summary Cell Selector - Table usability - Core plugin

--- a/demos/tableparser/js/sel-summary.js
+++ b/demos/tableparser/js/sel-summary.js
@@ -1,5 +1,5 @@
 /*!
- * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * Web Experience Toolkit (WET) / BoÃ®te Ã  outils de l'expÃ©rience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**

--- a/demos/tableparser/js/sel-tblheader.js
+++ b/demos/tableparser/js/sel-tblheader.js
@@ -1,6 +1,6 @@
 /*!
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**
  * row Selector - Table usability - Core plugin

--- a/demos/tableparser/js/sel-tblheader.js
+++ b/demos/tableparser/js/sel-tblheader.js
@@ -1,5 +1,5 @@
 /*!
- * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * Web Experience Toolkit (WET) / BoÃ®te Ã  outils de l'expÃ©rience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /**

--- a/demos/wamethod/css/wamethod-ie.css
+++ b/demos/wamethod/css/wamethod-ie.css
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 .guidance-block {
   margin-top: 20px;

--- a/demos/wamethod/css/wamethod.css
+++ b/demos/wamethod/css/wamethod.css
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .guidance-block h2 {
   margin-left: 10px;

--- a/demos/wamethod/js/wamethod.js
+++ b/demos/wamethod/js/wamethod.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Web Accessibility Assessment Methodology

--- a/index-eng.html
+++ b/index-eng.html
@@ -7,7 +7,7 @@
 <head>
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt -->
 <title>Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="dist/theme-gcwu-fegc/images/favicon.ico" />
@@ -103,7 +103,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li><a href="#themeable-and-reusable">Flexible and themeable templates and reusable components</a></li>
 <li>Open source software
 	<ul>
-	<li>Free to use for commercial and non-commercial purposes (MIT license - <a href="http://wet-boew.github.com/wet-boew/License-eng.txt">Terms and conditions</a>)</li>
+	<li>Free to use for commercial and non-commercial purposes (MIT license - <a href="http://wet-boew.github.io/wet-boew/License-eng.txt">Terms and conditions</a>)</li>
 	<li><a href="#collaborative-approach">Developed openly by the community on GitHub</a></li>
 	</ul>
 </li>

--- a/index-fra.html
+++ b/index-fra.html
@@ -7,7 +7,7 @@
 <head>
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt -->
 <title>Boîte à outils de l’expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="dist/theme-gcwu-fegc/images/favicon.ico" />
@@ -103,7 +103,7 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <li><a href="#personnalisable-et-rutilisable">Des modèles, ainsi que des composants réutilisables, qui sont flexibles et personnalisables</a></li>
 <li>Un logiciel libre
 	<ul>
-	<li>Libre d'utilisation à des fins commerciales et non commerciales (licence MIT - <a href="http://wet-boew.github.com/wet-boew/Licence-fra.txt">Conditions régissant l'utilisation</a>)</li>
+	<li>Libre d'utilisation à des fins commerciales et non commerciales (licence MIT - <a href="http://wet-boew.github.io/wet-boew/Licence-fra.txt">Conditions régissant l'utilisation</a>)</li>
 	<li><a href="#approche-collaborative">Développé ouvertement sur GitHub par la communauté</a></li>
 	</ul>
 </li>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 <head>
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt -->
 <title>Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="dist/theme-gcwu-fegc/images/favicon.ico" />

--- a/src/base/html/base.html
+++ b/src/base/html/base.html
@@ -7,7 +7,7 @@
 <head>
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt -->
+wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt -->
 <title>@%include-title@</title>
 
 @%include-theme-favicon@

--- a/src/base/sass/_default-desktop-screen.scss
+++ b/src/base/sass/_default-desktop-screen.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/base/sass/_default-desktop.scss
+++ b/src/base/sass/_default-desktop.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .mobile-hide {
 	display: block !important;

--- a/src/base/sass/_default-ie.scss
+++ b/src/base/sass/_default-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	#wb-skip {

--- a/src/base/sass/_default-mobile.scss
+++ b/src/base/sass/_default-mobile.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /* Override jQuery Mobile hiding of content on mobile loading to eliminate white flicker (exact opposite of what jQuery Mobile does) */
 .ui-mobile-rendering {

--- a/src/base/sass/_default-ns.scss
+++ b/src/base/sass/_default-ns.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/base/sass/_default-print-ie.scss
+++ b/src/base/sass/_default-print-ie.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/base/sass/_default-print.scss
+++ b/src/base/sass/_default-print.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 %wb-default-print-times-new-roman-font {
 	font-family: Times New Roman, serif;

--- a/src/base/sass/_default-screen-ie.scss
+++ b/src/base/sass/_default-screen-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	#wb-skip {

--- a/src/base/sass/_default-screen.scss
+++ b/src/base/sass/_default-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 %wb-default-screen-verdana-font {
 	font-family: Verdana, Arial, Helvetica, sans-serif;

--- a/src/base/sass/_default.scss
+++ b/src/base/sass/_default.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import 'compass/css3/opacity';
 @import '../../grids/sass/includes/mixins';

--- a/src/base/sass/_modern-vendor-prefix.scss
+++ b/src/base/sass/_modern-vendor-prefix.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /* turn off fixes for old IE */
 $legacy-support-for-ie: false;

--- a/src/base/sass/_oldie-vendor-prefix.scss
+++ b/src/base/sass/_oldie-vendor-prefix.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /* turn off vendor prefixes not supported by old IE */
 $legacy-support-for-ie: false;

--- a/src/grids/sass/_responsive-1200.scss
+++ b/src/grids/sass/_responsive-1200.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 [id|="wb-body-sec"] {
 	#wb-core {

--- a/src/grids/sass/_responsive-768.scss
+++ b/src/grids/sass/_responsive-768.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 [id|="wb-body-sec"] {
 	#wb-core {

--- a/src/grids/sass/_responsive-ie.scss
+++ b/src/grids/sass/_responsive-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	.equalize {

--- a/src/grids/sass/_responsive-ns.scss
+++ b/src/grids/sass/_responsive-ns.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/grids/sass/_responsive.scss
+++ b/src/grids/sass/_responsive.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 %grids-responsive-margin-left-10-margin-right-10 {
 	margin-left: 10px;

--- a/src/grids/sass/_util-ns.scss
+++ b/src/grids/sass/_util-ns.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/grids/sass/includes/_badge.scss
+++ b/src/grids/sass/includes/_badge.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @mixin badges {
 	%badge-border-radius-100 {

--- a/src/grids/sass/includes/_border.scss
+++ b/src/grids/sass/includes/_border.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
 */
 
 //TODO: Parent div important, or can this be combined with the %border-image placeholder. The same rules are applied in util-screen without the parent div.

--- a/src/grids/sass/includes/_button.scss
+++ b/src/grids/sass/includes/_button.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
 */
 @import "compass/css3/box-shadow";
 @import "compass/css3/border-radius";

--- a/src/grids/sass/includes/_color.scss
+++ b/src/grids/sass/includes/_color.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @mixin colors {
 

--- a/src/grids/sass/includes/_fix-ie.scss
+++ b/src/grids/sass/includes/_fix-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /* ---- IE7 fixes ---- */
 .ie7 {

--- a/src/grids/sass/includes/_form.scss
+++ b/src/grids/sass/includes/_form.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/appearance";
 

--- a/src/grids/sass/includes/_icon.scss
+++ b/src/grids/sass/includes/_icon.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/inline-block";
 

--- a/src/grids/sass/includes/_list.scss
+++ b/src/grids/sass/includes/_list.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/typography/lists/horizontal-list";
 @import "mixins";

--- a/src/grids/sass/includes/_mixins.scss
+++ b/src/grids/sass/includes/_mixins.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/utilities/color";
 

--- a/src/grids/sass/includes/_module.scss
+++ b/src/grids/sass/includes/_module.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/box-sizing";
 @import "compass/typography/lists/bullets";

--- a/src/grids/sass/includes/_table.scss
+++ b/src/grids/sass/includes/_table.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 @mixin tables {

--- a/src/grids/sass/includes/_thermometer.scss
+++ b/src/grids/sass/includes/_thermometer.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 @mixin thermometer {

--- a/src/grids/sass/includes/_util-desktop-screen.scss
+++ b/src/grids/sass/includes/_util-desktop-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/columns";
 

--- a/src/grids/sass/includes/_util-mobile.scss
+++ b/src/grids/sass/includes/_util-mobile.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
 */
 @import "compass/css3/inline-block";
 

--- a/src/grids/sass/includes/_util-print.scss
+++ b/src/grids/sass/includes/_util-print.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 @import "list";

--- a/src/grids/sass/includes/_util-screen.scss
+++ b/src/grids/sass/includes/_util-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 @import "compass/css3/opacity";

--- a/src/grids/sass/util-ie.scss
+++ b/src/grids/sass/util-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/grids/sass/util.scss
+++ b/src/grids/sass/util.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/dependencies/calendar.js
+++ b/src/js/dependencies/calendar.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/dependencies/charts.js
+++ b/src/js/dependencies/charts.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/dependencies/parserTable.js
+++ b/src/js/dependencies/parserTable.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/i18n/base.js
+++ b/src/js/i18n/base.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/polyfills/datalist.js
+++ b/src/js/polyfills/datalist.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/polyfills/datepicker.js
+++ b/src/js/polyfills/datepicker.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/polyfills/progress.js
+++ b/src/js/polyfills/progress.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/sass/_pe-ap-ns.scss
+++ b/src/js/sass/_pe-ap-ns.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 %pe-ap-ns-display-block {
 	display: block;

--- a/src/js/sass/includes/_archived.scss
+++ b/src/js/sass/includes/_archived.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 @import '../../../grids/sass/includes/mixins';

--- a/src/js/sass/includes/_calendar-base.scss
+++ b/src/js/sass/includes/_calendar-base.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .cal-container {
 	height: 22em;

--- a/src/js/sass/includes/_calendar-theme.scss
+++ b/src/js/sass/includes/_calendar-theme.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 .cal-cnt {

--- a/src/js/sass/includes/_charts.scss
+++ b/src/js/sass/includes/_charts.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 /* Charts and Graph */

--- a/src/js/sass/includes/_core.scss
+++ b/src/js/sass/includes/_core.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/js/sass/includes/_datalist-ie.scss
+++ b/src/js/sass/includes/_datalist-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	.wb-al-container {

--- a/src/js/sass/includes/_datalist.scss
+++ b/src/js/sass/includes/_datalist.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 datalist {
 	display: none;

--- a/src/js/sass/includes/_datepicker.scss
+++ b/src/js/sass/includes/_datepicker.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .cal-container {
 	&.picker-overlay {

--- a/src/js/sass/includes/_details-ie.scss
+++ b/src/js/sass/includes/_details-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 /* Add the pointers */

--- a/src/js/sass/includes/_details.scss
+++ b/src/js/sass/includes/_details.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 /* details polyfill */

--- a/src/js/sass/includes/_events-calendar.scss
+++ b/src/js/sass/includes/_events-calendar.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 ul {
 	&.ev-details {

--- a/src/js/sass/includes/_feedback.scss
+++ b/src/js/sass/includes/_feedback.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .wet-boew-feedback {
 	#web {

--- a/src/js/sass/includes/_footnotes-ie.scss
+++ b/src/js/sass/includes/_footnotes-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/inline-block";
 

--- a/src/js/sass/includes/_footnotes.scss
+++ b/src/js/sass/includes/_footnotes.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/inline-block";
 @import '../../../grids/sass/includes/mixins';

--- a/src/js/sass/includes/_formvalid.scss
+++ b/src/js/sass/includes/_formvalid.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 %formvalid-font-weight-700 {
 	font-weight: 700;

--- a/src/js/sass/includes/_lightbox.scss
+++ b/src/js/sass/includes/_lightbox.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/box-sizing";
 

--- a/src/js/sass/includes/_menubar-ie.scss
+++ b/src/js/sass/includes/_menubar-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	.mb-menu {

--- a/src/js/sass/includes/_menubar.scss
+++ b/src/js/sass/includes/_menubar.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/border-radius";
 @import "compass/css3/box-shadow";

--- a/src/js/sass/includes/_multimedia-ie.scss
+++ b/src/js/sass/includes/_multimedia-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
 */
 
 %multimedia-ie-backbround-overlay {

--- a/src/js/sass/includes/_multimedia.scss
+++ b/src/js/sass/includes/_multimedia.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
 */
 video, object.video {
 	width: 100%;

--- a/src/js/sass/includes/_prettify.scss
+++ b/src/js/sass/includes/_prettify.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 /* Pretty printing styles. Used with prettify.js. */

--- a/src/js/sass/includes/_progress.scss
+++ b/src/js/sass/includes/_progress.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 @mixin progress ($color){

--- a/src/js/sass/includes/_sessiontimeout-ie.scss
+++ b/src/js/sass/includes/_sessiontimeout-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7, .ie8 {
 	.sOverlay {

--- a/src/js/sass/includes/_sessiontimeout.scss
+++ b/src/js/sass/includes/_sessiontimeout.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /* Overlay class */
 .sOverlay {

--- a/src/js/sass/includes/_share-ie.scss
+++ b/src/js/sass/includes/_share-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /* Create new top-level stacking context to prevent overlap */
 .ie7 {

--- a/src/js/sass/includes/_share.scss
+++ b/src/js/sass/includes/_share.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ui-mobile {
 	div {

--- a/src/js/sass/includes/_slideout-ie.scss
+++ b/src/js/sass/includes/_slideout-ie.scss
@@ -1,6 +1,6 @@
 ﻿/*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .so-ie7 {
    position: relative;

--- a/src/js/sass/includes/_slideout.scss
+++ b/src/js/sass/includes/_slideout.scss
@@ -1,6 +1,6 @@
 ﻿/*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .wet-boew-slideout {
 	display: none;

--- a/src/js/sass/includes/_slider-ie.scss
+++ b/src/js/sass/includes/_slider-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /* fd-slider.min.css referencing individual .png images for IE7 */
 .ie7, .ie8 {

--- a/src/js/sass/includes/_slider.scss
+++ b/src/js/sass/includes/_slider.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/user-interface";
 @import "compass/css3/images";

--- a/src/js/sass/includes/_tabbedinterface-ie.scss
+++ b/src/js/sass/includes/_tabbedinterface-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 .ie7 {

--- a/src/js/sass/includes/_tabbedinterface.scss
+++ b/src/js/sass/includes/_tabbedinterface.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 

--- a/src/js/sass/includes/_texthighlight.scss
+++ b/src/js/sass/includes/_texthighlight.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .wet-boew-texthighlight {
 	.texthighlight {

--- a/src/js/sass/includes/_webwidget.scss
+++ b/src/js/sass/includes/_webwidget.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 @import "compass/css3/border-radius";

--- a/src/js/sass/includes/_zebra-ie.scss
+++ b/src/js/sass/includes/_zebra-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 /* IE7 hacks - should be in an IE7 only .css */

--- a/src/js/sass/includes/_zebra.scss
+++ b/src/js/sass/includes/_zebra.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 ul {
 	&.wet-boew-zebra {

--- a/src/js/sass/pe-ap-ie.scss
+++ b/src/js/sass/pe-ap-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/sass/pe-ap.scss
+++ b/src/js/sass/pe-ap.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/settings.js
+++ b/src/js/settings.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/js/workers/archived.js
+++ b/src/js/workers/archived.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Web archived top page banner

--- a/src/js/workers/charts.js
+++ b/src/js/workers/charts.js
@@ -1,6 +1,6 @@
 /*
 * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-* wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+* wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
 */
 /*
 * Chart for WET 3.0

--- a/src/js/workers/css3ie.js
+++ b/src/js/workers/css3ie.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * CSS3 for IE plugin

--- a/src/js/workers/deselectradio.js
+++ b/src/js/workers/deselectradio.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Deselectable radio buttons plugin

--- a/src/js/workers/equalize.js
+++ b/src/js/workers/equalize.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Equalize plugin

--- a/src/js/workers/eventscalendar.js
+++ b/src/js/workers/eventscalendar.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Events Calendar

--- a/src/js/workers/feedback.js
+++ b/src/js/workers/feedback.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Feedback form plugin

--- a/src/js/workers/footnotes.js
+++ b/src/js/workers/footnotes.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Footnotes

--- a/src/js/workers/formvalid.js
+++ b/src/js/workers/formvalid.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Form validation plugin

--- a/src/js/workers/langselect.js
+++ b/src/js/workers/langselect.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Web archived top page banner

--- a/src/js/workers/lightbox.js
+++ b/src/js/workers/lightbox.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Lightbox plugin

--- a/src/js/workers/menubar.js
+++ b/src/js/workers/menubar.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Menu bar plugin

--- a/src/js/workers/multimedia.js
+++ b/src/js/workers/multimedia.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
 * Multimedia player

--- a/src/js/workers/prettify.js
+++ b/src/js/workers/prettify.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Text highlighting functionality 

--- a/src/js/workers/sessiontimeout.js
+++ b/src/js/workers/sessiontimeout.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Share widget plugin

--- a/src/js/workers/share.js
+++ b/src/js/workers/share.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Share widget plugin

--- a/src/js/workers/slideout.js
+++ b/src/js/workers/slideout.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Slideout

--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Tabbed interface plugin

--- a/src/js/workers/texthighlight.js
+++ b/src/js/workers/texthighlight.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Text highlighting functionality 

--- a/src/js/workers/webwidget.js
+++ b/src/js/workers/webwidget.js
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 /*
  * Web feeds widget

--- a/src/js/workers/zebra.js
+++ b/src/js/workers/zebra.js
@@ -1,6 +1,6 @@
 /*
 * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-* wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+* wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
 */
 /*
 * Zebra stripping functionality for block level elements

--- a/src/theme-clf2-nsi2/js/theme.js
+++ b/src/theme-clf2-nsi2/js/theme.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-clf2-nsi2/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-desktop-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/inline-block";
 

--- a/src/theme-clf2-nsi2/sass/includes/_default-desktop.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-desktop.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-clf2-nsi2/sass/includes/_default-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
  .ie7 {
 	%clf2-default-ie7-bc-all {

--- a/src/theme-clf2-nsi2/sass/includes/_default-mobile.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-mobile.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-clf2-nsi2/sass/includes/_default-print-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-print-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	#cn-banner {

--- a/src/theme-clf2-nsi2/sass/includes/_default-print.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-print.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 %clf2-default-print-display-none {
 	display: none;

--- a/src/theme-clf2-nsi2/sass/includes/_default-responsive.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-responsive.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 body {
 	min-width: 780px;

--- a/src/theme-clf2-nsi2/sass/includes/_default-screen-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-screen-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	#wb-head {

--- a/src/theme-clf2-nsi2/sass/includes/_default-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 body {
 	margin: 0;

--- a/src/theme-clf2-nsi2/sass/includes/_default.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_default.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 @import '../../../grids/sass/includes/mixins';

--- a/src/theme-clf2-nsi2/sass/includes/_serv-desktop-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-desktop-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 html {

--- a/src/theme-clf2-nsi2/sass/includes/_serv-desktop.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-desktop.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-clf2-nsi2/sass/includes/_serv-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-ie.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-clf2-nsi2/sass/includes/_serv-print-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-print-ie.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-clf2-nsi2/sass/includes/_serv-print.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-print.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 #wb-head {
 	width: 100%;

--- a/src/theme-clf2-nsi2/sass/includes/_serv-responsive.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-responsive.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 body {
 	min-width: 780px;

--- a/src/theme-clf2-nsi2/sass/includes/_serv-screen-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-screen-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie8 {
 	#wb-body {

--- a/src/theme-clf2-nsi2/sass/includes/_serv-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 html {

--- a/src/theme-clf2-nsi2/sass/includes/_serv.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_serv.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 %clf2-serv-clip {
 	position: absolute;

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-desktop-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-desktop-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 #wb-skip {
 	li {

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-desktop.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-desktop.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	#cn-lower-msg {

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-print-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-print-ie.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-print.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-print.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-responsive.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-responsive.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 body {
 	min-width: 600px;

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-screen-ie.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-screen-ie.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe-screen.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe-screen.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-clf2-nsi2/sass/includes/_sp-pe.scss
+++ b/src/theme-clf2-nsi2/sass/includes/_sp-pe.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 html {

--- a/src/theme-clf2-nsi2/sass/theme-ie.scss
+++ b/src/theme-clf2-nsi2/sass/theme-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-clf2-nsi2/sass/theme-ns.scss
+++ b/src/theme-clf2-nsi2/sass/theme-ns.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-clf2-nsi2/sass/theme-serv-ie.scss
+++ b/src/theme-clf2-nsi2/sass/theme-serv-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-clf2-nsi2/sass/theme-serv.scss
+++ b/src/theme-clf2-nsi2/sass/theme-serv.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-clf2-nsi2/sass/theme-sp-pe-ie.scss
+++ b/src/theme-clf2-nsi2/sass/theme-sp-pe-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-clf2-nsi2/sass/theme-sp-pe.scss
+++ b/src/theme-clf2-nsi2/sass/theme-sp-pe.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-clf2-nsi2/sass/theme.scss
+++ b/src/theme-clf2-nsi2/sass/theme.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-fegc/jquerymobile/jquery.mobile.theme.css
+++ b/src/theme-gcwu-fegc/jquerymobile/jquery.mobile.theme.css
@@ -2,7 +2,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-fegc/js/theme.js
+++ b/src/theme-gcwu-fegc/js/theme.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-images-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-images-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 .ie7, .ie8 {

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-images.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-images.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 #gcwu-bc {
 	li {

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen-images.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen-images.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/images";
 

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/border-radius";
 @import "compass/css3/box-shadow";

--- a/src/theme-gcwu-fegc/sass/includes/_default-desktop.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-desktop.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 %gcwu-default-desktop-hidden-h2 {
 	h2 {

--- a/src/theme-gcwu-fegc/sass/includes/_default-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-ie.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-gcwu-fegc/sass/includes/_default-mobile-images.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-mobile-images.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 #gcwu-title {
 	background: #146094 url(../images/bg-waves.jpg);

--- a/src/theme-gcwu-fegc/sass/includes/_default-mobile-ns.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-mobile-ns.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .no-js {
 	%gcwu-default-mobile-ns-positioning {

--- a/src/theme-gcwu-fegc/sass/includes/_default-mobile.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-mobile.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/box-shadow";
 @import "compass/css3/border-radius";

--- a/src/theme-gcwu-fegc/sass/includes/_default-ns.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-ns.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-gcwu-fegc/sass/includes/_default-print-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-print-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	#gcwu-bnr {

--- a/src/theme-gcwu-fegc/sass/includes/_default-print.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-print.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 h1 {

--- a/src/theme-gcwu-fegc/sass/includes/_default-responsive-1200.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-responsive-1200.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 body, #wb-head, #wb-core, #wb-foot, #wb-head-in, #gcwu-gcnb, #gcwu-bnr, #gcwu-psnb, #gcwu-bc, #wb-foot-in, #gcwu-gcft, #gcwu-sft {
 	min-width: 1200px;

--- a/src/theme-gcwu-fegc/sass/includes/_default-responsive-768.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-responsive-768.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 body, #wb-head, #wb-core, #wb-foot, #wb-head-in, #gcwu-gcnb, #gcwu-bnr, #gcwu-psnb, #gcwu-bc, #wb-foot-in, #gcwu-gcft, #gcwu-sft {
 	min-width: 768px;

--- a/src/theme-gcwu-fegc/sass/includes/_default-responsive.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-responsive.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 body {
 	min-width: 960px;

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7, .ie8 {
 	.wet-boew-menubar {

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen-images-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen-images-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 @import "compass/css3/images";

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen-images.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen-images.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .wb-sec-def {
 	h3 {

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/border-radius";
 

--- a/src/theme-gcwu-fegc/sass/includes/_default.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/inline-block";
 

--- a/src/theme-gcwu-fegc/sass/includes/_serv-desktop-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-desktop-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ui-mobile {
 	#wb-foot {

--- a/src/theme-gcwu-fegc/sass/includes/_serv-desktop.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-desktop.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-gcwu-fegc/sass/includes/_serv-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	h1 {

--- a/src/theme-gcwu-fegc/sass/includes/_serv-mobile.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-mobile.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 #gcwu-sig {

--- a/src/theme-gcwu-fegc/sass/includes/_serv-print-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-print-ie.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-gcwu-fegc/sass/includes/_serv-print.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-print.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 #gcwu-sig {
 	img {

--- a/src/theme-gcwu-fegc/sass/includes/_serv-screen-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-screen-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 .ie7 {

--- a/src/theme-gcwu-fegc/sass/includes/_serv-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 html {

--- a/src/theme-gcwu-fegc/sass/includes/_serv.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_serv.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 h1 {

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-desktop-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-desktop-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 #gcwu-wmms {
 	text-align: right;

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-desktop.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-desktop.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	h2 {

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-images.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-images.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 %gcwu-sp-pe-images-langs {

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-mobile.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-mobile.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 h1 {

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-print-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-print-ie.scss
@@ -1,4 +1,4 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-print.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-print.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 h1 {

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-screen-ie.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-screen-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	#gcwu-sig {

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-screen-images.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-screen-images.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 #wb-core-in {
 	background: url(../images/sp-pe-bg.jpg) top center repeat-x #fff;

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 html {

--- a/src/theme-gcwu-fegc/sass/includes/_sp-pe.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_sp-pe.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/inline-block";
 @import "compass/css3/appearance";

--- a/src/theme-gcwu-fegc/sass/theme-ie.scss
+++ b/src/theme-gcwu-fegc/sass/theme-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-fegc/sass/theme-ns.scss
+++ b/src/theme-gcwu-fegc/sass/theme-ns.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-fegc/sass/theme-serv-ie.scss
+++ b/src/theme-gcwu-fegc/sass/theme-serv-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-fegc/sass/theme-serv.scss
+++ b/src/theme-gcwu-fegc/sass/theme-serv.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-fegc/sass/theme-sp-pe-ie.scss
+++ b/src/theme-gcwu-fegc/sass/theme-sp-pe-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-fegc/sass/theme-sp-pe.scss
+++ b/src/theme-gcwu-fegc/sass/theme-sp-pe.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-fegc/sass/theme.scss
+++ b/src/theme-gcwu-fegc/sass/theme.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-intranet/jquerymobile/jquery.mobile.theme.css
+++ b/src/theme-gcwu-intranet/jquerymobile/jquery.mobile.theme.css
@@ -2,7 +2,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-intranet/js/theme.js
+++ b/src/theme-gcwu-intranet/js/theme.js
@@ -1,7 +1,7 @@
 /*!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen-images.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen-images.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/images";
 

--- a/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-desktop-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 %gcwu-default-desktop-screen-intranetnb-sprite {

--- a/src/theme-gcwu-intranet/sass/includes/_default-ie.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .ie7 {
 	@extend %intranet-default-ie-all-versions;

--- a/src/theme-gcwu-intranet/sass/includes/_default-mobile.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-mobile.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 .intranet {
 	#gcwu-subsite {

--- a/src/theme-gcwu-intranet/sass/includes/_default-responsive-1200.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-responsive-1200.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 #gcwu-title-in {
 	width: 800px;

--- a/src/theme-gcwu-intranet/sass/includes/_default-responsive-768.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-responsive-768.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/border-radius";
 @import "compass/css3/box-shadow";

--- a/src/theme-gcwu-intranet/sass/includes/_default-responsive.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-responsive.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 #gcwu-title-in {
 	width: 550px;

--- a/src/theme-gcwu-intranet/sass/includes/_default-screen-images-ie.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default-screen-images-ie.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 @import "compass/css3/images";
 .ie7, .ie8 {

--- a/src/theme-gcwu-intranet/sass/includes/_default.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_default.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 /** From branding.css **/

--- a/src/theme-gcwu-intranet/sass/includes/_serv.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_serv.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 /** From branding.css **/

--- a/src/theme-gcwu-intranet/sass/includes/_sp-pe-screen.scss
+++ b/src/theme-gcwu-intranet/sass/includes/_sp-pe-screen.scss
@@ -1,6 +1,6 @@
 /*
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  */
 
 

--- a/src/theme-gcwu-intranet/sass/theme-ie.scss
+++ b/src/theme-gcwu-intranet/sass/theme-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-intranet/sass/theme-ns.scss
+++ b/src/theme-gcwu-intranet/sass/theme-ns.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-intranet/sass/theme-serv-ie.scss
+++ b/src/theme-gcwu-intranet/sass/theme-serv-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-intranet/sass/theme-serv.scss
+++ b/src/theme-gcwu-intranet/sass/theme-serv.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-intranet/sass/theme-sp-pe-ie.scss
+++ b/src/theme-gcwu-intranet/sass/theme-sp-pe-ie.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-intranet/sass/theme-sp-pe.scss
+++ b/src/theme-gcwu-intranet/sass/theme-sp-pe.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *

--- a/src/theme-gcwu-intranet/sass/theme.scss
+++ b/src/theme-gcwu-intranet/sass/theme.scss
@@ -2,7 +2,7 @@
 /*!!
  *
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
- * wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Licence-fra.txt
+ * wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt
  *
  * Version: @wet-boew-build.version@
  *


### PR DESCRIPTION
Details: https://github.com/blog/1452-new-github-pages-domain-github-io
