### PR TITLE
Temporary work around for libsass silent error on various color function...

### DIFF
--- a/src/plugins/mediaplayer/mediaplayer.scss
+++ b/src/plugins/mediaplayer/mediaplayer.scss
@@ -81,13 +81,13 @@
                 background: black;
                 border-radius: 50px;
                 padding: 2px;
-                box-shadow: 0 1px 0px 0 rgba(255, 255, 255, 0.2);
+                box-shadow: 0 1px 0px 0 unquote("rgba(255, 255, 255, 0.2)");
             }
             /* Now the value part */
             &::-webkit-progress-value {
                 border-radius: 50px;
-                box-shadow: inset 0 1px 1px 0 rgba(255, 255, 255, 0.4);
-                background: -webkit-linear-gradient(45deg, transparent, transparent 33%, rgba(0, 0, 0, 0.1) 33%, rgba(0, 0, 0, 0.1) 66%, transparent 66%), -webkit-linear-gradient(top, rgba(255, 255, 255, 0.25), rgba(0, 0, 0, 0.2)), -webkit-linear-gradient(left, #ba7448, #c4672d);
+                box-shadow: inset 0 1px 1px 0 unquote("rgba(255, 255, 255, 0.4)");
+                background: -webkit-linear-gradient(45deg, transparent, transparent 33%, unquote("rgba(0, 0, 0, 0.1)") 33%, unquote("rgba(0, 0, 0, 0.1)") 66%, transparent 66%), -webkit-linear-gradient(top, unquote("rgba(255, 255, 255, 0.25)"), unquote("rgba(0, 0, 0, 0.2)")), -webkit-linear-gradient(left, #ba7448, #c4672d);
                 /* Looks great, now animating it */
                 background-size: 25px 14px, 100% 100%, 100% 100%;
                 -webkit-animation: move 5s linear 0 infinite;


### PR DESCRIPTION
Libsass on a windows platform is generating silent errors on several
sass color functions ( rgba, rgb, hsla,hsl ). It appears that the c++
function is getting a bit confused and trying to interpolate the
variables and failing. The proposed hack will allow our build to run,
since it wraps rgba(....) in an unquote function that sass then
correctly treats as a literal in its interpolation instead of handing
off to the broken function.

There will be an issue logged with node-sass and libsass to look into
this, but there is a general feeling that it will be address at a later
date, since this behavior is not experienced in Linux and Mac variants.
