### PR TITLE
Working examples: added clearing elements to stop layout float drop

### DIFF
--- a/demos/opt-cont/frm-eng.html
+++ b/demos/opt-cont/frm-eng.html
@@ -119,11 +119,12 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <h2 id="req">Coding Requirements</h2>
 <p>The following summarizes selected techniques from the <a href="http://www.w3.org/TR/WCAG20/" rel="external">Web Content Accessibility Guidelines (WCAG) 2.0</a> for satisfying the most common applicable success criteria related to this topic.  Additional WCAG 2.0 success criteria, techniques, and failures not listed here may also be applicable depending on the content.</p>
+<div class="clear"></div>
 
 <h3>1. Labels</h3>
 
 <h4 id="lb">Associate Labels</h4>
-<div class="span-2 border-span-2 float-right align-right">
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">
 	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/text-equiv-all.html" rel="external">1.1.1 Non-text Content</a></em></li>
@@ -139,19 +140,20 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p>Set the form element's <code>value</code> attribute if it is a button <em>(for example, a <code>&lt;button&gt;</code> element or an <code>&lt;input&gt;</code> element with <code>type</code> attribute set to <code>&quot;submit&quot;</code> or <code>&quot;reset&quot;</code>)</em>.</p></li>
 </ul>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H44" rel="external">WCAG 2.0, Technique H44</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H65" rel="external">WCAG 2.0, Technique H65</a> and <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G167" rel="external">WCAG 2.0, Technique G167</a></em>.</p>
+<div class="clear"></div>
 
 <h4 id="ds">Descriptive Labels</h4>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html" rel="external">2.4.6 Headings and Labels</a></em></li>
 	</ul>
 </div>
 <p>Form elements must have descriptive labels that make a form element's purpose clear.</p>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G131" class="external" rel="external">WCAG 2.0, Technique G131</a></em></p>
-
+<div class="clear"></div>
 
 <h4 id="cs">Consistent Labels</h4>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/consistent-behavior-consistent-functionality.html" rel="external">3.2.4 Consistent Identification</a></em></li>
 	</ul>
@@ -159,19 +161,20 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <p>Form elements must also be labeled consistently.  Form elements which provide the same function on one or more pages should have a consistent label.</p>
 <p>For example, a button labeled <em>Go To Chapter 4</em> on one page, and <em>Go To Chapter 5</em> on another is consistent.  However, a button labeled <em>Go To Chapter 4</em> on one page and <em>Open Chapter 5</em> on another is not.</p>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G197" class="external" rel="external">WCAG 2.0, Technique G197</a></em></p>
+<div class="clear"></div>
 
 <h4 id="is">Instructions</h4>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/minimize-error-cues.html" rel="external">3.3.2 Labels or Instructions</a></em></li>
 	</ul>
 </div>
 <p>Some form controls require user input data that is mandatory, provided in a specific format, or selected from a set of values.  These instructions must be provided to the user through explanation, expected data formats, or examples  before the form control.</p>
 <p><em>Source: <a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/minimize-error-cues.html#minimize-error-cues-techniques-head" rel="external">WCAG 2.0, Success Criterion 3.3.2, Sufficient Techniques #1</a></em></p>
-
+<div class="clear"></div>
 
 <h3 id="err">2. Error Messages</h3>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/minimize-error-identified.html" rel="external">3.3.1 Error Identification</a></em></li>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/minimize-error-suggestions.html" rel="external">3.3.3 Error Suggestion</a></em></li>
@@ -185,9 +188,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p>Where possible, suggest corrections (unless it would jeopardize the security or purpose of the content).</p></li>
 </ul>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G83" rel="external">WCAG 2.0, Technique G83</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G84" rel="external">WCAG 2.0, Technique G84</a>, and <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G85" rel="external">WCAG 2.0, Technique G85</a></em></p>
+<div class="clear"></div>
 
 <h3 id="lt">3. Session Time Limits</h3>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/time-limits-required-behaviors.html" rel="external">2.2.1 Timing Adjustable</a></em></li>
 	</ul>
