### PR TITLE
Fixed extra top/bottom padding issue in tabbed interface's SCSS.

### DIFF
--- a/src/js/sass/includes/_tabbedinterface.scss
+++ b/src/js/sass/includes/_tabbedinterface.scss
@@ -129,7 +129,7 @@
 .tabs-panel {
     border: solid 1px #ccc;
     border-top: none;
-    padding: 10px;
+    padding: 1px 10px;
 	> {
 		div {
 			display: none;


### PR DESCRIPTION
Resolves issue #2289.
