### PR TITLE
Working Examples: fixed breadcrumbs and page titles

### DIFF
--- a/demos/charts/complex-eng.html
+++ b/demos/charts/complex-eng.html
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Complex examples - Charts and Graphs</li>
+<li><a href="index-eng.html">Charts and graphs</a></li>
+<li>Complex examples</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Complex examples - Charts and Graphs</h1>
+<h1 id="wb-cont">Complex examples</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Charts-and-graphs" class="button button-info">Documentation</a></li>

--- a/demos/charts/complex-fra.html
+++ b/demos/charts/complex-fra.html
@@ -77,7 +77,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-fra.html">Accueil</a></li>
 <li><a href="../index-fra.html">Exemples pratiques</a></li>
-<li>Exemples complexes - Graphiques</li>
+<li><a href="index-fra.html">Graphiques</a></li>
+<li>Exemples complexes</li>
 </ol>
 </div></div>
 </nav>
@@ -87,7 +88,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Exemples complexes - Graphiques</h1>
+<h1 id="wb-cont">Exemples complexes</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Graphiques" class="button button-info">Documentation</a></li>

--- a/demos/charts/index-eng.html
+++ b/demos/charts/index-eng.html
@@ -48,7 +48,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <section><div id="wet-fullhd"><h2>Full-width header area</h2>
 <div id="wet-fullhd-in">
 <ul>
-<li id="wet-fullhd-lang-2"><a href="simple-fra.html" lang="fr">Français</a></li>
+<li id="wet-fullhd-lang-2"><a href="index-fra.html" lang="fr">Français</a></li>
 <li id="wet-fullhd-lang-current">English</li>
 </ul>
 </div>

--- a/demos/charts/index-fra.html
+++ b/demos/charts/index-fra.html
@@ -48,7 +48,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-fullhd-in">
 <ul>
 <li id="wet-fullhd-lang-current">Français</li>
-<li id="wet-fullhd-lang-2"><a href="simple-eng.html" lang="en">English</a></li>
+<li id="wet-fullhd-lang-2"><a href="index-eng.html" lang="en">English</a></li>
 </ul>
 </div>
 </div></section>

--- a/demos/charts/labels-eng.html
+++ b/demos/charts/labels-eng.html
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Labels - Charts and graphs - Web Experience Toolkit (WET)</li>
+<li><a href="index-eng.html">Charts and graphs</a></li>
+<li>Labels</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Labels - Charts and graphs - Web Experience Toolkit (WET)</h1>
+<h1 id="wb-cont">Labels</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Charts-and-graphs" class="button button-info">Documentation</a></li>
@@ -161,7 +162,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 			<td headers="tbl1363314652944-7 tbl1363314652944-14 tbl1363314652944-58">25</td>
 			<td headers="tbl1363314652944-7 tbl1363314652944-15 tbl1363314652944-58">15</td>
 			<td headers="tbl1363314652944-8 tbl1363314652944-58">119</td>
-		</tr>		
+		</tr>
 	</tbody></table>
 
 <hr />
@@ -219,7 +220,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 			<td headers="tbl1363314702030-7 tbl1363314702030-14 tbl1363314702030-58">25</td>
 			<td headers="tbl1363314702030-7 tbl1363314702030-15 tbl1363314702030-58">15</td>
 			<td headers="tbl1363314702030-8 tbl1363314702030-58">119</td>
-		</tr>		
+		</tr>
 	</tbody>
 </table>
 
@@ -275,7 +276,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 			<td headers="tbl1363314739889-9 tbl1363314739889-56">25</td>
 			<td headers="tbl1363314739889-10 tbl1363314739889-56">15</td>
 			<td headers="tbl1363314739889-11 tbl1363314739889-56">119</td>
-		</tr>		
+		</tr>
 	</tbody>
 </table>
 
@@ -331,7 +332,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 			<td headers="tbl1363314789868-9 tbl1363314789868-56">25</td>
 			<td headers="tbl1363314789868-10 tbl1363314789868-56">15</td>
 			<td headers="tbl1363314789868-11 tbl1363314789868-56">119</td>
-		</tr>		
+		</tr>
 	</tbody>
 </table>
 
@@ -342,7 +343,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <p>By default, the tick is uniform because each table slot would have the same value (uniform value between slots). When deactivated, only the highest header row or column would get the uniform value. Child cells would get devised value attribution.</p>
 
 
-<h3>Examples</h3> 
+<h3>Examples</h3>
 
 <table class="wet-boew-charts wb-charts-uniformtick-false wb-charts-noencapsulation-true">
 <caption>Uniform Tick deactivated <code>wb-charts-uniformtick-false</code></caption>

--- a/demos/charts/labels-fra.html
+++ b/demos/charts/labels-fra.html
@@ -77,7 +77,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-fra.html">Accueil</a></li>
 <li><a href="../index-fra.html">Exemples pratiques</a></li>
