### PR TITLE
Slide out tab SCSS: Moved placeholder selector declaration into @media screen type.

### DIFF
--- a/src/js/sass/includes/_slideout.scss
+++ b/src/js/sass/includes/_slideout.scss
@@ -4,13 +4,13 @@
  */
 @import "compass/css3/transform";
 
-%so-float-right-border-left-0 {
-	border-left: 0;
-	float: right;
-}
-
 /*Screen SCSS*/
 @media screen {
+	%so-float-right-border-left-0 {
+		border-left: 0;
+		float: right;
+	}
+
 	.large-screen {
 		.wet-boew-slideout {
 			display: none;


### PR DESCRIPTION
Resolves SASS deprecation warnings when building.
