### PR TITLE
Update sessiontimeout.js

### DIFF
--- a/src/js/workers/sessiontimeout.js
+++ b/src/js/workers/sessiontimeout.js
@@ -57,7 +57,7 @@
 				if (opts.refreshCallbackUrl.length > 2) {
 					$.post(opts.refreshCallbackUrl,	function (responseData) {
 						// if the response data returns anything but "true", we should display that the session has timed out.
-						if (responseData && responseData.replace(/\s/g, '') == 'true') {
+						if (responseData && responseData.replace(/\s/g, '') === 'true') {
 							sessionTimeout = setTimeout(keep_session, timeParse(opts.sessionalive));
 						} else {
 							alert(alreadyTimeoutMsg);

--- a/src/js/workers/sessiontimeout.js
+++ b/src/js/workers/sessiontimeout.js
@@ -56,8 +56,8 @@
 				// If the refreshCallbackUrl not present then dont show any error
 				if (opts.refreshCallbackUrl.length > 2) {
 					$.post(opts.refreshCallbackUrl,	function (responseData) {
-						// if the response data returns "false", we should display that the session has timed out.
-						if (responseData && responseData.replace(/\s/g, '') !== 'false') {
+						// if the response data returns anything but "true", we should display that the session has timed out.
+						if (responseData && responseData.replace(/\s/g, '') == 'true') {
 							sessionTimeout = setTimeout(keep_session, timeParse(opts.sessionalive));
 						} else {
 							alert(alreadyTimeoutMsg);


### PR DESCRIPTION
Only extend the session if you get an explicit 'true' response. Otherwise the session will get extended client-side if an error occurs server-side.
