### PR TITLE
Test: added local Mocha testing with grunt-mocha

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -45,15 +45,19 @@ module.exports = (grunt) ->
 	)
 
 	@registerTask(
+		"test-mocha",
+		"Full build for running tests locally with Grunt Mocha",
+		[
+			"pre-mocha",
+			"mocha"
+		]
+	)
+
+	@registerTask(
 		"saucelabs",
 		"Full build for running tests on SauceLabs. Currently only for Travis builds",
 		[
-			"clean:dist",
-			"assets",
-			"js",
-			"css",
-			"copy:tests",
-			"assemble:tests"
+			"pre-mocha",
 			"connect",
 			"saucelabs-mocha",
 		]
@@ -136,6 +140,19 @@ module.exports = (grunt) ->
 			"assemble:site",
 			"assemble:plugins"
 			"assemble:polyfills"
+		]
+	)
+
+	@registerTask(
+		"pre-mocha",
+		"INTERNAL: prepare for running Mocha unit tests",
+		[
+			"clean:dist",
+			"assets",
+			"js",
+			"css",
+			"copy:tests",
+			"assemble:tests"
 		]
 	)
 
@@ -493,6 +510,12 @@ module.exports = (grunt) ->
 				csv: "src/i18n/i18n.csv"
 			src: "src/js/i18n/formvalid/*.js"
 
+		mocha:
+			all: [
+				"dist/demos/data-picture/data-picture-en.html"
+				"dist/demos/session-timeout/session-timeout-en.html"
+			]
+
 		"saucelabs-mocha":
 			all:
 				options:
@@ -536,6 +559,7 @@ module.exports = (grunt) ->
 	@loadNpmTasks "grunt-contrib-jshint"
 	@loadNpmTasks "grunt-contrib-uglify"
 	@loadNpmTasks "grunt-contrib-watch"
+	@loadNpmTasks "grunt-mocha"
 	@loadNpmTasks "grunt-modernizr"
 	@loadNpmTasks "grunt-gh-pages"
 	@loadNpmTasks "grunt-sass"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-gh-pages": "~0.8.0",
+    "grunt-mocha": "~0.4.1",
     "grunt-modernizr": "~0.3.0",
     "grunt-sass": "~0.6.1",
     "grunt-saucelabs": "~4.0.4",

--- a/src/plugins/session-timeout/test.js
+++ b/src/plugins/session-timeout/test.js
@@ -79,7 +79,7 @@ describe( "Session Timeout test suite", function() {
 			var len = spies.trigger.thisValues.length,
 				isSelector = false;
 			while ( !isSelector && len-- ) {
-				isSelector = spies.trigger.thisValues[len].selector === ".wb-session-timeout";
+				isSelector = spies.trigger.thisValues[len][0].className.indexOf( "wb-session-timeout" ) > -1;
 			}
 			expect( isSelector ).to.equal( true );
 		});


### PR DESCRIPTION
Todo by our resident build masters:
1. Find more elegant way of specifying test files.  Currently hardcoded array.
2. Possibly merge common tasks of `test-mocha` and `saucelabs` :

``` coffeescript
"clean:dist",
"assets",
"js",
"css",
"copy:tests",
"assemble:tests",
```
