### PR TITLE
CSS Equalize: removed IE9 display: block (caused issues in medium view)

### DIFF
--- a/src/grids/sass/includes/_equalize.scss
+++ b/src/grids/sass/includes/_equalize.scss
@@ -46,9 +46,6 @@
 
 		.ie9 {
 		    @extend %grids-equalize-all-modern-ie;
-			.equalize {
-				display: block !important;
-			}
 		}
 
 		.ie10 {


### PR DESCRIPTION
PR is removing the code that was added by 3be1450d as part of #1958.  The `display: block` was causing a gap in IE9's medium screen view and is not needed anymore to fix the secondary nav position.

If you want to test before merging, I've pushed the fix to my [gh-pages](http://patheard.github.io/wet-boew/demos/index-eng.html) branch.
