### PR TITLE
[datepicker] Fix min/max date issue.

### DIFF
--- a/src/js/polyfills/datepicker.js
+++ b/src/js/polyfills/datepicker.js
@@ -55,7 +55,7 @@
 			};
 
 			addLinksToCalendar = function (fieldid, year, month, days, minDate, maxDate, format) {
-				var field = container.parent().find('#' + fieldid),
+				var field = $('#' + fieldid),
 					lLimit,
 					hLimit;
 


### PR DESCRIPTION
The fieldid selector was wrong, couldn't find the field and fell-back to
the default min/maxDate (1800-01-01, 2100-01-01)
