### PR TITLE
Removed unnecessary padding property for external icons from Grids SCSS.

### DIFF
--- a/src/grids/sass/includes/_icon.scss
+++ b/src/grids/sass/includes/_icon.scss
@@ -47,7 +47,6 @@
 	
 	#wb-main & {
 		padding-right: 20px;
-		padding-left: 0;
 		
 		&.wb-icon-none {
 			padding-right: 0;


### PR DESCRIPTION
Resolves a leftover issue from pull #2202.
