### PR TITLE
Build: Fix Autoprefixer

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -70,16 +70,6 @@ module.exports = (grunt) ->
 
 		# Compiles the Sass files
 		sass:
-			options:
-				browsers: [
-					"last 2 versions,",
-					"ff >= 17",
-					"opera 12.1",
-					"bb >= 7",
-					"android >= 2.3",
-					"ie >= 8",
-					"ios 5"
-				]
 			all:
 				expand: true
 				cwd: "src/base"
@@ -88,6 +78,17 @@ module.exports = (grunt) ->
 				ext: ".css"
 
 		autoprefixer:
+			options:
+				browsers: [
+					"last 2 versions",
+					"ff >= 17",
+					"opera 12.1",
+					"bb >= 7",
+					"android >= 2.3",
+					"ie >= 8",
+					"ios 5"
+				]
+
 			all:
 				cwd: "dist/css"
 				src: [


### PR DESCRIPTION
Somehow got mixed up with the Sass target. Also had a errant semicolon in the "last 2 version" browser setting