-<li>Étiquettes - Graphiques</li>
+<li><a href="index-fra.html">Graphiques</a></li>
+<li>Étiquettes</li>
 </ol>
 </div></div>
 </nav>
@@ -87,7 +88,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Étiquettes - Graphiques</h1>
+<h1 id="wb-cont">Étiquettes</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Graphiques" class="button button-info">Documentation</a></li>
@@ -162,7 +163,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 			<td headers="tbl1363314652944-7 tbl1363314652944-14 tbl1363314652944-58">25</td>
 			<td headers="tbl1363314652944-7 tbl1363314652944-15 tbl1363314652944-58">15</td>
 			<td headers="tbl1363314652944-8 tbl1363314652944-58">119</td>
-		</tr>		
+		</tr>
 	</tbody></table>
 
 <hr />
@@ -220,7 +221,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 			<td headers="tbl1363314702030-7 tbl1363314702030-14 tbl1363314702030-58">25</td>
 			<td headers="tbl1363314702030-7 tbl1363314702030-15 tbl1363314702030-58">15</td>
 			<td headers="tbl1363314702030-8 tbl1363314702030-58">119</td>
-		</tr>		
+		</tr>
 	</tbody>
 </table>
 
@@ -276,7 +277,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 			<td headers="tbl1363314739889-9 tbl1363314739889-56">25</td>
 			<td headers="tbl1363314739889-10 tbl1363314739889-56">15</td>
 			<td headers="tbl1363314739889-11 tbl1363314739889-56">119</td>
-		</tr>		
+		</tr>
 	</tbody>
 </table>
 
@@ -332,7 +333,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 			<td headers="tbl1363314789868-9 tbl1363314789868-56">25</td>
 			<td headers="tbl1363314789868-10 tbl1363314789868-56">15</td>
 			<td headers="tbl1363314789868-11 tbl1363314789868-56">119</td>
-		</tr>		
+		</tr>
 	</tbody>
 </table>
 
@@ -342,7 +343,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <p>Par défaut, le positionnement des données du graphique est par intervale uniforme qui veux dire que chaque colonne du tableau occupe un espace equivalente dans le graphique. Lorsque le positionnement par intervale est désactivé, <code>wb-charts-uniformtick-false</code>, l'imbrication de la colonne à l'intérieur de d'autre groupe va influencer le positionnement des étiquettes, avec leurs données, par rapport à l'axe des x (horizontal).</p>
 
-<h3>Exemples</h3> 
+<h3>Exemples</h3>
 
 <table class="wet-boew-charts wb-charts-uniformtick-false wb-charts-noencapsulation-true">
 <caption>Intervale uniformes désactivé <code>wb-charts-uniformtick-false</code></caption>

--- a/demos/charts/pie-eng.html
+++ b/demos/charts/pie-eng.html
@@ -47,7 +47,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <section><div id="wet-fullhd"><h2>Full-width header area</h2>
 <div id="wet-fullhd-in">
 <ul>
-<li id="wet-fullhd-lang-2"><a href="labels-fra.html" lang="fr">Français</a></li>
+<li id="wet-fullhd-lang-2"><a href="pie-fra.html" lang="fr">Français</a></li>
 <li id="wet-fullhd-lang-current">English</li>
 </ul>
 
@@ -77,7 +77,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Pie charts - Charts and graphs - Web Experience Toolkit (WET)</li>
+<li><a href="index-eng.html">Charts and graphs</a></li>
+<li>Pie charts</li>
 </ol>
 </div></div>
 </nav>
@@ -87,7 +88,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Pie charts - Charts and graphs</h1>
+<h1 id="wb-cont">Pie charts</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Charts-and-graphs" class="button button-info">Documentation</a></li>

--- a/demos/charts/pie-fra.html
+++ b/demos/charts/pie-fra.html
@@ -77,7 +77,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-fra.html">Accueil</a></li>
 <li><a href="../index-fra.html">Exemples pratiques</a></li>
-<li>Diagramme circulaire - Représentations graphiques</li>
+<li><a href="index-fra.html">Graphiques</a></li>
+<li>Diagramme circulaire</li>
 </ol>
 </div></div>
 </nav>
@@ -87,7 +88,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Diagramme circulaire - Graphiques</h1>
+<h1 id="wb-cont">Diagramme circulaire</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Graphiques" class="button button-info">Documentation</a></li>

--- a/demos/charts/simple-eng.html
+++ b/demos/charts/simple-eng.html
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Simple examples - Charts and graphs</li>
+<li><a href="index-eng.html">Charts and graphs</a></li>
+<li>Simple examples</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Simple examples - Charts and graphs - Web Experience Toolkit (WET)</h1>
+<h1 id="wb-cont">Simple examples</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Charts-and-graphs" class="button button-info">Documentation</a></li>
@@ -144,11 +145,11 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 						<td>25</td>
 						<td>15</td>
 						<td>119</td>
