### PR TITLE
Override bootstrap link css

### DIFF
--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -13,8 +13,8 @@
 		<!-- Meta data -->
 		<meta name="description" content="{{description}}" />
 		<!-- Meta data-->
-		<link rel="stylesheet" href="{{assets}}/css/base{{environment.suffix}}.css">
 		<link rel="stylesheet" href="{{assets}}/css/bootstrap{{environment.suffix}}.css">
+		<link rel="stylesheet" href="{{assets}}/css/base{{environment.suffix}}.css">
 		<link rel="stylesheet" href="{{assets}}/css/theme{{environment.suffix}}.css">
 
 		<!-- Polyfill loader-->

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -2,7 +2,7 @@
  WET-BOEW - Web Experience Toolkit
  */
 @import 'partials/accessibility';
-@import 'partials/bootstrap-overrides'
+@import 'partials/bootstrap-overrides';
 @import 'partials/transitions';
 /*
  Plugins

--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -2,6 +2,7 @@
  WET-BOEW - Web Experience Toolkit
  */
 @import 'partials/accessibility';
+@import 'partials/bootstrap-overrides'
 @import 'partials/transitions';
 /*
  Plugins

--- a/src/base/partials/_bootstrap-overrides.scss
+++ b/src/base/partials/_bootstrap-overrides.scss
@@ -1,0 +1,10 @@
+/*
+  WET-BOEW
+  @title: Bootstrap overrides for WET-BOEW
+ */
+
+// Links
+
+a {
+	text-decoration: underline;		// re-enable underlining
+}

--- a/theme/layouts/theme.hbs
+++ b/theme/layouts/theme.hbs
@@ -13,8 +13,8 @@
 		<!-- Meta data -->
 		<meta name="description" content="{{description}}" />
 		<!-- Meta data-->
-		<link rel="stylesheet" href="{{assets}}/css/base{{environment.suffix}}.css">
 		<link rel="stylesheet" href="{{assets}}/css/bootstrap{{environment.suffix}}.css">
+		<link rel="stylesheet" href="{{assets}}/css/base{{environment.suffix}}.css">
 		<link rel="stylesheet" href="{{assets}}/css/theme{{environment.suffix}}.css">
 
 		<!-- Polyfill loader-->


### PR DESCRIPTION
These changes restore the underlining on links that is removed by the Bootstrap CSS.

To simplify the maintenance of the Bootstrap overrides, I created a partial that gets loaded into the base CSS. This will ensure that all Bootstrap overrides are in one place.

I also changed the order in which the styles sheets are loaded so that the Bootstrap CSS is loaded before the base CSS, which contains the Bootstrap overrides. This is needed for the Bootstrap overrides to override the Bootstrap defaults.
