### PR TITLE
Added vapour.js and web-boew.js exclusion from jsUncompress..

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -174,7 +174,7 @@ module.exports = (grunt) ->
 		clean:
 			dist: "dist"
 
-			jsUncompressed: ["dist/js/**/*.js", "!dist/js/**/*.min.js"]
+			jsUncompressed: ["dist/js/**/*.js", "!dist/js/**/*.min.js", "!**/*/vapour.js", "!**/*/wet-boew.js"]
 
 		watch:
 			lib_test:


### PR DESCRIPTION
A request from Drupal developers to have unminifed source of core files in /dist packaging for easier theme build debugging.
