### PR TITLE
Build: Fix IE8 asset building

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -197,16 +197,16 @@ module.exports = (grunt) ->
 				options:
 					stripBanners: false
 				src: [
-					"lib/respond/respond.min.js"
-					"lib/html5shiv/dist/html5shiv.js"
-					"lib/excanvas/excanvas.js"
 					"lib/jquery-ie/jquery.min.js"
+					"lib/respond/respond.src.js"
+					"lib/excanvas/excanvas.js"
+					"lib/html5shiv/dist/html5shiv.js"
 					"lib/selectivizr/selectivizr.js"
 					"src/polyfills/localstorage/localstorage.js"
 					"lib/modernizr/modernizr-custom.js"
 					"src/core/vapour.js"
 				]
-				dest: "dist/js/vapour-ie8.js"
+				dest: "dist/js/ie8-vapour.js"
 
 
 		# Builds the demos

--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "jquery-pjax": "1.7.3",
     "html5shiv": "3.7.0",
     "jquery-ie": "jquery#1.10.2",
-    "respond": "1.2.0",
+    "respond": "1.3.0",
     "selectivizr": "1.0.2",
     "excanvas": "*",
     "google-code-prettify": "1.0.0"

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -19,7 +19,7 @@
 
 		<!-- IE8 Support -->
 		<!--[if IE 8]>
-		<script src="{{assets}}/js/vapour-ie8{{environment.suffix}}.js"></script>
+		<script src="{{assets}}/js/ie8-vapour{{environment.suffix}}.js"></script>
 		<![endif]-->
 
 	</head>

--- a/theme/layouts/theme.hbs
+++ b/theme/layouts/theme.hbs
@@ -19,7 +19,7 @@
 
 		<!-- IE8 Support -->
 		<!--[if IE 8]>
-		<script src="{{assets}}/js/vapour-ie8{{environment.suffix}}.js"></script>
+		<script src="{{assets}}/js/ie8-vapour{{environment.suffix}}.js"></script>
 		<![endif]-->
 
 	</head>


### PR DESCRIPTION
- Use the unminified version of respond.js for bundling
- Load jQuery first in bundle because other plug-ins rely on it
- Bump respond version
- Rename the file so vapour.$src selector will find the file correctly
