### PR TITLE
Demo Reference Update

### DIFF
--- a/demos/index-eng.html
+++ b/demos/index-eng.html
@@ -293,8 +293,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 
 <section><h2 id="php">PHP variant</h2>
 <ul>
-<li><a href="php/index-eng.html"><span class="wb-invisible">PHP variant - </span>English examples</a></li>
-<li><a href="php/index-fra.html"><span class="wb-invisible">PHP variant - </span>French examples</a></li>
+<li><a href="http://wet-boew-php.azurewebsites.net/demos-php/index-eng.php"><span class="wb-invisible">PHP variant - </span>English examples</a></li>
+<li><a href="http://wet-boew-php.azurewebsites.net/demos-php/index-fra.php"><span class="wb-invisible">PHP variant - </span>French examples</a></li>
 </ul>
 </section>
 

--- a/demos/index-fra.html
+++ b/demos/index-fra.html
@@ -408,8 +408,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 
 <section><h2 id="php">Variant pour PHP</h2>
 <ul>
-<li><a href="ssi/index-eng.html"><span class="wb-invisible">Variant pour PHP - </span>Exemples en anglais</a></li>
-<li><a href="ssi/index-fra.html"><span class="wb-invisible">Variant pour PHP - </span>Exemples en français</a></li>
+<li><a href="http://wet-boew-php.azurewebsites.net/demos-php/index-eng.php"><span class="wb-invisible">Variant pour PHP - </span>Exemples en anglais</a></li>
+<li><a href="http://wet-boew-php.azurewebsites.net/demos-php/index-eng.php"><span class="wb-invisible">Variant pour PHP - </span>Exemples en français</a></li>
 </ul>
 </section>
 

--- a/demos/php/index-eng.html
+++ b/demos/php/index-eng.html
@@ -109,50 +109,13 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div class="span-4">
 <section><h2 id="home">Home pages</h2>
 <ul>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/home-accueil-eng.php" rel="external"><span class="wb-invisible">Home pages - </span>English example</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/home-accueil-fra.php" rel="external"><span class="wb-invisible">Home pages - </span>French example</a></li>
+<li><a href="http://wet-boew-php.azurewebsites.net/demos-php/index-eng.php" rel="external"><span class="wb-invisible">Home pages - </span>English example</a></li>
+<li><a href="http://wet-boew-php.azurewebsites.net/demos-php/index-fra.php" rel="external"><span class="wb-invisible">Home pages - </span>French example</a></li>
 </ul>
 </section>
-
-<section><h2 id="content">Content pages</h2>
-<ul>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/cont-eng.php" rel="external"><span class="wb-invisible">Content pages - </span>English example</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/cont-fra.php" rel="external"><span class="wb-invisible">Content pages - </span>French example</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/cont-secnav1-eng.php" rel="external"><span class="wb-invisible">Content pages - </span>English example - Secondary menu</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/cont-secnav1-fra.php" rel="external"><span class="wb-invisible">Content pages - </span>French example - Secondary menu</a></li>
-</ul>
-</section>
-
-<section><h2 id="webapp">Content pages - Web application template</h2>
-<ul>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/application-eng.php" rel="external"><span class="wb-invisible">Content pages - Web application template - </span>English example</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/application-fra.php" rel="external"><span class="wb-invisible">Content pages - Web application template - </span>French example</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/application-nosearchlang-eng.php" rel="external"><span class="wb-invisible">Content pages - Web application template - </span>English example - No search or language selection link</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/application-nosearchlang-fra.php" rel="external"><span class="wb-invisible">Content pages - Web application template - </span>French example - No search or language selection link</a></li>
-</ul>
-</section>
-</div>
-<div class="span-4">
-<section><h2 id="splash">Splash pages</h2>
-<ul>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/sp-pe-theme-gcwu-fegc-eng-fra.php" rel="external"><span class="wb-invisible">Splash pages - </span>English/French example</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/sp-pe-theme-gcwu-fegc-fra-eng.php" rel="external"><span class="wb-invisible">Splash pages - </span>French/English example</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/sp-pe-mult-theme-gcwu-fegc-eng-fra.php" rel="external"><span class="wb-invisible">Splash pages - </span>English/French example - Multilingual</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/sp-pe-mult-theme-gcwu-fegc-fra-eng.php" rel="external"><span class="wb-invisible">Splash pages - </span>French/English example - Multilingual</a></li>
-</ul>
-</section>
-
-<section><h2 id="serv">Server message pages</h2>
-<ul>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/serv-eng-fra.php" rel="external"><span class="wb-invisible">Server message pages - </span>English/French example</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/serv-fra-eng.php" rel="external"><span class="wb-invisible">Server message pages - </span>French/English example</a></li>
-</ul>
-</section>
-</div>
-<div class="clear"></div>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2012-09-17</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2013-05-16</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/demos/php/index-eng.html
+++ b/demos/php/index-eng.html
@@ -114,6 +114,8 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 </ul>
 </section>
 
