### PR TITLE
Modernizr build correction and reference in plugin layout

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -147,6 +147,8 @@ module.exports = function(grunt) {
 				"load" : true,
 				"mq" : true,
 				"css3": true,
+				"input": true,
+				"inputtypes": true,
 				"html5": true,
 				"cssclasses" : true,
 				"fontface": true,

--- a/src/templates/layouts/plugins.hbs
+++ b/src/templates/layouts/plugins.hbs
@@ -17,13 +17,13 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 
 <!-- Polyfill loader-->
 <!--[if lt IE 9]>
-<script src="js/oldie/respond.min.js"></script>
-<script src="js/oldie/jquery.min.js"></script>
-<script src="js/oldie/selectivizr.min.js"></script><![endif]-->
+<script src="../js/oldie/respond.min.js"></script>
+<script src="../js/oldie/jquery.min.js"></script>
+<script src="../js/oldie/selectivizr.min.js"></script><![endif]-->
 <!--[if gte IE 9 | !IE ]><!-->
-<script src="js/jquery.min.js"></script>
+<script src="../js/jquery.min.js"></script>
 <!--<![endif]-->
-<script src="js/vapour.min.js"></script>
+<script src="../js/vapour.js"></script>
 
 </head>
 <body>
@@ -201,6 +201,6 @@ wet-boew.github.io/wet-boew/License-eng.html / wet-boew.github.io/wet-boew/Licen
 	</section>
 </footer>
 
-<script src="js/wet-boew.min.js"></script>
+<script src="../js/wet-boew.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Added input and inputtypes to modernizer build to fix errors generated from vapour on polyfill tests
- Corrected plugin layout references since they are generated in a demo folder
