### PR TITLE
Grids icon SCSS: Set background to none for external links in page headers/footers

### DIFF
--- a/src/grids/sass/includes/_icon.scss
+++ b/src/grids/sass/includes/_icon.scss
@@ -46,7 +46,7 @@ $wb-icon-inline: not $legacy-support-for-ie8;
 
 	//gh-2104 fixes overriding background because of increased specificity when wb-main was used
 	#wb-head &, #wb-foot & {
-		background: inherit;
+		background: none;
 	}
 
 	#wb-main &, #colorbox & {


### PR DESCRIPTION
Prevents external icons from appearing in IE7's page headers/footers.
