### PR TITLE
Moved event binding outside of plugin.init()

### DIFF
--- a/src/core/vapour.coffee
+++ b/src/core/vapour.coffee
@@ -4,7 +4,7 @@
 ###
  Vapour Object that will store tombstone data for plugins to leverage
 ###
-do ( $ = jQuery, window, undef = undefined ) ->
+do ( $ = jQuery, window, document, undef = undefined ) ->
     $src = $('script[src$="vapour.js"],script[src$="vapour.min.js"]').last()
     $homepath = $src.prop("src").split('?')[0].split('/').slice(0, -1).join('/')
     $mode = if $src.prop("src").indexOf('.min') < 0 then '' else '.min'
@@ -13,8 +13,9 @@ do ( $ = jQuery, window, undef = undefined ) ->
         '/assets': "#{$homepath}/assets"
         '/templates': "#{$homepath}/assets/templates"
         '/deps': "#{$homepath}/deps"
-        'mode' : $mode
-        'doc' : $(document)
+        'mode': $mode
+        'doc': $(document)
+        'win': $(window)
 
         getPath: (prty)->
             res = if @hasOwnProperty(prty) then @[prty] else undef
@@ -68,7 +69,7 @@ do (yepnope, vapour) ->
 
     while i >= 0
       #console.log(this._elms[i].text());
-      @_elms[i].trigger "wb.timerpoke"
+      @_elms[i].trigger "timerpoke.wb"
       i--
     undefined
 

--- a/src/plugins/ajax-fetch/ajax-fetch.coffee
+++ b/src/plugins/ajax-fetch/ajax-fetch.coffee
@@ -30,7 +30,7 @@ do ($ = jQuery, window, vapour) ->
 	  randomstring
 
 
-	$document.on "wb.ajax-fetch", (event) ->
+	$document.on "ajax-fetch.wb", (event) ->
 
 		_caller  = event.element
 		_url = event.fetch
@@ -39,7 +39,7 @@ do ($ = jQuery, window, vapour) ->
 
 		$("<div id=\"#{_id}\" />").load _url, ->
 			$(_caller).trigger
-				type: "wb.ajax-fetched"
+				type: "ajax-fetched.wb"
 				pointer: $(@)
 
 		undefined

--- a/src/plugins/carousel/carousel.coffee
+++ b/src/plugins/carousel/carousel.coffee
@@ -9,72 +9,70 @@
 do ($ = jQuery, window, vapour) ->
 	$document = vapour.doc
 
-	$document.on "wb.timerpoke", ".wb-carousel", (event) ->
-	  _sldr = $(this)
-	  if (typeof _sldr.attr("data-delay")) is "undefined"
-	    _sldr.trigger "carousel.init.wb"
-	    return undefined
-	  
-	  # state stopped
-	  return undefined  if _sldr.hasClass("stopped")
-	  
-	  # continue;
-	  _setting = parseFloat(_sldr.attr("data-delay"))
-	  
-	  # add settings and counter
-	  _delay = parseFloat(_sldr.attr("data-ctime"))
-	  _delay += 0.5
-	  
-	  # check if we need
-	  if _setting < _delay
-	    _sldr.trigger "wb.shift"
-	    _delay = 0
-	  _sldr.attr "data-ctime", _delay
+	$document.on "timerpoke.wb carousel-init.wb shift.wb", ".wb-carousel", (event) ->
+		eventType = event.type
+		_sldr = $(this)
+		switch eventType
+			when "timerpoke"
+				if (typeof _sldr.attr("data-delay")) is "undefined"
+					_sldr.trigger "carousel-init.wb"
+					return undefined
 
+				# state stopped
+				return undefined  if _sldr.hasClass("stopped")
+			  
+				# continue;
+				_setting = parseFloat(_sldr.attr("data-delay"))
+			  
+				# add settings and counter
+				_delay = parseFloat(_sldr.attr("data-ctime"))
+				_delay += 0.5
+			  
+				# check if we need
+				if _setting < _delay
+					_sldr.trigger "shift.wb"
+					_delay = 0
+				_sldr.attr "data-ctime", _delay
 
