### PR TITLE
Grid icons: added padding-right to rel='external' links in lightbox

### DIFF
--- a/src/grids/sass/includes/_icon.scss
+++ b/src/grids/sass/includes/_icon.scss
@@ -6,7 +6,7 @@
 @import "compass/utilities/sprites";
 
 //Inline the sprite if not outputing for IE8
-$wb-icon-inline: not $legacy-support-for-ie8; 
+$wb-icon-inline: not $legacy-support-for-ie8;
 
 @import "wb-icon/*.png";
 
@@ -44,20 +44,20 @@ $wb-icon-inline: not $legacy-support-for-ie8;
 [rel="external"] {
 	background: url(../images/wb-icon/external.png) 100% 0 no-repeat;
 
-	//gh-2104 fixes overriding background because of increased specificity when wb-main was used	
+	//gh-2104 fixes overriding background because of increased specificity when wb-main was used
 	#wb-head &, #wb-foot & {
 		background: inherit;
 	}
-	
-	#wb-main & {
+
+	#wb-main &, #colorbox & {
 		padding-right: 20px;
-		
+
 		&.wb-icon-none {
 			padding-right: 0;
 		}
 	}
 }
-	
+
 .wb-icon-none {
 	background-image: none;
 	padding-left: 0;


### PR DESCRIPTION
Fixes #2420.

`#colorbox` element is attached outside of `#wb-main` so the padding-right for the rel="external" icon wasn't being applied.
