### PR TITLE
Added basic language selector support.

### DIFF
--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -3,6 +3,7 @@
  */
 @import 'partials/accessibility';
 @import 'partials/bootstrap-overrides';
+@import 'partials/language-selector';
 @import 'partials/transitions';
 /*
  Plugins

--- a/src/base/partials/_language-selector.scss
+++ b/src/base/partials/_language-selector.scss
@@ -1,0 +1,43 @@
+/*
+  WET-BOEW
+  @title: Language selector
+ */
+
+//	Sourced from http://css-tricks.com/snippets/css/clear-fix/
+%clear-fix {
+	content: "";
+	display: table;
+	clear: both;
+}
+
+%accessible-invisible {
+	height: 1px;
+	width: 1px;
+	clip: rect(1px, 1px, 1px, 1px);
+	overflow: hidden;
+	position: absolute;
+	margin: 0;
+}
+
+//	Horizontal language selector
+.wb-lang-links-horiz .wb-lang-link {
+	display: inline-block;
+}
+
+//	Vertical language selector
+.wb-lang-links-vert .wb-lang-link {
+	display: block;
+}
+
+//	Right-to-left horizontal language selector
+.wb-lang-links-rtl .wb-lang-link {
+	float: right;
+}
+
+.wb-lang-links-rtl:after {
+	@extend %clear-fix;
+}
+
+.wb-lang-heading {
+	@extend %accessible-invisible;
+}

--- a/src/base/partials/_language-selector.scss
+++ b/src/base/partials/_language-selector.scss
@@ -20,18 +20,24 @@
 }
 
 //	Horizontal language selector
-.wb-lang-links-horiz .wb-lang-link {
-	display: inline-block;
+.wb-lang-links-horiz {
+	.wb-lang-link {
+		display: inline-block;
+	}
 }
 
 //	Vertical language selector
-.wb-lang-links-vert .wb-lang-link {
-	display: block;
+.wb-lang-links-vert {
+	.wb-lang-link {
+		display: block;
+	}
 }
 
 //	Right-to-left horizontal language selector
-.wb-lang-links-rtl .wb-lang-link {
-	float: right;
+.wb-lang-links-rtl {
+	.wb-lang-link {
+		float: right;
+	}
 }
 
 .wb-lang-links-rtl:after {


### PR DESCRIPTION
This brings in support for displaying the language selector:
- Horizontally.
- Vertically.
- Horizontally from right to left.

It also hides the language selector heading, if any, by default as that's what we've always done. Although I'm not 100% that this should be the default behaviour.

Another layout we could support could be a multi-column layout, although I'm not sure how that would best be coded.
