### PR TITLE
Rolled module equalization properties into span ones in Grids SCSS.

### DIFF
--- a/src/grids/sass/includes/_equalize.scss
+++ b/src/grids/sass/includes/_equalize.scss
@@ -22,8 +22,8 @@
 					vertical-align: top !important;
 				}
 				[class*="span-"] {
-					border: 10px solid transparent;
-					outline-offset: -10px;
+					border: 0 solid transparent;
+					border-width: 0 10px 20px 10px; 
 					@include background-clip(padding-box);
 					@include background-origin(padding-box);
 					@include box-sizing(content-box);
@@ -33,6 +33,11 @@
 					&.row-end {
 						border-right: 0;
 					}
+				}
+				.module, [class*="module-"], [class*="border-"] {
+					border: 10px solid transparent;
+					outline-offset: -10px;
+					@include box-sizing(content-box);
 				}
 			}
 			&.module-gutter-bottom {
@@ -102,7 +107,7 @@
 		%grids-equalize-all-modern-ie {
 		    .equalize {
 		        > {
-		            [class*="span-"] {
+		            .module, [class*="module-"], [class*="border-"] {
 		                border: 0;
 		                float: left !important;
 		                display: block !important;
@@ -117,7 +122,7 @@
 		%grids-equalize-all-modern-ie-rtl {
 			.equalize {
 				> {
-					[class*="span-"] {
+					.module, [class*="module-"], [class*="border-"] {
 						float: right !important;
 					}
 				}

--- a/src/grids/sass/includes/_equalize.scss
+++ b/src/grids/sass/includes/_equalize.scss
@@ -22,21 +22,17 @@
 					vertical-align: top !important;
 				}
 				[class*="span-"] {
-					border: 0 solid transparent;
-					border-width: 0 10px 20px 10px;
+					border: 10px solid transparent;
+					outline-offset: -10px;
 					@include background-clip(padding-box);
 					@include background-origin(padding-box);
+					@include box-sizing(content-box);
 					&.row-start {
 						border-left: 0;
 					}
 					&.row-end {
 						border-right: 0;
 					}
-				}
-				.module, [class*="module-"] {
-					border: 10px solid transparent;
-					outline-offset: -10px;
-					@include box-sizing(content-box);
 				}
 			}
 			&.module-gutter-bottom {
@@ -106,7 +102,7 @@
 		%grids-equalize-all-modern-ie {
 		    .equalize {
 		        > {
-		            .module, [class*="module-"] {
+		            [class*="span-"] {
 		                border: 0;
 		                float: left !important;
 		                display: block !important;
@@ -121,7 +117,7 @@
 		%grids-equalize-all-modern-ie-rtl {
 			.equalize {
 				> {
-					.module, [class*="module-"] {
+					[class*="span-"] {
 						float: right !important;
 					}
 				}

--- a/src/grids/sass/includes/_equalize.scss
+++ b/src/grids/sass/includes/_equalize.scss
@@ -23,7 +23,7 @@
 				}
 				[class*="span-"] {
 					border: 0 solid transparent;
-					border-width: 0 10px 20px 10px; 
+					border-width: 0 10px 20px 10px;
 					@include background-clip(padding-box);
 					@include background-origin(padding-box);
 					@include box-sizing(content-box);


### PR DESCRIPTION
This pull fixes equalization in scenarios like the following:

``` html
<div class="equalize">
    <div class="span-3 border-all">
        <h2>Heading</h2>
        <p>Content</p>
    </div>
    <div class="span-3 border-all">
        <h2>Heading</h2>
        <p>Content</p>
    </div>
</div>
```

Also, since `module` classes are always used in conjunction with `span-*` classes (at least from what I've seen), it's highly unlikely that anything would break in any pre-existing equalization+module implementations as a result of this change.
