### PR TITLE
Rough port of the v3.1 Footnotes plugin to v4.0

### DIFF
--- a/src/base/base.scss
+++ b/src/base/base.scss
@@ -16,3 +16,4 @@
 @import '../plugins/feedback/feedback.scss';
 @import '../plugins/texthighlight/texthighlight.scss';
 @import '../plugins/prettify/prettify.scss';
+@import '../plugins/footnotes/footnotes.scss';

--- a/src/plugins/footnotes/demo-en.hbs
+++ b/src/plugins/footnotes/demo-en.hbs
@@ -1,0 +1,64 @@
+---
+title: Footnotes
+language: en
+---
+<section>
+	<h2>Overview</h2>
+	<p>The purpose of the Footnotes sub-project is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the <a href="#fnb">Footnotes</a> section. Supporting CSS is used to lay out the footnotes and hide navigational aids<sup id="fnb1-ref"><a class="footnote-link" href="#fnb1"><span class="wb-invisible">Footnote </span>1</a></sup>.</p>
+</section>
+
+<section>
+	<h2>Benefits</h2>
+	<ul>
+		<li>Conforms to WCAG 2.0 AA<sup id="fnb2a-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
+		<li>Progressive enhancement approach</li>
+		<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fnb2b-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
+		<li>Support for English and French</li>
+		<li>Configurable layout and design<sup id="fnb2c-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup>&#160;<sup id="fnb3-ref"><a class="footnote-link" href="#fnb3"><span class="wb-invisible">Footnote </span>3</a></sup></li>
+	</ul>
+</section>
+
+<section>
+	<h2>Recommended usage</h2>
+	<ul>
+		<li>Implementing footnotes in Web pages<sup id="fnb*-ref"><a class="footnote-link" href="#fnb*"><span class="wb-invisible">Footnote </span>*</a></sup></li>
+	</ul>
+</section>
+
+<div class="wb-footnotes" role="note">
+	<section>
+		<h2 id="fnb" class="wb-invisible">Footnotes</h2>
+		<dl>
+			<dt>Footnote 1</dt>
+			<dd id="fnb1">
+				<p>Example of a standard footnote.</p>
+				<p class="footnote-return">
+					<a href="#fnb1-ref"><span class="wb-invisible">Return to footnote </span>1<span class="wb-invisible"> referrer</span></a>
+				</p>
+			</dd>
+			<dt>Footnote 2</dt>
+			<dd id="fnb2">
+				<p>Example of a footnote being referenced by multiple pieces of content.</p>
+				<p class="footnote-return">
+					<a href="#fnb2a-ref"><span class="wb-invisible">Return to <span>first</span> footnote </span>2<span class="wb-invisible"> referrer</span></a>
+				</p>
+			</dd>
+			<dt>Footnote 3</dt>
+			<dd id="fnb3">
+				<p>Example of a footnote containing multiple paragraphs (first paragraph).</p>
+				<p>Example of a footnote containing multiple paragraphs (second paragraph).</p>
+				<p>Example of a footnote containing multiple paragraphs (third paragraph).</p>
+				<p class="footnote-return">
+					<a href="#fnb3-ref"><span class="wb-invisible">Return to footnote </span>3<span class="wb-invisible"> referrer</span></a>
+				</p>
+			</dd>
+			<dt>Footnote *</dt>
+			<dd id="fnb*">
+				<p>Example of a standard footnote, denoted by a symbol.</p>
+				<p class="footnote-return">
+					<a href="#fnb*-ref"><span class="wb-invisible">Return to footnote </span>*<span class="wb-invisible"> referrer</span></a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+</div>

