### PR TITLE
Grids: fixes #2069 left/right margin on nested grid cells

### DIFF
--- a/src/grids/sass/_responsive.scss
+++ b/src/grids/sass/_responsive.scss
@@ -96,9 +96,10 @@ details {
 		height: auto;
 		-ms-interpolation-mode: bicubic;
 	}
-	& & {
-		@extend %grids-responsive-no-margin;
-	}
+}
+
+.span-1 .span-1, .span-2 .span-2, .span-3 .span-3, .span-4 .span-4, .span-5 .span-5, .span-6 .span-6, .span-7 .span-7, .span-8 .span-8, .span-9 .span-9, .span-10 .span-10, .span-11 .span-11, .span-12 .span-12 {
+	@extend %grids-responsive-no-margin;
 }
 
 .border-top {


### PR DESCRIPTION
This fix already exists in master:
https://github.com/wet-boew/wet-boew/blob/master/src/grids/sass/_responsive-medium-large-screen.scss#L91-L103

Fixes #2069 
