### PR TITLE
WET theme: Fixed language toggle

### DIFF
--- a/site/includes/languagetoggle.hbs
+++ b/site/includes/languagetoggle.hbs
@@ -1,12 +1,23 @@
 <div class="container">
 	<div class="row text-right">
 		<ul data-ajax-before="{{assets}}/js/assets/mobmenu-{{language}}.html" class="visible-md visible-lg">
+{{#if_eq language compare="en"}}
+	{{#if page.fr}}
+			<li>
+				<a lang="fr" href="{{page.fr}}-fr.html">Français</a>
+			</li>
+	{{/if}}
+{{/if_eq}}
 			<li class="current">
 				{{#i18n "%lang-native"}}{{/i18n}}{{#i18n "%interword-space"}}{{/i18n}}<span>{{#i18n "%current"}}{{/i18n}}</span>
 			</li>
+{{#unless_eq language compare="en"}}
+	{{#if page.en}}
 			<li>
-				<a lang="fr" href="#">Français</a>
+				<a lang="en" href="{{page.en}}-en.html">English</a>
 			</li>
+	{{/if}}
+{{/unless_eq}}
 		</ul>
 	</div>
 </div>

--- a/src/Licence-fr.hbs
+++ b/src/Licence-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Boîte à outils de l'expérience Web (BOEW) - Conditions régissant l'utilisation
 language: fr
+en: License
 ---
 <p>Sauf indication contraire, le code source de la boîte à outils de l'expérience Web (BOEW) 
 est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué 

--- a/src/License-en.hbs
+++ b/src/License-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Web Experience Toolkit (WET) - Terms and Conditions of Use
 language: en
+fr: Licence
 ---
 
 <p>Unless otherwise noted, computer program source code of the Web Experience Toolkit (WET) is 

--- a/src/index-en.hbs
+++ b/src/index-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Web Experience Toolkit (WET)
 language: en
+fr: index
 ---
 
 	<h2 id="about">What is the Web Experience Toolkit?</h2>

--- a/src/index-fr.hbs
+++ b/src/index-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Boîte à outils de l’expérience Web (BOEW)
 language: fr
+en: index
 ---
 <section>
 	<h2 id="apropos">Qu’est-ce que la Boîte à outils de l’expérience Web?</h2>

--- a/src/plugins/carousel/carousel-en.hbs
+++ b/src/plugins/carousel/carousel-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Carousel
 language: en
+fr: carousel
 ---
 <p>Interface for cycling through content.</p>
 <section>

--- a/src/plugins/carousel/carousel-fr.hbs
+++ b/src/plugins/carousel/carousel-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Carrousel
 language: fr
+en: carousel
 ---
 <p>Interface pour cycler à travers le contenu.</p>
 <section>

--- a/src/plugins/feedback/feedback-en.hbs
+++ b/src/plugins/feedback/feedback-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Feedback form
 language: en
+fr: feedback
 ---
 <style>
 .wb-feedback label {

--- a/src/plugins/feedback/feedback-fr.hbs
+++ b/src/plugins/feedback/feedback-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Formulaire de rétroaction
 language: fr
+en: feedback
 ---
 <style>
 .wb-feedback label {

--- a/src/plugins/feeds/feeds-en.hbs
+++ b/src/plugins/feeds/feeds-en.hbs
@@ -1,6 +1,7 @@
 ---
-title: Web feeds
+title: Feeds
 language: en
+fr: feeds
 ---
 <style>
 .feeds-cont {

--- a/src/plugins/feeds/feeds-fr.hbs
+++ b/src/plugins/feeds/feeds-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Fils de syndication
 language: fr
+en: feeds
 ---
 <style>
 .feeds-cont {

--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -1,5 +1,5 @@
 /*
- * @title WET-BOEW Web feeds
+ * @title WET-BOEW Feeds
  * @overview Aggregates and displays entries from one or more Web feeds.
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28

--- a/src/plugins/footnotes/footnotes-en.hbs
+++ b/src/plugins/footnotes/footnotes-en.hbs
@@ -1,8 +1,7 @@
 ---
 title: Footnotes
 language: en
-sitetitle: Web Experience Toolkit (WET)
-tagline: Collaborative open source project led by the Government of Canada
+fr: footnotes
 ---
 <section>
 	<h2>Overview</h2>

--- a/src/plugins/footnotes/footnotes-fr.hbs
+++ b/src/plugins/footnotes/footnotes-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Notes de bas de page
 language: fr
+en: footnotes
 ---
 <section>
 	<h2>Vue d'ensemble</h2>

--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Form validation
 language: en
+fr: formvalid
 ---
 <style>
 .wb-formvalid fieldset {

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Validation de formulaires
 language: fr
+en: formvalid
 ---
 <style>
 .wb-formvalid fieldset {

--- a/src/plugins/index-en.hbs
+++ b/src/plugins/index-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Working examples
 language: en
+fr: index
 ---
 <table id="components" class="wb-prettify wb-tables" data-wet-boew='{"bZebra": true, "bVisible": false, "aColumns": [3], "aMobileColumns": [1,3], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1}'>
 	<thead>

--- a/src/plugins/index-fr.hbs
+++ b/src/plugins/index-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Exemples pratiques
 language: fr
+en: index
 ---
 <table id="components" class="wb-prettify wb-tables" data-wet-boew=data-wet-boew='{"bZebra": true, "bVisible": false, "aColumns": [3], "aMobileColumns": [1,3], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1}'>
 	<thead>

--- a/src/plugins/lightbox/lightbox-en.hbs
+++ b/src/plugins/lightbox/lightbox-en.hbs
@@ -1,8 +1,7 @@
 ---
 title: Lightbox
 language: en
-sitetitle: Web Experience Toolkit (WET)
-tagline: Collaborative open source project led by the Government of Canada
+fr: lightbox
 ---
 
 <style>

--- a/src/plugins/lightbox/lightbox-fr.hbs
+++ b/src/plugins/lightbox/lightbox-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Lightbox
 language: fr
+en: lightbox
 ---
 
 <style>

--- a/src/plugins/mediaplayer/mediaplayer-en.hbs
+++ b/src/plugins/mediaplayer/mediaplayer-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Multimedia Player
 language: en
+fr: mediaplayer
 ---
 <p>For video, the multimedia player leverages the native HTML5 video tag and relies on Flash as a fallback mechanism when the HTML5 video tag is not implemented. The MPEG 4 format (H264 codec) is the minimum requirement for video because the Flash fallback relies on it and H264 is the standard video format on many mobile devices. An optional but highly recommended Webm (VP8 codec) should be added as well to allow some browsers such as Firefox that do not include native support for H264 to leverage the native HTML5 performance gains.</p>
 <p>For <a href="#audio-only">audio only</a>, the multimedia player leverages the native HTML5 audio tag and relies on Flash as a fallback mechanism when the HTML5 audio tag is not implemented.</p>

--- a/src/plugins/mediaplayer/mediaplayer-fr.hbs
+++ b/src/plugins/mediaplayer/mediaplayer-fr.hbs
@@ -1,6 +1,7 @@
 ---
-title: Lecteur multimédia
+title: Lecteur média
 language: fr
+en: mediaplayer
 ---
 <section class="container">
 	<h2>Exemples</h2>

--- a/src/plugins/prettify/prettify-en.hbs
+++ b/src/plugins/prettify/prettify-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Prettify
 language: en
+fr: prettify
 ---
 
 <p>Syntax highlighting of source code snippets in an html page using <a href="http://code.google.com/p/google-code-prettify/" rel="external">google-code-prettify</a>.</p>

--- a/src/plugins/prettify/prettify-fr.hbs
+++ b/src/plugins/prettify/prettify-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Prettify
 language: fr
+en: prettify
 ---
 
 <p>Mise en surbrillance de syntaxe des extraits de code source dans une page html en utilisant <a href="http://code.google.com/p/google-code-prettify/" rel="external">google-code-prettify</a>.</p>

--- a/src/plugins/session-timeout/session-timeout-en.hbs
+++ b/src/plugins/session-timeout/session-timeout-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Session Timeout
 language: en
+fr: session-timeout
 ---
 
 <span class="wb-session-timeout wb-modal" data-wet-boew='{"inactivity": 30000}'></span>

--- a/src/plugins/session-timeout/session-timeout-fr.hbs
+++ b/src/plugins/session-timeout/session-timeout-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Expiration de la session
 language: fr
+en: session-timeout
 ---
 
 <span class="wb-session-timeout wb-modal" data-wet-boew='{"inactivity": 30000}'></span>

--- a/src/plugins/share/share-en.hbs
+++ b/src/plugins/share/share-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Share widget
 language: en
+fr: share
 ---
 
 <section>

--- a/src/plugins/share/share-fr.hbs
+++ b/src/plugins/share/share-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Gadget de partage
 language: fr
+en: share
 ---
 
 <section>

--- a/src/plugins/texthighlight/texthighlight-en.hbs
+++ b/src/plugins/texthighlight/texthighlight-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Text highlighting
 language: en
+fr: texthighlight
 ---
 <p>The Text highlighting sub project highlights any text within a pre-defined area that matches case-insensitive search criteria specified through the URL's query string. Supports multi-word strings, including spaces and basic punctuation.</p>
 <p><strong>Note:</strong> Search criteria using special regex characters such as <code>"</code>, <code>|</code>, <code>?</code>, <code>+</code>, <code>(</code> or <code>)</code> may be partially or fully excluded from the results.</p>

--- a/src/plugins/texthighlight/texthighlight-fr.hbs
+++ b/src/plugins/texthighlight/texthighlight-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Mise en surbrillance de texte
 language: fr
+en: texthighlight
 ---
 <p>Le composant de mise en subrillance de texte met en surbrillance n'importe quel texte dans un secteur pré-défini qui satisfait des critères de recherche. Les critères de recherche sont insensibles à la casse et sont spécifiés par la chaîne d'interrogation d'une addresse URL. Les chaînes avec plusieurs mots sont supportées, y compris les espaces et la ponctuation fondamentale.</p>
 <p><strong>Nota&#160;:</strong> Les critères de recherche regroupant des caractères spéciaux d'expression régulière («&#160;regex&#160;», <abbr title="par exemple">p.ex.</abbr>, «&#160;<code>"</code>&#160;», «&#160;<code>|</code>&#160;», «&#160;<code>?</code>&#160;», «&#160;<code>+</code>&#160;», «&#160;<code>(</code>&#160;» ou «&#160;<code>)</code>&#160;») peuvent être partiellement ou entièrement exclus des résultats.</p>

--- a/src/plugins/twitter/twitter-en.hbs
+++ b/src/plugins/twitter/twitter-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Twitter embedded timeline
 language: en
+fr: twitter
 ---
 <p>This plugin helps with implementing Twitter embedded timelines.</p>
 

--- a/src/plugins/twitter/twitter-fr.hbs
+++ b/src/plugins/twitter/twitter-fr.hbs
@@ -1,6 +1,7 @@
 ---
-title: Fils de syndication
+title: Chronologie intégrée Twitter
 language: fr
+en: twitter
 ---
 <p>Ce plugiciel aide à afficher des chronologies intégrées Twitter.</p>
 

--- a/src/polyfills/datalist/datalist-en.hbs
+++ b/src/polyfills/datalist/datalist-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Datalist polyfill
 language: en
+fr: datalist
 ---
 <p>The <code>datalist</code> tag specifies a list of pre-defined options for an <code>input</code> element.</p>
 

--- a/src/polyfills/datalist/datalist-fr.hbs
+++ b/src/polyfills/datalist/datalist-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Correctif datalist
 language: fr
+en: datalist
 ---
 <p>La balise <code lang="en">datalist</code> spécifie une liste d'options pré-définis pour un élément <code lang="en">input</code>.</p>
 

--- a/src/polyfills/details/details-en.hbs
+++ b/src/polyfills/details/details-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Details/summary polyfill
 language: en
+fr: details
 ---
 <style>
 .example2 summary {

--- a/src/polyfills/details/details-fr.hbs
+++ b/src/polyfills/details/details-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Correctif details/summary
 language: fr
+en: details
 ---
 <style>
 .example2 summary {

--- a/src/polyfills/progress/progress-en.hbs
+++ b/src/polyfills/progress/progress-en.hbs
@@ -1,6 +1,7 @@
 ---
 title: Progress polyfill
 language: en
+fr: progress
 ---
 <style>
 progress {

--- a/src/polyfills/progress/progress-fr.hbs
+++ b/src/polyfills/progress/progress-fr.hbs
@@ -1,6 +1,7 @@
 ---
 title: Correctif progress
 language: fr
+en: progress
 ---
 <style>
 progress {


### PR DESCRIPTION
- Only displays language link if language is supported (support needs to be manually set in the YAML front matter)
- Maintains the order of language links regardless of the language of the current page
- Other language now changes dependent upon the language of the current page (rather than always being French)
