### PR TITLE
Tabbed Interface: fix mobile tab creation

### DIFF
--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -59,7 +59,7 @@
 			// Create the accordion panels
 			for (index = 0, len = $panels.length; index < len; index += 1) {
 				$link = $tabs.eq(index).children('a');
-				accordion += '<div data-role="collapsible"' + (index === defaultTab ? ' data-collapsed="false"' : '') + ' data-tab="' + this._get_hash($link.attr('href')) + '">' + hopen + $link.text() + hclose + '</div>';
+				accordion += '<div data-role="collapsible"' + (index === defaultTab ? ' data-collapsed="false"' : '') + ' data-tab="' + this._get_hash($link.attr('href')) + '">' + hopen + $link.html() + hclose + '</div>';
 			}
 			$accordion = $(accordion);
 


### PR DESCRIPTION
Changed to `$link.html()` when creating the mobile accordion tab labels.  This prevents the text of hidden tab link children from showing in mobile (fixes #3193). 
