### PR TITLE
Test: changed Chai to Expect.js (IE8 support)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "grunt-gh-pages": "~0.7.2",
     "grunt-autoprefixer": "~0.3.0",
     "mocha": "~1.13.0",
-    "chai": "~1.8.0",
+    "expect.js": "~0.2.0",
     "grunt-saucelabs": "~4.0.4"
   }
 }

--- a/site/includes/test.hbs
+++ b/site/includes/test.hbs
@@ -3,14 +3,13 @@
 <!-- Mocha -->
 <link rel="stylesheet" href="{{assets}}/../node_modules/mocha/mocha.css" >
 <script src="{{assets}}/../node_modules/mocha/mocha.js"></script>
-<!-- Chai -->
-<script src="{{assets}}/../node_modules/chai/chai.js"></script>
+<!-- Expect.js -->
+<script src="{{assets}}/../node_modules/expect.js/expect.js"></script>
 
 <script>
-	var expect = chai.expect;
-	mocha.setup('bdd');
-	$(document).on('ready', function(){
-		setTimeout(mocha.run, 2000);
+	mocha.setup( "bdd" );
+	vapour.doc.on( "ready", function() {
+		setTimeout( mocha.run, 2000 );
 	});
 </script>
 

--- a/src/plugins/carousel/test.js
+++ b/src/plugins/carousel/test.js
@@ -1,11 +1,11 @@
 /* global jQuery:false, describe: false, it: false, expect: false*/
 /*jshint unused:vars */
-(function($) {
+(function( $ ) {
 
-	describe("Sample test", function () {
-		it("should pass", function () {
-			expect(true).to.equal(true);
+	describe( "Sample test", function() {
+		it( "should pass", function() {
+			expect( true ).to.equal( true );
 		});
 	});
 
-}) (jQuery);
+})( jQuery );


### PR DESCRIPTION
@LaurentGoderre this is so we'll have IE8 support in our unit tests.  Expect.js is a similar `expect` assertion style to the one offered by Chai, so in theory it should be interchangeable in the future if we ever want to change.
