### PR TITLE
Slide out tab SCSS: Redeclared display block placeholder selector in IE7-8.

### DIFF
--- a/src/js/sass/includes/_details-ie.scss
+++ b/src/js/sass/includes/_details-ie.scss
@@ -2,8 +2,20 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
+
+/* details polyfill */
+
+/* <details> and <summary> are block level elements */
+%pe-ie-details-display-block {
+    display: block;
+}
+
 .ie7, .ie8 {
+	summary {
+		@extend %pe-ie-details-display-block;
+	}
 	details {
+		@extend %pe-ie-details-display-block;
 		> {
 			* {
 				display: none;


### PR DESCRIPTION
Prevents details/summary elements from being treated as inline by IE7-8. The :not pseudo-selector's presence in the standard SCSS file causes the entire placeholder selector's outputted rule to be ignored by those browsers.
