### PR TITLE
Form Validation: "for" attribute only on labels

### DIFF
--- a/src/js/dependencies/validate.js
+++ b/src/js/dependencies/validate.js
@@ -685,9 +685,13 @@ $.extend($.validator, {
 			} else {
 				// create label
 				label = $("<" + this.settings.errorElement + ">")
-					.attr("for", this.idOrName(element))
 					.addClass(this.settings.errorClass)
 					.html(message || "");
+
+				if ( /label/.test( this.settings.errorElement ) ) {
+					label.attr( "for", this.idOrName( element ) );
+				}
+
 				if ( this.settings.wrapper ) {
 					// make sure the element is visible, even in IE
 					// actually showing the wrapped element is handled elsewhere


### PR DESCRIPTION
Fixes gh-3063
Pending upstream patch https://github.com/jzaefferer/jquery-validation/pull/900
