### PR TITLE
Fixes for when link is both a download and external

### DIFF
--- a/demos/grids/grid-icon-eng.html
+++ b/demos/grids/grid-icon-eng.html
@@ -221,7 +221,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <li><span class="wb-icon-exclamation"></span>wb-icon-exclamation</li>
 <li><span class="wb-icon-exclamation-alt"></span>wb-icon-exclamation-alt</li>
 <li><span class="wb-icon-exclamation-alt2"></span>wb-icon-exclamation-alt2</li>
-
+<li><span class="wb-icon-external"></span>wb-icon-external</li>
 <li><span class="wb-icon-film"></span>wb-icon-film</li>
 <li><span class="wb-icon-folder"></span>wb-icon-folder</li>
 <li><span class="wb-icon-folder-alt"></span>wb-icon-folder-alt</li>

--- a/src/grids/sass/includes/_icon.scss
+++ b/src/grids/sass/includes/_icon.scss
@@ -47,6 +47,7 @@
 	
 	#wb-main & {
 		padding-right: 20px;
+		padding-left: 0;
 		
 		&.wb-icon-none {
 			padding-right: 0;


### PR DESCRIPTION
Since only one background image can be displayed with CSS, the
padding-left was still present when the file was a download but the
image wouldn't come through because it was also external
(rel="external") so the padding left is not always "0" on rel external
to make sure there is no dead space.

Also added the external icon example to the master list of icons.
