### PR TITLE
[Datepicker] Fix issue with IDs containing periods

### DIFF
--- a/src/js/polyfills/datepicker.js
+++ b/src/js/polyfills/datepicker.js
@@ -365,7 +365,7 @@
 
 				pe.document.on('click vclick touchstart focusin', function () {
 					if (container.attr('aria-hidden') === 'false') {
-						hide(container.parent().find('#' + container.attr('aria-controls')));
+						hide(container.parent().find('#' + pe.string.jqescape(container.attr('aria-controls'))));
 						return false;
 					}
 				});


### PR DESCRIPTION
#2849 Datepicker wasn't closing when clicking outside the calendar area due to missing jqescape.
