### PR TITLE
Build: Concat IE8 assets and align markup

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -74,7 +74,6 @@ module.exports = (grunt) ->
 		[
 			"coffee",
 			"copy:jquery",
-			"copy:oldie",
 			"copy:polyfills",
 			"copy:deps",
 			"copy:jsAssets",
@@ -175,6 +174,22 @@ module.exports = (grunt) ->
 				]
 				dest: "dist/js/vapour.js"
 
+			coreIE8:
+				options:
+					stripBanners: false
+				src: [
+					"lib/respond/respond.min.js"
+					"lib/html5shiv/dist/html5shiv.js"
+					"lib/excanvas/excanvas.js"
+					"lib/jquery-ie/jquery.min.js"
+					"lib/selectivizr/selectivizr.js"
+					"src/polyfills/localstorage/localstorage.js"
+					"lib/modernizr/modernizr-custom.js"
+					"src/core/vapour.js"
+				]
+				dest: "dist/js/vapour-ie8.js"
+
+
 		# Builds the demos
 		assemble:
 			options:
@@ -273,6 +288,7 @@ module.exports = (grunt) ->
 					preserveComments: "some"
 				files:
 					"dist/js/vapour<%= environment.suffix %>.js": "dist/js/vapour.js"
+					"dist/js/vapour-ie8<%= environment.suffix %>.js": "dist/js/vapour-ie8.js"
 
 			plugins:
 				options:
@@ -310,7 +326,6 @@ module.exports = (grunt) ->
 				ext: "<%= environment.suffix %>.css"
 
 		coffee:
-
 			plugins:
 				options:
 					bare: true
@@ -321,14 +336,14 @@ module.exports = (grunt) ->
 			devFile: "lib/modernizr/modernizr-custom.js"
 			outputFile: "lib/modernizr/modernizr-custom.js"
 			extra:
-				shiv: true
+				shiv: false
 				printshiv: false
 				load: true
 				mq: true
 				css3: true
 				input: true
 				inputtypes: true
-				html5: true
+				html5: false
 				cssclasses: true
 				csstransitions: true
 				fontface: true
@@ -356,18 +371,6 @@ module.exports = (grunt) ->
 				]
 				dest: "dist/js"
 				expand: true
-
-			oldie:
-				cwd: "lib"
-				src: [
-					"jquery-ie/jquery.min.js",
-					"jquery-ie/jquery.min.map",
-					"selectivizr/selectivizr.js",
-					"respond/respond.min.js"
-				]
-				dest: "dist/js/oldie"
-				expand: true
-				flatten: true
 
 			bootstrap:
 				files: [
@@ -411,24 +414,11 @@ module.exports = (grunt) ->
 				expand: true
 
 			polyfills:
-				files: [
-					(
-						cwd: "src/polyfills"
-						src: "**/*.js"
-						dest: "dist/js/polyfills"
-						expand: true
-						flatten: true
-					)
-					(
-						cwd: "lib"
-						src: [
-							"excanvas/excanvas.js"
-						]
-						dest: "dist/js/polyfills"
-						expand: true
-						flatten: true
-					)
-				]
+				cwd: "src/polyfills"
+				src: "**/*.js"
+				dest: "dist/js/polyfills"
+				expand: true
+				flatten: true
 
 			deps:
 				cwd: "lib"

--- a/bower.json
+++ b/bower.json
@@ -31,6 +31,7 @@
     "DataTables": "1.9.4",
     "magnific-popup": "0.9.6",
     "jquery-pjax": "1.7.3",
+    "html5shiv": "3.7.0",
     "jquery-ie": "jquery#1.10.2",
     "respond": "1.2.0",
     "selectivizr": "1.0.2",

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<!--[if IE 8]><html class="no-js lt-ie9" lang="{{language}}"><![endif]-->
+<!--[if IE 8]><html class="no-js ie8" lang="{{language}}"><![endif]-->
 <!--[if gt IE 8]><!-->
 <html lang="{{language}}">
 <!--<![endif]-->
@@ -17,15 +17,10 @@
 		<link rel="stylesheet" href="{{assets}}/css/base{{environment.suffix}}.css">
 		<link rel="stylesheet" href="{{assets}}/css/theme{{environment.suffix}}.css">
 
-		<!-- Polyfill loader-->
-		<!--[if lt IE 9]>
-		<script src="{{assets}}/js/oldie/respond.min.js"></script>
-		<script src="{{assets}}/js/oldie/jquery.min.js"></script>
-		<script src="{{assets}}/js/oldie/selectivizr.min.js"></script><![endif]-->
-		<!--[if gte IE 9 | !IE ]><!-->
-		<script src="{{assets}}/js/jquery.min.js"></script>
-		<!--<![endif]-->
-		<script src="{{assets}}/js/vapour{{environment.suffix}}.js"></script>
+		<!-- IE8 Support -->
+		<!--[if IE 8]>
+		<script src="{{assets}}/js/vapour-ie8{{environment.suffix}}.js">
+		<![endif]-->
 
 	</head>
 	<body vocab="http://schema.org/" typeof="WebPage">{{#if environment.test}}{{>test}}{{/if}}
@@ -80,8 +75,10 @@
 				{{>footer}}
 			</nav>
 		</footer>
-
+		<!--[if gte IE 9 | !IE ]><!-->
+		<script src="{{assets}}/js/jquery.min.js"></script>
+		<script src="{{assets}}/js/vapour{{environment.suffix}}.js"></script>
+		<!--<![endif]-->
 		<script src="{{assets}}/js/wet-boew{{environment.suffix}}.js"></script>
-		<script src="{{assets}}/js/theme.js"></script>
 	</body>
 </html>

--- a/src/core/vapour.js
+++ b/src/core/vapour.js
@@ -267,9 +267,6 @@ window._timer = {
  *-----------------------------*/
 window.Modernizr.load([
 	{
-		test: Modernizr.canvas,
-		nope: "disabled!site!modejs!polyfills/excanvas.min.js"
-	}, {
 		test: Modernizr.details,
 		nope: "disabled!site!modejs!polyfills/detailssummary.min.js"
 	}, {


### PR DESCRIPTION
Create vapour-ie8.js that includes all IE8 polyfills and Vapour loader
- Remove Excanvas since it is concated for IE8 only
- Use more up-to-date HTML5 Shiv
- Update markup for IE8 only backwards support