--- a/src/plugins/footnotes/demo-fr.hbs
+++ b/src/plugins/footnotes/demo-fr.hbs
@@ -1,0 +1,64 @@
+---
+title: Notes de bas de page
+language: fr
+---
+<section>
+	<h2>Vue d'ensemble</h2>
+	<p>Le sous-projet Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section <a href="#fnb">Notes de bas de page</a>. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation<sup id="fnb1-ref"><a class="footnote-link" href="#fnb1"><span class="wb-invisible">Note de bas de page </span>1</a></sup>.</p>
+</section>
+
+<section>
+	<h2>Avantages</h2>
+	<ul>
+		<li>Conformes à WCAG 2.0 AA<sup id="fnb2a-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
+		<li>Approche d'amélioration progressive</li>
+		<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fnb2b-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
+		<li>Soutien pour l'anglais et le français</li>
+		<li>Mise en page et conception configurable<sup id="fnb2c-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup>&#160;<sup id="fnb3-ref"><a class="footnote-link" href="#fnb3"><span class="wb-invisible">Note de bas de page </span>3</a></sup></li>
+	</ul>
+</section>
+
+<section>
+	<h2>Utilisation recommandée</h2>
+		<ul>
+			<li>Exécuter les notes de bas de page dans les pages Web<sup id="fnb*-ref"><a class="footnote-link" href="#fnb*"><span class="wb-invisible">Note de bas de page </span>*</a></sup></li>
+		</ul>
+</section>
+
+<div class="wb-footnotes" role="note">
+	<section>
+		<h2 id="fnb" class="wb-invisible">Notes de bas de page</h2>
+		<dl>
+			<dt>Note de bas de page 1</dt>
+			<dd id="fnb1">
+				<p>Exemple de note de bas de page standard.</p>
+				<p class="footnote-return">
+					<a href="#fnb1-ref"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>1</a>
+				</p>
+			</dd>
+			<dt>Note de bas de page 2</dt>
+			<dd id="fnb2">
+				<p>Exemple de note de bas de page qui comporte de nombreux liens.</p>
+				<p class="footnote-return">
+					<a href="#fnb2a-ref"><span class="wb-invisible">Retour à la <span>première</span> référence de la note de bas de page </span>2</a>
+				</p>
+			</dd>
+			<dt>Note de bas de page 3</dt>
+			<dd id="fnb3">
+				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (premier paragraphe).</p>
+				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).</p>
+				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).</p>
+				<p class="footnote-return">
+					<a href="#fnb3-ref"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>3</a>
+				</p>
+			</dd>
+			<dt>Note de bas de page *</dt>
+			<dd id="fnb*">
+				<p>Exemple de note de bas de page standard, représentée par un symbole.</p>
+				<p class="footnote-return">
+					<a href="#fnb*-ref"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>*</a>
+				</p>
+			</dd>
+		</dl>
+	</section>
+</div>

