### PR TITLE
Icons: Fix external link class specificity

### DIFF
--- a/src/grids/sass/includes/_icon.scss
+++ b/src/grids/sass/includes/_icon.scss
@@ -36,6 +36,7 @@
 	}
 }
 
+// Adds icon to indicate that links are external to all elements outside the header and footer
 [rel="external"] {
 	background: url(../images/external.png) 100% 0 no-repeat;
 	padding-right: 20px;

--- a/src/grids/sass/includes/_icon.scss
+++ b/src/grids/sass/includes/_icon.scss
@@ -36,7 +36,7 @@
 	}
 }
 
-// Adds icon to indicate that links are external to all elements outside the header and footer
+// Adds icon to all external links that are outside the header or footer
 [rel="external"] {
 	background: url(../images/external.png) 100% 0 no-repeat;
 	padding-right: 20px;

--- a/src/grids/sass/includes/_icon.scss
+++ b/src/grids/sass/includes/_icon.scss
@@ -39,11 +39,18 @@
 // Adds icon to all external links that are outside the header or footer
 [rel="external"] {
 	background: url(../images/external.png) 100% 0 no-repeat;
-	padding-right: 20px;
 
 	//gh-2104 fixes overriding background because of increased specificity when wb-main was used	
 	#wb-head &, #wb-foot & {
 		background: inherit;
+	}
+	
+	#wb-main & {
+		padding-right: 20px;
+		
+		&.wb-icon-none {
+			padding-right: 0;
+		}
 	}
 }
 	

--- a/src/grids/sass/includes/_icon.scss
+++ b/src/grids/sass/includes/_icon.scss
@@ -36,22 +36,16 @@
 	}
 }
 
+[rel="external"] {
+	background: url(../images/external.png) 100% 0 no-repeat;
+	padding-right: 20px;
 
-#wb-main {
-	[rel="external"] {
-		background-image: url(../images/external.png);
-		background-position: right 0;
-		background-repeat: no-repeat;
-		padding-right: 20px;
-		&.wb-icon-none {
-			background-image: none;
-			padding-right: 0;
-		}
-		&.button {
-			background-image: none;
-		}
+	//gh-2104 fixes overriding background because of increased specificity when wb-main was used	
+	#wb-head &, #wb-foot & {
+		background: inherit;
 	}
 }
+	
 
 .wb-icon-none {
 	background-image: none;


### PR DESCRIPTION
- Header and footer external links exhibit the same behaviour as before without the increased specificity on the body
- The padding  is restricted to links in the wb-main to prevent changing layout in the header/footer nav

Fixes gh-2104
