### PR TITLE
Modal: use $.extend to build settings

### DIFF
--- a/src/plugins/modal/modal.js
+++ b/src/plugins/modal/modal.js
@@ -17,6 +17,17 @@ var selector = ".wb-modal",
 	$document = vapour.doc,
 
 	/*
+	 * Plugin users can override these defaults by setting attributes on the html elements that the
+	 * selector matches.
+	 * For example, adding the attribute data-option1="false", will override option1 for that plugin instance.
+	 */
+	defaults = {
+		modal: false,		// When true, force a modal-like behaviour (no close button and escape key or overlay click won't close)
+		mainClass: "mfp",	// CSS class for the modal wrapper element
+		removalDelay: 0		// Number of milliseconds to wait before removing modal element from DOM (use with closing animations)
+	},
+
+	/*
 	 * Init runs once per plugin element on the page. There may be multiple elements.
 	 * It will run more than once per plugin if you don't remove the selector from the timer.
 	 * @function init
@@ -42,13 +53,7 @@ var selector = ".wb-modal",
 	 * @param {Object} settings Key-value object
 	 */
 	show = function( event, settings ) {
-		$.magnificPopup.open({
-			modal: settings.modal == null ? "false" : settings.modal,
-			mainClass: settings.mainClass == null ? "mfp" : settings.mainClass,
-			removalDelay: settings.removalDelay == null ? 0 : settings.removalDelay,
-			items: settings.items,
-			callbacks: settings.callbacks
-		});
+		$.magnificPopup.open( $.extend( {}, defaults, settings ) );
 	},
 
 	/*

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -114,9 +114,9 @@ var selector = ".wb-session-timeout",
 					$buttonSignin.data( "logouturl", settings.logouturl );
 
 					// Build the modal dialog
-					$document.trigger( "build.wb-modal",  {
+					$document.trigger( "build.wb-modal", {
 						content: "<p>" + i18nText.timeoutAlready + "</p>",
-						buttons:  $buttonSignin,
+						buttons: $buttonSignin,
 						deferred: building
 					});
 
@@ -129,6 +129,7 @@ var selector = ".wb-session-timeout",
 						setTimeout(function() {
 							// Open the popup
 							$document.trigger( "show.wb-modal", {
+								modal: true,
 								mainClass: "mfp-zoom-in",
 								items: { src: $modal, type: "inline" }
 							});
@@ -152,7 +153,7 @@ var selector = ".wb-session-timeout",
 			time = getTime( settings.reactionTime ),
 			content = i18nText.timeout
 				.replace( "#min#", "<span class='min'>" + time.minutes + "</span>" )
-				.replace( "#sec#",  "<span class='sec'>" + time.seconds + "</span>" ),
+				.replace( "#sec#", "<span class='sec'>" + time.seconds + "</span>" ),
 			$modal = $( "#wb-session-modal" );
 
 		// Modal does not exists: build it


### PR DESCRIPTION
1. Build up the modal dialog settings with `$.extend`.
2. Fix the session timeout "timed out" message behaviour.
3. Fix double spacing issues.