-					</tr>		
+					</tr>
 				</tbody>
 			</table>
-			
-			
+
+
 			<table class="wet-boew-charts wb-charts-area">
 				<caption>Some data</caption>
 				<thead>
@@ -177,10 +178,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 						<td>1000</td>
 						<td>245</td>
 						<td>964</td>
-					</tr>	
+					</tr>
 				</tbody>
 			</table>
-			
+
 			<table class="wet-boew-charts wb-charts-bar">
 				<caption>2009 Individual Sales by Category</caption>
 				<thead>
@@ -230,10 +231,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 						<td>25</td>
 						<td>15</td>
 						<td>119</td>
-					</tr>		
+					</tr>
 				</tbody>
 			</table>
-			
+
 			<table class="wet-boew-charts wb-charts-pie">
 				<caption>2009 Individual Sales by Category</caption>
 				<thead>
@@ -283,7 +284,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 						<td>25</td>
 						<td>15</td>
 						<td>119</td>
-					</tr>		
+					</tr>
 				</tbody>
 			</table>
 

--- a/demos/charts/simple-fra.html
+++ b/demos/charts/simple-fra.html
@@ -77,7 +77,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-fra.html">Accueil</a></li>
 <li><a href="../index-fra.html">Exemples pratiques</a></li>
-<li>Exemples simples - Graphiques</li>
+<li><a href="index-fra.html">Graphiques</a></li>
+<li>Exemples simples</li>
 </ol>
 </div></div>
 </nav>
@@ -87,7 +88,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Exemples simples - Graphiques</h1>
+<h1 id="wb-cont">Exemples simples</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Graphiques" class="button button-info">Documentation</a></li>
@@ -143,11 +144,11 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 						<td>25</td>
 						<td>15</td>
 						<td>119</td>
-					</tr>		
+					</tr>
 				</tbody>
 			</table>
-			
-			
+
+
 			<table class="wet-boew-charts wb-charts-area">
 				<caption>Certaines données</caption>
 				<thead>
@@ -176,10 +177,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 						<td>1000</td>
 						<td>245</td>
 						<td>964</td>
-					</tr>	
+					</tr>
 				</tbody>
 			</table>
-			
+
 			<table class="wet-boew-charts wb-charts-bar">
 				<caption>Ventes individuelles par catégorie en 2009</caption>
 				<thead>
@@ -229,10 +230,10 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 						<td>25</td>
 						<td>15</td>
 						<td>119</td>
-					</tr>		
+					</tr>
 				</tbody>
 			</table>
-			
+
 			<table class="wet-boew-charts wb-charts-pie">
 				<caption>Ventes individuelles par catégorie en 2009</caption>
 				<thead>
@@ -282,7 +283,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 						<td>25</td>
 						<td>15</td>
 						<td>119</td>
-					</tr>		
+					</tr>
 				</tbody>
 			</table>
 

--- a/demos/charts/simpleCustomized-eng.html
+++ b/demos/charts/simpleCustomized-eng.html
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Customized examples - Charts and Graphs</li>
+<li><a href="index-eng.html">Charts and graphs</a></li>
+<li>Customized examples</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Customized examples - Charts and Graphs</h1>
+<h1 id="wb-cont">Customized examples</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Charts-and-graphs" class="button button-info">Documentation</a></li>
@@ -107,7 +108,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
             <th>2010-11</th>
         </tr>
     </thead>
-    
+
     <tbody>
         <tr>
             <th class="wb-charts-color-midnightblue">Patent Searches</th>
