### PR TITLE
Migrated multiple plugins to the new v4.0 plugin template

### DIFF
--- a/src/plugins/ajax-fetch/ajax-fetch.js
+++ b/src/plugins/ajax-fetch/ajax-fetch.js
@@ -1,60 +1,62 @@
 /*
-    Web Experience Toolkit (WET) / Boîte à outils de l\'expérience Web (BOEW)
-    _plugin : Ajax Fetch [ ajax-fetch ]
-    _author : World Wide Web
-    _notes  : A basic AjaxLoader wrapper for WET-BOEW that appends to elements
-    _licence: wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
-*/
+ * @title WET-BOEW Ajax Fetch [ ajax-fetch ]
+ * @overview A basic AjaxLoader wrapper for WET-BOEW
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author WET Community
+ */
+(function ( $, vapour ) {
+	"use strict";
 
-(function ( $, window, vapour ) {
+	$.ajaxSettings.cache = false;
 
-"use strict";
+	/* 
+	 * Variable and function definitions. 
+	 * These are global to the plugin - meaning that they will be initialized once per page,
+	 * not once per instance of plugin on the page. So, this is a good place to define
+	 * variables that are common to all instances of the plugin on a page.
+	 */
+	var $document = vapour.doc,
 
-$.ajaxSettings.cache = false;
+		/*
+		 * @method generateSerial
+		 * @param {integer} Length of the random string to be generated
+		 */
+		generateSerial = function ( len ) {
+			var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz",
+				string_length = len,
+				randomstring = "",
+				counter = 0,
+				letterOrNumber,
+				newNum,
+				rnum;
 
-var $document = vapour.doc,
-    generateSerial;
-    
-generateSerial = function ( len ) { //internal core functions
+			for ( counter; counter !== string_length; counter += 1 ) {
+				letterOrNumber = Math.floor( Math.random( ) * 2 );
+				if ( letterOrNumber === 0 ) {
+					newNum = Math.floor( Math.random( ) * 9 );
+					randomstring += newNum;
+				} else {
+					rnum = Math.floor( Math.random( ) * chars.length );
+					randomstring += chars.substring( rnum, rnum + 1 );
+				}
+			}
+			return randomstring;
+		};
 
-    var chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXTZabcdefghiklmnopqrstuvwxyz",
-        string_length = len,
-        randomstring = "",
-        counter = 0,
-        letterOrNumber,
-        newNum,
-        rnum;
+	// Event binding
+	$document.on( "ajax-fetch.wb", function ( event ) {
+		var _caller = event.element,
+			_url = event.fetch,
+			_id = "wb" + ( generateSerial( 8 ) );
 
-    while ( counter < string_length ) {
-        letterOrNumber = Math.floor( Math.random( ) * 2 );
-        if ( letterOrNumber === 0 ) {
-            newNum = Math.floor( Math.random( ) * 9 );
-            randomstring += newNum;
-        }
-        else {
-            rnum = Math.floor( Math.random( ) * chars.length );
-            randomstring += chars.substring( rnum, rnum + 1 );
-        }
-        counter++;
-    }
-    return randomstring;
-};
+		$( "<div id='" + _id + "' />" )
+			.load( _url, function () {
+				$( _caller )
+					.trigger( {
+						type: "ajax-fetched.wb",
+						pointer: $( this )
+					} );
+			} );
+	} );
 
-//Event binding
-$document.on( "ajax-fetch.wb", function ( event ) {
-    var _caller = event.element,
-        _url = event.fetch,
-        _id = "wb" + ( generateSerial( 8 ) );
-
-    $( "<div id='" + _id + "' />" )
-        .load( _url, function () {
-            $( _caller )
-                .trigger( {
-                    type: "ajax-fetched.wb",
-                    pointer: $( this )
-                } );
-        } );
-
-});
-
-})( jQuery, window, vapour );
+} )( jQuery, vapour );

