### PR TITLE
Fixed Firefox autoHeight issue in tabbed interface SCSS.

### DIFF
--- a/src/js/sass/includes/_tabbedinterface.scss
+++ b/src/js/sass/includes/_tabbedinterface.scss
@@ -153,6 +153,24 @@
 	}
 }
 
+@-moz-document url-prefix() {
+	.tabs-panel {
+		> {
+			div {
+				&.active {
+					> {
+						* {
+							&:last-child {
+								padding-bottom: 0.001em;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
 .clear {
     clear: both;
     display: block;

--- a/src/js/sass/includes/_tabbedinterface.scss
+++ b/src/js/sass/includes/_tabbedinterface.scss
@@ -153,19 +153,29 @@
 	}
 }
 
+/* Workaround for Firefox autoHeight margin collapsing bug. See issue #2471 and pull #2486 for more information. */
 @-moz-document url-prefix() {
-	.tabs-panel {
-		> {
-			div {
-				&.active {
-					> {
-						* {
-							&:last-child {
-								padding-bottom: 0.001em;
-							}
-						}
-					}
+	%tabbedinterface-auto-height-bottom-padding {
+		padding-bottom: 11px !important;
+	}
+	.wet-boew-tabbedinterface {
+		&:not(.auto-height-none) {
+			.tabs-panel {
+				@extend %tabbedinterface-auto-height-bottom-padding;
+			}
+		}
+		&.tabs-style-1 {
+			&:not(.auto-height-none) {
+				.tabs-panel {
+					@extend %tabbedinterface-auto-height-bottom-padding;
 				}
+			}
+		}
+	}
+	[class*="tabs-style-"] {
+		&:not(.auto-height-none) {
+			.tabs-panel {
+				padding-bottom: 0 !important;
 			}
 		}
 	}


### PR DESCRIPTION
Resolves issue #2471.
