### PR TITLE
Changes to skip link CSS

### DIFF
--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -32,10 +32,10 @@
 		<div id="wb-skip">
 			<ul id="wb-tphp">
 				<li id="wb-skip1">
-					<a href="#wb-cont">{{#i18n "%tmpl-skip-cont"}}{{/i18n}}</a>
+					<a class="wb-skip-link" href="#wb-cont">{{#i18n "%tmpl-skip-cont"}}{{/i18n}}</a>
 				</li>
 				<li id="wb-skip2">
-					<a href="#wb-nav">{{#i18n "%tmpl-skip-foot"}}{{/i18n}}</a>
+					<a class="wb-skip-link" href="#wb-nav">{{#i18n "%tmpl-skip-foot"}}{{/i18n}}</a>
 				</li>
 			</ul>
 		</div>

--- a/src/base/partials/_accessibility.scss
+++ b/src/base/partials/_accessibility.scss
@@ -13,15 +13,11 @@
 }
 
 %accessible-invisible-show {
-	background-color: #000;
-	color: #FFF;
-	text-decoration: none;
-	clip: rect(auto, auto, auto, auto);
 	height: inherit !important;
+	width: inherit !important;
+	clip: rect(auto, auto, auto, auto);
 	overflow: inherit !important;
 	position: static;
-	width: inherit !important;
-	z-index: 501;
 	margin: inherit !important;
 }
 

--- a/src/base/partials/_accessibility.scss
+++ b/src/base/partials/_accessibility.scss
@@ -4,21 +4,21 @@
  */
 
 %accessible-invisible {
-	height: 1px !important;
-	width: 1px !important;
+	height: 1px;
+	width: 1px;
 	clip: rect(1px, 1px, 1px, 1px);
-	overflow: hidden !important;
+	overflow: hidden;
 	position: absolute;
-	margin: 0 !important;
+	margin: 0;
 }
 
 %accessible-invisible-show {
-	height: inherit !important;
-	width: inherit !important;
+	height: inherit;
+	width: inherit;
 	clip: rect(auto, auto, auto, auto);
-	overflow: inherit !important;
+	overflow: inherit;
 	position: static;
-	margin: inherit !important;
+	margin: inherit;
 }
 
 .wb-skip-link, .wb-invisible, .wb-mnavbar a, .wb-srch label, a + .wb-st-nav h2, .wb-srch h2, .wb-sttng h2, .wb-org-nav .wb-ft h3 {

--- a/src/base/partials/_accessibility.scss
+++ b/src/base/partials/_accessibility.scss
@@ -21,41 +21,10 @@
 	margin: inherit !important;
 }
 
-
-.wb-skip {
-		float: left;
-		height: 0;
-		ul {
-			list-style-type: none;
-			margin-top: -1.8em;
-		}
-		li {
-			left: 0;
-			position: absolute;
-			text-align: center;
-			top: 10px;
-			width: 100%;
-			z-index: 3;
-		}
-		a {
-			background-color: transparent;
-			color: #FFF;
-			font-weight: 700;
-			&:link, &:visited {
-				  background-color: transparent;
-				  color: #FFF;
-				  font-weight: 700;
-			}
-			padding: 5px;
-	  }
-}
-
-
-.wb-invisible, .wb-mnavbar a, .wb-srch label, a + .wb-st-nav h2, .wb-srch h2, .wb-sttng h2, .wb-org-nav .wb-ft h3, .wb-skip a, .wb-skip a:link, .wb-skip a:visited {
+.wb-skip-link, .wb-invisible, .wb-mnavbar a, .wb-srch label, a + .wb-st-nav h2, .wb-srch h2, .wb-sttng h2, .wb-org-nav .wb-ft h3 {
 	@extend %accessible-invisible;
 }
 
-.wb-skip a:focus, .wb-mnavbar a:focus {
+.wb-skip-link:focus, .wb-mnavbar a:focus {
 	@extend %accessible-invisible-show;
 }
-

--- a/theme/layouts/theme.hbs
+++ b/theme/layouts/theme.hbs
@@ -32,10 +32,10 @@
 		<div id="wb-skip">
 			<ul id="wb-tphp">
 				<li id="wb-skip1">
-					<a href="#wb-cont">{{#i18n "%tmpl-skip-cont"}}{{/i18n}}</a>
+					<a class="wb-skip-link" href="#wb-cont">{{#i18n "%tmpl-skip-cont"}}{{/i18n}}</a>
 				</li>
 				<li id="wb-skip2">
-					<a href="#wb-nav">{{#i18n "%tmpl-skip-foot"}}{{/i18n}}</a>
+					<a class="wb-skip-link" href="#wb-nav">{{#i18n "%tmpl-skip-foot"}}{{/i18n}}</a>
 				</li>
 			</ul>
 		</div>

--- a/theme/sass/includes/_screen.scss
+++ b/theme/sass/includes/_screen.scss
@@ -22,11 +22,6 @@
 			background-color: transparent;
 			color: #FFF;
 			font-weight: 700;
-			&:link, &:visited {
-				  background-color: transparent;
-				  color: #FFF;
-				  font-weight: 700;
-			}
 			padding: 5px;
 	  }
 }

--- a/theme/sass/includes/_screen.scss
+++ b/theme/sass/includes/_screen.scss
@@ -2,3 +2,38 @@
 * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
 */
+
+.wb-skip {
+		float: left;
+		height: 0;
+		ul {
+			list-style-type: none;
+			margin-top: -1.8em;
+		}
+		li {
+			left: 0;
+			position: absolute;
+			text-align: center;
+			top: 10px;
+			width: 100%;
+			z-index: 3;
+		}
+		a {
+			background-color: transparent;
+			color: #FFF;
+			font-weight: 700;
+			&:link, &:visited {
+				  background-color: transparent;
+				  color: #FFF;
+				  font-weight: 700;
+			}
+			padding: 5px;
+	  }
+}
+
+.wb-skip-link:focus {
+	background-color: #000;
+	color: #FFF;
+	text-decoration: none;
+	z-index: 501;
+}


### PR DESCRIPTION
Included:
- Decoupling the skip link CSS from the markup.
- Reducing the accessibility-specific CSS to hiding the skip links by default and showing them on focus.
- Moving presentation-specific (visuals and layout) CSS properties from the accessibility additions to the theme CSS.
- Updating the layout templates to use the new, decoupled skip link CSS.

Excluded:
- Cleaning up the presentation-specific (visuals and layout) CSS properties for the skip links.
