### PR TITLE
Set print dd width to 100% in footnotes SCSS. Prevents short footnotes f...

### DIFF
--- a/src/js/sass/includes/_footnotes.scss
+++ b/src/js/sass/includes/_footnotes.scss
@@ -162,6 +162,7 @@ table {
 		dl {
 			dd {
 				border: 0;
+				width: 100%;
 				@include inline-block;
 				p {
 					&.footnote-return {


### PR DESCRIPTION
...rom appearing side-by-side.
