### PR TITLE
Tabbedinterface: fixed check for hidden child tab panels

### DIFF
--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -349,7 +349,7 @@
 							var panel,
 								panelId;
 							panel = anchor.parents('[role="tabpanel"]:hidden');
-							if (panel) {
+							if (panel.length !== 0) {
 								e.preventDefault();
 								panelId = panel.attr('id');
 								panel.parent().siblings('.tabs').find('a').filter('[href="#' + panelId + '"]').trigger('click');


### PR DESCRIPTION
Fixes the page jump issue of #2649 when nested tabs are clicked.
