### PR TITLE
Build: fix assemble of grunt test builds

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -65,7 +65,7 @@ module.exports = (grunt) ->
 					layout: "default.hbs"
 					environment:
 						suffix: "<%= environment.suffix %>"
-					test: if grunt.cli.tasks.indexOf('test') then true else false
+						test: grunt.cli.tasks.indexOf('test') > -1
 				expand: true
 				cwd: "src/plugins"
 				src: ["**/*.hbs"]

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -28,7 +28,7 @@
 		<script src="{{assets}}/js/vapour{{environment.suffix}}.js"></script>
 
 	</head>
-	<body vocab="http://schema.org/" typeof="WebPage">{{#if test}}{{>test}}{{/if}}
+	<body vocab="http://schema.org/" typeof="WebPage">{{#if environment.test}}{{>test}}{{/if}}
 		<div id="wb-skip">
 			<ul id="wb-tphp">
 				<li id="wb-skip1">


### PR DESCRIPTION
Fixed assemble condition so the unit test resources are only added when `grunt test` task is run.
