### PR TITLE
Build: Native Bower setup

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "lib"
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,7 +113,7 @@ module.exports = function(grunt) {
 					preserveComments : 'some'
 				},
 				files: {
-					'dist/js/deps/jquery.pjax.min.js': 'lib/pjax/jquery.pjax.js'
+					'dist/js/deps/jquery.pjax.min.js': 'lib/jquery-pjax/jquery.pjax.js'
 				}
 			}
 
@@ -195,11 +195,11 @@ module.exports = function(grunt) {
 				}]
 			},
 			oldie: {
-				cwd: 'lib/oldie',
+				cwd: 'lib',
 				src: [
-					'jquery/jquery.min.js',
-					'jquery/jquery.min.map',
-					'selectivizr.js', //TODO: Minify
+					'jquery-ie/jquery.min.js',
+					'jquery-ie/jquery.min.map',
+					'selectivizr/selectivizr.js', //TODO: Minify
 					'respond/respond.min.js'
 					],
 				dest: 'dist/js/oldie',
@@ -272,28 +272,6 @@ module.exports = function(grunt) {
 				}
 			}
 		},
-		bowerful: {
-			dist: {
-				packages: {
-					bootstrap: '3.0.0',
-					jquery: '2.0.3',
-					"jquery.validation": '1.11.1',
-					flot: '0.8.1',
-					DataTables: '1.9.4',
-					'magnific-popup': '0.9.5',
-					'jquery-pjax': '1.7.3'
-				},
-				store: 'lib',
-			},
-			oldie: {
-				packages: {
-					jquery: '1.10.2',
-					respond: '1.2.0',
-					selectivizr: '1.0.2'
-				},
-				store: 'lib/oldie',
-			}
-		},
 		i18n: {
 			options: {
 				template: 'src/i18n/base.js',
@@ -312,7 +290,6 @@ module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-coffee');
 	grunt.loadNpmTasks('grunt-contrib-clean');
 	grunt.loadNpmTasks('grunt-contrib-connect');
-	grunt.loadNpmTasks('grunt-bowerful');
 	grunt.loadNpmTasks('grunt-sass');
 	grunt.loadNpmTasks("grunt-modernizr");
 	grunt.loadNpmTasks("assemble");
@@ -324,5 +301,5 @@ module.exports = function(grunt) {
 	grunt.registerTask('html', ['assemble']);
 	grunt.registerTask('default', ['clean', 'build', 'test']);
 	grunt.registerTask('server', ['connect','watch:source']);
-	grunt.registerTask('init', ['bowerful', 'modernizr']);
+	grunt.registerTask('init', ['modernizr']);
 };

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,36 @@
+{
+  "name": "wet-boew",
+  "version": "v4.0-a1-development",
+  "homepage": "https://github.com/wet-boew/wet-boew",
+  "authors": [
+    "WET-BOEW Team"
+  ],
+  "description": "Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)",
+  "keywords": [
+    "i18n",
+    "a11y",
+    "wet-boew",
+    "bootstrap"
+  ],
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "jquery.validation": "1.11.1",
+    "bootstrap": "3.0.0",
+    "jquery": "2.0.3",
+    "flot": "0.8.1",
+    "DataTables": "1.9.4",
+    "magnific-popup": "0.9.5",
+    "jquery-pjax": "1.7.3",
+    "jquery-ie": "jquery#1.10.2",
+    "respond": "1.2.0",
+    "selectivizr": "1.0.2"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -32,5 +32,8 @@
     "jquery-ie": "jquery#1.10.2",
     "respond": "1.2.0",
     "selectivizr": "1.0.2"
+  },
+  "resolutions": {
+    "jquery": ">= 1.9.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.html",
   "scripts": {
     "test": "grunt -v",
-    "postinstall": "grunt init"
+    "postinstall": "npm install -g grunt-cli bower && bower install && grunt init"
   },
   "repository": {
     "type": "git",
@@ -38,7 +38,6 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-connect": "~0.3.0",
     "grunt-sass": "~0.6.1",
-    "grunt-bowerful": "~0.3.0",
     "csv": "~0.3.6",
     "grunt-modernizr": "~0.3.0",
     "assemble": "~0.4.4"


### PR DESCRIPTION
Removes grunt-bowerful and replaces it with a native [Bower](http://bower.io) setup.
This adds bower as a global dependency (`npm install bower -g`), but we already have the same situation with `grunt-cli`. All the global dependencies are now installed as part of the postinstall hook, so this should be transparent to the use :smile: 

The other benefit of setting up (and publishing) a bower package is that the themes can then consume this package.

---

Ping @jeresiv, @patheard,  @LaurentGoderre, @masterbee: could you test this tomorrow on your work machines to see if this resolves some of the issues from #2914