@@ -202,9 +206,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p><strong>20 Hour Exception:</strong> The time limit is longer than 20 hours.</p></li>
 </ul>
 <p><em>Source: <a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/time-limits-required-behaviors.html" rel="external">WCAG 2.0, Success Criterion 2.2.1 Timing Adjustable</a></em></p>
+<div class="clear"></div>
 
 <h3 id="lg">4. Legal Committments and Financial Transactions</h3>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/minimize-error-reversible.html" rel="external">3.3.4 Error Prevention (Legal, Financial, Data)</a></em></li>
 	</ul>
@@ -215,6 +220,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p>Provide a mechanism to review, confirm, and correct before finalizing the submission.  Check the data for user input errors.</p></li>
 </ul>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G98" rel="external">WCAG 2.0, Technique G98</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G99" rel="external">WCAG 2.0, Technique G99</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G155" rel="external">WCAG 2.0, Technique G155</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G164" rel="external">WCAG 2.0, Technique G164</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G168" rel="external">WCAG 2.0, Technique G168</a></em></p>
+<div class="clear"></div>
 
 <h3>5. Ensure Form Elements Are Keyboard Accessible</h3>
 <p>See general web accessibility requirements for the <a href="#">keyboard</a>.</p>
@@ -298,8 +304,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		</fieldset>
 		<details>
 			<summary>Source Code</summary>
-			<pre><code>&lt;fieldset&gt;<br />	&lt;legend&gt;Postal Code:&lt;/legend&gt;<br />	&lt;input type=&quot;text&quot; size=&quot;3&quot; maxlength=&quot;3&quot; name=&quot;postalcode_first3&quot; id=&quot;postalcode_first3&quot; 
-		title=&quot;Fires three characters of postal code&quot; /&gt;-&lt;input type=&quot;text&quot; size=&quot;3&quot; maxlength=&quot;3&quot; 
+			<pre><code>&lt;fieldset&gt;<br />	&lt;legend&gt;Postal Code:&lt;/legend&gt;<br />	&lt;input type=&quot;text&quot; size=&quot;3&quot; maxlength=&quot;3&quot; name=&quot;postalcode_first3&quot; id=&quot;postalcode_first3&quot;
+		title=&quot;Fires three characters of postal code&quot; /&gt;-&lt;input type=&quot;text&quot; size=&quot;3&quot; maxlength=&quot;3&quot;
 		name=&quot;postalcode_last3&quot; id=&quot;postalcode_last3&quot; title=&quot;Last three digits of phone number&quot; /&gt;<br />&lt;/fieldset&gt;</code></pre>
 		</details>
 	</li>

--- a/demos/opt-cont/hdg-eng.html
+++ b/demos/opt-cont/hdg-eng.html
@@ -138,22 +138,24 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 
 <h3 id="dh">2. Descriptive Headings</h3>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/navigation-mechanisms-descriptive.html" rel="external">2.4.6 Headings and Labels</a></em></li>
 	</ul>
 </div>
 <p>Headings must identify its section of the content.   A heading does not need to be lengthy.  A word, of even a single character, may suffice if it provides an appropriate cue to finding and navigating content.</p>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G130" class="external" rel="external">WCAG 2.0, Technique G130</a></em></p>
+<div class="clear"></div>
 
 <h3 id="dt">3. Descriptive Page Titles</h3>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/navigation-mechanisms-title.html" rel="external">2.4.2 Page Titled</a></em></li>
 	</ul>
 </div>
 <p>Every web page requires a page title marked up using the <code>&lt;title&gt;</code> element.  The page title does not need to be unique but it does need to be sufficiently descriptive to identify the contents of the web page among a group of web pages.</p>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G88" class="external" rel="external">WCAG 2.0, Technique G88</a> and  <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H25" class="external" rel="external">WCAG 2.0, Technique H25</a></em></p>
