### PR TITLE
Fixed display of button-styled summaries in Grids SCSS.

### DIFF
--- a/src/grids/sass/includes/_button.scss
+++ b/src/grids/sass/includes/_button.scss
@@ -28,6 +28,11 @@
 			text-shadow: none;
 		}
 	}
+	summary {
+		&.button {
+			display: inline-block !important;
+		}
+	}
 
 	%grid-button-color-button-accent {
 		@include color-button($accent);


### PR DESCRIPTION
One of pull #2177's changes impacted how button-styled summaries are displayed. Specifically, `display: block !important;` overrides the button class' default display property (`display: inline-block;`). This pull should resolve it :).
