### PR TITLE
Removed creation of jQuery object before appending AJAXed in menu content to fix issue #1919.

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -271,7 +271,7 @@
 					if (replace) {
 						$o.empty();
 					}
-					$o.append($(data));
+					$o.append(data);
 				}, 'html');
 			})).always(function () {
 				// Wait for localisation and ajax content to load plugins


### PR DESCRIPTION
Seems jQuery does not like to create a jQuery object with text that has blank lines or white spaces at the beginning.