-	# ------ Init --------------
-	$document.on "carousel.init.wb", ".wb-carousel", (event) ->
-	  _sldr = $(this)
-	  _interval = 6
-	  _interval = 9  if _sldr.hasClass("slow")
-	  _interval = 3  if _sldr.hasClass("fast")
-	  _sldr.find(".item:not(.in)").addClass "out"
-	  _sldr.attr("data-delay", _interval).attr "data-ctime", 0
+			# ------ Init --------------
+			when "carousel-init"
+				_interval = 6
+				_interval = 9  if _sldr.hasClass("slow")
+				_interval = 3  if _sldr.hasClass("fast")
+				_sldr.find(".item:not(.in)").addClass "out"
+				_sldr.attr("data-delay", _interval).attr "data-ctime", 0
 
+			# ------ Change Slides --------------
+			when "shift"
+				_items = _sldr.find(".item")
+				_current = _items.index(".in")
+				_next = (if (event.shiftto) then event.shiftto else (if ((_current + 1) > _items.length) then 0 else _current + 1))
+				_items.eq(_current).removeClass("in").addClass "out"
+				_items.eq(_next).removeClass("out").addClass "in"
 
 	# ------ Next / Prev --------------
 	$document.on "click", ".wb-carousel .prv, .wb-carousel .nxt, .wb-carousel .plypause", (event) ->
-	  event.preventDefault()
-	  _elm = $(this)
-	  _sldr = _elm.parents(".wb-carousel")
-	  _items = _sldr.find(".item")
-	  _current = parseInt(_items.index(".in"))
-	  _current = (if (_current < 0) then 0 else _current)
-	  _action = _elm.attr("class")
-	  switch _action
-	    when "prv"
-	      _next = (if ((_current - 1) < 0) then _items.length - 1 else _current - 1)
-	      _elm.trigger "wb.shift",
-	        shiftto: _next
+		event.preventDefault()
+		_elm = $(this)
+		_sldr = _elm.parents(".wb-carousel")
+		_items = _sldr.find(".item")
+		_current = parseInt(_items.index(".in"))
+		_current = (if (_current < 0) then 0 else _current)
+		_action = _elm.attr("class")
+		switch _action
+			when "prv"
+				_next = (if ((_current - 1) < 0) then _items.length - 1 else _current - 1)
+				_elm.trigger "shift.wb",
+					shiftto: _next
 
-	    when "nxt"
-	      _next = (if ((_current + 1) > _items.length) then 0 else _current + 1)
-	      _elm.trigger "wb.shift",
-	        shiftto: _next
+			when "nxt"
+				_next = (if ((_current + 1) > _items.length) then 0 else _current + 1)
+				_elm.trigger "shift.wb",
+					shiftto: _next
 
-	    else # playpause
-	      _sldr.toggleClass "stopped"
-	  _sldr.attr "data-ctime", 0 # all clicks reset the clock;
-
-
-	# ------ Change Slides --------------
-	$document.on "wb.shift", ".wb-carousel", (event) ->
-	  _sldr = $(this)
-	  _items = _sldr.find(".item")
-	  _current = _items.index(".in")
-	  _next = (if (event.shiftto) then event.shiftto else (if ((_current + 1) > _items.length) then 0 else _current + 1))
-	  _items.eq(_current).removeClass("in").addClass "out"
-	  _items.eq(_next).removeClass("out").addClass "in"
+			else # playpause
+				_sldr.toggleClass "stopped"
+		_sldr.attr "data-ctime", 0 # all clicks reset the clock;
 
 	# ------ Register carousel --------------
 	window._timer.add ".wb-carousel"

--- a/src/plugins/data-after/data-after.coffee
+++ b/src/plugins/data-after/data-after.coffee
@@ -10,21 +10,24 @@ do ($ = jQuery, window, vapour) ->
 	$document = vapour.doc
 	$.ajaxSettings.cache = false
 
-	$document.on "wb.timerpoke", "[data-ajax-after]", (event) ->
-		console.log "ok ajax-after inited"
-		window._timer.remove "[data-ajax-after]"
-		_elm = $(@)
-		_url = _elm.data("ajax-after")
-		$document.trigger
-			type: "wb.ajax-fetch"
-			element: _elm
-			fetch: _url
-		undefined
+	$document.on "timerpoke.wb ajax-fetched.wb", "[data-ajax-append]", (event) ->
+		eventType = event.type
+		switch eventType
+			when "timerpoke"
+				window._timer.remove "[data-ajax-after]"
+				_elm = $(@)
+				_url = _elm.data("ajax-after")
+				$document.trigger
+					type: "ajax-fetch.wb"
+					element: _elm
+					fetch: _url
+				undefined
 
