### PR TITLE
Optimized Vapour which included the following:

### DIFF
--- a/src/core/vapour/vapour.coffee
+++ b/src/core/vapour/vapour.coffee
@@ -1,47 +1,79 @@
 ###
-	WET-BOEW Vapour loader
+    WET-BOEW Vapour loader
 ###
-# Lets establish the base path to be more flexiable in terms of WCMS where JS can reside in theme folders and not in the root of sites
-(($)->
-    Modernizr._vpbpath = $('script[src$="vapour.js"],script[src$="vapour.min.js"]').last().prop("src").split('?')[0].split('/').slice(0, -1).join('/')
-    console.log Modernizr._vpbpath
-)(jQuery)
+###
+ Lets establish the base path to be more flexiable in terms of WCMS where JS can reside in theme folders and not in the root of sites
+###
+((yepnope) ->
+  yepnope.addPrefix "site", (resourceObj) ->
+    _path = $('script[src$="vapour.js"],script[src$="vapour.min.js"]').last().prop("src").split('?')[0].split('/').slice(0, -1).join('/')
+    resourceObj.url = _path +  "/" + resourceObj.url
+    resourceObj
+
+) @yepnope
+###
+ Our Base timer for all event driven plugins
+###
+;window._timer =
+  _elms: []
+  _cache : $('body') # this is performace boast to allow for body targetting. 
+
+  add: (_rg) ->
+    _obj = @_cache.find(_rg)
+    @_elms.push _obj if (_obj.length > 0)
+    undefined
+
+  remove: (_rg) ->
+    i = @_elms.length - 1
+
+    while i >= 0
+      @_elms.splice i, 1  if @_elms[i].selector is _rg
+      i--
+    undefined
+  start : ()->
+    #console.log "[PloyFills loaded lets start]"
+    setInterval (->
+      window._timer.touch()
+    ), 500
+    undefined
+  touch: ->
+    i = @_elms.length - 1
+
+    while i >= 0
+      #console.log(this._elms[i].text());
+      @_elms[i].trigger "wb.timerpoke"
+      i--
+    undefined
+
 
 # Using Modernizer to load the polyfills
-Modernizr.load [
-        ## test for media query support
-        test: Modernizr.mq('only all'),
-        nope : "#{Modernizr._vpbpath}/polyfills/respond.min.js"
-    ,
+;Modernizr.load [
+
         ## test for Canvas support
         test: Modernizr.canvas,
-        nope: "#{Modernizr._vpbpath}/polyfills/excanvas.min.js"
+        nope: "site!polyfills/excanvas.min.js"
     ,
-    	test: Modernizr.input.list,
-    	nope : "#{Modernizr._vpbpath}/polyfills/datalist.min.js"
+        test: Modernizr.input.list,
+        nope : "site!polyfills/datalist.min.js"
     ,
-    	test: Modernizr.inputtypes["range"],
-    	nope : "#{Modernizr._vpbpath}/polyfills/slider.min.js"
+        test: Modernizr.inputtypes["range"],
+        nope : "site!polyfills/slider.min.js"
     ,
-    	test: Modernizr.sessionstorage,
-    	nope : "#{Modernizr._vpbpath}/polyfills/sessionstorage.min.js"
+        test: Modernizr.sessionstorage,
+        nope : "site!polyfills/sessionstorage.min.js"
     ,
-    	test: Modernizr.progress,
-    	nope : "#{Modernizr._vpbpath}/polyfills/progress.min.js"
+        test: Modernizr.progress,
+        nope : "site!polyfills/progress.min.js"
     ,
-    	test: Modernizr.meter
-    	nope : "#{Modernizr._vpbpath}/polyfills/meter.min.js"
+        test: Modernizr.meter
+        nope : "site!/polyfills/meter.min.js"
     ,
-    	test: Modernizr.localstorage,
-    	nope : "#{Modernizr._vpbpath}/polyfills/sessionstorage.min.js"
+        test: Modernizr.localstorage,
+        nope : "site!polyfills/sessionstorage.min.js"
     ,
-	    test: Modernizr.lastchild,
-    	nope : "#{Modernizr._vpbpath}/vendor/selectivizr.min.js"
+        test: Modernizr.lastchild,
+        nope : "site!vendor/selectivizr.min.js"
     ,
-    	load: "#{Modernizr._vpbpath}/wet-boew.min.js"
-    #,
-       # load : "//code.jquery.com/mobile/1.3.1/jquery.mobile-1.3.1.min.js",
-       # complete :->
-       #  Modernizr.load "#{Modernizr._vpbpath}/vendor/jquery-mobile-1.3.1.min.js" if  window.jQuery.mobile?
-    #,
+        complete: ()->
+            window._timer.start()
 ]


### PR DESCRIPTION
- Removed respond.js and selectorviz,js since they are targetting only IE8 and below and they will be address in the conditional comments already provided by WET-BOEW
- Created a yepnope prefix for polyfill loading and future dependency loading to streamline correct path finding function for the location of WET
- Introduced the global timer that will be used by plugins in the new v4.0
