### PR TITLE
Reverting i18n.csv file back to UTF-8 no BOM

### DIFF
--- a/src/js/i18n/i18n.csv
+++ b/src/js/i18n/i18n.csv
@@ -1,4 +1,4 @@
-﻿,String code,English,French,Spanish
+,String code,English,French,Spanish
 Language code (ISO 639-1),%lang-code,en,fr,es
 Language code (ISO 639-2/T),%lang-code-iso-639-2,eng,fra,spa
 Language name (English),%lang-eng,English,French,Spanish


### PR DESCRIPTION
Reverting i18n.csv file back to UTF-8 no BOM as encountered increased risk of corruption when handled by multiple tools. Need to find a way to make this much easier for people to contribute and edit translations as it is problematic to deal with the encoding issues between Excel and other programs. Seems many are using Google Docs as a workaround.
