### PR TITLE
Vapour: Fix IE8 script tag

### DIFF
--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -19,7 +19,7 @@
 
 		<!-- IE8 Support -->
 		<!--[if IE 8]>
-		<script src="{{assets}}/js/vapour-ie8{{environment.suffix}}.js">
+		<script src="{{assets}}/js/vapour-ie8{{environment.suffix}}.js"></script>
 		<![endif]-->
 
 	</head>


### PR DESCRIPTION
Unclosed script tag was causing IE8 to treat the rest of the body as a JS until the closing script tag at the bottom.
