### PR TITLE
Set pseudo-focused button background colours to !important in Grids SCSS...

### DIFF
--- a/src/grids/sass/includes/_button.scss
+++ b/src/grids/sass/includes/_button.scss
@@ -209,7 +209,7 @@
 
 	@include background-image(linear-gradient($color, darken($color, 10%)));
 	@include pseudo-focus {
-		background-color: darken($color, 10%);
+		background-color: darken($color, 10%) !important;
 	}
 	@if $experimental-support-for-mozilla {
 		&:focus::-moz-focus-inner, &:active::-moz-focus-inner {


### PR DESCRIPTION
.... Prevents button-styled summaries from losing background colours on hover/focus when JS is disabled.
