### PR TITLE
Tabbedinterface (mobile): allow URL hash to determine active tab to display

### DIFF
--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -38,9 +38,12 @@
 				index,
 				len;
 
-			// Check if there's an active tab from the user's session
-			$activeTab = $tabs.find('a[href="' + this._get_active_panel(tabListIdx) + '"]');
-			if ($activeTab.length) {
+			// Check if there's a default tab specified by the URL hash or in the user's session
+			$activeTab = $tabs.find('a[href="#' + _pe.urlhash + '"]');
+			if ($activeTab.length === 0) {
+				$activeTab = $tabs.find('a[href="' + this._get_active_panel(tabListIdx) + '"]');
+			}
+			if ($activeTab.length > 0) {
 				$tabs.removeClass('default');
 				$activeTab.parent('li').addClass('default');
 			}
@@ -75,7 +78,7 @@
 			elm.empty().append($accordion);
 
 			// Track the active panel during the user's session
-			elm.find('[data-role="collapsible"]').on('expand', function () {
+			$panelElms.on('expand', function () {
 				_pe.fn.tabbedinterface._set_active_panel($(this).data('tab'), tabListIdx);
 				setTimeout(function() {
 					_pe.window.trigger('resize');
@@ -182,7 +185,7 @@
 						if (!$target.is($tabs.filter('.' + opts.tabActiveClass))) {
 							selectTab($target, $tabs, $panels, opts, false);
 						} else {
-							href = $target.attr('href'),
+							href = $target.attr('href');
 							hash = href.substring(href.indexOf('#'));
 							_pe.focus($panels.filter(hash));
 						}
@@ -194,7 +197,7 @@
 						e.preventDefault();
 					}
 				} else {
-					href = $target.attr('href'),
+					href = $target.attr('href');
 					hash = href.substring(href.indexOf('#'));
 					if ($target.is($tabs.filter('.' + opts.tabActiveClass))) {
 						_pe.focus($panels.filter(hash));


### PR DESCRIPTION
Adds ability to specify active tab with URL hash when in mobile view.  This makes the tabbed interface behaviour more consistent between desktop/mobile (part of the change from PR #2423).

I'll add a comment to #2331 that documents the low risk breaking change this introduces so we can add it to the release notes: 
- **Mobile:** URL hash panel select takes precedence over sessionStorage panel select.
