### PR TITLE
Added symbol demos to footnotes working example pages.

### DIFF
--- a/demos/footnotes/footnotes-eng.html
+++ b/demos/footnotes/footnotes-eng.html
@@ -111,16 +111,16 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <section><h2>Benefits</h2>
 <ul>
 	<li>Conforms to WCAG 2.0 AA<sup id="fnb2a-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
-	<li>Progressive enhancement approach</li>
-	<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fnb2b-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
-	<li>Support for English and French<sup id="fnb2c-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
-	<li>Configurable layout and design</li>
+	<li>Progressive enhancement approach<sup id="fnb2b-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
+	<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fnb2c-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
+	<li>Support for English and French</li>
+	<li>Configurable layout and design<sup id="fnb3-ref"><a class="footnote-link" href="#fnb3"><span class="wb-invisible">Footnote </span>3</a></sup></li>
 </ul>
 </section>
 
 <section><h2>Recommended usage</h2>
 <ul>
-	<li>Implementing footnotes in Web pages<sup id="fnb3-ref"><a class="footnote-link" href="#fnb3"><span class="wb-invisible">Footnote </span>3</a></sup></li>
+	<li>Implementing footnotes in Web pages<sup id="fnb*-ref"><a class="footnote-link" href="#fnb*"><span class="wb-invisible">Footnote </span>*</a></sup></li>
 </ul>
 </section>
 
@@ -143,6 +143,11 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<p>Example of a footnote containing multiple paragraphs (second paragraph).</p>
 		<p>Example of a footnote containing multiple paragraphs (third paragraph).</p>
 		<p class="footnote-return"><a href="#fnb3-ref"><span class="wb-invisible">Return to footnote </span>3<span class="wb-invisible"> referrer</span></a></p>
+	</dd>
+	<dt>Footnote *</dt>
+	<dd id="fnb*">
+		<p>Example of a standard footnote, denoted by a symbol.</p>
+		<p class="footnote-return"><a href="#fnb*-ref"><span class="wb-invisible">Return to footnote </span>*<span class="wb-invisible"> referrer</span></a></p>
 	</dd>
 </dl>
 </section>

--- a/demos/footnotes/footnotes-fra.html
+++ b/demos/footnotes/footnotes-fra.html
@@ -111,17 +111,16 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <section><h2>Avantages</h2>
 <ul>
 	<li>Conformes à WCAG 2.0 AA<sup id="fnb2a-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
-	<li>Approche d'amélioration progressive</li>
-	<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fnb2b-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
-
-	<li>Soutien pour l'anglais et le français<sup id="fnb2c-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
-	<li>Mise en page et conception configurable</li>
+	<li>Approche d'amélioration progressive<sup id="fnb2b-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
+	<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fnb2c-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
+	<li>Soutien pour l'anglais et le français</li>
+	<li>Mise en page et conception configurable<sup id="fnb3-ref"><a class="footnote-link" href="#fnb3"><span class="wb-invisible">Note de bas de page </span>3</a></sup></li>
 </ul>
 </section>
 
 <section><h2>Utilisation recommandée</h2>
 <ul>
-	<li>Exécuter les notes de bas de page dans les pages Web<sup id="fnb3-ref"><a class="footnote-link" href="#fnb3"><span class="wb-invisible">Note de bas de page </span>3</a></sup></li>
+	<li>Exécuter les notes de bas de page dans les pages Web<sup id="fnb*-ref"><a class="footnote-link" href="#fnb*"><span class="wb-invisible">Note de bas de page </span>*</a></sup></li>
 
 </ul>
 </section>
@@ -145,6 +144,11 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<p>Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).</p>
 		<p>Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).</p>
 		<p class="footnote-return"><a href="#fnb3-ref"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>3</a></p>
+	</dd>
+	<dt>Note de bas de page *</dt>
+	<dd id="fnb*">
+		<p>Exemple de note de bas de page standard, représentée par un symbole.</p>
+		<p class="footnote-return"><a href="#fnb*-ref"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>*</a></p>
 	</dd>
 </dl></section>
 </div>


### PR DESCRIPTION
Partially addresses issue #1570.
