### PR TITLE
Added enviroment.suffix to modernizr load

### DIFF
--- a/src/core/vapour.js
+++ b/src/core/vapour.js
@@ -168,7 +168,7 @@ Modernizr.load( [{
     yep: "site!polyfills/jawsariafixes" + ( vapour.getMode() ) + ".js"
 }, {
 
-    load: "site!i18n/" + document.documentElement.lang + ".js",
+    load: "site!i18n/" + document.documentElement.lang + ( vapour.getMode() ) + ".js",
     complete: function () {
         window._timer.start();
     }


### PR DESCRIPTION
- Minified building was not preserved in the vapour modernizr call for i18n files
