### PR TITLE
Build: Change submodule CI updating

### DIFF
--- a/build/post_build.sh
+++ b/build/post_build.sh
@@ -76,7 +76,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] &&  [ "$TRAVIS_REPO_SLUG" == "wet-boew/
 		else
 			cd "$TRAVIS_BRANCH-ci"
 		fi
-		git pull origin $build_branch
+		git checkout $build_branch
 		cd ..
 		git add .
 		git commit -q -m "Travis build $TRAVIS_BUILD_NUMBER"


### PR DESCRIPTION
The clone operation on Travis will already update the submodules. The checkout is all that is required to reset the headless repo in the folder to the latest commit.
