### PR TITLE
Gitignore file: Added lib folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ csslint.out.xml
 *.tmp
 *.log
 node_modules/
+lib/


### PR DESCRIPTION
I believe this folder gets created when running `npm install` or `grunt` to build WET 4.0. So there'd be value in ignoring it in the same manner as the node-modules folder.
