### PR TITLE
theme-gcwu-fegc: improved contrast of non-linked h3 in sidenav

### DIFF
--- a/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
@@ -17,11 +17,12 @@ body {
 		@extend %gcwu-default-screen-complex-border;
 		@extend %gcwu-default-screen-a-psuedo-underline;
 		&.top-section {
+			color: #222;
+			font-size: 1.1em;
 			a {
 				color: #FFF;
 				padding-top: 5px;
 				padding-bottom: 5px;
-				font-size: 1.1em;
 				@include pseudo-focus {
 					color: #FFF;
 					text-decoration: underline;


### PR DESCRIPTION
1. Matches font-size of non-linked and linked `<h3 class="top-section">`  elements.
2. Improves contrast of non-linked `<h3 class="top-section">` elements (currently set at #666666).

Example of how it looks with the changes is below:

![h3-top-section](https://f.cloud.github.com/assets/2110107/467594/d49ec1f8-b67d-11e2-9947-8c2dbf21031b.png)