--- a/src/plugins/carousel/carousel.js
+++ b/src/plugins/carousel/carousel.js
@@ -5,14 +5,14 @@
  * @author WET Community
  */
 (function ( $, window, vapour ) {
-    "use strict";
+	"use strict";
 
-    /* 
-     * Variable and function definitions. 
-     * These are global to the plugin - meaning that they will be initialized once per page,
-     * not once per instance of plugin on the page. So, this is a good place to define
-     * variables that are common to all instances of the plugin on a page.
-     */
+	/* 
+	 * Variable and function definitions. 
+	 * These are global to the plugin - meaning that they will be initialized once per page,
+	 * not once per instance of plugin on the page. So, this is a good place to define
+	 * variables that are common to all instances of the plugin on a page.
+	 */
 	var selector = ".wb-carousel",
 		$document = vapour.doc,
 		controls = selector + " .prv, " + selector + " .nxt, " + selector + " .plypause",
@@ -101,7 +101,6 @@
 		var eventType = event.type,
 
 			// "this" is cached for all events to utilize
-
 			$elm = $( this );
 
 		switch ( eventType ) {
@@ -124,10 +123,10 @@
 			break;
 		}
 		
-        /*
-         * Since we are working with events we want to ensure that we are being passive about our control, 
-         * so returning true allows for events to always continue
-         */
+		/*
+		 * Since we are working with events we want to ensure that we are being passive about our control, 
+		 * so returning true allows for events to always continue
+		 */
 		return true;
 	} );
 
@@ -152,14 +151,14 @@
 		}
 		_sldr.attr( "data-ctime", 0 );
 
-        /*
-         * Since we are working with events we want to ensure that we are being passive about our control, 
-         * so returning true allows for events to always continue
-         */
+		/*
+		 * Since we are working with events we want to ensure that we are being passive about our control, 
+		 * so returning true allows for events to always continue
+		 */
 		return true;
 	} );
 
 	// Add the timer poke to initialize the plugin
-
 	window._timer.add( ".wb-carousel" );
-})( jQuery, window, vapour );
+
+} )( jQuery, window, vapour );

--- a/src/plugins/data-after/data-after.js
+++ b/src/plugins/data-after/data-after.js
@@ -1,44 +1,65 @@
 /*
-    Web Experience Toolkit (WET) / Boîte à outils de l\'expérience Web (BOEW)
-    _plugin : Ajax Loader [ data-append ]
-    _author : World Wide Web
-    _notes  : A basic AjaxLoader wrapper for WET-BOEW that appends to elements
-    _licence: wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
-*/
-
+ * @title WET-BOEW Ajax Loader [ data-append ]
+ * @overview A basic AjaxLoader wrapper for WET-BOEW that inserts content after elements
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author WET Community
+ */
 (function ( $, window, vapour ) {
+	"use strict";
 
-"use strict";
+	$.ajaxSettings.cache = false;
 
-$.ajaxSettings.cache = false;
+	/* 
+	 * Variable and function definitions. 
+	 * These are global to the plugin - meaning that they will be initialized once per page,
+	 * not once per instance of plugin on the page. So, this is a good place to define
+	 * variables that are common to all instances of the plugin on a page.
+	 */
+	var selector = "[data-ajax-after]",
+		$document = vapour.doc,
 
-var $document = vapour.doc;
+		/*
+		 * Init runs once per plugin element on the page. There may be multiple elements. 
+		 * It will run more than once per plugin if you don't remove the selector from the timer.
+		 * @method init
+		 * @param {jQuery DOM element} $elm The plugin element being initialized
+		 */
+		init = function ( $elm ) {
 
-$document.on( "timerpoke.wb ajax-fetched.wb", "[data-ajax-append]", function (
-    event ) {
-    var eventType = event.type,
-        _elm = $( this ),
-        _url;
+			var _url = $elm.data( "ajax-after" );
 
-    switch ( eventType ) {
-    case "timerpoke":
-        window._timer.remove( "[data-ajax-after]" );
-        _url = _elm.data( "ajax-after" );
-        $document.trigger({
-            type: "ajax-fetch.wb",
-            element: _elm,
-            fetch: _url
-        });
-        break;
-    case "ajax-fetched":
-        _elm.after( event.pointer.html() );
-        _elm.trigger( "ajax-after-loaded.wb" );
-        break;
+			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
+			window._timer.remove( selector );
 
-    }
-    return false;
-} );
+			$document.trigger( {
+				type: "ajax-fetch.wb",
+				element: $elm,
+				fetch: _url
+			} );
+		};
 
-window._timer.add( "[data-ajax-after]" );
+	$document.on( "timerpoke.wb ajax-fetched.wb", selector, function ( event ) {
+		var eventType = event.type,
+			$elm = $( this );
 
-})( jQuery, window, vapour );
+		switch ( eventType ) {
+		case "timerpoke":
+			init( $elm );
+			break;
+		case "ajax-fetched":
+			$elm.after( event.pointer.html() )
+				.trigger( "ajax-after-loaded.wb" );
+			break;
+		}
+
+		/*
+		 * Since we are working with events we want to ensure that we are being passive about our control, 
+		 * so returning true allows for events to always continue
+		 */
+		return true;
+	} );
+
+	// Add the timer poke to initialize the plugin
+	window._timer.add( selector );
+
+} )( jQuery, window, vapour );