--- a/src/plugins/footnotes/footnotes-ie.scss
+++ b/src/plugins/footnotes/footnotes-ie.scss
@@ -1,0 +1,74 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+
+/*SCSS Variables*/
+$clrWhite: #FFF;
+$clrLight: #EEE;
+$clrDark: #555;
+
+/*Default SCSS*/
+.ie7 {
+	.wb-footnotes {
+		display: inline-block;
+		dl {
+			dt {
+				position: relative;
+				float: left;
+				margin-bottom: -1px;
+			}
+		}
+	}
+}
+
+/*Screen SCSS*/
+@media screen {
+	.ie7 {
+		.wb-footnotes {
+			dd {
+				&.footnote-focus {
+					background-color: $clrLight;
+					border-color: $clrDark;
+					p {
+						&.footnote-return {
+							a {
+								color: $clrWhite !important;
+								background-color: $clrDark;
+								border-color: $clrDark;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+/*Print SCSS*/
+@media print {
+	.ie7 {
+		.wb-footnotes {
+			dl {
+				dd {
+					overflow: auto;
+				}
+			}
+		}
+	}
+	.ie8 {
+		.wb-footnotes {
+			dl {
+				dd {
+					display: block;
+					p {
+						display: inline-block;
+						&.footnote-return {
+							display: block;
+						}
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/plugins/footnotes/footnotes.js
+++ b/src/plugins/footnotes/footnotes.js
@@ -1,0 +1,96 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+/*
+ * WET-BOEW Footnotes plugin
+ */
+(function ( $, window, document, vapour ) {
+	"use strict";
+
+	var selector = ".wb-footnotes",
+		$document = vapour.doc,
+		plugin = {
+			init: function ( $elm ) {
+				// all plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
+				window._timer.remove( selector );
+
+				var $contentArea = $document.find( "main" ).not( ".wb-footnotes" ), //reference to the content area (which needs to be scanned for footnote references)
+					footnote_dd = this.getElementsByTagName( "dd" ),
+					footnote_dt = this.getElementsByTagName( "dt" ),
+					i, len, dd, dt, dtId, button, $returnLinks, $returnLink, refId;
+
+				// Apply aria-labelledby and set initial event handlers for return to referrer links
+				len = footnote_dd.length;
+				for ( i = 0; i !== len; i += 1 ) {
+					dd = footnote_dd[ i ];
+					dt = footnote_dt[ i ];
+					dtId = dd.id + "-dt";
+					dd.setAttribute( "tabindex", "-1" );
+					dd.setAttribute( "aria-labelledby", dtId );
+					dt.id = dtId ;
+				}
+
+				//remove "first/premier/etc"-style text from certain footnote return links (via the child spans that hold those bits of text)
+				$returnLinks = $elm.find( "dd p.footnote-return a" );
+				len = $returnLinks.length;
+				for ( i = 0; i !== len; i += 1 ) {
+					$returnLink = $returnLinks.eq( i );
+					$returnLink.find( "span span" ).remove();
+				}
+
+				$returnLinks.off( "click vclick" ).on( "click.wb-footnotes vclick.wb-footnotes", function( event ) {
+					button = event.which;
+					if ( !button || button === 1 ) { // Ignore middle/right mouse buttons
+						refId = vapour.jqEscape( this.getAttribute( "href" ) ).substring( 1 );
+						//TODO: Replace with global focus function
+						setTimeout( function () {
+							$contentArea.find( refId + " a" ).focus();
+						}, 0 );
+							return false;
+					}
+				});
+
+				//listen for footnote reference links that get clicked
+				$contentArea.find( "sup a.footnote-link" ).on( "click vclick", function ( event ) {
+					//captures certain information about the clicked link
+					var $refLinkDest = $elm.find( vapour.jqEscape( this.getAttribute( "href" ) ).substring( 1 ) ),
+						button = event.which;
+					if ( !button || button === 1 ) { // Ignore middle/right mouse buttons
+						$refLinkDest.find( "p.footnote-return a" )
+									.attr( "href", "#" + this.parentNode.id )
+									.off( "click vclick" )
+									.on( "click.wb-footnotes vclick.wb-footnotes", function ( event ) {
+							var button = event.which,
+								refId;
+							if ( !button || button === 1 ) { // Ignore middle/right mouse buttons
+								refId = vapour.jqEscape( this.getAttribute( "href" ) ).substring( 1 );
+								//TODO: Replace with global focus function
+								setTimeout( function () {
+									$contentArea.find( refId + " a" ).focus();
+								}, 0 );
+
+								return false;
+							}
+						});
+
+						//TODO: Replace with global focus function
+						setTimeout( function () {
+							$refLinkDest.focus();
+						}, 0 );
+
+						return false;
+					}
+				});
+			}
+		};
+
+	// Bind the init event of the plugin
+	$document.on( "timerpoke.wb", selector, function () {
+		plugin.init.apply( this, [ $( this ) ] );
+		return true; // since we are working with events we want to ensure that we are being passive about out control, so return true allows for events to always continue
+	});
+
+	// Add the timer poke to initialize the plugin
+	window._timer.add( selector );
+})( jQuery, window, document, vapour );

--- a/src/plugins/footnotes/footnotes.scss
+++ b/src/plugins/footnotes/footnotes.scss
@@ -1,0 +1,204 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+
+/*SCSS Variables*/
+$spacing: .375em;
+$ddRtnWidth: 2.75em;
+$clrWhite: #FFF;
+$clrLight: #EEE;
+$clrMedium: #CCC;
+$clrDark: #555;
+
+/*Default SCSS*/
+%footnote-link-highlight {
+	color: $clrWhite !important;
+	background-color: $clrDark;
+	border-color: $clrDark;
+}
+%footnote-link-background-white {
+	background-color: $clrWhite;
+}
+%footnote-link-background-light-border-medium-padding-whitespace {
+	background-color: $clrLight;
+	border: 1px solid $clrMedium;
+	padding: 0 4px 1px;
+	white-space: nowrap;
+	&:hover, &:focus {
+		@extend %footnote-link-highlight;
+	}
+}
+sup {
+	a {
+		&.footnote-link {
+			@extend %footnote-link-background-light-border-medium-padding-whitespace;
+		}
+	}
+}
+.background-light {
+	sup {
+		a {
+			&.footnote-link {
+				@extend %footnote-link-background-white;
+				&:hover, &:focus {
+					@extend %footnote-link-highlight;
+				}
+			}
+		}
+	}
+}
+table {
+	th {
+		sup {
+			a {
+				&.footnote-link {
+					@extend %footnote-link-background-white;
+					text-shadow: none;
+				}
+			}
+		}
+	}
+}
+.wb-footnotes {
+	margin: 2em 10px 0 10px;
+	border-width: 1px 0 1px 0;
+	border-style: solid;
+	border-color: $clrMedium;
+	h2 {
+		margin-left: 0;
+		margin-right: 0;
+		margin-top: 0;
+	}
+	dl {
+		margin: 0;
+		dt {
+			position: absolute;
+			clip: rect(0, 0, 0, 0);
+			height: 1px;
+			width: 1px;
+			overflow: hidden;
+			margin: 0;
+		}
+		dd {
+			position: relative;
+			margin: $spacing 0;
+			border: 1px solid transparent;
+			&:focus {
+				background-color: $clrLight;
+				border-color: $clrDark;
+				p {
+					&.footnote-return {
+						a {
+							@extend %footnote-link-highlight;
+						}
+					}
+				}
+			}
+			p {
+				margin: 0 0 0 ($spacing + $ddRtnWidth);
+				padding: 0 $spacing $spacing $spacing;
+				&:first-child {
+					padding-top: $spacing;
+				}
+				&.footnote-return {
+					top: 0;
+					margin: 0;
+					padding-top: $spacing;
+					padding-right: 0;
+					position: absolute;
+					width: $ddRtnWidth;
+					overflow: hidden;
+					a {
+						@extend %footnote-link-background-light-border-medium-padding-whitespace;
+						display: inline-block;
+						padding-bottom: 0;
+					}
+				}
+			}
+		}
+	}
+}
+
+/* Right to left (RTL) CSS */
+[dir="rtl"] {
+	.wb-footnotes {
+		dl {
+			dd {
+				p {
+					margin-left: 0;
+					margin-right: 3.125em;
+					padding-left: 0;
+					padding-right: 0.375em;
+					&.footnote-return {
+						margin-right: 0;
+						padding-right: 0;
+					}
+				}
+			}
+		}
+	}
+}
+
+/*Print SCSS*/
+@media print {
+	%footnote-link-background-transparent {
+		background-color: transparent;
+	}
+	%footnote-print-link-background-transparent-border-0-padding-0 {
+		background-color: transparent;
+		border: 0;
+		padding: 0;
+	}
+	sup {
+		a {
+			&.footnote-link {
+				@extend %footnote-print-link-background-transparent-border-0-padding-0;
+			}
+		}
+	}
+	.background-light {
+		sup {
+			a {
+				&.footnote-link {
+					@extend %footnote-link-background-transparent;
+				}
+			}
+		}
+	}
+	table {
+		th {
+			sup {
+				a {
+					&.footnote-link {
+						@extend %footnote-link-background-transparent;
+					}
+				}
+			}
+		}
+	}
+	.wb-footnotes {
+		border {
+			left: 0;
+			right: 0;
+		}
+		margin-left: 0;
+		margin-right: 0;
+		margin-bottom: 1em;
+		dl {
+			dd {
+				border: 0;
+				width: 100%;
+				display: inline-block;
+				p {
+					&.footnote-return {
+						overflow: visible;
+						a {
+							@extend %footnote-print-link-background-transparent-border-0-padding-0;
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Notes:
1. footnotes-ie.scss has not been attached. Not sure how to deal with oldIE-specific SCSS
2. Removed pseudo-focus and clip-rect mixin references. Not sure how they should be referenced in v4.0 or if they are still needed.
3. Remove inline-block Compass mixin since Compass doesn't seem to be supported and don't know what is the alternative (or if the inline-block mixin is still needed)
4. Uses .background-light in the SCSS which might be an artifact of the old grid system.
