### PR TITLE
HTML Data addition to WET 4.0

### DIFF
--- a/License-en.html
+++ b/License-en.html
@@ -34,7 +34,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <!-- CustomCSSEnd -->
 </head>
 
-<body><div id="wb-body">
+<body vocab="http://schema.org/" typeof="WebPage"><div id="wb-body">
 <div id="wb-skip">
 <ul id="wb-tphp">
 <li id="wb-skip1"><a href="#wb-cont">Skip to main content</a></li>
@@ -64,7 +64,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div></section>
 </div></div>
 
-<nav role="navigation">
+<nav role="navigation" typeof="SiteNavigationElement">
 <div id="wet-psnb"><h2>Site menu</h2><div id="wet-psnb-in"><div class="wet-boew-menubar mb-mega"><div>
 <ul class="mb-menu" data-ajax-replace="demos/includes/projectmenu-eng.txt">
 <li><div><a href="http://wet-boew.github.io/wet-boew/index-en.html">WET project</a></div></li>
@@ -73,7 +73,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </ul>
 </div></div></div></div>
 
-<div id="wet-bc"><h2>Breadcrumb trail</h2><div id="wet-bc-in">
+<div id="wet-bc" property="breadcrumb"><h2>Breadcrumb trail</h2><div id="wet-bc-in">
 <ol>
 <li><a href="index-eng.html">Home</a></li>
 <li>Web Experience Toolkit (WET) - Terms and Conditions of Use</li>
@@ -84,9 +84,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </header></div></div>
 
 <div id="wb-core"><div id="wb-core-in" class="equalize">
-<div id="wb-main" role="main"><div id="wb-main-in">
+<div id="wb-main" role="main" property="mainContentOfPage"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Web Experience Toolkit (WET) - Terms and Conditions of Use</h1>
+<h1 id="wb-cont" property="name">Web Experience Toolkit (WET) - Terms and Conditions of Use</h1>
 
 <p>Unless otherwise noted, computer program source code of the Web Experience Toolkit (WET) is 
 covered under Crown Copyright, Government of Canada, and is distributed under the <a href="#license">MIT License</a>.</p>
@@ -122,7 +122,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
 </section>
 
 <dl id="wet-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-06-25</time></span></dd>
+<dt>Date modified:</dt><dd><span><time property="dateModified" datetime="2013-06-25T00:00:01+00:00">2013-06-25</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/License-fr.html
+++ b/License-fr.html
@@ -34,7 +34,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <!-- CustomCSSEnd -->
 </head>
 
-<body><div id="wb-body">
+<body vocab="http://schema.org/" typeof="WebPage"><div id="wb-body">
 <div id="wb-skip">
 <ul id="wb-tphp">
 <li id="wb-skip1"><a href="#wb-cont">Passer au contenu principal</a></li>
@@ -64,7 +64,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div></section>
 </div></div>
 
-<nav role="navigation">
+<nav role="navigation" typeof="SiteNavigationElement">
 <div id="wet-psnb"><h2>Menu du site</h2><div id="wet-psnb-in"><div class="wet-boew-menubar mb-mega"><div>
 <ul class="mb-menu" data-ajax-replace="demos/includes/projectmenu-fra.txt">
 <li><div><a href="http://wet-boew.github.io/wet-boew/index-fr.html">Projet de la BOEW</a></div></li>
@@ -84,9 +84,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </header></div></div>
 
 <div id="wb-core"><div id="wb-core-in" class="equalize">
-<div id="wb-main" role="main"><div id="wb-main-in">
+<div id="wb-main" role="main" property="mainContentOfPage"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Boîte à outils de l'expérience Web (BOEW) - Conditions régissant l'utilisation</h1>
+<h1 id="wb-cont" property="name">Boîte à outils de l'expérience Web (BOEW) - Conditions régissant l'utilisation</h1>
 
 <p>Sauf indication contraire, le code source de la boîte à outils de l'expérience Web (BOEW) 
 est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué 
@@ -127,7 +127,7 @@ DE TOUTE DEMANDE, DOMMAGE OU BRIS DE CONTRAT, DÉLIT CIVIL OU TOUT AUTRE MANQUEM
 </section>
 
 <dl id="wet-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-06-25</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time property="dateModified" datetime="2013-06-25T00:00:01+00:00">2013-06-25</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/index-en.html
+++ b/index-en.html
@@ -34,7 +34,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <!-- CustomCSSEnd -->
 </head>
 
-<body><div id="wb-body">
+<body vocab="http://schema.org/" typeof="WebPage"><div id="wb-body">
 <div id="wb-skip">
 <ul id="wb-tphp">
 <li id="wb-skip1"><a href="#wb-cont">Skip to main content</a></li>
@@ -64,7 +64,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div></section>
 </div></div>
 
-<nav role="navigation">
+<nav role="navigation" typeof="SiteNavigationElement">
 <div id="wet-psnb"><h2>Site menu</h2><div id="wet-psnb-in"><div class="wet-boew-menubar mb-mega"><div>
 <ul class="mb-menu" data-ajax-replace="demos/includes/projectmenu-en.txt">
 <li><div><a href="http://wet-boew.github.io/wet-boew/index-en.html">WET project</a></div></li>
@@ -77,9 +77,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </header></div></div>
 
 <div id="wb-core"><div id="wb-core-in" class="equalize">
-<div id="wb-main" role="main"><div id="wb-main-in">
+<div id="wb-main" role="main" property="mainContentOfPage"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Web Experience Toolkit (WET)</h1>
+<h1 id="wb-cont" property="name">Web Experience Toolkit (WET)</h1>
 
 <section><h2 id="about">What is the Web Experience Toolkit?</h2>
 <ul>
