### PR TITLE
Linting: move comment blocks

### DIFF
--- a/src/base/sass/_default.scss
+++ b/src/base/sass/_default.scss
@@ -166,11 +166,12 @@ h6 {
 	@extend %wb-clip;
 }
 
+/* Start of RTL fixes for jQuery Mobile's way of hiding stuff
+ * TODO: Fix in jQuery Mobile rather than here
+ */
 [dir="rtl"] {
-	/* Start of RTL fixes for jQuery Mobile's way of hiding stuff
-	 * TODO: Fix in jQuery Mobile rather than here
-	 */
-	/* Fixes left: -9999px */
+
+	// Fixes left: -9999px
 	.ui-nojs {
 		@extend %wb-default-left-auto-right--9999;
 	}
@@ -229,7 +230,7 @@ h6 {
 			@extend %wb-default-left-auto-right--9999;
 		}
 	}
-	/* Fixes text-indent: -9999px */
+	// Fixes text-indent: -9999px
 	.ui-btn-hidden {
 		@extend %wb-default-text-indent-9999;
 	}
@@ -242,5 +243,5 @@ h6 {
 			}
 		}
 	}
-	/* End of RTL fixes for jQuery Mobile's way of hiding stuff */
 }
+/* End of RTL fixes for jQuery Mobile's way of hiding stuff */


### PR DESCRIPTION
This is done so Sass doesn't output empty rules. These rules are
stripped by the compressor, but show up in CSSLint
