### PR TITLE
Build: Bump gh-pages for silent option

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -492,6 +492,7 @@ module.exports = (grunt) ->
 				branch: process.env.build_branch
 				clone: "wet-boew-dist"
 				message: "Travis build " + process.env.TRAVIS_BUILD_NUMBER
+				silent: true
 			src: [
 				"dist/**/*.*",
 				"*.html",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-jshint": "~0.6.2",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-gh-pages": "~0.7.2",
+    "grunt-gh-pages": "~0.8.0",
     "grunt-modernizr": "~0.3.0",
     "grunt-sass": "~0.6.1",
     "grunt-saucelabs": "~4.0.4",

--- a/travis.sh
+++ b/travis.sh
@@ -23,9 +23,7 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_REPO_SLUG" == "wet-boew/w
 
 	export build_branch="$TRAVIS_BRANCH-dist"
 
-	grunt deploy > /dev/null 2>&1  || error_exit "Error cloning the artifact repository";
-
-	echo -e "Done uploading the build artifact for branch $TRAVIS_BRANCH\n"
+	grunt deploy || error_exit "Error running gh-pages task";
 
 	#Update the working examples
 	echo -e "Updating working examples...\n"
@@ -51,9 +49,6 @@ if [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_REPO_SLUG" == "wet-boew/w
 	git add .
 	git commit -q -m "Travis build $TRAVIS_BUILD_NUMBER"
 	git push -fq origin master > /dev/null 2>&1 || error_exit "Error uploading the working examples"
-
-
-	echo -e "Finished updating the working examples\n"
 
 fi
 


### PR DESCRIPTION
Trying to fix #3125 again :frowning: 

---

The silent option now swallows the logging, so /dev/null piping isn't required. https://github.com/tschaub/grunt-gh-pages/pull/16

/cc @LaurentGoderre for the merge
