### PR TITLE
Added clustering support for overlays.

### DIFF
--- a/demos/geomap/data/config-en.js
+++ b/demos/geomap/data/config-en.js
@@ -121,6 +121,7 @@ var wet_boew_geomap = {
 				latitude: 'Longitude',				
 				updated_at: 'Last updated'
 			},
+			clustering: true,
 			visible: true,	
 			zoom:  [true, {type: 'text'}],
 			datatable: true,

--- a/demos/geomap/data/config-fr.js
+++ b/demos/geomap/data/config-fr.js
@@ -122,6 +122,7 @@ var wet_boew_geomap = {
 				latitude: 'Longitude',				
 				updated_at: 'Dernière mise à jour'
 			},
+			clustering: true,
 			visible: true,	
 			zoom:  [true, {type: 'text'}],
 			datatable: true,

--- a/demos/geomap/geomap-eng.html
+++ b/demos/geomap/geomap-eng.html
@@ -4,6 +4,9 @@
 <!--[if gt IE 8]><!-->
 <html lang="en" class="no-js">
 <!--<![endif]-->
+
+
+
 <head>
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
@@ -33,9 +36,11 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 <!-- CustomCSSStart -->
 
 <!-- CustomCSSEnd -->
+
 </head>
 
 <body><div id="wb-body">
+        
 <div id="wb-skip">
 <ul id="wb-tphp">
 <li id="wb-skip1"><a href="#wb-cont">Skip to main content</a></li>
@@ -161,7 +166,7 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 			"popups": true
 		}]    
 	}'>
-
+    
 	<!-- Insert Map Start (mandatory) -->
 	<div class="wet-boew-geomap-map span-6"></div>
 	<!-- Insert Map End -->

