### PR TITLE
Added ability to modify liblocation

### DIFF
--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -1677,8 +1677,12 @@
 				* @type {string}
 				*/
 				liblocation: (function () {
+					// check for a meta tag entry of name="description" with an attribute of data-liblocation="PATH" instead of 
+					// the request path to pe-ap, otherwise, use path. 
+					var metaLibLocation = $('meta[name=description]').attr("data-liblocation");
 					var pefile = $('body script[src*="/pe-ap"]').attr('src');
-					return pefile.substr(0, pefile.lastIndexOf('/') + 1);
+					metaLibLocation = metaLibLocation.length ? metaLibLocation : pefile.substr(0, pefile.lastIndexOf('/') + 1);
+					return metaLibLocation
 				} ()),
 				themecsslocation: (function () {
 					var themecss = (wet_boew_theme !== null ? $('head link[rel="stylesheet"][href*="' + wet_boew_theme.theme + '"]') : '');

--- a/src/js/pe-ap.js
+++ b/src/js/pe-ap.js
@@ -1679,10 +1679,10 @@
 				liblocation: (function () {
 					// check for a meta tag entry of name="description" with an attribute of data-liblocation="PATH" instead of 
 					// the request path to pe-ap, otherwise, use path. 
-					var metaLibLocation = $('meta[name=description]').attr("data-liblocation");
-					var pefile = $('body script[src*="/pe-ap"]').attr('src');
+					var metaLibLocation = $('meta[name=description]').attr("data-liblocation"),
+					pefile = $('body script[src*="/pe-ap"]').attr('src');
 					metaLibLocation = metaLibLocation.length ? metaLibLocation : pefile.substr(0, pefile.lastIndexOf('/') + 1);
-					return metaLibLocation
+					return metaLibLocation;
 				} ()),
 				themecsslocation: (function () {
 					var themecss = (wet_boew_theme !== null ? $('head link[rel="stylesheet"][href*="' + wet_boew_theme.theme + '"]') : '');


### PR DESCRIPTION
Added ability to modify liblocation for development frameworks, such as JSF, by allowing the addition of data-liblocation  to the description meta tag.

``` html
<meta name="description" content="#{msg['termDescription']}" data-liblocation="#{request.contextPath}/resources/js/" /> 
```

 If data-liblocation is present, use it, otherwise use the default.
