### PR TITLE
Details: maintains display property of details children

### DIFF
--- a/src/js/sass/includes/_details-ie.scss
+++ b/src/js/sass/includes/_details-ie.scss
@@ -6,13 +6,15 @@
 	details {
 		> {
 			* {
-				visibility: hidden;
+				display: none;
 			}
 		}
-		&[open] {
+	}
+	&.no-js {
+		details {
 			> {
 				* {
-					visibility: visible;
+					display: block;
 				}
 			}
 		}

--- a/src/js/sass/includes/_details.scss
+++ b/src/js/sass/includes/_details.scss
@@ -67,21 +67,18 @@ details {
 	}
 }
 
-.detailssummary {
-	details {
-		> {
-			* { /* Show the details content for browsers that natively support it. */
-				@extend %pe-details-display-block;
-			}
-		}
-	}
-}
-
 .no-js {
 	details {
 		> {
 			* {
 				@extend %pe-details-display-block;
+			}
+		}
+		&:not([open]) {
+			> {
+				* {
+					@extend %pe-details-display-block;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Stops the details element from overriding the browser default
  display property of its children.
- Fixes #2753 IE8 summary arrows and details load speed.