+<div class="clear"></div>
 
 <h2 id="con">Web Accessibility Considerations</h2>
 <h3>Cognitive Impairments</h3>

--- a/demos/opt-cont/lin-eng.html
+++ b/demos/opt-cont/lin-eng.html
@@ -129,7 +129,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <h3>1. Descriptive and Consistent Link Text</h3>
 <h4 id="ds">Descriptive Link Text</h4>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/consistent-behavior-receive-focus.html" rel="external">2.4.4 Link Purpose (In Context)</a></em></li>
 		<li><em><a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-descriptive.html" rel="external">2.4.6 Headings and Labels</a></em></li>
@@ -144,9 +144,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p>The preceding heading element.</p></li>
 </ul>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G53" rel="external">WCAG 2.0, Technique G53</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H30" rel="external">WCAG 2.0, Technique H30</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H33" rel="external">WCAG 2.0, Technique H33</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H77" rel="external">WCAG 2.0, Technique H77</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H78" rel="external">WCAG 2.0, Technique H78</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H79" rel="external">WCAG 2.0, Technique H79</a>, <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H80" rel="external">WCAG 2.0, Technique H80</a>, and <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H81" rel="external">WCAG 2.0, Technique H81</a></em></p>
+<div class="clear"></div>
 
 <h4 id="cs">Consistent Link Text</h4>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h5>Related to Success Criteria:</h5></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/consistent-behavior-consistent-functionality.html" rel="external">3.2.4 Consistent Identification</a></em></li>
 	</ul>
@@ -155,9 +156,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <p>For example, a link labeled <em>Go To Chapter 4</em> on one page, and <em>Go To Chapter 5</em> on another is consistent.  However, a link labeled <em>Go To Chapter 4</em> on one page and <em>Open Chapter 5</em> on another is not.</p>
 <!--<p>Multiple links which have the same link text should provide identical functionality (such as resolving to the same page).</p>-->
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G197" class="external" rel="external">WCAG 2.0, Technique G197</a></em></p>
+<div class="clear"></div>
 
 <h3 id="rp">2. Repeated Navigation</h3>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/navigation-mechanisms-skip.html" rel="external">2.4.1 Bypass Blocks</a></em></li>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/consistent-behavior-consistent-locations.html" rel="external">3.2.3 Consistent Navigation</a></em></li>
@@ -174,9 +176,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<p>By default, the Web Experience Toolkit (WET) templates satisfy the requirement to skip repeated links by adding a link at the top of each page that goes directly to the main content area.</p>
 </div>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G61" class="external" rel="external">WCAG 2.0, Technique G61</a> and <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/G1" class="external" rel="external">WCAG 2.0, Technique G1</a></em></p>
+<div class="clear"></div>
 
 <h3 id="sr">3. Finding Web Pages</h3>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-mult-loc.html" rel="external">2.4.5 Multiple Ways</a></em></li>
 	</ul>
@@ -194,6 +197,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <h3>5. Use Of Colour</h3>
 <p>See general web accessibility requirements for <a href="#">colour</a>.</p>
+<div class="clear"></div>
 
 <h2 id="ex">Content Examples</h2>
 
@@ -255,7 +259,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<div class="indent-medium">
 		<details>
 			<summary>Source Code</summary>
-			<pre><code>&lt;p&gt;The Smallville Times &lt;a href=&quot;#&quot;&gt;reports that&lt;/a&gt; the School Board chose a 2007 school calendar 
+			<pre><code>&lt;p&gt;The Smallville Times &lt;a href=&quot;#&quot;&gt;reports that&lt;/a&gt; the School Board chose a 2007 school calendar
 that starts on August 27.&quot;&lt;/p&gt;</code></pre>
 		</details>
 	</div>
@@ -266,7 +270,7 @@ that starts on August 27.&quot;&lt;/p&gt;</code></pre>
 	<div class="indent-medium">
 		<details>
 			<summary>Source Code</summary>
