### PR TITLE
Changed opened details to use child combinator selector in IE7-8 (via IE...

### DIFF
--- a/src/js/sass/includes/_details-ie.scss
+++ b/src/js/sass/includes/_details-ie.scss
@@ -14,7 +14,7 @@
 			}
 		}
 		&[open] {
-			* {
+			> * {
 				display: block;
 			}
 		}


### PR DESCRIPTION
... details SCSS). Prevents deeper child elements from inheriting "display: block;" properties.
