### PR TITLE
Using $.trim() on AJAXed-in menus and fixed WET theme secondary menu visited link colour (#1074)

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -271,7 +271,7 @@
 					if (replace) {
 						$o.empty();
 					}
-					$o.append(data);
+					$o.append($.trim(data));
 				}, 'html');
 			})).always(function () {
 				// Wait for localisation and ajax content to load plugins

--- a/src/theme-wet-boew/sass/includes/_default-screen.scss
+++ b/src/theme-wet-boew/sass/includes/_default-screen.scss
@@ -184,8 +184,10 @@ input {
 		a {
 			&, &.ui-link {
 				display: block;
-				@extend %wet-default-screen-color-333;
 				text-decoration: none;
+				&:link, &:visited {
+					@extend %wet-default-screen-color-333;
+				}
 				@include pseudo-focus {
 					@extend %wet-default-screen-color-333;
 					text-decoration: underline;


### PR DESCRIPTION
- Using $.trim() to clean up AJAXed-in menus before appending.
- Fixed secondary menu visited link colour in the WET theme (#1074). 
