### PR TITLE
Changed reload method for mobile/desktop view transition to prevent hashfrom being stripped and allowing posts to be reposted

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -1965,7 +1965,7 @@
 						var mobilecheck = pe.mobilecheck();
 						if (pe.mobile !== mobilecheck) {
 							pe.mobile = mobilecheck;
-							window.location.href = decodeURI(pe.url(window.location.href).removehash());
+							window.location.reload();
 						}
 					});
 				}


### PR DESCRIPTION
Fixes #2367 and #2369.