-	$document.on "wb.ajax-fetched", "[data-ajax-after]", (event) ->
-		_elm = $(@)
-		_elm.after event.pointer.html()
-		_elm.trigger "wb.ajax-after-loaded"
-		undefined
+			when "ajax-fetched"
+				_elm = $(@)
+				_elm.after event.pointer.html()
+				_elm.trigger "ajax-after-loaded.wb"
+				undefined
+
 	# Register Ajax Replacement
 	window._timer.add "[data-ajax-after]"

--- a/src/plugins/data-append/data-append.coffee
+++ b/src/plugins/data-append/data-append.coffee
@@ -10,21 +10,24 @@ do ($ = jQuery, window, vapour) ->
 	$document = vapour.doc
 	$.ajaxSettings.cache = false
 
-	$document.on "wb.timerpoke", "[data-ajax-append]", (event) ->
-		window._timer.remove "[data-ajax-append]"
-		_elm = $(@)
-		_url = _elm.data("ajax-append")
-		$document.trigger
-			type: "wb.ajax-fetch"
-			element: _elm
-			fetch: _url
-		undefined
+	$document.on "timerpoke.wb ajax-fetched.wb", "[data-ajax-append]", (event) ->
+		eventType = event.type
+		switch eventType
+			when "timerpoke"
+				window._timer.remove "[data-ajax-append]"
+				_elm = $(@)
+				_url = _elm.data("ajax-append")
+				$document.trigger
+					type: "ajax-fetch.wb"
+					element: _elm
+					fetch: _url
+				undefined
 
-	$document.on "wb.ajax-fetched", "[data-ajax-append]", (event) ->
-		_elm = $(@)
-		_elm.append event.pointer.html()
-		_elm.trigger "wb.ajax-append-loaded"
-		undefined
+			when "ajax-fetched"
+				_elm = $(@)
+				_elm.append event.pointer.html()
+				_elm.trigger "ajax-append-loaded.wb"
+				undefined
 
 	# Register Ajax Replacement
 	window._timer.add "[data-ajax-append]"

--- a/src/plugins/data-before/data-before.coffee
+++ b/src/plugins/data-before/data-before.coffee
@@ -10,21 +10,24 @@ do ($ = jQuery, window, vapour) ->
 	$document = vapour.doc
 	$.ajaxSettings.cache = false
 
-	$document.on "wb.timerpoke", "[data-ajax-before]", (event) ->
-		console.log "ok ajax-after inited"
-		window._timer.remove "[data-ajax-before]"
-		_elm = $(@)
-		_url = _elm.data("ajax-before")
-		$document.trigger
-			type: "wb.ajax-fetch"
-			element: _elm
-			fetch: _url
-		undefined
+	$document.on "timerpoke.wb ajax-fetched.wb", "[data-ajax-before]", (event) ->
+		eventType = event.type
+		switch eventType
+			when "timerpoke"
+				window._timer.remove "[data-ajax-before]"
+				_elm = $(@)
+				_url = _elm.data("ajax-before")
+				$document.trigger
+					type: "ajax-fetch.wb"
+					element: _elm
+					fetch: _url
+				undefined
 
-	$document.on "wb.ajax-fetched", "[data-ajax-before]", (event) ->
-		_elm = $(@)
-		_elm.before event.pointer.html()
-		_elm.trigger "wb.ajax-after-loaded"
-		undefined
+			when "ajax-fetched"
+				_elm = $(@)
+				_elm.before event.pointer.html()
+				_elm.trigger "ajax-after-loaded.wb"
+				undefined
+
 	# Register Ajax Replacement
 	window._timer.add "[data-ajax-before]"

--- a/src/plugins/data-inview/data-inview.coffee
+++ b/src/plugins/data-inview/data-inview.coffee
@@ -10,7 +10,8 @@ do( $ = jQuery, window, vapour) ->
 	$document = vapour.doc
 
 	# Initialization