-			<pre><code>&lt;p&gt;&lt;a href=&quot;#&quot; title=&quot;Read more about failed elephant evacuation&quot;&gt;Evacuation Crumbles Under 
+			<pre><code>&lt;p&gt;&lt;a href=&quot;#&quot; title=&quot;Read more about failed elephant evacuation&quot;&gt;Evacuation Crumbles Under
 Jumbo load&lt;/a&gt;&lt;/p&gt;</code></pre>
 		</details>
 	</div>
@@ -290,7 +294,7 @@ Jumbo load&lt;/a&gt;&lt;/p&gt;</code></pre>
 	<div class="indent-medium">
 		<details>
 			<summary>Source Code</summary>
-			<pre><code>&lt;h4&gt;The final 15&lt;/h4&gt;<br />&lt;p&gt;Coming soon to a town near you...the final 15 in the National Folk Festival lineup. 
+			<pre><code>&lt;h4&gt;The final 15&lt;/h4&gt;<br />&lt;p&gt;Coming soon to a town near you...the final 15 in the National Folk Festival lineup.
 &lt;a href=&quot;#&quot;&gt;[Read more...]&lt;/a&gt;&lt;/p&gt;</code></pre>
 		</details>
 	</div>
@@ -298,7 +302,7 @@ Jumbo load&lt;/a&gt;&lt;/p&gt;</code></pre>
 <div class="span-6 border-span-6">
 	<h3 class="background-light">7. Link Text and Preceding Heading</h3>
 	<h4>Annual Report 2006-2007</h4>
-	<p><a href="#">(HTML)</a>&nbsp;<a href="#">(PDF)</a>&nbsp;<a href="#">(RTF)</a></p> 
+	<p><a href="#">(HTML)</a>&nbsp;<a href="#">(PDF)</a>&nbsp;<a href="#">(RTF)</a></p>
 	<div class="indent-medium">
 		<details>
 			<summary>Source Code</summary>
@@ -310,7 +314,7 @@ Jumbo load&lt;/a&gt;&lt;/p&gt;</code></pre>
 	<h3 class="background-light">8. Link Text and Parent List Item</h3>
 	<ul>
 		<li>Annual Report 2005-2006
-			<ul> 
+			<ul>
 				<li><a href="#">(HTML)</a></li>
 				<li><a href="#">(PDF)</a></li>
 				<li><a href="#">(RTF)</a></li>

--- a/demos/opt-cont/qlg-eng.html
+++ b/demos/opt-cont/qlg-eng.html
@@ -124,7 +124,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <p>The following summarizes selected techniques from the <a href="http://www.w3.org/TR/WCAG20/" rel="external">Web Content Accessibility Guidelines (WCAG) 2.0</a> for satisfying the most common applicable success criterion related to this topic.  Additional WCAG 2.0 success criterions, techniques, and failures not listed here may also be applicable depending on the content.</p>
 
 <h3 id="q">1. Quotations</h3>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/content-structure-separation-programmatic.html" rel="external">1.3.1 Info and Relationships</a></em></li>
 	</ul>
@@ -132,9 +132,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <p>If a quotation is <strong>long</strong> and requires paragraph breaks, use the <code>&lt;blockquote&gt;</code> element. When quotations marks (&quot;, &laquo;, &raquo;) are desired, they should appear <strong>inside</strong> the <code>&lt;blockquote&gt;</code> element.</p>
 <p>If a quotation is <strong>short</strong> and appears within a paragraph, use the <code>&lt;q&gt;</code> element. When quotations marks (&quot;, &laquo;, &raquo;) are desired, they should appear <strong>outside</strong> the <code>&lt;blockquote&gt;</code> element.</p>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H49" class="external" rel="external">WCAG 2.0, Technique H49</a></em></p>
+<div class="clear"></div>
 
 <h3 id="pl">2. Primary Natural Human Language Of The Page</h3>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/meaning-doc-lang-id.html" rel="external">3.1.1 Language of Page</a></em></li>
 	</ul>