@@ -150,7 +151,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>CSS class parameterss</summary>
-	
+
 	<p>Table element (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -160,9 +161,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-topvalue-4000000</li>
 		<li>wb-charts-bottomvalue-0</li>
 	</ul>
-      
+
     <p>Table heading element (th) associated to each bar</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 		<li>wb-charts-color-slateblue</li>
@@ -186,7 +187,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
             <th>2010-11</th>
         </tr>
     </thead>
-    
+
     <tbody>
     	<tr>
         	<th class="wb-charts-color-midnightblue">Enquiries</th>
@@ -200,7 +201,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>CSS class parameterss</summary>
-	
+
 	<p>Table element (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -210,9 +211,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-topvalue-80000</li>
 		<li>wb-charts-bottomvalue-0</li>
 	</ul>
-      
+
     <p>Table heading element (th) associated to each bar</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 	</ul>
@@ -231,7 +232,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
         	<th class="wb-charts-color-midnightblue">Enquiries</th>
         </tr>
     </thead>
-    
+
     <tbody>
     	<tr>
             <th>2008-09</th>
@@ -253,7 +254,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>CSS Class Parameter</summary>
-	
+
 	<p>Table element (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -265,9 +266,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-nolegend-true</li>
 		<li>wb-charts-parsedirection-y</li>
 	</ul>
-      
+
     <p>Cell heading element (th) associated to each bar</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 	</ul>
@@ -312,7 +313,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>CSS class parameters</summary>
-	
+
 	<p>Table element (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -322,9 +323,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-topvalue-50</li>
 		<li>wb-charts-bottomvalue-0</li>
 	</ul>
-      
+
     <p>Table heading element (th) associated to each bar</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 		<li>wb-charts-color-slateblue</li>
@@ -362,7 +363,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>CSS class parameters</summary>
-	
+
 	<p>Table element (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -372,9 +373,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-topvalue-1200</li>
 		<li>wb-charts-bottomvalue-0</li>
 	</ul>
-      
+
     <p>Table heading element (th) associated to each bar</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 	</ul>
@@ -396,7 +397,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
             <th>March 2011</th>
         </tr>
     </thead>
-    
+
     <tbody>
     	<tr>
         	<th class="wb-charts-color-midnightblue">Male</th>
@@ -415,7 +416,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>CSS class parameters</summary>
-	
+
 	<p>Table element (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -425,9 +426,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-topvalue-700</li>
 		<li>wb-charts-bottomvalue-0</li>
 	</ul>
-      
+
     <p>Table heading element (th) associated to each bar</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 		<li>wb-charts-color-slateblue</li>
@@ -448,7 +449,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
             <th>Information</th>
         </tr>
     </thead>
-    
+
     <tbody>
     	<tr>
         	<th>Revenues by products and services</th>
@@ -464,7 +465,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>CSS class parameters</summary>
-	
+
 	<p>Table element (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -473,7 +474,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-decimal-1</li>
 		<li>wb-charts-percentlegend-true</li>
 	</ul>
-      
+
     <p>Table heading element (th) associated to each bar</p>
 	<ul>
 		<li>wb-charts-color-olivedrab</li>

--- a/demos/charts/simpleCustomized-fra.html
+++ b/demos/charts/simpleCustomized-fra.html
@@ -77,7 +77,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-fra.html">Accueil</a></li>
 <li><a href="../index-fra.html">Exemples pratiques</a></li>
-<li>Exemples personnalisés - Graphiques</li>
+<li><a href="index-fra.html">Graphiques</a></li>
+<li>Exemples personnalisés</li>
 </ol>
 </div></div>
 </nav>
@@ -87,7 +88,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Exemples personnalisés - Graphiques</h1>
+<h1 id="wb-cont">Exemples personnalisés</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Graphiques" class="button button-info">Documentation</a></li>
@@ -106,7 +107,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
             <th>2010-11</th>
         </tr>
     </thead>
-    
+
     <tbody>
         <tr>
             <th class="wb-charts-color-midnightblue">Recherches des brevets</th>
@@ -149,7 +150,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>Paramètres en forme de classe CSS</summary>
-	
+
 	<p>L'élément de table (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -160,9 +161,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-bottomvalue-0</li>
 		<li>wb-charts-nocutaxis-true</li>
 	</ul>
-      
+
     <p>L'élément d'en-tête de table (th) associé à chaque barre</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 		<li>wb-charts-color-slateblue</li>
@@ -186,7 +187,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
             <th>2010-11</th>
         </tr>
     </thead>
-    
+
     <tbody>
     	<tr>
         	<th class="wb-charts-color-midnightblue">Enquêtes</th>
@@ -200,7 +201,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>Paramètres en forme de classe CSS</summary>
-	
+
 	<p>L'élément de table (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -212,9 +213,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-steps-5500</li>
 		<li>wb-charts-nocutaxis-true</li>
 	</ul>
-      
+
     <p>L'élément d'en-tête de table (th) associé à chaque barre</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 	</ul>
@@ -262,7 +263,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>Paramètres en forme de classe CSS</summary>
-	
+
 	<p>L'élément de table (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -273,9 +274,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-bottomvalue-0</li>
 		<li>wb-charts-nocutaxis-true</li>
 	</ul>
-      
+
     <p>L'élément d'en-tête de table (th) associé à chaque barre</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 		<li>wb-charts-color-slateblue</li>
@@ -313,7 +314,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>Paramètres en forme de classe CSS</summary>
-	
+
 	<p>L'élément de table (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -324,9 +325,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-bottomvalue-0</li>
 		<li>wb-charts-nocutaxis-true</li>
 	</ul>
-      
+
     <p>L'élément d'en-tête de table (th) associé à chaque barre</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 	</ul>
@@ -348,7 +349,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
             <th>Mars 2011</th>
         </tr>
     </thead>
-    
+
     <tbody>
     	<tr>
         	<th class="wb-charts-color-midnightblue">Mâle</th>
@@ -367,7 +368,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>Paramètres en forme de classe CSS</summary>
-	
+
 	<p>L'élément de table (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -379,9 +380,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-steps-60</li>
 		<li>wb-charts-nocutaxis-true</li>
 	</ul>
-      
+
     <p>L'élément d'en-tête de table (th) associé à chaque barre</p>
-	
+
 	<ul>
 		<li>wb-charts-color-midnightblue</li>
 		<li>wb-charts-color-slateblue</li>
@@ -402,7 +403,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
             <th>Information</th>
         </tr>
     </thead>
-    
+
     <tbody>
     	<tr>
         	<th>Revenus selon les produits et services</th>
@@ -418,7 +419,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 
 <details>
 	<summary>Paramètres en forme de classe CSS</summary>
-	
+
 	<p>L'élément de table (table)</p>
 	<ul>
 		<li>wet-boew-charts</li>
@@ -430,9 +431,9 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		<li>wb-charts-steps-60</li>
 		<li>wb-charts-nocutaxis-true</li>
 	</ul>
-      
+
     <p>L'élément d'en-tête de table (th) associé à chaque barre</p>
-	
+
 	<ul>
 		<li>wb-charts-color-olivedrab</li>
 		<li>wb-charts-color-yellowgreen</li>

--- a/demos/zebra/columnhighlight.html
+++ b/demos/zebra/columnhighlight.html
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Column Highlight Table - Zebra striping</li>
+<li><a href="zebra-eng.html">Zebra striping</a></li>
+<li>Column Highlight Table</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Column Highlight Table - Zebra striping</h1>
+<h1 id="wb-cont">Column Highlight Table</h1>
 
 
 <ul class="button-group">

--- a/demos/zebra/hover-effect-with-row-group.html
+++ b/demos/zebra/hover-effect-with-row-group.html
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Simple Table - Zebra striping</li>
+<li><a href="zebra-eng.html">Zebra striping</a></li>
+<li>Table Mouse Hover Effect with Row Group</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Table Mouse Hover Effect with Row Group - Zebra striping - Web Experience Toolkit (WET)</h1>
+<h1 id="wb-cont">Table Mouse Hover Effect with Row Group</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Zebra-striping" class="button button-info">Documentation</a></li>

--- a/demos/zebra/hover-effect.html
+++ b/demos/zebra/hover-effect.html
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Simple Table - Zebra striping</li>
+<li><a href="zebra-eng.html">Zebra striping</a></li>
+<li>Table Mouse Hover Effect</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Table Mouse Hover Effect - Zebra striping</h1>
+<h1 id="wb-cont">Table Mouse Hover Effect</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Zebra-striping" class="button button-info">Documentation</a></li>

--- a/demos/zebra/invoice.html
+++ b/demos/zebra/invoice.html
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Invoice Table - Zebra striping</li>
+<li><a href="zebra-eng.html">Zebra striping</a></li>
+<li>Invoice Table</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Invoice Table - Zebra striping</h1>
+<h1 id="wb-cont">Invoice Table</h1>
 
 
 <ul class="button-group">

--- a/demos/zebra/rowlevelwithsummary.html
+++ b/demos/zebra/rowlevelwithsummary.html
@@ -8,7 +8,7 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licence-fra.txt -->
-<title>Row level with summary Table - Zebra striping - Working examples - Web Experience Toolkit&#160;(WET)</title>
+<title>Row Level with Summary Table - Zebra striping - Working examples - Web Experience Toolkit&#160;(WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-wet-boew/images/favicon.ico" />
 <meta name="description" content="English description / Description en anglais" />
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Row level with summary Table - Zebra striping</li>
+<li><a href="zebra-eng.html">Zebra striping</a></li>
+<li>Row Level with Summary Table</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Row level with summary Table - Zebra striping</h1>
+<h1 id="wb-cont">Row Level with Summary Table</h1>
 
 
 <ul class="button-group">

--- a/demos/zebra/simple.html
+++ b/demos/zebra/simple.html
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Simple Table - Zebra striping</li>
+<li><a href="zebra-eng.html">Zebra striping</a></li>
+<li>Simple Table</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Simple Table - Zebra striping</h1>
+<h1 id="wb-cont">Simple Table</h1>
 
 
 <ul class="button-group">

--- a/demos/zebra/simplegrouping.html
+++ b/demos/zebra/simplegrouping.html
@@ -78,7 +78,8 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-eng.html">Home</a></li>
 <li><a href="../index-eng.html">Working examples</a></li>
-<li>Simple Grouping Table - Zebra striping</li>
+<li><a href="zebra-eng.html">Zebra striping</a></li>
+<li>Simple Grouping Table</li>
 </ol>
 </div></div>
 </nav>
@@ -88,7 +89,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Simple Grouping Table - Zebra striping</h1>
+<h1 id="wb-cont">Simple Grouping Table</h1>
 
 <ul class="button-group">
 <li><a href="https://github.com/wet-boew/wet-boew/wiki/Zebra-striping" class="button button-info">Documentation</a></li>

--- a/demos/zebra/zebra-eng.html
+++ b/demos/zebra/zebra-eng.html
@@ -99,14 +99,14 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <li><a href="#table-examples">Table examples</a></li>
 <li><a href="#list-examples">List examples</a></li>
 <li>Other examples
-	<ul> 
+	<ul>
 	<li><a href="simple.html">Simple Table</a></li>
 	<li><a href="simplegrouping.html">Simple Grouping Table</a></li>
 	<li><a href="columnhighlight.html">Column Highlight Table</a></li>
-	<li><a href="hover-effect-with-row-group.html">Table Mouse Hover Effect</a></li>
-	<li><a href="columnhighlight.html">Table Mouse Hover Effect with Row Group</a></li>
+	<li><a href="hover-effect.html">Table Mouse Hover Effect</a></li>
+	<li><a href="hover-effect-with-row-group.html">Table Mouse Hover Effect with Row Group</a></li>
 	<li><a href="invoice.html">Invoice Table</a></li>
-	<li><a href="rowlevelwithsummary.html">Row level with summary Table</a></li>
+	<li><a href="rowlevelwithsummary.html">Row Level with Summary Table</a></li>
 	</ul>
 </li>
 </ul>
@@ -206,7 +206,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 </tbody>
 </table>
 </section></div>
-<div class="clear"></div>					
+<div class="clear"></div>
 </section>
 </div>
 
@@ -221,24 +221,24 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam condimentum mass
 	<li>
 	<div>Brian</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Duis dictum lacus ac turpis gravida in interdum mauris adipiscing. Mauris leo lorem, lobortis eu malesuada a, molestie sed eros. 
+	Duis dictum lacus ac turpis gravida in interdum mauris adipiscing. Mauris leo lorem, lobortis eu malesuada a, molestie sed eros.
 		<ol>
 		<li>
 		<div>Elizabeth</div>
 		<div><time datetime="2009-11-19">November 19, 2009</time></div>
-		Vestibulum et dui ut velit dictum iaculis. Curabitur auctor viverra rutrum. Quisque id quam urna. Mauris quis urna in leo accumsan ultricies vitae sit amet felis.  
+		Vestibulum et dui ut velit dictum iaculis. Curabitur auctor viverra rutrum. Quisque id quam urna. Mauris quis urna in leo accumsan ultricies vitae sit amet felis.
 		</li>
 		<li>
 		<div>Chris</div>
 		<div><time datetime="2009-11-19">November 19, 2009</time></div>
-		Ut vel risus tellus. Suspendisse potenti. Sed est urna, venenatis at auctor eu, vulputate bibendum sem.   
+		Ut vel risus tellus. Suspendisse potenti. Sed est urna, venenatis at auctor eu, vulputate bibendum sem.
 		</li>
-		</ol>  
+		</ol>
 	</li>
 	<li>
 	<div>Laura</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Aliquam erat volutpat. Maecenas aliquam dignissim urna nec viverra. Nulla fringilla fringilla orci, eget consectetur massa vulputate in. Morbi consectetur aliquam lacus, nec sollicitudin lorem molestie ut. Pellentesque scelerisque nulla eget mauris eleifend ac rutrum ligula scelerisque.  
+	Aliquam erat volutpat. Maecenas aliquam dignissim urna nec viverra. Nulla fringilla fringilla orci, eget consectetur massa vulputate in. Morbi consectetur aliquam lacus, nec sollicitudin lorem molestie ut. Pellentesque scelerisque nulla eget mauris eleifend ac rutrum ligula scelerisque.
 	</li>
 	</ol>
 </li>
@@ -255,14 +255,14 @@ Phasellus accumsan risus id lacus cursus vitae fringilla sapien pulvinar. Duis v
 	<li>
 	<div>Bob</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 	</li>
-	</ol> 
+	</ol>
 </li>
 <li>
 <div>Sarah</div>
 <div><time datetime="2009-11-19">November 19, 2009</time></div>
-Donec iaculis diam eget sem bibendum consequat. 
+Donec iaculis diam eget sem bibendum consequat.
 </li>
 </ol>
 </section></div>
@@ -277,24 +277,24 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam condimentum mass
 	<li>
 	<div>Brian</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Duis dictum lacus ac turpis gravida in interdum mauris adipiscing. Mauris leo lorem, lobortis eu malesuada a, molestie sed eros. 
+	Duis dictum lacus ac turpis gravida in interdum mauris adipiscing. Mauris leo lorem, lobortis eu malesuada a, molestie sed eros.
 		<ul>
 		<li>
 		<div>Elizabeth</div>
 		<div><time datetime="2009-11-19">November 19, 2009</time></div>
-		Vestibulum et dui ut velit dictum iaculis. Curabitur auctor viverra rutrum. Quisque id quam urna. Mauris quis urna in leo accumsan ultricies vitae sit amet felis.  
+		Vestibulum et dui ut velit dictum iaculis. Curabitur auctor viverra rutrum. Quisque id quam urna. Mauris quis urna in leo accumsan ultricies vitae sit amet felis.
 		</li>
 		<li>
 		<div>Chris</div>
 		<div><time datetime="2009-11-19">November 19, 2009</time></div>
-		Ut vel risus tellus. Suspendisse potenti. Sed est urna, venenatis at auctor eu, vulputate bibendum sem.   
+		Ut vel risus tellus. Suspendisse potenti. Sed est urna, venenatis at auctor eu, vulputate bibendum sem.
 		</li>
-		</ul>  
+		</ul>
 	</li>
 	<li>
 	<div>Laura</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Aliquam erat volutpat. Maecenas aliquam dignissim urna nec viverra. Nulla fringilla fringilla orci, eget consectetur massa vulputate in. Morbi consectetur aliquam lacus, nec sollicitudin lorem molestie ut. Pellentesque scelerisque nulla eget mauris eleifend ac rutrum ligula scelerisque.  
+	Aliquam erat volutpat. Maecenas aliquam dignissim urna nec viverra. Nulla fringilla fringilla orci, eget consectetur massa vulputate in. Morbi consectetur aliquam lacus, nec sollicitudin lorem molestie ut. Pellentesque scelerisque nulla eget mauris eleifend ac rutrum ligula scelerisque.
 	</li>
 	</ul>
 </li>
@@ -311,14 +311,14 @@ Phasellus accumsan risus id lacus cursus vitae fringilla sapien pulvinar. Duis v
 	<li>
 	<div>Bob</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 	</li>
-	</ul> 
+	</ul>
 </li>
 <li>
 <div>Sarah</div>
 <div><time datetime="2009-11-19">November 19, 2009</time></div>
-Donec iaculis diam eget sem bibendum consequat. 
+Donec iaculis diam eget sem bibendum consequat.
 </li>
 </ul>
 </section></div>
@@ -334,24 +334,24 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam condimentum mass
 	<li>
 	<div>Brian</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Duis dictum lacus ac turpis gravida in interdum mauris adipiscing. Mauris leo lorem, lobortis eu malesuada a, molestie sed eros. 
+	Duis dictum lacus ac turpis gravida in interdum mauris adipiscing. Mauris leo lorem, lobortis eu malesuada a, molestie sed eros.
 		<ol>
 		<li>
 		<div>Elizabeth</div>
 		<div><time datetime="2009-11-19">November 19, 2009</time></div>
-		Vestibulum et dui ut velit dictum iaculis. Curabitur auctor viverra rutrum. Quisque id quam urna. Mauris quis urna in leo accumsan ultricies vitae sit amet felis.  
+		Vestibulum et dui ut velit dictum iaculis. Curabitur auctor viverra rutrum. Quisque id quam urna. Mauris quis urna in leo accumsan ultricies vitae sit amet felis.
 		</li>
 		<li>
 		<div>Chris</div>
 		<div><time datetime="2009-11-19">November 19, 2009</time></div>
-		Ut vel risus tellus. Suspendisse potenti. Sed est urna, venenatis at auctor eu, vulputate bibendum sem.   
+		Ut vel risus tellus. Suspendisse potenti. Sed est urna, venenatis at auctor eu, vulputate bibendum sem.
 		</li>
-		</ol>  
+		</ol>
 	</li>
 	<li>
 	<div>Laura</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Aliquam erat volutpat. Maecenas aliquam dignissim urna nec viverra. Nulla fringilla fringilla orci, eget consectetur massa vulputate in. Morbi consectetur aliquam lacus, nec sollicitudin lorem molestie ut. Pellentesque scelerisque nulla eget mauris eleifend ac rutrum ligula scelerisque.  
+	Aliquam erat volutpat. Maecenas aliquam dignissim urna nec viverra. Nulla fringilla fringilla orci, eget consectetur massa vulputate in. Morbi consectetur aliquam lacus, nec sollicitudin lorem molestie ut. Pellentesque scelerisque nulla eget mauris eleifend ac rutrum ligula scelerisque.
 	</li>
 	</ol>
 </li>
@@ -368,14 +368,14 @@ Phasellus accumsan risus id lacus cursus vitae fringilla sapien pulvinar. Duis v
 	<li>
 	<div>Bob</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 	</li>
-	</ol> 
+	</ol>
 </li>
 <li>
 <div>Sarah</div>
 <div><time datetime="2009-11-19">November 19, 2009</time></div>
-Donec iaculis diam eget sem bibendum consequat. 
+Donec iaculis diam eget sem bibendum consequat.
 </li>
 </ol>
 </section></div>
@@ -390,24 +390,24 @@ Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam condimentum mass
 	<li>
 	<div>Brian</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Duis dictum lacus ac turpis gravida in interdum mauris adipiscing. Mauris leo lorem, lobortis eu malesuada a, molestie sed eros. 
+	Duis dictum lacus ac turpis gravida in interdum mauris adipiscing. Mauris leo lorem, lobortis eu malesuada a, molestie sed eros.
 		<ol>
 		<li>
 		<div>Elizabeth</div>
 		<div><time datetime="2009-11-19">November 19, 2009</time></div>
-		Vestibulum et dui ut velit dictum iaculis. Curabitur auctor viverra rutrum. Quisque id quam urna. Mauris quis urna in leo accumsan ultricies vitae sit amet felis.  
+		Vestibulum et dui ut velit dictum iaculis. Curabitur auctor viverra rutrum. Quisque id quam urna. Mauris quis urna in leo accumsan ultricies vitae sit amet felis.
 		</li>
 		<li>
 		<div>Chris</div>
 		<div><time datetime="2009-11-19">November 19, 2009</time></div>
-		Ut vel risus tellus. Suspendisse potenti. Sed est urna, venenatis at auctor eu, vulputate bibendum sem.   
+		Ut vel risus tellus. Suspendisse potenti. Sed est urna, venenatis at auctor eu, vulputate bibendum sem.
 		</li>
-		</ol>  
+		</ol>
 	</li>
 	<li>
 	<div>Laura</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Aliquam erat volutpat. Maecenas aliquam dignissim urna nec viverra. Nulla fringilla fringilla orci, eget consectetur massa vulputate in. Morbi consectetur aliquam lacus, nec sollicitudin lorem molestie ut. Pellentesque scelerisque nulla eget mauris eleifend ac rutrum ligula scelerisque.  
+	Aliquam erat volutpat. Maecenas aliquam dignissim urna nec viverra. Nulla fringilla fringilla orci, eget consectetur massa vulputate in. Morbi consectetur aliquam lacus, nec sollicitudin lorem molestie ut. Pellentesque scelerisque nulla eget mauris eleifend ac rutrum ligula scelerisque.
 	</li>
 	</ol>
 </li>
@@ -424,14 +424,14 @@ Phasellus accumsan risus id lacus cursus vitae fringilla sapien pulvinar. Duis v
 	<li>
 	<div>Bob</div>
 	<div><time datetime="2009-11-19">November 19, 2009</time></div>
-	Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 	</li>
-	</ol> 
+	</ol>
 </li>
 <li>
 <div>Sarah</div>
 <div><time datetime="2009-11-19">November 19, 2009</time></div>
-Donec iaculis diam eget sem bibendum consequat. 
+Donec iaculis diam eget sem bibendum consequat.
 </li>
 </ol>
 </section></div>
@@ -463,7 +463,7 @@ Donec iaculis diam eget sem bibendum consequat.
 <li>Phasellus accumsan risus id lacus cursus vitae fringilla sapien pulvinar. Duis viverra consectetur quam vitae pellentesque. Donec iaculis diam eget sem bibendum consequat. Nullam rhoncus bibendum lobortis. Sed consequat sagittis pharetra. Pellentesque accumsan, felis ut venenatis semper, metus odio sollicitudin libero, nec vestibulum lectus nibh vel libero. Fusce iaculis lectus vel ipsum auctor porta. Proin nec lectus augue, varius cursus orci.</li>
 </ul>
 </section></div>
-  
+
 
 <div class="clear"></div>
 

--- a/demos/zebra/zebra-fra.html
+++ b/demos/zebra/zebra-fra.html
@@ -99,14 +99,14 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 <li><a href="#table-examples">Exemples - Tableaux</a></li>
 <li><a href="#list-examples">Exemples - Listes</a></li>
 <li>Autres examples
-	<ul> 
+	<ul>
 	<li><a href="simple.html" lang="en">Simple Table</a> (anglais seulement)</li>
 	<li><a href="simplegrouping.html" lang="en">Simple Grouping Table</a> (anglais seulement)</li>
 	<li><a href="columnhighlight.html" lang="en">Column Highlight Table</a> (anglais seulement)</li>
-	<li><a href="hover-effect-with-row-group.html" lang="en">Table Mouse Hover Effect</a> (anglais seulement)</li>
-	<li><a href="columnhighlight.html" lang="en">Table Mouse Hover Effect with Row Group</a> (anglais seulement)</li>
+	<li><a href="hover-effect.html" lang="en">Table Mouse Hover Effect</a> (anglais seulement)</li>
+	<li><a href="hover-effect-with-row-group.html" lang="en">Table Mouse Hover Effect with Row Group</a> (anglais seulement)</li>
 	<li><a href="invoice.html" lang="en">Invoice Table</a></li>
-	<li><a href="rowlevelwithsummary.html" lang="en">Row level with summary Table</a></li>
+	<li><a href="rowlevelwithsummary.html" lang="en">Row Level with Summary Table</a></li>
 	</ul>
 </li>
 </ul>


### PR DESCRIPTION
Fixed the breadcrumbs and page titles for the charts/graphs and zebra working examples:
1. added missing parent breadcrumb, and
2. removed parent page names from page titles.
