### PR TITLE
Build: Validate built HTML files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ csslint.out.xml
 *.log
 node_modules/
 lib/
+
+# Html validation reports
+validation-report.json
+validation-status.json

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -226,6 +226,11 @@ module.exports = (grunt) ->
 				csv: "src/i18n/i18n.csv"
 			src: "src/js/i18n/formvalid/*.js"
 
+		validation:
+			dist:
+				files:
+					src: "dist/**/*.html"
+
 
 	# These plugins provide necessary tasks.
 	@loadNpmTasks "grunt-contrib-concat"
@@ -238,6 +243,7 @@ module.exports = (grunt) ->
 	@loadNpmTasks "grunt-contrib-connect"
 	@loadNpmTasks "grunt-sass"
 	@loadNpmTasks "grunt-modernizr"
+	@loadNpmTasks "grunt-html-validation"
 	@loadNpmTasks "assemble"
 	@loadTasks "tasks"
 
@@ -246,6 +252,6 @@ module.exports = (grunt) ->
 
 	@registerTask "build", ["coffee", "sass", "concat", "i18n", "uglify", "clean:jsUncompressed", "copy", "assemble"]
 	@registerTask "test", ["jshint"]
-	@registerTask "html", ["assemble"]
+	@registerTask "html", ["assemble", "validation"]
 	@registerTask "server", ["connect", "watch:source"]
 	@registerTask "init", ["modernizr"]

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "grunt-sass": "~0.6.1",
     "csv": "~0.3.6",
     "grunt-modernizr": "~0.3.0",
-    "assemble": "~0.4.4"
+    "assemble": "~0.4.4",
+    "grunt-html-validation": "~0.1.5"
   }
 }


### PR DESCRIPTION
Submit files to w3c for validation.
- Failures of the tests are currently just output and don't fail the build.
- No settings file has been added to customize which rules to error vs ignore