--- a/src/js/workers/geomap.js
+++ b/src/js/workers/geomap.js
@@ -1111,9 +1111,10 @@
 					var $table = _pe.fn.geomap.createTable(index, layer.title, layer.caption, layer.datatable);
 
 					if (layer.type === 'kml') {	
+						var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
-								strategies: [new OpenLayers.Strategy.Fixed()],
+								strategies: strategies,
 								protocol: new OpenLayers.Protocol.HTTP({
 									url: layer.url,
 									format: new OpenLayers.Format.KML({
@@ -1191,10 +1192,11 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;
 					} else if (layer.type === 'atom') {
+						var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
-								strategies: [new OpenLayers.Strategy.Fixed()],
+								strategies: strategies,
 								protocol: new OpenLayers.Protocol.HTTP({
 									url: layer.url,
 									format: new OpenLayers.Format.Atom({
@@ -1254,10 +1256,11 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;					
 					} else if (layer.type === 'georss') {
+						var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
-								strategies: [new OpenLayers.Strategy.Fixed()],
+								strategies: strategies,
 								protocol: new OpenLayers.Protocol.HTTP({
 									url: layer.url,
 									format: new OpenLayers.Format.GeoRSS({									
@@ -1321,10 +1324,11 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;
 					} else if (layer.type === 'json') {
+						var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
-								strategies: [new OpenLayers.Strategy.Fixed()],
+								strategies: strategies,
 								protocol: new OpenLayers.Protocol.Script({
 									url: layer.url,
 									params: layer.params,
@@ -1387,11 +1391,12 @@
 						geomap.map.addLayer(olLayer);											
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;			
-					} else if (layer.type ==='geojson') {						
+					} else if (layer.type ==='geojson') {
+						var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
-								strategies: [new OpenLayers.Strategy.Fixed()],
+								strategies: strategies,
 								protocol: new OpenLayers.Protocol.Script({
 									url: layer.url,
 									params: layer.params,
@@ -1444,7 +1449,7 @@
 								},
 								styleMap: _pe.fn.geomap.getStyleMap(overlayData[index])
 							}
-						);
+						);						
 						olLayer.name = 'overlay_' + index;
 						olLayer.datatable = layer.datatable;
 						olLayer.popupsInfo = layer.popupsInfo;
@@ -1560,6 +1565,7 @@
 				tableLayer.popupsInfo = table.popupsInfo;
 				tableLayer.popups = table.popups;
 				tableLayer.name = table.id;
+				
 				geomap.map.addLayer(tableLayer);
 				geomap.queryLayers.push(tableLayer);
 

--- a/src/js/workers/geomap.js
+++ b/src/js/workers/geomap.js
@@ -1108,10 +1108,9 @@
 			if (overlayData.length !== 0) {
 				geomap.overlays = overlayData.length;
 				$.each(overlayData, function(index, layer) {	
-					var $table = _pe.fn.geomap.createTable(index, layer.title, layer.caption, layer.datatable);
-
+					var strategies, $table = _pe.fn.geomap.createTable(index, layer.title, layer.caption, layer.datatable);
 					if (layer.type === 'kml') {	
-						var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
+						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								strategies: strategies,
@@ -1192,7 +1191,7 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;
 					} else if (layer.type === 'atom') {
-						var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
+						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
@@ -1256,7 +1255,7 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;					
 					} else if (layer.type === 'georss') {
-						var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
+						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
@@ -1324,7 +1323,7 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;
 					} else if (layer.type === 'json') {
-						var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
+						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
@@ -1392,7 +1391,7 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;			
 					} else if (layer.type ==='geojson') {
-						var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
+						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
@@ -1449,7 +1448,7 @@
 								},
 								styleMap: _pe.fn.geomap.getStyleMap(overlayData[index])
 							}
-						);						
+						);
 						olLayer.name = 'overlay_' + index;
 						olLayer.datatable = layer.datatable;
 						olLayer.popupsInfo = layer.popupsInfo;
@@ -1477,6 +1476,7 @@
 			var thZoom = '<th>' + _pe.dic.get('%geo-zoomfeature') + '</th>',
 				thSelect = ('<th>' + _pe.dic.get('%geo-select') + '</th>'),
 				wktFeature,
+				tableFeatures = [],
 				wktParser = new OpenLayers.Format.WKT({						
 					'internalProjection': projMap,
 					'externalProjection': projLatLon
@@ -1488,15 +1488,17 @@
 					table = opts.tables[lenTable],
 					attr = [],
 					thead_tfoot_tr,
+					strategies = table.clustering ? [new OpenLayers.Strategy.Cluster()] : null,
 					tableLayer = new OpenLayers.Layer.Vector($table.find('caption').text(), {
-						styleMap: _pe.fn.geomap.getStyleMap(table)
+						styleMap: _pe.fn.geomap.getStyleMap(table),
+						strategies: strategies			
 					}),
 					thElms = $table[0].getElementsByTagName('th'),
 					thlen = thElms.length,
 					trElms = $table[0].getElementsByTagName('tr'),
 					trlen = trElms.length,
 					useMapControls = opts.useMapControls;
-
+					
 				// get the attributes from table header
 				while (thlen--) {
 					attr[thlen] = thElms[thlen].innerHTML.replace(/<\/?[^>]+>/gi, '');
@@ -1554,11 +1556,17 @@
 						// set the table row id
 						trElmsInd.setAttribute('id', vectorFeatures.id.replace(/\W/g, '_'));
 
-						// add the attributes to the feature then add it to the map
-						vectorFeatures.attributes = attrMap;										
-						tableLayer.addFeatures([vectorFeatures]);
+						// add the attributes to the feature
+						vectorFeatures.attributes = attrMap;
+						tableFeatures.push(vectorFeatures);
 					}
 				}
+				
+				// add layer to the map
+				geomap.map.addLayer(tableLayer);
+				
+				// add features to the layer
+				tableLayer.addFeatures(tableFeatures);
 
 				tableLayer.id = '#' + table.id;
 				tableLayer.datatable = table.datatable;
@@ -1566,7 +1574,7 @@
 				tableLayer.popups = table.popups;
 				tableLayer.name = table.id;
 				
-				geomap.map.addLayer(tableLayer);
+				
 				geomap.queryLayers.push(tableLayer);
 
 				if (table.tab) {

--- a/src/js/workers/geomap.js
+++ b/src/js/workers/geomap.js
@@ -1108,9 +1108,9 @@
 			if (overlayData.length !== 0) {
 				geomap.overlays = overlayData.length;
 				$.each(overlayData, function(index, layer) {	
-					var strategies, $table = _pe.fn.geomap.createTable(index, layer.title, layer.caption, layer.datatable);
+					var strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()], 
+						$table = _pe.fn.geomap.createTable(index, layer.title, layer.caption, layer.datatable);
 					if (layer.type === 'kml') {	
-						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()];
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								strategies: strategies,
@@ -1191,7 +1191,6 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;
 					} else if (layer.type === 'atom') {
-						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()];
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
@@ -1255,7 +1254,6 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;					
 					} else if (layer.type === 'georss') {
-						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()];
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
@@ -1323,7 +1321,6 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;
 					} else if (layer.type === 'json') {
-						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()];
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
@@ -1391,7 +1388,6 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;			
 					} else if (layer.type ==='geojson') {
-						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()];
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,

--- a/src/js/workers/geomap.js
+++ b/src/js/workers/geomap.js
@@ -1110,7 +1110,7 @@
 				$.each(overlayData, function(index, layer) {	
 					var strategies, $table = _pe.fn.geomap.createTable(index, layer.title, layer.caption, layer.datatable);
 					if (layer.type === 'kml') {	
-						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
+						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()];
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								strategies: strategies,
@@ -1191,7 +1191,7 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;
 					} else if (layer.type === 'atom') {
-						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
+						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()];
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
@@ -1255,7 +1255,7 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;					
 					} else if (layer.type === 'georss') {
-						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
+						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()];
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
@@ -1323,7 +1323,7 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;
 					} else if (layer.type === 'json') {
-						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
+						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()];
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,
@@ -1391,7 +1391,7 @@
 						_pe.fn.geomap.addLayerData(geomap, $table, layer.visible, olLayer.id, layer.tab);
 						olLayer.visibility = layer.visible;			
 					} else if (layer.type ==='geojson') {
-						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()]
+						strategies = layer.clustering ? [new OpenLayers.Strategy.Cluster(), new OpenLayers.Strategy.Fixed()] : [new OpenLayers.Strategy.Fixed()];
 						olLayer = new OpenLayers.Layer.Vector(
 							layer.title, {
 								projection: geomap.map.displayProjection,


### PR DESCRIPTION
Note that features loaded from an inline data source (e.g. HTML table) with rule-based or unique styles 
don't yet support clustering. All overlays are still assigned the Fixed strategy.
