### PR TITLE
Test: changed to minimal browser test config

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -1,60 +1,17 @@
 [{
-	"browserName": "firefox",
-	"platform": "Windows XP"
-}, {
-	"browserName": "firefox",
-	"platform": "Windows 7"
-}, {
-	"browserName": "chrome",
-	"platform": "Windows XP"
-}, {
-	"browserName": "chrome",
-	"platform": "Windows 7"
-}, {
-	"browserName": "chrome",
-	"platform": "Linux"
-}, {
-	"browserName": "internet explorer",
-	"platform": "Windows 8",
-	"version": "10"
-}, {
-	"browserName": "internet explorer",
-	"platform": "Windows 7",
-	"version": "9"
-}, {
-	"browserName": "internet explorer",
-	"platform": "Windows XP",
-	"version": "8"
-}, {
-	"browserName": "opera",
-	"platform": "Windows 7",
-	"version": "12"
-}, {
-	"browserName": "safari",
-	"platform": "OS X 10.6",
-	"version": "5"
-}, {
-	"browserName": "iphone",
-	"platform": "OS X 10.8",
-	"version": "6"
-}, {
-	"browserName": "iphone",
-	"platform": "OS X 10.6",
-	"version": "5.0"
-}, {
-	"browserName": "iphone",
-	"platform": "OS X 10.6",
-	"version": "4"
-}, {
-	"browserName": "ipad",
-	"platform": "OS X 10.8",
-	"version": "6"
-}, {
-	"browserName": "ipad",
-	"platform": "OS X 10.6",
-	"version": "5.0"
-}, {
-	"browserName": "ipad",
-	"platform": "OS X 10.6",
-	"version": "4"
+    "browserName": "firefox",
+    "version": "22",
+    "platform": "XP"
+},{
+    "browserName": "firefox",
+    "version": "21",
+    "platform": "XP"
+},{
+    "browserName": "chrome",
+    "version": "29",
+    "platform": "XP"
+},{
+    "browserName": "chrome",
+    "version": "28",
+    "platform": "Mac 10.6"
 }]


### PR DESCRIPTION
This minimal browser config works consistently for me locally running `grunt saucelabs`.  My testing today seems to show that Saucelabs is not able to consistently initialize browser sessions for the latest versions of Firefox and Chrome.

@nschonni @LaurentGoderre is there a way for me to test this with Travis without submitting a PR against v4.0?

Related to PR #3102.
