### PR TITLE
Form valid: fixed error placement when fieldset is a jQM controlgroup

### DIFF
--- a/src/js/workers/formvalid.js
+++ b/src/js/workers/formvalid.js
@@ -120,7 +120,7 @@
 						if (type === 'radio' || type === 'checkbox') {
 							fieldset = element.closest('fieldset');
 							if (fieldset.length !== 0) {
-								legend = fieldset.children('legend');
+								legend = fieldset.find('legend').first();
 								if (legend.length !== 0 && fieldset.find('input[name="' + element.attr('name') + '"]') !== 1) {
 									error.appendTo(legend);
 									return;


### PR DESCRIPTION
Fixes the error placement when the fieldset has the `data-role="controlgroup"` attribute set.  This is needed because jQM wraps the legend element in a `<div role="heading">` element.
