### PR TITLE
Tabbed interface: URL hash used to select default tab

### DIFF
--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -200,15 +200,15 @@
 				}
 			});
 
-			// Find the default tab: precendence given to the active tab from sessionStorage
-			$default_tab = $tabs.filter('[href="' + this._get_active_panel(tabListIdx) + '"]');
-			if ($default_tab.length > 0) {
-				opts.defaultTab = '.default';
-				$nav.find('li').removeClass('default');
-				$default_tab.parent('li').addClass('default');
-			} else {
-				$default_tab = $tabs.filter('[href="*#' + _pe.urlhash + '"]');
-				if ($default_tab.length === 0) {
+			// Find the default tab: precendence given to the URL hash
+			$default_tab = $tabs.filter('[href="#' + _pe.urlhash + '"]');
+			if ($default_tab.length === 0) {
+				$default_tab = $tabs.filter('[href="' + this._get_active_panel(tabListIdx) + '"]');
+				if ($default_tab.length > 0) {
+					opts.defaultTab = '.default';
+					$nav.find('li').removeClass('default');
+					$default_tab.parent('li').addClass('default');
+				} else {
 					$default_tab = $nav.find('.default a');
 					if ($default_tab.length === 0) {
 						$default_tab = $nav.find('li:first-child a');


### PR DESCRIPTION
The URL hash has been given precedence when determining the default tab
to display.  Order of determining default tab is now:
1. URL hash that matches tab panel ID.
2. Last tab panel opened during user's session.
3. Tab with the .default CSS class.
4. First tab panel.

I'll also update the 3.1.2 release notes with this breaking change.

Fixes #2407.
