### PR TITLE
Disabled left/right margins on module-news-article images in mobile view...

### DIFF
--- a/src/grids/sass/includes/_util-mobile.scss
+++ b/src/grids/sass/includes/_util-mobile.scss
@@ -102,6 +102,13 @@ ul {
 	max-width: 280px;
 }
 
+.module-news-article {
+	img {
+		margin-left: 0 !important;
+		margin-right: 0 !important;
+	}
+}
+
 .module-poster {
 	@include inline-block;
 }


### PR DESCRIPTION
.... Prevents too much left/right spacing from appearing around images that use margin-left/right-\* classes in larger view modes.