@@ -143,9 +144,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <p><strong>HTML5 Example:</strong> <code>&lt;html lang=&quot;en&quot;&gt;</code></p>
 <p><strong>XHTML 1.0 Strict Example: </strong> <code>&lt;html xmlns=&quot;http://www.w3.org/1999/xhtml&quot; lang=&quot;en&quot; xml:lang=&quot;en&quot;&gt;</code></p>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H57" class="external" rel="external">WCAG 2.0, Technique H57</a></em></p>
+<div class="clear"></div>
 
 <h3 id="pt">3. Changes To The Natural Human Language Of The Page</h3>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h4>Related to Success Criteria:</h4></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/meaning-other-lang-id.html" rel="external">3.1.2 Language of Parts</a></em></li>
 	</ul>
@@ -153,6 +155,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <p>When content (especially a quotation) is in a different natural human language than the page's primary natural human language <em>(e.g. French on an English page)</em>, it must be indicated using the <code>lang</code> and <code>xml:lang</code> <em>(XHTML 1.0 Strict Only)</em> attributes.</p>
 <p>The <code>lang</code> and <code>xml:lang</code> attributes are typically applied on the <code>&lt;span&gt;</code> element.   However they can be applied to any HTML element, provided it accurately surrounds only the content that is in the different natural human language.</p>
 <p><em>Source: <a href="http://www.w3.org/TR/2012/NOTE-WCAG20-TECHS-20120103/H58" class="external" rel="external">WCAG 2.0, Technique H58</a></em></p>
+<div class="clear"></div>
 
 <h2 id="ex">Content Examples</h2>
 

--- a/demos/opt-cont/smm-eng.html
+++ b/demos/opt-cont/smm-eng.html
@@ -101,7 +101,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <h1 id="wb-cont">Summary Of Coding Requirements - Optimal Content Examples</h1>
 
 <h2 id="clr"><a href="clr-eng.html">Colour</a></h2>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-without-color.html" rel="external">1.4.1 Use Of Color</a></em></li>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/visual-audio-contrast-contrast.html" rel="external">1.4.3 Contrast (Minimum)</a></em></li>
@@ -112,9 +112,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<p><strong><a href="clr-eng.html#ct">Contrast</a></strong>: Ensure sufficient contrast between foreground text and background color.</p></li>
 	<li><p><strong><a href="clr-eng.html#us">Use Of Colour</a></strong>:  Ensure alternatives exists when colour conveys information (e.g. charts and graphs, forms and user controls, links).</p></li>
 </ol>
+<div class="clear"></div>
 
 <h2 id="frm"><a href="frm-eng.html">Forms</a></h2>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/text-equiv-all.html" rel="external">1.1.1 Non-text Content</a></em></li>
 		<li><em><a href="http://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-programmatic.html" rel="external">1.3.1 Info and Relationships</a></em></li>
@@ -141,9 +142,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p><strong><a href="frm-eng.html#lt">Session Time Limits</a></strong>: Ensure time limits can be extended or stopped.</p>
 	<li><p><strong><a href="frm-eng.html#lg">Legal Committments and Financial Transactions</a></strong>: Ensure submissions can be reversed or confirmed prior to submitting a form which causes legal committments or financial transactions.</p>
 </ol>
+<div class="clear"></div>
 
 <h2 id="hdg"><a href="hdg-eng.html">Headings and Titles</a></h2>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/content-structure-separation-programmatic.html" rel="external">1.3.1 Info and Relationships</a></em></li>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/navigation-mechanisms-title.html" rel="external">2.4.2 Page Titled</a></em></li>
@@ -155,9 +157,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p><strong><a href="hdg-eng.html#dh">Descriptive Headings</a></strong>: Ensure headings identify its section of the content.</p></li>
 	<li><p><strong><a href="hdg-eng.html#dt">Descriptive Page Titles</a></strong>: Ensure page titles are used and identify the contents of the page (within a group of pages).</p></li>
 </ol>