--- a/src/plugins/data-append/data-append.js
+++ b/src/plugins/data-append/data-append.js
@@ -1,48 +1,65 @@
 /*
-    Web Experience Toolkit (WET) / Boîte à outils de l\'expérience Web (BOEW)
-    _plugin : Ajax Loader [ data-append ]
-    _author : World Wide Web
-    _notes  : A basic AjaxLoader wrapper for WET-BOEW that appends to elements
-    _licence: wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
-*/
-
+ * @title WET-BOEW Ajax Loader [ data-append ]
+ * @overview A basic AjaxLoader wrapper for WET-BOEW that appends to elements
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author WET Community
+ */
 (function ( $, window, vapour ) {
+	"use strict";
 
-"use strict";
+	$.ajaxSettings.cache = false;
 
-$.ajaxSettings.cache = false;
+	/* 
+	 * Variable and function definitions. 
+	 * These are global to the plugin - meaning that they will be initialized once per page,
+	 * not once per instance of plugin on the page. So, this is a good place to define
+	 * variables that are common to all instances of the plugin on a page.
+	 */
+	var selector = "[data-ajax-append]",
+		$document = vapour.doc,
 
-var $document = vapour.doc;
+		/*
+		 * Init runs once per plugin element on the page. There may be multiple elements. 
+		 * It will run more than once per plugin if you don't remove the selector from the timer.
+		 * @method init
+		 * @param {jQuery DOM element} $elm The plugin element being initialized
+		 */
+		init = function ( $elm ) {
 
-$document.on( "timerpoke.wb ajax-fetched.wb", "[data-ajax-append]", function (
-    event ) {
+			var _url = $elm.data( "ajax-append" );
 
-    var eventType = event.type,
-        _elm = $( this ),
-        _url;
+			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
+			window._timer.remove( selector );
 
-    switch ( eventType ) {
-    case "timerpoke":
+			$document.trigger( {
+				type: "ajax-fetch.wb",
+				element: $elm,
+				fetch: _url
+			} );
+		};
 
-        window._timer.remove( "[data-ajax-append]" );
-        _url = _elm.data( "ajax-append" );
-        $document.trigger( {
-            type: "ajax-fetch.wb",
-            element: _elm,
-            fetch: _url
-        } );
-        break;
+	$document.on( "timerpoke.wb ajax-fetched.wb", selector, function ( event ) {
+		var eventType = event.type,
+			$elm = $( this );
 
-    case "ajax-fetched":
+		switch ( eventType ) {
+		case "timerpoke":
+			init( $elm );
+			break;
+		case "ajax-fetched":
+			$elm.append( event.pointer.html() )
+				.trigger( "ajax-append-loaded.wb" );
+			break;
+		}
 
-        _elm.append( event.pointer.html() );
-        _elm.trigger( "ajax-append-loaded.wb" );
-        break;
+		/*
+		 * Since we are working with events we want to ensure that we are being passive about our control, 
+		 * so returning true allows for events to always continue
+		 */
+		return true;
+	} );
 
-    }
-    return false;
-} );
+	// Add the timer poke to initialize the plugin
+	window._timer.add( selector );
 
-window._timer.add( "[data-ajax-append]" );
-
-})( jQuery, window, vapour );
+} )( jQuery, window, vapour );