-	$document.on 'wb.timerpoke', '.wb-inview', (e)->
+	$document.on 'timerpoke.wb', '.wb-inview', (e)->
+		$window = vapour.win
 		window._timer.remove '.wb-inview'
 
 		$this = $(@)
@@ -20,13 +21,13 @@ do( $ = jQuery, window, vapour) ->
 		# lets set some events to help manage this control
 
 		# bind our event
-		$(window).on 'scroll scrollstop resize', (e)->
+		$window.on 'scroll scrollstop resize', (e)->
 			$this.trigger 'scroll.wb-inview'
 
 		# set the element listeners
 		$this.on 'scroll.wb-inview', (e)->
 			_elm = $(@)
-			_viewport = $(window)
+			_viewport = $window
 			# lets start computing values
 			elementWidth = _elm.outerWidth()
 			elementHeight = _elm.outerHeight()

--- a/src/plugins/data-picture/data-picture.js
+++ b/src/plugins/data-picture/data-picture.js
@@ -27,16 +27,16 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 					complete: function() {
 						if ( plugin.events === false ) {
 							plugin.events = true;
-							$document.on( "wb-data-picture.init", window.picturefill );
+							$document.on( "init.wb-data-picture", window.picturefill );
 						}
-						$document.trigger( "wb-data-picture.init" );
+						$document.trigger( "init.wb-data-picture" );
 					}
 				});
 			}
 		};
 
 	// Bind the init event of the plugin
-	$document.on( "wb.timerpoke", plugin.selector, plugin.init );
+	$document.on( "timerpoke.wb", plugin.selector, plugin.init );
 
 	// Add the timer poke to initialize the plugin
 	window._timer.add( plugin.selector );

--- a/src/plugins/data-picture/data-picture.js
+++ b/src/plugins/data-picture/data-picture.js
@@ -10,33 +10,40 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 	"use strict";
 	var $document = vapour.doc,
 		plugin = {
-			events: false,
 			selector: "[data-picture]",
 
 			/**
 			 * Initialize the plugin
 			 */
 			init: function() {
+				var mode = vapour.getMode();
 				window._timer.remove( plugin.selector );
 
 				// Load picturefill dependencies and bind the init event handler
 				window.Modernizr.load({
 					test: window.matchMedia,
-					nope: "site!deps/matchMedia.min.js",
-					load: "site!deps/picturefill.min.js",
+					nope: "site!deps/matchMedia" + mode + ".js",
+					load: "site!deps/picturefill" + mode + ".js",
 					complete: function() {
-						if ( plugin.events === false ) {
-							plugin.events = true;
-							$document.on( "init.wb-data-picture", window.picturefill );
-						}
-						$document.trigger( "init.wb-data-picture" );
+						$document.trigger( "picturefill.wb-data-picture" );
 					}
 				});
+			},
+
+			/**
+			 * Invoke the picturefill library if it has been loaded
+			 */
+			picturefill: function() {
+				if ( window.picturefill !== undefined ) {
+					window.picturefill();
+				}
 			}
 		};
 
-	// Bind the init event of the plugin
-	$document.on( "timerpoke.wb", plugin.selector, plugin.init );
+	// Bind the plugin's events
+	$document
+		.on( "timerpoke.wb", plugin.selector, plugin.init)
+		.on( "picturefill.wb-data-picture", plugin.picturefill );
 
 	// Add the timer poke to initialize the plugin
 	window._timer.add( plugin.selector );

--- a/src/plugins/data-replace/data-replace.coffee
+++ b/src/plugins/data-replace/data-replace.coffee
@@ -10,11 +10,11 @@ do ($ = jQuery, window, vapour) ->
 	$document = vapour.doc
 	$.ajaxSettings.cache = false
 
-	$document.on "wb.timerpoke", "[data-ajax-replace]", (event) ->
+	$document.on "timerpoke.wb", "[data-ajax-replace]", (event) ->
 	  _elm = $(@)
 	  _url = _elm.data("ajax-replace")
 	  _elm.load _url, ->
-	    $(@).trigger "wb.ajax-replace-loaded"
+	    $(@).trigger "ajax-replace-loaded.wb"
 	  # lets remove the event from continous throddling
 	  window._timer.remove "[data-ajax-replace]"
 	  undefined

