### PR TITLE
Menu and ajax hotfix

### DIFF
--- a/src/plugins/data-after/data-after.coffee
+++ b/src/plugins/data-after/data-after.coffee
@@ -12,10 +12,10 @@ do ($ = jQuery, window, vapour) ->
 
 	$document.on "timerpoke.wb ajax-fetched.wb", "[data-ajax-append]", (event) ->
 		eventType = event.type
+		_elm = $(@)
 		switch eventType
 			when "timerpoke"
 				window._timer.remove "[data-ajax-after]"
-				_elm = $(@)
 				_url = _elm.data("ajax-after")
 				$document.trigger
 					type: "ajax-fetch.wb"
@@ -24,7 +24,6 @@ do ($ = jQuery, window, vapour) ->
 				undefined
 
 			when "ajax-fetched"
-				_elm = $(@)
 				_elm.after event.pointer.html()
 				_elm.trigger "ajax-after-loaded.wb"
 				undefined

--- a/src/plugins/data-append/data-append.coffee
+++ b/src/plugins/data-append/data-append.coffee
@@ -12,10 +12,10 @@ do ($ = jQuery, window, vapour) ->
 
 	$document.on "timerpoke.wb ajax-fetched.wb", "[data-ajax-append]", (event) ->
 		eventType = event.type
+		_elm = $(@)
 		switch eventType
 			when "timerpoke"
 				window._timer.remove "[data-ajax-append]"
-				_elm = $(@)
 				_url = _elm.data("ajax-append")
 				$document.trigger
 					type: "ajax-fetch.wb"
@@ -24,7 +24,6 @@ do ($ = jQuery, window, vapour) ->
 				undefined
 
 			when "ajax-fetched"
-				_elm = $(@)
 				_elm.append event.pointer.html()
 				_elm.trigger "ajax-append-loaded.wb"
 				undefined

--- a/src/plugins/data-before/data-before.coffee
+++ b/src/plugins/data-before/data-before.coffee
@@ -12,10 +12,10 @@ do ($ = jQuery, window, vapour) ->
 
 	$document.on "timerpoke.wb ajax-fetched.wb", "[data-ajax-before]", (event) ->
 		eventType = event.type
+		_elm = $(@)
 		switch eventType
 			when "timerpoke"
 				window._timer.remove "[data-ajax-before]"
-				_elm = $(@)
 				_url = _elm.data("ajax-before")
 				$document.trigger
 					type: "ajax-fetch.wb"
@@ -24,7 +24,6 @@ do ($ = jQuery, window, vapour) ->
 				undefined
 
 			when "ajax-fetched"
-				_elm = $(@)
 				_elm.before event.pointer.html()
 				_elm.trigger "ajax-after-loaded.wb"
 				undefined

--- a/src/plugins/data-replace/data-replace.coffee
+++ b/src/plugins/data-replace/data-replace.coffee
@@ -14,7 +14,7 @@ do ($ = jQuery, window, vapour) ->
 	  _elm = $(@)
 	  _url = _elm.data("ajax-replace")
 	  _elm.load _url, ->
-	    $(@).trigger "ajax-replace-loaded.wb"
+	  	_elm.removeAttr('data-ajax-replace').trigger "ajax-replace-loaded.wb"
 	  # lets remove the event from continous throddling
 	  window._timer.remove "[data-ajax-replace]"
 	  undefined

--- a/src/plugins/menu/menu-en.hbs
+++ b/src/plugins/menu/menu-en.hbs
@@ -5,7 +5,7 @@ language: en
 <section>
 	<h1>{{title}}</h1>
 	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione, minima deleniti autem tenetur odit nostrum sunt eligendi quasi maiores veritatis voluptate tempore dolorem animi libero!</p>
-	<nav role="navigation" id="wb-sm" data-ajax-replace="menu-{{language}}.txt" class="wb-menu">
+	<nav role="navigation" id="wb-sm" data-ajax-replace="menu-{{language}}.txt" data-post-remove="remove after init" class="wb-menu remove after init">
 		<h2>Navigation</h2>
 		<ul class="list-inline menu">
 			<li><a href="http://www.canada.gc.ca">Lorem ipsum dolor sit amet.</a></li>

--- a/src/plugins/menu/menu.coffee
+++ b/src/plugins/menu/menu.coffee
@@ -20,24 +20,31 @@ do ($ = jQuery, window, vapour) ->
 
 	$document.on "ajax-replace-loaded.wb mouseleave focusout select.wb increment.wb reset.wb display.wb", ".wb-menu", (event) ->
 		eventType = event.type
+		$container = $(@)
 		switch eventType
 			# Init
 			when "ajax-replace-loaded"
 				event.stopPropagation()
-				$container = $(@)
+				###
+				Some hooks for post transformation
+				 - @data-post-remove : removes the space delimited class for the element. This is more a feature to fight the FOUC 
+				###
+				if $container.has('[data-post-remove]')
+					$container.removeClass($container.data('post-remove')).removeAttr('data-post-remove')
+
 				$menu = $container.find ".menu :focusable"
 				$items = $container.find ".item"
-				# lets store the object for maximun performance - prevent the jQuery overhead re-querying
-				$container.data('self', $container).data('menu', $menu).data('items',$items)
 				# lets disable tabbing through the menu for usability - leaving the first element open to the tab order
 				$container.find(':discoverable').attr('tabindex', '-1').eq(0).attr('tabindex', '0')
 				# lets add our down arrows where we need to
 				$menu.filter("[href^='#']").append "<span class=\"expandicon\"></span>"
+				# lets store the object for maximun performance - prevent the jQuery overhead re-querying
+				$container.data('self', $container).data('menu', $menu).data('items',$items)
 				undefined
 
 			# Global Menu Events
 			when "mouseleave", "focusout"
-				$(@).trigger('menu-reset.wb')
+				$container.trigger('reset.wb')
 
 			when "select"
 				event.stopPropagation()
@@ -48,7 +55,6 @@ do ($ = jQuery, window, vapour) ->
 
 			when "increment"
 				event.stopPropagation()
-				$container = $(@)
 				$links = event.cnode
 				$next =  event.current + event.increment
 				$index = $next
@@ -67,13 +73,11 @@ do ($ = jQuery, window, vapour) ->
 			when "reset"
 				# Clear all open menus
 				event.stopPropagation()
-				$container = $(@)
 				$container.find('.open').removeClass('open')
 				$container.find('.active').removeClass('active')
 
 			when "display"
 				event.stopPropagation()
-				$container = $(@)
 				# lets reset the menu
 				$container.trigger
 					type: 'reset.wb'


### PR DESCRIPTION
- Added a self cleaning function to ajax method to safeguard against other plugins triggering data-replace, data-before , etc\* events
- Optimized data-replace, data-before, etc code base by creating the _elm reference at the beginning of the event trap once instead of have the same code duplicated throughout all variation of the switch statements ( less code )
- Added a menu post-ajax hook to allow for class manipulation to help fight the flash of un-styled content.
