### PR TITLE
Grids SCSS: Adjusted module-news-article's padding/margin properties.

### DIFF
--- a/src/grids/sass/includes/_module.scss
+++ b/src/grids/sass/includes/_module.scss
@@ -232,10 +232,11 @@
 	}
 
 	.module-news-article {
-		padding: $spacing-medium $spacing-medium 0;
+		padding: 0 $spacing-medium;
 		@include module-colorize($border: "border", $shadow: true);
 		img {
 			display: block;
+			margin: $spacing-medium 0;
 		}
 	}
 


### PR DESCRIPTION
Prevents a "double" top spacing effect when images aren't used.
