### PR TITLE
Form Validation: Concat and event based file load

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -77,12 +77,12 @@ module.exports = (grunt) ->
 		"js",
 		"INTERNAL: Copies all third party JS to the dist folder",
 		[
-			"copy:jquery",
-			"copy:polyfills",
-			"copy:deps",
-			"copy:jsAssets",
-			"concat",
+			"copy:jquery"
+			"copy:polyfills"
+			"copy:deps"
+			"copy:jsAssets"
 			"i18n"
+			"concat"
 		]
 	)
 
@@ -207,6 +207,38 @@ module.exports = (grunt) ->
 				]
 				dest: "dist/js/ie8-vapour.js"
 
+			i18n:
+				options:
+					process: ( src, filepath ) ->
+						lang = filepath.replace "dist/js/i18n/", ""
+						# jQuery validation uses an underscore for locals
+						lang = lang.replace "_", "-"
+						validationPath = "lib/jquery.validation/localization/"
+
+						# Check and append message file
+						messagesPath = validationPath + "messages_" + lang
+						messages = if grunt.file.exists messagesPath then grunt.file.read( messagesPath ) else ""
+
+						# Check and append method file
+						methodsPath = validationPath + "methods_" + lang
+						methods = if grunt.file.exists methodsPath then grunt.file.read( methodsPath ) else ""
+
+						if methods != "" or messages != ""
+							src += "\nvapour.doc.one( \"formLanguages.wb\", function() {\n"
+							src += messages
+							src += "\n"
+							src += methods
+							src += "\n});"
+
+						return src
+
+				cwd: "dist/js/i18n"
+				src: [
+					"*.js"
+					"!*.min.js"
+				]
+				dest: "dist/js/i18n"
+				expand: true
 
 		# Builds the demos
 		assemble:

--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -50,9 +50,6 @@ var selector = ".wb-formvalid",
 			both: [
 				"site!deps/jquery.validate" + modeJS,
 				"site!deps/additional-methods" + modeJS
-				// TODO: Need more elegant way to do these loads. Shouldn't load at all if English or if language file doesn't exist because complete never happens.
-				//"site!deps/messages_" + lang + modeJS,
-				//"site!deps/methods_" + lang + modeJS
 			],
 			complete: function() {
 				var $form = $elm.find( "form" ),
@@ -236,6 +233,9 @@ var selector = ".wb-formvalid",
 						}
 					}
 				});
+
+				// Tell the i18n file to execute to run any $.validator extends
+				$form.trigger( "formLanguages.wb" );
 			}
 		});
 	};


### PR DESCRIPTION
This correctly merges the jQuery Validation messages, but the proper guard for the extending the possible non-loaded `$.validator` needs to be discussed. I was thinking about an on/remove pattern in fitting with the JEP model, but was unsure of the namespacing for the event.
