### PR TITLE
Expand/collapse all: initial v4.0 commit of plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -172,7 +172,9 @@ module.exports = function(grunt) {
 				"domprefixes" : true
 			},
 			// Define any tests you want to impliticly include.
-			"tests" : [],
+			"tests" : [
+				"elem_details"
+			],
 			// By default, this task will crawl your project for references to Modernizr tests.
 			// Set to false to disable.
 			"parseFiles" : false,

--- a/src/core/vapour.coffee
+++ b/src/core/vapour.coffee
@@ -56,6 +56,9 @@
         test: Modernizr.canvas,
         nope: "site!polyfills/excanvas.min.js"
     ,
+        test: Modernizr.details,
+        nope: "site!polyfills/detailssummary.min.js"
+    ,
         test: Modernizr.input.list,
         nope : "site!polyfills/datalist.min.js"
     ,

--- a/src/plugins/expand-collapse-all/expand-collapse-all-en.hbs
+++ b/src/plugins/expand-collapse-all/expand-collapse-all-en.hbs
@@ -1,0 +1,26 @@
+---
+title: Expand/Collapse All
+---
+<section>
+	<h2>Expand/Collapse All Example</h2>
+	<details>
+		<summary>Testing</summary>
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, quisquam, optio corporis incidunt ipsa quaerat repellendus consequatur natus accusamus sapiente! Nobis fugit atque dolor mollitia doloremque! Veritatis ea consectetur ut.</p>
+		<p>Omnis, ex facilis vel quas ab! Perspiciatis, asperiores, quod repudiandae ad aperiam rem impedit eos quibusdam hic in omnis deleniti autem quos quaerat accusantium esse minus tempora dolore? Ab, quas?</p>
+	</details>
+	<div id="foo">
+		<details>
+			<summary>More testing</summary>
+			<p>Harum, nulla, consequuntur, sed, earum voluptate omnis laudantium necessitatibus sint totam id beatae corrupti nisi animi provident illo praesentium reprehenderit in quis quod itaque repellendus dolor vel. Vitae, reiciendis, voluptatibus!</p>
+			<p>Inventore, aut, ea quisquam quis dignissimos sed illo nihil assumenda eaque perferendis optio magnam repellat pariatur maxime accusamus deserunt possimus modi neque sunt debitis nesciunt at esse odit commodi dolorum.</p>
+			<p>Provident, ipsa laudantium necessitatibus hic quibusdam omnis vero quidem quasi molestias deleniti voluptatem est maiores. Ipsa, pariatur, corporis saepe deleniti quisquam accusantium tempora sapiente error quis expedita nam eos ducimus!</p>
+			<p>Rerum fugiat omnis id mollitia commodi tempore quibusdam modi. Minima ipsa magnam minus obcaecati accusamus! Vitae, quam ratione deleniti voluptates consequuntur ipsum earum quibusdam possimus voluptatibus dignissimos nihil officia adipisci.</p>
+			<p>Laboriosam, velit, id, tempora omnis atque voluptatem quo tempore est ipsam illo consequatur distinctio sed illum? Architecto, reprehenderit, alias incidunt quod in numquam rerum! Corporis ducimus dicta quod ab at.</p>
+			<p>Explicabo, magni, dicta assumenda dignissimos sunt consequatur aut pariatur saepe cupiditate nulla nemo nam? Qui, fugiat, reiciendis, hic sint optio minus eos cum ut et blanditiis quaerat consectetur ipsa mollitia.</p>
+			<p>Quisquam, numquam, veniam, minus vero doloremque delectus corporis ducimus a quo aliquid fugit quos magni omnis voluptatibus in accusantium ipsa odit quia ut eum quae velit consequuntur iure adipisci hic.</p>
+			<p>Nostrum, ab aspernatur impedit odio explicabo? Doloremque, quos, corporis ut quibusdam aperiam inventore fugiat sunt minima iure dolorum facere molestiae similique quas itaque repellendus! Facere, nam quas blanditiis aperiam rem?</p>
+		</details>
+	</div>
+	<a href="#" class="wb-expand-collapse-all" data-print-open="true">Toggle</a>
+	<a href="#" class="wb-expand-collapse-all" data-print-open="true" data-parent="#foo">Toggle</a>
+</section>

