### PR TITLE
Build: Init submodule for Travis demo building

### DIFF
--- a/build/post_build.sh
+++ b/build/post_build.sh
@@ -72,10 +72,17 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] &&  [ "$TRAVIS_REPO_SLUG" == "wet-boew/
 		cd wet-boew.github.io
 
 		if [ "$TRAVIS_BRANCH" == "master" ]; then
-			cd wet-boew
+			submodule_name="wet-boew"
 		else
-			cd "$TRAVIS_BRANCH-ci"
+			submodule_name="$TRAVIS_BRANCH-ci"
 		fi
+
+		echo -e "Updating submodule '$submodule_name'"
+		#Use the existing local repo for initializing the submodule
+		git submodule update --reference ../wet-boew-dist --init "$submodule_name"
+
+		cd "$submodule_name"
+		#Checkout dist branch to move forward submodule HEAD pointer
 		git checkout $build_branch
 		cd ..
 		git add .


### PR DESCRIPTION
Use the already cloned wet-boew-dist to save the extra full clone. Thereare notes on using the `--reference` command on https://www.kernel.org/pub/software/scm/git/docs/git-clone.html, but those shouldn't be affected by this usage.

---

This builds on the work in #2511, but I found an issue with the difference between the raw Git clone vs the GH4W in the treatment of submodules.
