### PR TITLE
Shortened vapour.document property to vapour.doc since .document wasn't being minified

### DIFF
--- a/src/core/vapour.coffee
+++ b/src/core/vapour.coffee
@@ -14,7 +14,7 @@ do ( $ = jQuery, window, undef = undefined ) ->
         '/templates': "#{$homepath}/assets/templates"
         '/deps': "#{$homepath}/deps"
         'mode' : $mode
-        'document' : $(document)
+        'doc' : $(document)
 
         getPath: (prty)->
             res = if @hasOwnProperty(prty) then @[prty] else undef

--- a/src/plugins/ajax-fetch/ajax-fetch.coffee
+++ b/src/plugins/ajax-fetch/ajax-fetch.coffee
@@ -7,7 +7,7 @@
 ###
 
 do ($ = jQuery, window, vapour) ->
-	$document = vapour.document
+	$document = vapour.doc
 	$.ajaxSettings.cache = false
 
 	### internal core functions ###

--- a/src/plugins/carousel/carousel.coffee
+++ b/src/plugins/carousel/carousel.coffee
@@ -7,7 +7,7 @@
 ###
 
 do ($ = jQuery, window, vapour) ->
-	$document = vapour.document
+	$document = vapour.doc
 
 	$document.on "wb.timerpoke", ".wb-carousel", (event) ->
 	  _sldr = $(this)

--- a/src/plugins/data-after/data-after.coffee
+++ b/src/plugins/data-after/data-after.coffee
@@ -7,7 +7,7 @@
 ###
 
 do ($ = jQuery, window, vapour) ->
-	$document = vapour.document
+	$document = vapour.doc
 	$.ajaxSettings.cache = false
 
 	$document.on "wb.timerpoke", "[data-ajax-after]", (event) ->

--- a/src/plugins/data-append/data-append.coffee
+++ b/src/plugins/data-append/data-append.coffee
@@ -7,7 +7,7 @@
 ###
 
 do ($ = jQuery, window, vapour) ->
-	$document = vapour.document
+	$document = vapour.doc
 	$.ajaxSettings.cache = false
 
 	$document.on "wb.timerpoke", "[data-ajax-append]", (event) ->

--- a/src/plugins/data-before/data-before.coffee
+++ b/src/plugins/data-before/data-before.coffee
@@ -7,7 +7,7 @@
 ###
 
 do ($ = jQuery, window, vapour) ->
-	$document = vapour.document
+	$document = vapour.doc
 	$.ajaxSettings.cache = false
 
 	$document.on "wb.timerpoke", "[data-ajax-before]", (event) ->

--- a/src/plugins/data-inview/data-inview.coffee
+++ b/src/plugins/data-inview/data-inview.coffee
@@ -7,7 +7,7 @@
 ###
 
 do( $ = jQuery, window, vapour) ->
-	$document = vapour.document
+	$document = vapour.doc
 
 	# Initialization
 	$document.on 'wb.timerpoke', '.wb-inview', (e)->

--- a/src/plugins/data-picture/data-picture.js
+++ b/src/plugins/data-picture/data-picture.js
@@ -8,7 +8,7 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 */
 (function( $, window, vapour ) {
 	"use strict";
-	var $document = vapour.document,
+	var $document = vapour.doc,
 		plugin = {
 			events: false,
 			selector: "[data-picture]",

--- a/src/plugins/data-replace/data-replace.coffee
+++ b/src/plugins/data-replace/data-replace.coffee
@@ -7,7 +7,7 @@
 ###
 
 do ($ = jQuery, window, vapour) ->
-	$document = vapour.document
+	$document = vapour.doc
 	$.ajaxSettings.cache = false
 
 	$document.on "wb.timerpoke", "[data-ajax-replace]", (event) ->

--- a/src/plugins/menu/menu.coffee
+++ b/src/plugins/menu/menu.coffee
@@ -7,7 +7,7 @@
 ###
 
 do ($ = jQuery, window, vapour) ->
-	$document = vapour.document
+	$document = vapour.doc
 
 	###
 	Lets leverage JS assigment deconstruction to reduce the code output

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -8,7 +8,7 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 */
 (function( $, window, vapour ) {
 	"use strict";
-	var $document = vapour.document,
+	var $document = vapour.doc,
 		plugin = {
 			events: false,
 			selector: ".wb-toggle",


### PR DESCRIPTION
Shouldn't affect anyone since vapour.doc should only be used for caching the global jQuery document object in a locally scoped variable.
