### PR TITLE
Added 3 new helpers additions to data-ajax functionality

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -194,6 +194,12 @@ module.exports = (grunt) ->
 				expand: true
 				flatten: true
 
+			misc:
+				cwd: "src/plugins"
+				src: ["**/*.txt"]
+				dest: "dist/demo"
+				expand: true
+				flatten: true
 		clean:
 			dist: "dist"
 

--- a/src/plugins/ajax-fetch/ajax-fetch.coffee
+++ b/src/plugins/ajax-fetch/ajax-fetch.coffee
@@ -1,0 +1,44 @@
+###
+	Web Experience Toolkit (WET) / Boîte à outils de l\'expérience Web (BOEW)
+	_plugin : Ajax Fetch [ ajax-fetch ]
+	_author : World Wide Web
+	_notes: A basic AjaxLoader wrapper for WET-BOEW that appends to elements
+	_licence: wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+###
+
+do ($ = jQuery, window, document) ->
+	$.ajaxSettings.cache = false;
+
+	### internal core functions ###
+
+	generateSerial = (len) ->
+	  chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz"
+	  string_length = 10
+	  randomstring = ""
+	  x = 0
+
+	  while x < string_length
+	    letterOrNumber = Math.floor(Math.random() * 2)
+	    if letterOrNumber is 0
+	      newNum = Math.floor(Math.random() * 9)
+	      randomstring += newNum
+	    else
+	      rnum = Math.floor(Math.random() * chars.length)
+	      randomstring += chars.substring(rnum, rnum + 1)
+	    x++
+	  randomstring
+
+
+	$(document).on "wb.ajax-fetch", (event) ->
+
+		_caller  = event.element
+		_url = event.fetch
+		_id = "wb#{generateSerial(8)}"
+
+
+		$("<div id=\"#{_id}\" />").load _url, ->
+			$(_caller).trigger
+				type: "wb.ajax-fetched"
+				pointer: $(@)
+
+		undefined

--- a/src/plugins/data-after/data-after-en.hbs
+++ b/src/plugins/data-after/data-after-en.hbs
@@ -1,0 +1,17 @@
+---
+title: Data After
+language: en
+---
+<section>
+	<h2>{{title}}</h2>
+
+	<section data-ajax-after="data-ajax-extra.txt">
+		<h3 id="anchor1">Hello World</h3>
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate, dolorem explicabo perferendis vitae magnam nobis.</p>
+	</section>
+	<section data-ajax-after="data-ajax-extra-2.txt">
+		<h3 id="anchor1">Hello World - Part 2</h3>
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate, dolorem explicabo perferendis vitae magnam nobis.</p>
+	</section>
+
+</section>

--- a/src/plugins/data-after/data-after.coffee
+++ b/src/plugins/data-after/data-after.coffee
@@ -1,0 +1,29 @@
+###
+	Web Experience Toolkit (WET) / Boîte à outils de l\'expérience Web (BOEW)
+	_plugin : Ajax Loader [ data-append ]
+	_author : World Wide Web
+	_notes: A basic AjaxLoader wrapper for WET-BOEW that appends to elements
+	_licence: wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+###
+
+do ($ = jQuery, window, document) ->
+	$.ajaxSettings.cache = false;
+
+	$(document).on "wb.timerpoke", "[data-ajax-after]", (event) ->
+		console.log "ok ajax-after inited"
+		window._timer.remove "[data-ajax-after]"
+		_elm = $(@)
+		_url = _elm.data("ajax-after")
+		$(document).trigger
+			type: "wb.ajax-fetch"
+			element: _elm
+			fetch: _url
+		undefined
+
+	$(document).on "wb.ajax-fetched", "[data-ajax-after]", (event) ->
+		_elm = $(@)
+		_elm.after event.pointer.html()
+		_elm.trigger "wb.ajax-after-loaded"
+		undefined
+	# Register Ajax Replacement
+	window._timer.add "[data-ajax-after]"

--- a/src/plugins/data-append/data-append-en.hbs
+++ b/src/plugins/data-append/data-append-en.hbs
@@ -1,0 +1,17 @@
+---
+title: Data After
+language: en
+---
+<section>
+	<h2>{{title}}</h2>
+
+	<section data-ajax-append="data-ajax-extra.txt">
+		<h3 id="anchor1">Hello World</h3>
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate, dolorem explicabo perferendis vitae magnam nobis.</p>
+	</section>
+	<section data-ajax-append="data-ajax-extra-2.txt">
+		<h3 id="anchor1">Hello World - Part 2</h3>
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate, dolorem explicabo perferendis vitae magnam nobis.</p>
+	</section>
+
+</section>

