### PR TITLE
Build: Localize build timestamp timezone

### DIFF
--- a/build/build-tasks.xml
+++ b/build/build-tasks.xml
@@ -6,7 +6,7 @@
 	<!-- Version and build time-->
 	<property name="wet-boew-build.version" value="v3.0.8-development"/>
 	<tstamp>
-		<format property="wet-boew-build.starttime" pattern="yyyy-MM-dd hh:mm aa" locale="en,CA"/>
+		<format property="wet-boew-build.starttime" pattern="yyyy-MM-dd hh:mm aa" locale="en,CA" timezone="America/Toronto" />
 	</tstamp>
 	
 	<!-- ant contribs task definition  -->
@@ -298,6 +298,7 @@
 	</target>
 	
 	<target name="-update-headers" extensionOf="finalize">
+		<echo>Setting build timestamp to '${wet-boew-build.starttime}'</echo>
 		<replace dir="${dist.dir}" encoding="UTF-8">
 			<include name="**/*.js"/>
 			<include name="**/*.css"/>


### PR DESCRIPTION
Use a daylight savings time aware timezone string, because Travis CI builds kept setting the timestamp values to GMT
Fixes gh-2546
