### PR TITLE
Hotfix disabled

### DIFF
--- a/src/core/vapour.js
+++ b/src/core/vapour.js
@@ -105,13 +105,13 @@ var getUrlParts = function( url ) {
 	 * @return {boolean} of state of disabled flag
 	 */
 	disabled = (function() {
-			var disabled = currentpage.params.wbdisable;
+		var disabled = currentpage.params.wbdisable;
 
-			if ( disabled === undefined && localStorage && localStorage.getItem( "wbdisable" ) ) {
-					disabled = localStorage.getItem( "wbdisable" );
-			}
-			return !!disabled;
-		}()),
+		if ( disabled === undefined && localStorage && localStorage.getItem( "wbdisable" ) ) {
+				disabled = localStorage.getItem( "wbdisable" );
+		}
+		return (typeof disabled === "string") ? (disabled.toLowerCase() === "true") : Boolean(disabled);
+	}()),
 
 	/*-----------------------------
 	 * Vapour Core Object

--- a/src/core/vapour.js
+++ b/src/core/vapour.js
@@ -105,15 +105,12 @@ var getUrlParts = function( url ) {
 	 * @return {boolean} of state of disabled flag
 	 */
 	disabled = (function() {
-			var disabled = currentpage.params.wbdisable,
-				toBoolean = function( sBoolean ) {
-					return ( /^true$/i ).test( sBoolean.toString() );
-				};
+			var disabled = currentpage.params.wbdisable;
 
 			if ( disabled === undefined && localStorage && localStorage.getItem( "wbdisable" ) ) {
 					disabled = localStorage.getItem( "wbdisable" );
 			}
-			return toBoolean( disabled );
+			return !!disabled;
 		}()),
 
 	/*-----------------------------
@@ -270,8 +267,6 @@ window._timer = {
  *-----------------------------*/
 window.Modernizr.load([
 	{
-		load: "site!i18n!modejs!i18n/"
-	}, {
 		test: Modernizr.canvas,
 		nope: "disabled!site!modejs!polyfills/excanvas.min.js"
 	}, {
@@ -299,6 +294,8 @@ window.Modernizr.load([
 		test: vapour.ie && vapour.desktop,
 		yep: "disabled!site!modejs!polyfills/jawsariafixes.min.js",
 	*/
+	}, {
+		load: "site!i18n!modejs!i18n/",
 		complete: function() {
 			window._timer.start();
 		}

--- a/src/core/vapour.js
+++ b/src/core/vapour.js
@@ -110,7 +110,7 @@ var getUrlParts = function( url ) {
 		if ( disabled === undefined && localStorage && localStorage.getItem( "wbdisable" ) ) {
 				disabled = localStorage.getItem( "wbdisable" );
 		}
-		return (typeof disabled === "string") ? (disabled.toLowerCase() === "true") : Boolean(disabled);
+		return ( typeof disabled === "string" ) ? ( disabled.toLowerCase() === "true" ) : Boolean( disabled );
 	}()),
 
 	/*-----------------------------


### PR DESCRIPTION
Normalized the boolean casting to trap safetly for "string" representations of true and false. Boolean() handles all other cases of null,undefined, 1, 0, etc.
