### PR TITLE
Switching i18n.csv to UTF-8 with BOM

### DIFF
--- a/src/js/i18n/i18n.csv
+++ b/src/js/i18n/i18n.csv
@@ -1,4 +1,4 @@
-,String code,English,French,Spanish
+﻿,String code,English,French,Spanish
 Language code (ISO 639-1),%lang-code,en,fr,es
 Language code (ISO 639-2/T),%lang-code-iso-639-2,eng,fra,spa
 Language name (English),%lang-eng,English,French,Spanish


### PR DESCRIPTION
Switching i18n.csv to UTF-8 with BOM so compatible with Microsoft Excel and Notepad++ opens in the correct character encoding every time. Way too much work to work with Excel with no BOM then clean up the mess after.