--- a/src/plugins/menu/menu.coffee
+++ b/src/plugins/menu/menu.coffee
@@ -18,34 +18,81 @@ do ($ = jQuery, window, vapour) ->
 		_items = if (scopeitems) then _elm.data('items').has(elment) else _elm.data('items')
 		[_elm.data('self'), _elm.data('menu'), _items, $elm]
 
-	###
-	Init
-	###
-	$document.on "wb.ajax-replace-loaded", ".wb-menu", (event) ->
-		event.stopPropagation()
-		$container = $(@)
-		$menu = $container.find ".menu :focusable"
-		$items = $container.find ".item"
-		# lets store the object for maximun performance - prevent the jQuery overhead re-querying
-		$container.data('self', $container).data('menu', $menu).data('items',$items)
-		# lets disable tabbing through the menu for usability - leaving the first element open to the tab order
-		$container.find(':discoverable').attr('tabindex', '-1').eq(0).attr('tabindex', '0')
-		# lets add our down arrows where we need to
-		$menu.filter("[href^='#']").append "<span class=\"expandicon\"></span>"
-		undefined
+	$document.on "ajax-replace-loaded.wb mouseleave focusout select.wb increment.wb reset.wb display.wb", ".wb-menu", (event) ->
+		eventType = event.type
+		switch eventType
+			# Init
+			when "ajax-replace-loaded"
+				event.stopPropagation()
+				$container = $(@)
+				$menu = $container.find ".menu :focusable"
+				$items = $container.find ".item"
+				# lets store the object for maximun performance - prevent the jQuery overhead re-querying
+				$container.data('self', $container).data('menu', $menu).data('items',$items)
+				# lets disable tabbing through the menu for usability - leaving the first element open to the tab order
+				$container.find(':discoverable').attr('tabindex', '-1').eq(0).attr('tabindex', '0')
+				# lets add our down arrows where we need to
+				$menu.filter("[href^='#']").append "<span class=\"expandicon\"></span>"
+				undefined
+
+			# Global Menu Events
+			when "mouseleave", "focusout"
+				$(@).trigger('menu-reset.wb')
+
+			when "select"
+				event.stopPropagation()
+				$elm = event.goto
+				setTimeout ( ->
+						$elm.focus()
+				), 1
+
+			when "increment"
+				event.stopPropagation()
+				$container = $(@)
+				$links = event.cnode
+				$next =  event.current + event.increment
+				$index = $next
+
+				if $next >= $links.length
+					$index = 0
+				if $next < 0
+					$index = $links.length - 1
+
+				$container.trigger
+					type: "select.wb"
+					goto: $links.eq($index)
+				undefined
+
+			# Helper Events
+			when "reset"
+				# Clear all open menus
+				event.stopPropagation()
+				$container = $(@)
+				$container.find('.open').removeClass('open')
+				$container.find('.active').removeClass('active')
+
+			when "display"
+				event.stopPropagation()
+				$container = $(@)
+				# lets reset the menu
+				$container.trigger
+					type: 'reset.wb'
+				# add the active class to the menu item
+				$container.find(".menu [href='#{event.ident}']").addClass('active')
+				$container.find(event.ident).addClass('open')
 
 	###
-	 Menu Keyboard bindings
+	Menu Keyboard bindings
 	###
 	$document.on "mouseover focusin", ".wb-menu .menu :focusable", (event) ->
 		event.stopPropagation()
 		[$container, $menu, $items, $elm] = expand(event.target)
 		# some housecleaning
-		$menu.trigger('wb.reset')
+		$menu.trigger('reset.wb')
 		# end of housecleaning
 		if $elm.find('.expandicon').length > 0
 			$menu.trigger
-					type: 'wb.display'
+					type: 'display.wb'
 					ident: $elm.attr('href')
 
 	$document.on "keydown", ".wb-menu .menu", (event) ->
@@ -53,40 +100,44 @@ do ($ = jQuery, window, vapour) ->
 		[$container, $menu, $items, $elm] = expand(event.target)
 		$code = event.which
 		$index = $menu.index($elm.get(0))