--- a/src/plugins/data-append/data-append.coffee
+++ b/src/plugins/data-append/data-append.coffee
@@ -1,0 +1,28 @@
+###
+	Web Experience Toolkit (WET) / Boîte à outils de l\'expérience Web (BOEW)
+	_plugin : Ajax Loader [ data-append ]
+	_author : World Wide Web
+	_notes: A basic AjaxLoader wrapper for WET-BOEW that appends to elements
+	_licence: wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+###
+
+do ($ = jQuery, window, document) ->
+	$.ajaxSettings.cache = false;
+	$(document).on "wb.timerpoke", "[data-ajax-append]", (event) ->
+		window._timer.remove "[data-ajax-append]"
+		_elm = $(@)
+		_url = _elm.data("ajax-append")
+		$(document).trigger
+			type: "wb.ajax-fetch"
+			element: _elm
+			fetch: _url
+		undefined
+
+	$(document).on "wb.ajax-fetched", "[data-ajax-append]", (event) ->
+		_elm = $(@)
+		_elm.append event.pointer.html()
+		_elm.trigger "wb.ajax-append-loaded"
+		undefined
+
+	# Register Ajax Replacement
+	window._timer.add "[data-ajax-append]"

--- a/src/plugins/data-before/data-ajax-extra-2.txt
+++ b/src/plugins/data-before/data-ajax-extra-2.txt
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+<!-- DataAjaxFragmentStart -->
+<section>
+	<h3>Hi was ajaxed in Part 2</h3>
+	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Rerum, officia, placeat ducimus earum velit animi debitis consequatur est similique dolores!</p>
+</section>
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/src/plugins/data-before/data-ajax-extra.txt
+++ b/src/plugins/data-before/data-ajax-extra.txt
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+<!-- DataAjaxFragmentStart -->
+<section>
+	<h3>Hi was ajaxed in</h3>
+	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Rerum, officia, placeat ducimus earum velit animi debitis consequatur est similique dolores!</p>
+</section>
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/src/plugins/data-before/data-before-en.hbs
+++ b/src/plugins/data-before/data-before-en.hbs
@@ -1,0 +1,17 @@
+---
+title: Data After
+language: en
+---
+<section>
+	<h2>{{title}}</h2>
+
+	<section data-ajax-before="data-ajax-extra.txt">
+		<h3 id="anchor1">Hello World</h3>
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate, dolorem explicabo perferendis vitae magnam nobis.</p>
+	</section>
+	<section data-ajax-before="data-ajax-extra-2.txt">
+		<h3 id="anchor1">Hello World - Part 2</h3>
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Cupiditate, dolorem explicabo perferendis vitae magnam nobis.</p>
+	</section>
+
+</section>

--- a/src/plugins/data-before/data-before.coffee
+++ b/src/plugins/data-before/data-before.coffee
@@ -1,0 +1,29 @@
+###
+	Web Experience Toolkit (WET) / Boîte à outils de l\'expérience Web (BOEW)
+	_plugin : Ajax Loader [ data-append ]
+	_author : World Wide Web
+	_notes: A basic AjaxLoader wrapper for WET-BOEW that appends to elements
+	_licence: wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+###
+
+do ($ = jQuery, window, document) ->
+	$.ajaxSettings.cache = false;
+
+	$(document).on "wb.timerpoke", "[data-ajax-before]", (event) ->
+		console.log "ok ajax-after inited"
+		window._timer.remove "[data-ajax-before]"
+		_elm = $(@)
+		_url = _elm.data("ajax-before")
+		$(document).trigger
+			type: "wb.ajax-fetch"
+			element: _elm
+			fetch: _url
+		undefined
+
+	$(document).on "wb.ajax-fetched", "[data-ajax-before]", (event) ->
+		_elm = $(@)
+		_elm.before event.pointer.html()
+		_elm.trigger "wb.ajax-after-loaded"
+		undefined
+	# Register Ajax Replacement
+	window._timer.add "[data-ajax-before]"


### PR DESCRIPTION
- data-ajax-append : appends the URL contents to the element
- data-ajax-before : puts the URL contents before the element
- data-ajax-after : puts the URL contents after the element

Optimizations:
- removed the data-fetch into it's own event to allow for uniqID generation of ajaxed content to prevent collisions
- function now available to all elements that require ajax-fetching
- added a misc glod in the coffeescript to bring over .txt files. This could be improved but is required for ajax files
