### PR TITLE
Geomap: improve zoom to element

### DIFF
--- a/demos/geomap/data/config-en.js
+++ b/demos/geomap/data/config-en.js
@@ -122,7 +122,7 @@ var wet_boew_geomap = {
 				updated_at: 'Last updated'
 			},
 			visible: true,	
-			zoom:  true,
+			zoom:  [true, {type: 'text'}],
 			datatable: true,
 			tab: true,		
 			// default style			

--- a/demos/geomap/data/config-fr.js
+++ b/demos/geomap/data/config-fr.js
@@ -123,7 +123,7 @@ var wet_boew_geomap = {
 				updated_at: 'Dernière mise à jour'
 			},
 			visible: true,	
-			zoom:  true,
+			zoom:  [true, {type: 'text'}],
 			datatable: true,
 			tab: true,		
 			// default style			

--- a/demos/geomap/geomap-eng.html
+++ b/demos/geomap/geomap-eng.html
@@ -102,7 +102,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		"layersFile": "data/config-en.js", 
 		"tables": [{ 
 			"id": "cities", 
-			"zoom": true,
+			"zoom": [true, {type: "all"}],
 			"tab": false,
 			"datatable": true,
 			"popups": true,
@@ -157,6 +157,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		{
 			"id": "bbox",
 			"tab": true,
+			"zoom": [true, {"type": "image"}],
 			"popups": true
 		}]    
 	}'>

--- a/demos/geomap/geomap-fra.html
+++ b/demos/geomap/geomap-fra.html
@@ -102,7 +102,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		"layersFile": "data/config-fr.js",
 		"tables": [{ 
 			"id": "cities", 
-			"zoom": true,
+			"zoom": [true, {type: "all"}],
 			"tab": false,
 			"datatable": true,
 			"popups": true,
@@ -157,6 +157,7 @@ wet-boew.github.io/wet-boew/License-eng.txt / wet-boew.github.io/wet-boew/Licenc
 		{
 			"id": "bbox", 
 			"tab": true,
+			"zoom": [true, {"type": "image"}],
 			"popups": true
 		}] 
 	}'>


### PR DESCRIPTION
zoom parameter is now an array e.g. zoom: [true, ["type": "text"}] so the user can select the type of button (image, text or both like default).

previous version it was zoom: true. This is still functional and gives the same results even if it is deprecated.