--- a/src/plugins/expand-collapse-all/expand-collapse-all.js
+++ b/src/plugins/expand-collapse-all/expand-collapse-all.js
@@ -1,0 +1,176 @@
+/*
+Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+plugin : Expand/collapse all details
+author : @patheard
+notes: Plugin that supports controls that can expand or collapse all details elements on a page.
+licence: wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+*/
+(function($, window, document) {
+	'use strict';
+	var plugin = {
+		css: '.wb-expand-collapse-all',
+		links: null,
+		isOpen: {global: false},
+		isPolyfill: false,
+
+		/**
+		 * Initialize the plugin
+		 */
+		init: function () {
+			window._timer.remove(plugin.css);
+
+			plugin.links = $(plugin.css);
+			plugin.isPolyfill = !window.Modernizr.details;
+			plugin.initAriaControls();
+			if (plugin.links.data('print-open') === true) {
+				plugin.initPrint();
+			}
+		},
+
+		/**
+		 * Sets the aria-controls attribute of the toggle control elements
+		 */
+		initAriaControls: function () {
+			var $details,
+				$detail,
+				$link,
+				ariaControls,
+				cache = {},
+				parent;
+
+			// Loop through all toggle controls and figure out which details element they control
+			for (var i = 0, clen = plugin.links.length; i < clen; i++) {
+				$link = plugin.links.eq(i);
+				parent = $link.data('parent') !== undefined ? $link.data('parent') : 'global';
+
+				// If not cached, get the space separated list of details IDs the current element controls
+				if (!cache.hasOwnProperty(parent)) {
+					ariaControls = '';
+					$details = parent !== 'global' ? $(parent).find('details') : $('details');
+					for (var j = 0, dlen = $details.length; j < dlen; j++) {
+						$detail = $details.eq(j);
+						if ($detail.attr('id') === undefined) {
+							$detail.attr('id', 'details_' + j);
+						}
+						ariaControls += $detail.attr('id') + ' ';
+					}
+					cache[parent] = ariaControls.slice(0, -1);
+				}
+				$link.attr('aria-controls', cache[parent]);
+			}
+		},
+
+		/**
+		 * Setup the before print behaviour that opens all details on the page when printing
+		 */
+		initPrint: function () {
+			var $details = $('details'),
+				$window = $(window),
+				mediaQuery;
+
+			// Native event support: open all details on the page before printing
+			$window.on('beforeprint', function() {
+				plugin.setDetailsOpen($details, true);
+				plugin.setOpen(null, true);
+			});
+
+			// Fallback for browsers that don't support print event
+			if (typeof window.matchMedia !== 'undefined') {
+				mediaQuery = window.matchMedia('print');
+				if (typeof mediaQuery.addListener !== 'undefined') {
+					mediaQuery.addListener(function(query) {
+						if (query.matches) {
+							$window.trigger('beforeprint');
+						}
+					});
+				}
+			}
+
+			// Polyfill open using CSS
+			$details.addClass('print-open');
+		},
+
+		/**
+		 * Handle click events on a toggle control element
+		 * @param {jQuery event} event
+		 */
+		click: function (link, event) {
+			var $link = $(link),
+				type = $link.data('type'),
+				parent = $link.data('parent'),
+				open = !plugin.getOpen(parent, type);
+
+			plugin.setDetailsOpen((typeof parent === 'string' ? $(parent).find('details') : $('details')), open);
+			plugin.setOpen(parent, open);
+
+			event.preventDefault();
+			event.target.focus();
+		},
+
+		/**
+		 * Sets the open property of passed in details element(s)
+		 * @param {jQuery DOM object} $details The details elements to set the open property of
+		 * @param {boolean} open Value to set the details open property
+		 */
+		setDetailsOpen: function ($details, open) {
+			if (plugin.isPolyfill) {
+				$details.prop('open', !open);
+				$details.find('summary').click();
+			} else {
+				$details.prop('open', open);
+			}
+		},
+
+		/**
+		 * Gets the open state of the page's details elements.
+		 * @param {string} parent Property key for the plugin's isOpen object.
+		 * @param {string} type The type of toggle control that was clicked.
+		 */
+		getOpen: function (parent, type) {
+			var open;
+			if (type === 'open') {
+				open = false;
+			} else if (type === 'close') {
+				open = true;
+			} else {
+				open = typeof parent === 'string' && plugin.isOpen.hasOwnProperty(parent) ? plugin.isOpen[parent] : plugin.isOpen.global;
+			}
+			return open;
+		},
+
+		/**
+		 * Sets the open state of the page's details elements.
+		 * @param {string} parent Property key for the plugin's isOpen object.
+		 * @param {boolean} open State to set the isOpen property key to
+		 */
+		setOpen: function (parent, open) {
+
+			// If there's a parent, set its open property (this creates the property if it doesn't already exist)
+			if (typeof parent === 'string') {
+				plugin.isOpen[parent] = open;
+
+			// No parent spec'd means set all open properties.  This is because global toggle controls change the
+			// state of toggle controls that are restricted by parent (but not vice versa).
+			} else {
+				for (var p in plugin.isOpen) {
+					if (plugin.isOpen.hasOwnProperty(p)) {
+						plugin.isOpen[p] = open;
+					}
+				}
+			}
+		},
+	};
+
+	// Bind the event handlers to initialize the plugin and handle clicks
+	$(document).on('wb.timerpoke click', plugin.css, function (event) {
+		if (event.type === 'click') {
+			plugin.click(this, event);
+		} else {
+			plugin.init();
+		}
+	});
+
+	// Add the timer poke to initialize the plugin
+	window._timer.add(plugin.css);
+
+}(jQuery, window, document));

--- a/src/plugins/expand-collapse-all/expand-collapse-all.scss
+++ b/src/plugins/expand-collapse-all/expand-collapse-all.scss
@@ -1,0 +1,11 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+
+/* Print open of details polyfill */
+@media print {
+  details.print-open > * {
+    display: block !important;
+  }
+}


### PR DESCRIPTION
1. **Core:** Tests and loads the details summary polyfill.  More work is needed to get this polyfill working which I'll take care of this week.
2. **Expand/collapse all:** Initial commit of the expand/collapse plugin:
   1. User can now specify their own expand/collapse all link element.
   2. Type of link element is set with [data-type] attribute.
   3. Link elements can be restricted to only expanding/collapsing
      details within a given parent using [data-parent] attribute.

@masterbee can you take a look at this and let me know if it's in line with what you were thinking for v4.0 plugins.
