### PR TITLE
Polyfil checks if label or value are undefined as opposed to 'undefined'

### DIFF
--- a/src/js/polyfills/datalist.js
+++ b/src/js/polyfills/datalist.js
@@ -83,7 +83,7 @@
 				if (value === 'undefined') {
 					value = $this.text();
 				}	
-				datalist_items.push('<li class="al-option" id="al-option-' + index + '-' + index2 + '"><a href="javascript:;"><span class="al-value">' + (value !== 'undefined' ? value : "") + '</span><span class="al-label">' + (label !== 'undefined' ? label : "") + '</span></a></li>');
+				datalist_items.push('<li class="al-option" id="al-option-' + index + '-' + index2 + '"><a href="javascript:;"><span class="al-value">' + (value !== undefined ? value : "") + '</span><span class="al-label">' + (label !== undefined ? label : "") + '</span></a></li>');
 			});
 
 			elm.attr({'autocomplete': 'off', 'role': 'textbox', 'aria-haspopup': 'true', 'aria-autocomplete': 'list', 'aria-owns': 'wb-autolist-' + index, 'aria-activedescendent': ''}).wrap('<div class="wb-al-container" role="application" aria-' + (label.length !== 0 ? 'labelledby="' + uniqueid : '-label="' + elm.attr('title')) + '"/>');


### PR DESCRIPTION
This fixes the issue with IE8 displaying undefined if no label is there, when it should display nothing.
