### PR TITLE
Build: Move global install to separate scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
     - POST_BUILD=true
 
 before_install:
-  - npm install -g grunt-cli
+  - ./run-first
 
 script:
   - npm test

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.html",
   "scripts": {
     "test": "grunt -v",
-    "postinstall": "npm install -g grunt-cli bower && bower install && grunt init"
+    "postinstall": "bower install && grunt init"
   },
   "repository": {
     "type": "git",

--- a/run-first
+++ b/run-first
@@ -1,0 +1,2 @@
+#!/bin/sh
+npm install -g bower grunt-cli

--- a/run-first.cmd
+++ b/run-first.cmd
@@ -1,0 +1,1 @@
+npm install -g bower grunt-cli


### PR DESCRIPTION
Bower and the Grunt CLI are one time only global installs. They cause alot of noise for other packages that consume the repo.
Alternate "run-first" scripts have been added for convenience