+<div class="clear"></div>
 
 <h2 id="img"><a href="img-eng.html">Images</a></h2>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/text-equiv-all.html" rel="external">1.1.1 Non-text Content</a></em></li>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/visual-audio-contrast-text-presentation.html" rel="external">1.4.5 Images of Text</a></em></li>
@@ -168,9 +171,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p><strong><a href="img-eng.html#im">Images Of Text</a></strong>: Ensure text embedded with images for presentation purposes only (some exceptions) are not used.</p></li>
 	<li><p><strong><a href="img-eng.html#an">Animated Images</a></strong>: Ensure animated images meet the same requirements as video-only content.</p></li>
 </ol>
+<div class="clear"></div>
 
 <h2 id="kbcv"><a href="kb-cv-eng.html">Keyboard</a></h2>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/keyboard-operation-keyboard-operable.html" rel="external">2.1.1 Keyboard</a></em></li>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/keyboard-operation-trapping.html" rel="external">2.1.2 No Keyboard Trap</a></em></li>
@@ -192,9 +196,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p><strong><a href="kb-cv-eng.html#js">Client Side Scripting (JavaScript)</a></strong>: Ensure only independent event handlers are relied upon.</p></li>
 	<li><p><strong><a href="kb-cv-eng.html#tc">Other Technologies</a></strong>: Ensure keyboard accessibility when using non-HTML technologies as the primary format (e.g. PDF, Flash, Sliverlight)</p></li>
 </ol>
+<div class="clear"></div>
 
 <h2 id="lin"><a href="lin-eng.html">Links</a></h2>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/navigation-mechanisms-skip.html" rel="external">2.4.1 Bypass Blocks</a></em></li>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/consistent-behavior-receive-focus.html" rel="external">2.4.4 Link Purpose (In Context)</a></em></li>
@@ -216,7 +221,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div class="clear"></div>
 
 <h2 id="qlg"><a href="qlg-eng.html">Quotations and Language</a></h2>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/content-structure-separation-programmatic.html" rel="external">1.3.1 Info and Relationships</a></em></li>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/meaning-doc-lang-id.html" rel="external">3.1.1 Language of Page</a></em></li>
@@ -228,9 +233,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p><strong><a href="qlg-eng.html#pl">Primary Natural Human Language Of The Page</a></strong>: Ensure a primary human language for the web page is set.</p></li>
 	<li><p><strong><a href="qlg-eng.html#pt">Changes To The Natural Human Language Of The Page</a></strong>: Ensure components on a web page which are in a different natural human language than the primary one are indicated.</p></li>
 </ol>
+<div class="clear"></div>
 
 <h2 id="tbl"><a href="tbl-eng.html">Tables</a></h2>
-<div class="span-2 border-span-2 float-right align-right">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
+<div class="span-2 border-span-2 float-right align-right margin-bottom-none">	<div class="background-light"><h3>Related to Success Criteria:</h3></div>
 	<ul>
 		<li><em><a href="http://www.w3.org/TR/2012/NOTE-UNDERSTANDING-WCAG20-20120103/content-structure-separation-programmatic.html" rel="external">1.3.1 Info and Relationships</a></em></li>
 	</ul>
@@ -239,6 +245,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 	<li><p><strong><a href="tbl-eng.html#cl">Header and Data Cell Association</a></strong>: Ensure all data cells are correctly associated to their header cells.</p></li>
 	<li><p><strong><a href="tbl-eng.html#mk">Table Markup</a></strong>: Ensure tables are marked up with table markup.</p></li>
 </ol>
+<div class="clear"></div>
 
 <dl id="gcwu-date-mod" role="contentinfo">
 <dt>Date modified:</dt><dd><span><time>2013-04-11</time></span></dd>


### PR DESCRIPTION
Fixes the float drop of the "Related to Success Criteria:" `float-right` content blocks as the page width changes.