@@ -258,7 +258,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="wet-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-08-06</time></span></dd>
+<dt>Date modified:</dt><dd><span><time property="dateModified" datetime="2013-08-06T00:00:01+00:00">2013-08-06</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/index-fr.html
+++ b/index-fr.html
@@ -34,7 +34,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <!-- CustomCSSEnd -->
 </head>
 
-<body><div id="wb-body">
+<body vocab="http://schema.org/" typeof="WebPage"><div id="wb-body">
 <div id="wb-skip">
 <ul id="wb-tphp">
 <li id="wb-skip1"><a href="#wb-cont">Passer au contenu principal</a></li>
@@ -64,7 +64,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div></section>
 </div></div>
 
-<nav role="navigation">
+<nav role="navigation" typeof="SiteNavigationElement">
 <div id="wet-psnb"><h2>Menu du site</h2><div id="wet-psnb-in"><div class="wet-boew-menubar mb-mega"><div>
 <ul class="mb-menu" data-ajax-replace="demos/includes/projectmenu-fr.txt">
 <li><div><a href="http://wet-boew.github.io/wet-boew/index-fr.html">Projet de la BOEW</a></div></li>
@@ -77,9 +77,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </header></div></div>
 
 <div id="wb-core"><div id="wb-core-in" class="equalize">
-<div id="wb-main" role="main"><div id="wb-main-in">
+<div id="wb-main" role="main" property="mainContentOfPage"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Boîte à outils de l’expérience Web (BOEW)</h1>
+<h1 id="wb-cont" property="name">Boîte à outils de l’expérience Web (BOEW)</h1>
 
 <section><h2 id="apropos">Qu’est-ce que la Boîte à outils de l’expérience Web?</h2>
 <ul>
@@ -259,7 +259,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="wet-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-08-06</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time property="dateModified" datetime="2013-08-06T00:00:01+00:00">2013-08-06</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <!-- CustomCSSEnd -->
 </head>
 
-<body><div id="wb-body">
+<body vocab="http://schema.org/" typeof="WebPage"><div id="wb-body">
 <div id="wb-head"><div id="wb-head-in"><header>
 <!-- HeaderStart -->
 <div id="wet-fullhd"><div id="wet-fullhd-in">
@@ -46,9 +46,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </header></div></div>
 
 <div id="wb-core"><div id="wb-core-in" class="equalize">
-<div id="wb-main" role="main"><div id="wb-main-in">
+<div id="wb-main" role="main" property="mainContentOfPage"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Language selection / <span lang="fr">Sélection de langue</span></h1>
+<h1 id="wb-cont" property="name">Language selection / <span lang="fr">Sélection de langue</span></h1>
 
 <div class="span-4">
 <ul class="button-group">

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -28,7 +28,7 @@
 		<script src="{{assets}}/js/vapour{{environment.suffix}}.js"></script>
 
 	</head>
-	<body>{{#if test}}{{>test}}{{/if}}
+	<body vocab="http://schema.org/" typeof="WebPage">{{#if test}}{{>test}}{{/if}}
 		<div id="wb-skip">
 			<ul id="wb-tphp">
 				<li id="wb-skip1">
@@ -54,24 +54,24 @@
 				</section>
 			</div>
 
-			<nav role="navigation" id="wb-sm">
+			<nav role="navigation" id="wb-sm" typeof="SiteNavigationElement">
 				<h2>{{#i18n "%tmpl-site-menu"}}{{/i18n}}</h2>
 				{{>sitemenu}}
 			</nav>
 
-			<nav role="navigation" id="wb-bc">
+			<nav role="navigation" id="wb-bc" property="breadcrumb">
 				<h2>{{#i18n "%tmpl-bcrumb"}}{{/i18n}}</h2>
 				{{>breadcrumbs}}
 			</nav>
 		</header>
 
-		<main role="main">
-			<h1 id="wb-cont">{{title}}</h1>
+		<main role="main" property="mainContentOfPage">
+			<h1 id="wb-cont" property="name">{{title}}</h1>
 			{{>body}}
 		</main>
 
 		<!-- Secondary Menu [optional] -->
-		<nav role="navigation" id="wb-sec">
+		<nav role="navigation" id="wb-sec" typeof="SiteNavigationElement">
 			<h2>{{#i18n "%tmpl-sec-menu"}}{{/i18n}}</h2>
 			{{>supporting}}
 		</nav>

--- a/src/plugins/menu/menu-en.hbs
+++ b/src/plugins/menu/menu-en.hbs
@@ -5,7 +5,7 @@ language: en
 <section>
 	<h1>{{title}}</h1>
 	<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione, minima deleniti autem tenetur odit nostrum sunt eligendi quasi maiores veritatis voluptate tempore dolorem animi libero!</p>
-	<nav role="navigation" id="wb-sm" data-ajax-replace="menu-{{language}}.txt" data-post-remove="remove after init" class="wb-menu remove after init">
+	<nav role="navigation" id="wb-sm" data-ajax-replace="menu-{{language}}.txt" data-post-remove="remove after init" class="wb-menu remove after init" typeof="SiteNavigationElement">
 		<h2>Navigation</h2>
 		<ul class="list-inline menu">
 			<li><a href="http://www.canada.gc.ca">Lorem ipsum dolor sit amet.</a></li>


### PR DESCRIPTION
As per https://github.com/wet-boew/wet-boew/wiki/GC-Semantic-Web-Implementation-Guide the following has been marked up.
- breadcrumb
- mainContentOfPage
- name
- SiteNavigationElement
- dateModified
