### PR TITLE
Build: Flatten polyfill Sass compile path

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -284,6 +284,7 @@ module.exports = (grunt) ->
 				]
 				dest: "dist/css/polyfills/"
 				ext: ".css"
+				flatten: true
 
 		autoprefixer:
 			options:


### PR DESCRIPTION
The loader was expecting css/polyfills/polyfillname.css, but was building out to css/polyfills/polyfillname/polyfillname.css
