### PR TITLE
Tabbed interface: fix enter key blocking on tabs

### DIFF
--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -185,7 +185,6 @@
 					isKeyPrev = e.keyCode === 37 || e.keyCode === 38;	// left, up
 					isKeyNext = e.keyCode === 39 || e.keyCode === 40;	// right, down
 					if (isKeySelect || isKeyPrev || isKeyNext) {
-						e.preventDefault();
 						if (opts.cycle) {
 							stopCycle();
 						}
@@ -266,7 +265,7 @@
 					$current = $tabs.filter('.' + opts.tabActiveClass);
 					$pbar = $current.siblings('.tabs-roller');
 					$nav.addClass('started');
-					elm.find('.tabs-toggle').data('state', 'started').attr('aria-live', 'polite');
+					elm.find('.tabs-toggle').data('state', 'started');
 					return $pbar.show().animate({
 						width : $current.parent().width()
 					}, opts.cycle - 200, 'linear', function () {
@@ -343,15 +342,17 @@
 				}
 
 				_pe.document.on('keydown', function (e) {
-					var $tabsToggle;
 					if (e.keyCode === 27) { // Escape
-						$tabsToggle = elm.find('.tabs-toggle');
-						if ($tabsToggle.data('state') === 'started') {
-							$tabsToggle.attr('aria-live', 'off');
-							stopCycle();
+						if ($toggleRow.data('state') === 'started') {
 							_pe.focus(elm.find('.tabs .' + opts.tabActiveClass));
+							stopCycle();
 						}
 					}
+				});
+
+				// Only have the play/pause button speak its changes when focused
+				$toggleButton.on('focus blur', function (e) {
+					$toggleButton.attr('aria-live', e.type === 'focus' ? 'polite' : 'off');
 				});
 			}
 


### PR DESCRIPTION
1. `e.preventDefault()` has been removed from the tab's keydown event
   handler.  This allows enter key presses to pass through to screen
   readers that don't implement their own enter key behaviour.
2. The play button only has `aria-live="polite"` set when it has
   focus.  This prevents extra speaking of its changed text.

Discussion is in #1018.
