### PR TITLE
Build: Flatten dist directory on wet-boew-dist

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -39,7 +39,8 @@ module.exports = (grunt) ->
 		"deploy",
 		"Build and deploy artifacts to wet-boew-dist",
 		[
-			"dist",
+			"dist"
+			"copy:deploy"
 			"gh-pages"
 		]
 	)
@@ -482,6 +483,14 @@ module.exports = (grunt) ->
 				dest: "dist"
 				expand: true
 
+			deploy:
+				src: [
+					"*.txt"
+					"README.md"
+				]
+				dest: "dist"
+				expand: true
+
 		clean:
 			dist: "dist"
 
@@ -555,11 +564,9 @@ module.exports = (grunt) ->
 				clone: "wet-boew-dist"
 				message: "Travis build " + process.env.TRAVIS_BUILD_NUMBER
 				silent: true
+				base: "dist"
 			src: [
-				"dist/**/*.*",
-				"*.html",
-				"*.md",
-				"*.txt"
+				"**/*.*"
 			]
 
 


### PR DESCRIPTION
See https://github.com/nschonni/wet-boew-dist/tree/e4fcbf08fe48834b0ba6435c5461bfa03f5c51b6 for the example of the new layout. Now that the demos live below the dist directory, referencing them using `dist/demos` seems like a bad url structure.
(Related to gh-2470)
I will add an index.html template as a separate pull
