### PR TITLE
Shortened the class names for the skip link CSS.

### DIFF
--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -25,11 +25,11 @@
 	</head>
 	<body vocab="http://schema.org/" typeof="WebPage">
 		<ul id="wb-tphp">
-			<li class="wb-skip">
-				<a class="wb-skip-link" href="#wb-cont">{{#i18n "%tmpl-skip-cont"}}{{/i18n}}</a>
+			<li class="wb-slc">
+				<a class="wb-sl" href="#wb-cont">{{#i18n "%tmpl-skip-cont"}}{{/i18n}}</a>
 			</li>
-			<li class="wb-skip">
-				<a class="wb-skip-link" href="#wb-nav">{{#i18n "%tmpl-skip-foot"}}{{/i18n}}</a>
+			<li class="wb-slc">
+				<a class="wb-sl" href="#wb-nav">{{#i18n "%tmpl-skip-foot"}}{{/i18n}}</a>
 			</li>
 		</ul>
 		<header role="banner">

--- a/src/base/partials/_accessibility.scss
+++ b/src/base/partials/_accessibility.scss
@@ -12,7 +12,7 @@
 	margin-bottom: 0;
 }
 
-.wb-skip {
+.wb-slc {
 	left: 0;
 	position: absolute;
 	text-align: center;
@@ -21,7 +21,7 @@
 	z-index: 3;
 }
 
-.wb-skip-link {
+.wb-sl {
 	@extend %accessible-invisible;
 	padding: 5px;
 	&:focus {

--- a/src/plugins/wb-disable/disable.js
+++ b/src/plugins/wb-disable/disable.js
@@ -31,7 +31,7 @@ var selector = vapour.sDisabled,
 			$html = vapour.html,
 			i18n = window.i18n;
 
-		li.className = "wb-skip";
+		li.className = "wb-slc";
 
 
 		// Rebuild the query string
@@ -50,7 +50,7 @@ var selector = vapour.sDisabled,
 			}
 
 			// Append the Standard version link
-			li.innerHTML = "<a class='wb-skip-link' href='" + nQuery + "wbdisable=false'>" + i18n( "%wb-enable" ) + "</a>";
+			li.innerHTML = "<a class='wb-sl' href='" + nQuery + "wbdisable=false'>" + i18n( "%wb-enable" ) + "</a>";
 
 			// Add link to re-enable WET plugins and polyfills
 			elm.appendChild( li );
@@ -62,7 +62,7 @@ var selector = vapour.sDisabled,
 		}
 
 		// Append the Basic HTML version link version
-		li.innerHTML = "<a class='wb-skip-link' href='" + nQuery + "wbdisable=true'>" + i18n( "%wb-disable" ) + "</a>";
+		li.innerHTML = "<a class='wb-sl' href='" + nQuery + "wbdisable=true'>" + i18n( "%wb-disable" ) + "</a>";
 		elm.appendChild( li ); // Add link to disable WET plugins and polyfills
 	};
 

--- a/theme/layouts/theme.hbs
+++ b/theme/layouts/theme.hbs
@@ -25,11 +25,11 @@
 	</head>
 	<body vocab="http://schema.org/" typeof="WebPage">
 		<ul id="wb-tphp" class="sr-only">
-			<li class="wb-skip">
-				<a class="wb-skip-link" href="#wb-cont">{{#i18n "%tmpl-skip-cont"}}{{/i18n}}</a>
+			<li class="wb-slc">
+				<a class="wb-sl" href="#wb-cont">{{#i18n "%tmpl-skip-cont"}}{{/i18n}}</a>
 			</li>
-			<li class="wb-skip">
-				<a class="wb-skip-link" href="#wb-nav">{{#i18n "%tmpl-skip-foot"}}{{/i18n}}</a>
+			<li class="wb-slc">
+				<a class="wb-sl" href="#wb-nav">{{#i18n "%tmpl-skip-foot"}}{{/i18n}}</a>
 			</li>
 		</ul>
 		<header role="banner">

--- a/theme/sass/includes/_screen.scss
+++ b/theme/sass/includes/_screen.scss
@@ -3,7 +3,7 @@
 * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
 */
 
-.wb-skip {
+.wb-slc {
 		float: left;
 		height: 0;
 		ul {
@@ -26,9 +26,11 @@
 	  }
 }
 
-.wb-skip-link:focus {
-	background-color: #000;
-	color: #FFF;
-	text-decoration: none;
-	z-index: 501;
+.wb-sl {
+	&:focus {
+		background-color: #000;
+		color: #FFF;
+		text-decoration: none;
+		z-index: 501;
+	}
 }

--- a/theme/sass/parts/_skipnav.scss
+++ b/theme/sass/parts/_skipnav.scss
@@ -3,7 +3,7 @@
 	min-height: 2.3em;
 }
 
-.wb-skip-link {
+.wb-sl {
 	background-color: #000;
 	color: #FFF;
 	font-weight: 700;


### PR DESCRIPTION
`wb-skip` changed to `wb-slc` (slc stands for skip link container)
`wb-skip-link` changed to `wb-sl` (sl stands for skip link)

This is related to #3286.