-		if $elm.find('.expandicon').length > 0
-			# ok we have a menu we want to listen for
-			if $code is 13 or $code is 40
-				event.preventDefault()
-				$anchor = $elm.attr('href').slice(1)
-				$goto = $items.filter('[id="' + $anchor + '"]').find(':discoverable').first()
-				console.log $anchor
+		switch $code
+			when 13, 40
+				if $elm.find('.expandicon').length > 0
+					# ok we have a menu we want to listen for
+					event.preventDefault()
+					$anchor = $elm.attr('href').slice(1)
+					$goto = $items.filter('[id="' + $anchor + '"]').find(':discoverable').first()
+					console.log $anchor
+					$container.trigger
+						type: 'display.wb'
+						ident: $elm.attr('href')
+					.trigger
+						type: 'select.wb'
+						goto: $goto
+
+			# since we have set the tabindex on elements the tabkey event should only
+			# ever close the menu since it is only used to enter and leave the menu
+			when 9
 				$container.trigger
-					type: 'wb.display'
-					ident: $elm.attr('href')
-				.trigger
-					type: 'wb.select'
-					goto: $goto
-		# since we have set the tabindex on elements the tabkey event should only
-		# ever close the menu since it is only used to enter and leave the menu
-		if $code is 9
-			$container.trigger
-				type: 'wb.reset'
-		if $code is 37
+					type: 'reset.wb'
+
 			# left arrow
-			event.preventDefault()
-			$container.trigger
-				type: 'wb.increment'
-				cnode:  $menu
-				increment: -1
-				current: $index
-		if $code is 39
+			when 37
+				event.preventDefault()
+				$container.trigger
+					type: 'increment.wb'
+					cnode:  $menu
+					increment: -1
+					current: $index
+
 			# right arrow
-			event.preventDefault()
-			$container.trigger
-				type: 'wb.increment'
-				cnode:  $menu
-				increment: 1
-				current: $index
+			when 39
+				event.preventDefault()
+				$container.trigger
+					type: 'increment.wb'
+					cnode:  $menu
+					increment: 1
+					current: $index
 
 	###
 	 Item Keyboard bindings
@@ -98,86 +149,30 @@ do ($ = jQuery, window, vapour) ->
 		$links = $items.find(':focusable')
 		$index = $links.index($elm.get(0))
 
-		# escape key
-		if $code is 27 or $code is 37
-			event.preventDefault()
-			# look into this more
-			$goto = $menu.filter('[href="#' + $items.attr('id') + '"]')
-			$container.trigger
-				type: 'wb.select'
-				goto: $goto
+		switch $code
+			# escape key
+			when 27, 37
+				event.preventDefault()
+				# look into this more
+				$goto = $menu.filter('[href="#' + $items.attr('id') + '"]')
+				$container.trigger
+					type: 'select.wb'
+					goto: $goto
 
-		if $code is 38
 			# up arrow
-			event.preventDefault()
-			$container.trigger
-				type: 'wb.increment'
-				cnode:  $links
-				increment: -1
-				current: $index
+			when 38
+				event.preventDefault()
+				$container.trigger
+					type: 'increment.wb'
+					cnode:  $links
+					increment: -1
+					current: $index
 
-		if $code is 40
 			# down arrow
