### PR TITLE
Working examples: added wet-boew-multimedia class to multimedia demo

### DIFF
--- a/demos/guide-design/javascript-eng.html
+++ b/demos/guide-design/javascript-eng.html
@@ -219,7 +219,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
   <p> </p>
   <h3 class="margin-bottom-none">Correct use</h3>
   <p>Refer to: <a href=" https://github.com/wet-boew/wet-boew/wiki/Charts-and-graphs">Charts and graphs wiki</a></p>
- 
+
 </div>
 <div class="border-left float-right">
   <div class="span-2 margin-bottom-none">
@@ -278,7 +278,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
     <li>Do not use as a means to tidy up the look of your page. If the page is deemed too busy, consider other options like separating the content over several pages or chunking the information in a more aesthetically pleasing way.</li>
   <li>Refer to: <a href="https://github.com/wet-boew/wet-boew/wiki/Expandable-collapsible-content-%28details-summary-polyfill%29">Expand/collapse content wiki</a></li>
  <li>Refer to: <a href="https://github.com/wet-boew/wet-boew/wiki/Expand-Collapse-All-Content">Expand/collapse all content wiki</a></li>
- 
+
   </ul>
 </div>
 <div class="border-left float-right">
@@ -376,8 +376,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
   <p> </p>
   <h3 class="margin-bottom-none">Correct use</h3>
   <p>Refer to: <a href=" https://github.com/wet-boew/wet-boew/wiki/Mathematical-Scientific-formula-display-%28MathML-polyfill%29">Mathematical/scientific formula display wiki</a></p>
-  
- 
+
+
 </div>
 <div class="border-left float-right">
   <div class="span-2 margin-bottom-none">
@@ -429,10 +429,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
   <p> </p>
   <h3 class="margin-bottom-none">Correct use</h3>
    <p>Refer to: <a href="https://github.com/wet-boew/wet-boew/wiki/Multimedia-player">Multimedia player wiki</a></p>
-  
+
 </div>
 <div class="border-left float-right">
-  <div class="span-2 margin-bottom-none">
+  <div class="wet-boew-multimedia span-2 margin-bottom-none">
     <h3 class="margin-top-none margin-bottom-none">Demo</h3>
     <video width="480" height="270" poster="http://31591.vws.magma.ca/sct-tbs/wet-boew/thumbnail.png" title="Video Example">
       <source src="http://31591.vws.magma.ca/sct-tbs/wet-boew/demo-eng.webm" type="video/webm" />


### PR DESCRIPTION
Enables the multimedia player demo in the design guide.

@cfarquharson are you ok with this change to the guide?  I tested and it didn't seem to cause any problems to have the player active.