+<div class="clear"></div>
+
 <dl id="gcwu-date-mod" role="contentinfo">
 <dt>Date modified:</dt><dd><span><time>2013-05-16</time></span></dd>
 </dl>

--- a/demos/php/index-fra.html
+++ b/demos/php/index-fra.html
@@ -109,50 +109,15 @@ wet-boew.github.com/wet-boew/License-eng.txt / wet-boew.github.com/wet-boew/Lice
 <div class="span-4">
 <section><h2 id="accueil">Pages d'accueil</h2>
 <ul>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/home-accueil-eng.php" rel="external"><span class="wb-invisible">Pages d'accueil - </span>Exemple en anglais</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/home-accueil-fra.php" rel="external"><span class="wb-invisible">Pages d'accueil - </span>Exemple en français</a></li>
+<li><a href="http://wet-boew-php.azurewebsites.net/demos-php/index.php" rel="external"><span class="wb-invisible">Pages d'accueil - </span>Exemple en anglais</a></li>
+<li><a href="http://wet-boew-php.azurewebsites.net/demos-php/index.php" rel="external"><span class="wb-invisible">Pages d'accueil - </span>Exemple en français</a></li>
 </ul>
 </section>
 
-<section><h2 id="contenu">Pages de contenu</h2>
-<ul>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/cont-eng.php" rel="external"><span class="wb-invisible">Pages de contenu - </span>Exemple en anglais</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/cont-fra.php" rel="external"><span class="wb-invisible">Pages de contenu - </span>Exemple en français</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/cont-secnav1-eng.php" rel="external"><span class="wb-invisible">Pages de contenu - </span>Exemple en anglais - Menu secondaire</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/cont-secnav1-fra.php" rel="external"><span class="wb-invisible">Pages de contenu - </span>Exemple en français - Menu secondaire</a></li>
-</ul>
-</section>
-
-<section><h2 id="appweb">Pages de contenu - Modèle de page d'application Web</h2>
-<ul>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/application-eng.php" rel="external"><span class="wb-invisible">Pages de contenu - Modèle de page d'application Web - </span>Exemple en anglais</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/application-fra.php" rel="external"><span class="wb-invisible">Pages de contenu - Modèle de page d'application Web - </span>Exemple en français</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/application-nosearchlang-eng.php" rel="external"><span class="wb-invisible">Pages de contenu - Modèle de page d'application Web - </span>Exemple en anglais - Sans recherche ou lien de sélection de la langue</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/application-nosearchlang-fra.php" rel="external"><span class="wb-invisible">Pages de contenu - Modèle de page d'application Web - </span>Exemple en français - Sans recherche ou lien de sélection de la langue</a></li>
-</ul>
-</section>
-</div>
-<div class="span-4">
-<section><h2 id="entre">Pages d'entrée</h2>
-<ul>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/sp-pe-theme-gcwu-fegc-eng-fra.php" rel="external"><span class="wb-invisible">Pages d'entrée - </span>Exemple en anglais/français</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/sp-pe-theme-gcwu-fegc-fra-eng.php" rel="external"><span class="wb-invisible">Pages d'entrée - </span>Exemple en français/anglais</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/sp-pe-mult-theme-gcwu-fegc-eng-fra.php" rel="external"><span class="wb-invisible">Pages d'entrée - </span>Exemple en anglais/français - Multilingue</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/sp-pe-theme-gcwu-fegc-fra-eng.php" rel="external"><span class="wb-invisible">Pages d'entrée - </span>Exemple en français/anglais - Multilingue</a></li>
-</ul>
-</section>
-
-<section><h2 id="serv">Pages de messages du serveur</h2>
-<ul>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/serv-eng-fra.php" rel="external"><span class="wb-invisible">Pages de messages du serveur - </span>Exemple en anglais/français</a></li>
-<li><a href="http://wet-boew.pub.rcmp-grc.gc.ca/demos-php/theme-gcwu-fegc/serv-fra-eng.php" rel="external"><span class="wb-invisible">Pages de messages du serveur - </span>Exemple en français/anglais</a></li>
-</ul>
-</section>
-</div>
 <div class="clear"></div>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2012-09-17</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2013-05-16</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->


### PR DESCRIPTION
I've updated the references to the PHP Variant demos to point to the new Azure deployment of the site.

The main index-eng.html and index-fra.html files point directly to the demos site, but I've also updated the php/index-eng.html and php/index-fra.html files so people with bookmarks won't end up with a 404 if we were to removed the php/index-xxx.html pages altogether or by being pointed to the older RCMP demos deployment.
