### PR TITLE
data-picture: Converted to fully event-driven

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -274,8 +274,6 @@ module.exports = (grunt) ->
 				cwd: "lib"
 				src: [
 					"jquery-pjax/jquery.pjax.js"
-					"matchMedia/matchmedia.js"
-					"picturefill/picturefill.js"
 				]
 				dest: "dist/js/deps"
 				expand: true

--- a/bower.json
+++ b/bower.json
@@ -32,8 +32,6 @@
     "jquery-ie": "jquery#1.10.2",
     "respond": "1.2.0",
     "selectivizr": "1.0.2",
-    "picturefill": "1.2.0",
-    "matchmedia": "0.1.0",
     "excanvas": "*"
   },
   "resolutions": {

--- a/src/plugins/data-picture/data-picture.js
+++ b/src/plugins/data-picture/data-picture.js
@@ -1,49 +1,77 @@
-/*
-Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-plugin	:	Picturefill
-author	:	@patheard
-notes	:	Wrapper for @scottjehl's Picturefill library
-licence	:	wet-boew.github.io/wet-boew/License-en.html /
-			wet-boew.github.io/wet-boew/Licence-fr.html
-*/
+/**
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * @title data-picture Plugin
+ * @overview Event driven port of the Picturefill library: https://github.com/scottjehl/picturefill
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @patheard
+ */
 (function( $, window, vapour ) {
 	"use strict";
-	var $document = vapour.doc,
-		plugin = {
+	var plugin = {
 			selector: "[data-picture]",
 
 			/**
-			 * Initialize the plugin
+			 * Initialize the [data-picture] elements
 			 */
 			init: function() {
-				var mode = vapour.getMode();
 				window._timer.remove( plugin.selector );
-
-				// Load picturefill dependencies and bind the init event handler
-				window.Modernizr.load({
-					test: window.matchMedia,
-					nope: "site!deps/matchMedia" + mode + ".js",
-					load: "site!deps/picturefill" + mode + ".js",
-					complete: function() {
-						$document.trigger( "picturefill.wb-data-picture" );
-					}
-				});
+				$( this ).trigger( "picturefill.wb-data-picture" );
 			},
 
 			/**
-			 * Invoke the picturefill library if it has been loaded
+			 * Handles window resize so images can be updated as new media queries match
+			 */
+			resize: function() {
+				$( plugin.selector ).trigger( "picturefill.wb-data-picture" );
+			},
+
+			/**
+			 * Updates the image displayed according to media queries.  This is the logic
+			 * ported from Picturefill.
 			 */
 			picturefill: function() {
-				if ( window.picturefill !== undefined ) {
-					window.picturefill();
+				var i, len, matchedElm, media,
+					matches = [],
+					img = this.getElementsByTagName( "img" )[ 0 ],
+					sources = this.getElementsByTagName( "span" );
+
+				// Loop over the data-media elements and find matching media queries
+				for ( i = 0, len = sources.length; i < len; i++ ) {
+					media = sources[ i ].getAttribute( "data-media" );
+					if ( media === undefined || window.Modernizr.mq( media ) ) {
+						matches.push( sources[ i ] );
+					}
+				}
+
+				// If a media query match was found, add the image to the page
+				if ( matches.length !== 0 ) {
+					matchedElm = matches.pop();
+					if ( img === undefined ) {
+						img = vapour.doc[0].createElement( "img" );
+						img.alt = this.getAttribute( "data-alt" );
+					}
+					img.src =  matchedElm.getAttribute( "data-src" );
+					matchedElm.appendChild( img );
+
+				// No match and an image exists: delete it
+				} else if ( img !== undefined ) {
+					img.parentNode.removeChild( img );
 				}
 			}
 		};
 
 	// Bind the plugin's events
-	$document
-		.on( "timerpoke.wb", plugin.selector, plugin.init)
-		.on( "picturefill.wb-data-picture", plugin.picturefill );
+	vapour.doc.on( "timerpoke.wb picturefill.wb-data-picture", plugin.selector, function( event ) {
+		switch( event.type ) {
+			case "timerpoke":
+				plugin.init.apply( this, arguments );
+				break;
+			case "picturefill":
+				plugin.picturefill.apply( this, arguments );
+				break;
+		}
+	});
+	vapour.win.on( "resize", plugin.resize );
 
 	// Add the timer poke to initialize the plugin
 	window._timer.add( plugin.selector );


### PR DESCRIPTION
1. Ported Picturefull code into `plugin.picturefill` function.  This
   allows the plugin to only enhance the element(s) that trigger the
   `picturefill.wb-data-picture` event.
2. Removed picturefill and matchMedia dependencies (Modernizr.mq is
   now used to match media queries).

@masterbee these are the changes we were talking about earlier today:
- saves the DOM from thrashing, and
- allows any element to use `picturefill.wb-data-picture` event (no init required).
