### PR TITLE
Slide out tab SCSS: Restored "raw" content when printing.

### DIFF
--- a/src/js/sass/includes/_slideout-ie.scss
+++ b/src/js/sass/includes/_slideout-ie.scss
@@ -2,6 +2,10 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
-.so-ie7 {
-   position: relative;
+
+/*Screen SCSS*/
+@media screen {
+	.so-ie7 {
+	   position: relative;
+	}
 }

--- a/src/js/sass/includes/_slideout.scss
+++ b/src/js/sass/includes/_slideout.scss
@@ -2,78 +2,82 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
-.wet-boew-slideout {
-	display: none;
-}
-
-.no-js {
+ 
+/*Screen SCSS*/
+@media screen {
 	.wet-boew-slideout {
-		display: block;
+		display: none;
 	}
-}
 
-#slideoutInnerWrapper {
-	overflow: hidden;
-	position: relative;
-	width: 295px;
-}
-
-.slideoutWrapper { /* Follows on scrolling */
-	overflow: hidden;
-	position: fixed;
-    z-index: 1;
-}
-
-.slideoutWrapperRel { /* Does not follow on scrolling */
-    float: right;
-    right: 0;
-    position: absolute;
-    top: 0;
-    z-index: 1;
-}
-
-.slideoutToggle {
-	float: left;
-	position: relative; /* Needed for animation */
-}
-
-#toggleLink {
-	cursor: pointer;
-	img {
-		margin: 0;
+	.no-js {
+		.wet-boew-slideout {
+			display: block;
+		}
 	}
-}
 
-.tabbedSlideout {
-	background-color: #FFF;
-	border: 1px solid #CCC;
-	border-right: none;
-	float: left;
-	padding: 8px;
-	position: relative;
-	margin: auto;
-	width: 245px;
-	#slideoutClose {
+	#slideoutInnerWrapper {
+		overflow: hidden;
+		position: relative;
+		width: 295px;
+	}
+
+	.slideoutWrapper { /* Follows on scrolling */
+		overflow: hidden;
+		position: fixed;
+		z-index: 1;
+	}
+
+	.slideoutWrapperRel { /* Does not follow on scrolling */
 		float: right;
+		right: 0;
+		position: absolute;
+		top: 0;
+		z-index: 1;
 	}
-}
 
-div {
-	&.tabbedSlideout {
-		h2 {
+	.slideoutToggle {
+		float: left;
+		position: relative; /* Needed for animation */
+	}
+
+	#toggleLink {
+		cursor: pointer;
+		img {
 			margin: 0;
-			padding: 0 5px 5px 5px;
-			text-align: left;
 		}
-		ul, ol {
-			margin: 0;
-			list-style-type: none;
-			padding: 0 5px;
+	}
+
+	.tabbedSlideout {
+		background-color: #FFF;
+		border: 1px solid #CCC;
+		border-right: none;
+		float: left;
+		padding: 8px;
+		position: relative;
+		margin: auto;
+		width: 245px;
+		#slideoutClose {
+			float: right;
 		}
-		li {
-			margin: 6px 0;
+	}
+
+	div {
+		&.tabbedSlideout {
+			h2 {
+				margin: 0;
+				padding: 0 5px 5px 5px;
+				text-align: left;
+			}
 			ul, ol {
-				margin-left: 20px;
+				margin: 0;
+				list-style-type: none;
+				padding: 0 5px;
+			}
+			li {
+				margin: 6px 0;
+				ul, ol {
+					margin-left: 20px;
+				}
 			}
 		}
 	}
@@ -81,7 +85,24 @@ div {
 
 /*Print SCSS*/
 @media print {
-	#slideoutWrapper {
-		display: none;
-	}
+  %slideout-width-100-important {
+	width: 100% !important;
+  }
+  
+  #slideoutWrapper {
+	@extend %slideout-width-100-important;
+  }
+  
+  #slideoutInnerWrapper {
+	@extend %slideout-width-100-important;
+	padding: 0 !important;
+  }
+  
+  .wet-boew-slideout {
+    display: block !important;
+  }
+  
+  #slideoutToggle, #slideoutClose {
+	display: none;
+  }
 }


### PR DESCRIPTION
Partially addresses gh-2733.

**PS:** On a side note, the diff makes this pull's changes look much more significant than they really are. I added screen media types around what's already present (along with tabbing for indentation) and revised the print media type's classes/properties. That's it. None of what's now situated within the screen media type was modified whatsoever.