--- a/src/plugins/data-inview/data-inview.js
+++ b/src/plugins/data-inview/data-inview.js
@@ -1,65 +1,102 @@
 /*
-    Web Experience Toolkit (WET) / Boîte à outils de l\'expérience Web (BOEW)
-    _plugin : Data Inview Plugin v1.0
-    _author : WET Community
-    _notes  : A simplified data-attribute driven plugin that responds to moving in and out of the viewport.
-    _licence: wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
-*/
-
+ * @title WET-BOEW Data Inview
+ * @overview A simplified data-attribute driven plugin that responds to moving in and out of the viewport.
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @YOU or WET Community
+ */
 (function ( $, window, vapour ) {
+	"use strict";
 
-"use strict";
+	/* 
+	 * Variable and function definitions. 
+	 * These are global to the plugin - meaning that they will be initialized once per page,
+	 * not once per instance of plugin on the page. So, this is a good place to define
+	 * variables that are common to all instances of the plugin on a page.
+	 */
+	var selector = ".wb-inview",
+		$document = vapour.doc,
+		$window = vapour.win,
 
-var $document = vapour.doc;
+		/*
+		 * Init runs once per plugin element on the page. There may be multiple elements. 
+		 * It will run more than once per plugin if you don't remove the selector from the timer.
+		 * @method init
+		 * @param {jQuery DOM element} $elm The plugin element being initialized
+		 */
+		init = function ( $elm ) {
 
-$document.on( "timerpoke.wb", ".wb-inview", function () {
-    window._timer.remove( ".wb-inview" );
+			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
+			window._timer.remove( selector );
 
-    var $window = vapour.win,
-        $this = $( this ),
-        $message = $this.find( ".pg-banner, .pg-panel" )
-            .attr( "role", "toolbar" )
-            .attr( "aria-hidden", "true" );
+			$elm.trigger( "scroll.wb-inview" );
+		},
 
-    $window.on( "scroll scrollstop resize", function () {
-        $this.trigger( "scroll.wb-inview" );
-    });
+		/*  
+		 * @method onInview
+		 * @param {jQuery DOM element} $elm The plugin element
+		 * @param {jQuery Event} event The event that triggered this method call
+		 */
+		onInview = function ( $elm ) {
+			var $window = vapour.win,
+				elementWidth = $elm.outerWidth(),
+				elementHeight = $elm.outerHeight(),
+				viewportHeight = $window.height(),
+				scrollTop = $window.scrollTop(),
+				scrollLeft = $window.scrollLeft(),
+				scrollRight = scrollLeft + elementWidth,
+				scrollBottom = scrollTop + viewportHeight,
+				x1 = $elm.offset().left,
+				x2 = x1 + elementWidth,
+				y1 = $elm.offset().top,
+				y2 = y1 + elementHeight,
+				$message = $elm.find( ".pg-banner, .pg-panel" ).attr( {
+					"role": "toolbar",
+					"aria-hidden": "true"
+				} );
 
-    $this.on( "scroll.wb-inview", function () {
-        var _elm = $( this ),
-            _viewport = $window,
-            elementWidth = _elm.outerWidth(),
-            elementHeight = _elm.outerHeight(),
-            viewportHeight = _viewport.height(),
-            scrollTop = _viewport.scrollTop(),
-            scrollLeft = _viewport.scrollLeft(),
-            scrollRight = scrollLeft + elementWidth,
-            scrollBottom = scrollTop + viewportHeight,
-            x1 = _elm.offset()
-                .left,
-            x2 = x1 + elementWidth,
-            y1 = _elm.offset()
-                .top,
-            y2 = y1 + elementHeight;
-        if ( ( scrollBottom < y1 || scrollTop > y2 ) || ( scrollRight < x1 ||
-            scrollRight > x2 ) ) {
-            $message.removeClass( "in" )
-                .addClass( "out" )
-                .wb( "hide", true );
-        }
-        else {
-            $message.removeClass( "out" )
-                .addClass( "in" )
-                .wb( "show", true );
-        }
-        return false;
-    });
+			if ( ( scrollBottom < y1 || scrollTop > y2 ) || ( scrollRight < x1 || scrollRight > x2 ) ) {
+				$message.removeClass( "in" )
+					.addClass( "out" )
+					.wb( "hide", true );
+			}
+			else {
+				$message.removeClass( "out" )
+					.addClass( "in" )
+					.wb( "show", true );
+			}
+		};
 
-    $this.trigger( "scroll.wb-inview" );
+	// Bind the init event of the plugin
+	$document.on( "timerpoke.wb scroll.wb-inview", selector, function ( event ) {
+		var eventType = event.type,
+			$elm = $( this );
 
-    return false;
-});
+		switch ( eventType ) {
+		case "timerpoke":
+			init( $elm );
+			break;
+		case "scroll":
+			onInview( $elm );
+			break;
+		}
 
-window._timer.add( ".wb-inview" );
+		/*
+		 * Since we are working with events we want to ensure that we are being passive about our control, 
+		 * so returning true allows for events to always continue
+		 */
+		return true;
+	} );
 
-})( jQuery, window, vapour );
+	$window.on( "scroll scrollstop", function () {
+		$( selector ).trigger( "scroll.wb-inview" );
+	} );
+
+	$document.on( "text-resize.wb window-resize-width.wb window-resize-height.wb", function () {
+		$( selector ).trigger( "scroll.wb-inview" );
+	} );
+
+	// Add the timer poke to initialize the plugin
+
+	window._timer.add( selector );
+
+} )( jQuery, window, vapour );

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -16,6 +16,11 @@
 	var selector = ".wb-equalheight",
 		$document = vapour.doc,
 
+		/*
+		 * Init runs once per plugin element on the page. There may be multiple elements. 
+		 * It will run more than once per plugin if you don't remove the selector from the timer.
+		 * @method init
+		 */
 		init = function () {
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
@@ -24,7 +29,10 @@
 			onResize();
 		},
 
-		// Re-equalise any time the window/document or a child element of 'selector' is resized.
+		/*
+		 * Re-equalise any time the window/document or a child element of 'selector' is resized.
+		 * @method onResize
+		 */
 		onResize = function () {
 			var $elm = $( selector ),
 				$children = $elm.children(),
@@ -62,6 +70,11 @@
 			}
 		},
 
+		/*
+		 * @method setRowHeight
+		 * @param {array} row The rows to be updated
+		 * @param {integer} height The new row height
+		 */
 		setRowHeight = function ( row, height ) {
 			for ( var i = row.length - 1; i >= 0; i-- ) {
 				row[ i ].style.height = height + "px";


### PR DESCRIPTION
The following plugins were migrated to the new template:
- ajax-fetch
- carousel
- data-after
- data-append
- data-before
- data-inview
- data-picture
- data-replace
- equalheights
