### PR TITLE
Arms of Canada signature CSS Modifications

### DIFF
--- a/src/theme-gcwu-fegc/sass/includes/_default-large-images-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-large-images-screen.scss
@@ -12,6 +12,7 @@
 		color: #fff;
 	}
 }
+
 %gcwu-default-large-screen-images-deco-side {
 	background: {
 		image: url(../images/content-deco-side.gif), url(../images/content-deco-side.gif);
@@ -28,6 +29,12 @@
 #wb-head-in {
 	@extend %gcwu-default-large-screen-images-header-background;
 	background-color: #406C93;
+}
+
+.ui-body-coa {
+	background: {
+		position: center 5em !important;
+	}
 }
 
 #wb-core-in {

--- a/src/theme-gcwu-fegc/sass/includes/_default-large-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-large-screen.scss
@@ -19,8 +19,7 @@
 	width: 234px;
 	height: 22px;
 }
-%gcwu-default-large-screen-width-342-height-61 {
-	width: 342px;
+%gcwu-default-large-screen-height-61 {
 	height: 61px;
 }
 %gcwu-default-large-screen-font-weight-400-color-333 {
@@ -267,15 +266,15 @@ h1 {
 	margin: 2px 0 2px 10px;
 	img {
 		@extend %gcwu-default-large-screen-margin-left-0;
-		@extend %gcwu-default-large-screen-width-342-height-61;
+		@extend %gcwu-default-large-screen-height-61;
 	}
 	object {
-		@extend %gcwu-default-large-screen-width-342-height-61;
+		@extend %gcwu-default-large-screen-height-61;
 	}
 }
 
 #gcwu-sig-coa-in {
-	@extend %gcwu-default-large-screen-width-342-height-61;
+	@extend %gcwu-default-large-screen-height-61;
 }
 
 #gcwu-gcnb {

--- a/src/theme-gcwu-fegc/sass/includes/_default-large-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-large-screen.scss
@@ -19,6 +19,10 @@
 	width: 234px;
 	height: 22px;
 }
+%gcwu-default-large-screen-width-342-height-61 {
+	width: 342px;
+	height: 61px;
+}
 %gcwu-default-large-screen-font-weight-400-color-333 {
 	@extend %gcwu-default-large-screen-font-weight-400;
 	color: #333;
@@ -258,6 +262,22 @@ h1 {
 	@extend %gcwu-default-large-screen-width-234-height-22;
 }
 
+#gcwu-sig-coa {
+	@extend %gcwu-default-large-screen-float-left;
+	margin: 2px 0 2px 10px;
+	img {
+		@extend %gcwu-default-large-screen-margin-left-0;
+		@extend %gcwu-default-large-screen-width-342-height-61;
+	}
+	object {
+		@extend %gcwu-default-large-screen-width-342-height-61;
+	}
+}
+
+#gcwu-sig-coa-in {
+	@extend %gcwu-default-large-screen-width-342-height-61;
+}
+
 #gcwu-gcnb {
 	min-height: 3.6em;
 	a {
@@ -279,6 +299,9 @@ h1 {
 #gcwu-gcnb-in {
 	@extend %gcwu-default-large-screen-overflow-hidden;
 	min-height: 41px;
+	.ui-coa {
+		padding-top:12px;
+	}
 }
 
 #gcwu-title {
@@ -536,6 +559,18 @@ h1 {
 	}
 
 	#gcwu-sig-in {
+		@extend %gcwu-default-large-screen-margin-right-10;
+		@extend %gcwu-default-large-screen-margin-left-0;
+	}
+
+	#gcwu-sig-coa {
+		@extend %gcwu-default-large-screen-float-right;
+		img {
+			@extend %gcwu-default-large-screen-margin-right-0;
+		}
+	}
+
+	#gcwu-sig-coa-in {
 		@extend %gcwu-default-large-screen-margin-right-10;
 		@extend %gcwu-default-large-screen-margin-left-0;
 	}

--- a/src/theme-gcwu-fegc/sass/includes/_default-ns.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-ns.scss
@@ -11,3 +11,6 @@
 #gcwu-sig-in {
 	@extend %gcwu-default-ns-display-block;
 }
+#gcwu-sig-coa-in {
+	@extend %gcwu-default-ns-display-block;
+}

--- a/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-screen.scss
@@ -23,12 +23,18 @@
 	#gcwu-sig-in {
 		@extend %gcwu-default-screen-display-none;
 	}
+	#gcwu-sig-coa-in {
+		@extend %gcwu-default-screen-display-none;
+	}
 }
 %gcwu-default-screen-wmms-sig-display-block {
 	#gcwu-wmms-in {
 		@extend %gcwu-default-screen-display-block;
 	}
 	#gcwu-sig-in {
+		@extend %gcwu-default-screen-display-block;
+	}
+	#gcwu-sig-coa-in {
 		@extend %gcwu-default-screen-display-block;
 	}
 }
@@ -132,6 +138,9 @@ body {
 	@extend %gcwu-default-screen-display-none;
 }
 #gcwu-sig-in {
+	@extend %gcwu-default-screen-display-none;
+}
+#gcwu-sig-coa-in {
 	@extend %gcwu-default-screen-display-none;
 }
 .svg {

--- a/src/theme-gcwu-fegc/sass/includes/_default-small-medium-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-small-medium-screen.scss
@@ -228,6 +228,9 @@ table {
 #gcwu-sig {
 	@extend %gcwu-default-small-medium-screen-display-none;
 }
+#gcwu-sig-coa {
+	@extend %gcwu-default-small-medium-screen-display-none;
+}
 #gcwu-bnr {
 	#gcwu-wmms {
 		@extend %gcwu-default-small-medium-screen-display-none-important;


### PR DESCRIPTION
New SASS Only pull request for Arms of Canada Signature

Added classes to support a 65 pixel high navigation top bar for use with Arms of Canada signatures.

Also added two example pages in the demo section. Not yet linked to the index page. Not sure how you would like to proceed with an example.

RCMP crest files added for now as an example, these can also be changed/modified as per your preferences.