-			event.preventDefault()
-			$container.trigger
-				type: 'wb.increment'
-				cnode:  $links
-				increment: 1
-				current: $index
-
-	###
-	 Global Menu Events
-	###
-	$document.on "mouseleave focusout", ".wb-menu", (event) ->
-		$(@).trigger('wb.menu-reset')
-
-
-	$document.on "wb.select", ".wb-menu", (event) ->
-		event.stopPropagation()
-		$elm = event.goto
-		setTimeout ( ->
-  				$elm.focus()
-		), 1
-
-	$document.on "wb.increment", ".wb-menu", (event)->
-		event.stopPropagation()
-		$container = $(@)
-		$links = event.cnode
-		$next =  event.current + event.increment
-		$index = $next
-
-		if $next >= $links.length
-			$index = 0
-		if $next < 0
-			$index = $links.length - 1
-
-		$container.trigger
-			type: "wb.select"
-			goto: $links.eq($index)
-		undefined
-
-	###
-	 Helper Events
-	###
-
-	# Clear all open menus
-	$document.on "wb.reset", ".wb-menu", (event) ->
-		event.stopPropagation()
-		$container = $(@)
-		$container.find('.open').removeClass('open')
-		$container.find('.active').removeClass('active')
-
-
-	$document.on "wb.display", ".wb-menu", (event) ->
-		event.stopPropagation()
-		$container = $(@)
-		# lets reset the menu
-		$container.trigger
-			type: 'wb.reset'
-		# add the active class to the menu item
-		$container.find(".menu [href='#{event.ident}']").addClass('active')
-		$container.find(event.ident).addClass('open')
-
-
-
-
+			when 40
+				event.preventDefault()
+				$container.trigger
+					type: 'increment.wb'
+					cnode:  $links
+					increment: 1
+					current: $index

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -27,14 +27,14 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 				if ( plugin.events === false ) {
 					plugin.events = true;
 					$document
-						.on( "wb-toggle.ariaControls", plugin.selector, plugin.setAriaControls )
-						.on( "wb-toggle.toggle", plugin.selector, plugin.toggle )
+						.on( "ariaControls.wb-toggle", plugin.selector, plugin.setAriaControls )
+						.on( "toggle.wb-toggle", plugin.selector, plugin.toggle )
 						.on( "click", plugin.selector, plugin.click );
 				}
 
 				// Initialize the aria-controls attribute of the link
 				if ( link.data( "selector" ) !== undefined  ) {
-					link.trigger( "wb-toggle.ariaControls", {
+					link.trigger( "ariaControls.wb-toggle", {
 						selector: link.data( "selector" ),
 						parent: link.data( "parent" )
 					});
@@ -72,7 +72,7 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 			click: function( event ) {
 				var link = $( this );
 
-				link.trigger( "wb-toggle.toggle", {
+				link.trigger( "toggle.wb-toggle", {
 					selector: link.data( "selector" ),
 					parent: link.data( "parent" ),
 					type: link.data( "type" )
@@ -151,7 +151,7 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 		};
 
 	// Bind the init event of the plugin
-	$document.on( "wb.timerpoke", plugin.selector, plugin.init );
+	$document.on( "timerpoke.wb", plugin.selector, plugin.init );
 
 	// Add the timer poke to initialize the plugin
 	window._timer.add( plugin.selector );

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -10,7 +10,6 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 	"use strict";
 	var $document = vapour.doc,
 		plugin = {
-			events: false,
 			selector: ".wb-toggle",
 			state: {},
 			stateOn: "on",
@@ -22,15 +21,6 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 			init: function() {
 				var link = $( this );
 				window._timer.remove( plugin.selector );
-
-				// Bind the plugin's event handlers only once
-				if ( plugin.events === false ) {
-					plugin.events = true;
-					$document
-						.on( "ariaControls.wb-toggle", plugin.selector, plugin.setAriaControls )
-						.on( "toggle.wb-toggle", plugin.selector, plugin.toggle )
-						.on( "click", plugin.selector, plugin.click );
-				}
 
 				// Initialize the aria-controls attribute of the link
 				if ( link.data( "selector" ) !== undefined  ) {
@@ -98,7 +88,7 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 			},
 
 			/**
-			 * Gets the current toggle state of a links given set of elements (based on selector and parent).
+			 * Gets the current toggle state of a link given set of elements (based on selector and parent).
 			 * @param {String} selector CSS selector of the elements the link controls
 			 * @param {String} parent CSS selector of the parent DOM element the link is restricted to.
 			 * @param {String} type The type of link: undefined (toggle), "on" or "off"
@@ -150,8 +140,24 @@ licence	:	wet-boew.github.io/wet-boew/License-en.html /
 			}
 		};
 
-	// Bind the init event of the plugin
-	$document.on( "timerpoke.wb", plugin.selector, plugin.init );
+	// Bind the plugin's events
+	$document.on( "timerpoke.wb ariaControls.wb-toggle toggle.wb-toggle click", plugin.selector, function( event ) {
+		switch( event.type ) {
+			case "click":
+				plugin.click.apply( this, arguments );
+				break;
+			case "toggle":
+				plugin.toggle.apply( this, arguments );
+				break;
+			case "ariaControls":
+				plugin.setAriaControls.apply( this, arguments );
+				break;
+			case "timerpoke":
+				plugin.init.apply( this, arguments );
+				break;
+		}
+	});
+
 
 	// Add the timer poke to initialize the plugin
 	window._timer.add( plugin.selector );


### PR DESCRIPTION
This is related to the discussion in #3026 and making plugin logic available to the rest of the framework even if the plugin isn't being used on the page.
