### PR TITLE
Build: Install latest node-sass under grunt-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.html",
   "scripts": {
     "test": "grunt -v",
-    "postinstall": "npm install -g grunt-cli bower && bower install && grunt init"
+    "postinstall": "npm install -g grunt-cli bower && bower install && grunt init && cd node_modules/grunt-sass && npm install https://github.com/andrew/node-sass/tarball/master"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Temporary workaround till the updated node-sass npm package is released with the fixed Windows binaries
