### PR TITLE
Tabbedinterface: fixes mobile creation of nested tabbed interfaces

### DIFF
--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -15,14 +15,7 @@
 	_pe.fn.tabbedinterface = {
 		type : 'plugin',
 		depends : (_pe.mobile ? [] : ['easytabs']),
-		mobile : function (elm, nested) {
-			// Process any nested tabs
-			if (typeof nested === 'undefined' || !nested) {
-				elm.find('.wet-boew-tabbedinterface').each(function () {
-					_pe.fn.tabbedinterface.mobile($(this), true);
-				});
-			}
-
+		mobile : function (elm) {
 			var $accordion,
 				$panelElms,
 				$panels = elm.children('.tabs-panel').children('div'),


### PR DESCRIPTION
Now that plugin elements are enhanced in reverse order, the nested looping in `_pe.fn.tabbedinterface.mobile` is no longer required.

Fixes  #2649.
