### PR TITLE
Footnotes: Shortened class names and ids as described in #3286 (with a few tweaks)

### DIFF
--- a/src/plugins/footnotes/footnotes-en.hbs
+++ b/src/plugins/footnotes/footnotes-en.hbs
@@ -5,59 +5,59 @@ fr: footnotes
 ---
 <section>
 	<h2>Overview</h2>
-	<p>The purpose of the Footnotes sub-project is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the <a href="#fnb">Footnotes</a> section. Supporting CSS is used to lay out the footnotes and hide navigational aids<sup id="fnb1-ref"><a class="footnote-link" href="#fnb1"><span class="wb-invisible">Footnote </span>1</a></sup>.</p>
+	<p>The purpose of the Footnotes sub-project is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the <a href="#fn">Footnotes</a> section. Supporting CSS is used to lay out the footnotes and hide navigational aids<sup id="fn1-rf"><a class="fn-lnk" href="#fn1"><span class="wb-invisible">Footnote </span>1</a></sup>.</p>
 </section>
 
 <section>
 	<h2>Benefits</h2>
 	<ul>
-		<li>Conforms to WCAG 2.0 AA<sup id="fnb2a-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
+		<li>Conforms to WCAG 2.0 AA<sup id="fn2a-rf"><a class="fn-lnk" href="#fn2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
 		<li>Progressive enhancement approach</li>
-		<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fnb2b-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
+		<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fn2b-rf"><a class="fn-lnk" href="#fn2"><span class="wb-invisible">Footnote </span>2</a></sup></li>
 		<li>Support for English and French</li>
-		<li>Configurable layout and design<sup id="fnb2c-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Footnote </span>2</a></sup>&#160;<sup id="fnb3-ref"><a class="footnote-link" href="#fnb3"><span class="wb-invisible">Footnote </span>3</a></sup></li>
+		<li>Configurable layout and design<sup id="fn2c-rf"><a class="fn-lnk" href="#fn2"><span class="wb-invisible">Footnote </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-invisible">Footnote </span>3</a></sup></li>
 	</ul>
 </section>
 
 <section>
 	<h2>Recommended usage</h2>
 	<ul>
-		<li>Implementing footnotes in Web pages<sup id="fnb*-ref"><a class="footnote-link" href="#fnb*"><span class="wb-invisible">Footnote </span>*</a></sup></li>
+		<li>Implementing footnotes in Web pages<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-invisible">Footnote </span>*</a></sup></li>
 	</ul>
 </section>
 
-<div class="wb-footnotes" role="note">
+<div class="wb-fnote" role="note">
 	<section>
-		<h2 id="fnb" class="wb-invisible">Footnotes</h2>
+		<h2 id="fn" class="wb-invisible">Footnotes</h2>
 		<dl>
 			<dt>Footnote 1</dt>
-			<dd id="fnb1">
+			<dd id="fn1">
 				<p>Example of a standard footnote.</p>
-				<p class="footnote-return">
-					<a href="#fnb1-ref"><span class="wb-invisible">Return to footnote </span>1<span class="wb-invisible"> referrer</span></a>
+				<p class="fn-rtn">
+					<a href="#fn1-rf"><span class="wb-invisible">Return to footnote </span>1<span class="wb-invisible"> referrer</span></a>
 				</p>
 			</dd>
 			<dt>Footnote 2</dt>
-			<dd id="fnb2">
+			<dd id="fn2">
 				<p>Example of a footnote being referenced by multiple pieces of content.</p>
-				<p class="footnote-return">
-					<a href="#fnb2a-ref"><span class="wb-invisible">Return to <span>first</span> footnote </span>2<span class="wb-invisible"> referrer</span></a>
+				<p class="fn-rtn">
+					<a href="#fn2a-rf"><span class="wb-invisible">Return to <span>first</span> footnote </span>2<span class="wb-invisible"> referrer</span></a>
 				</p>
 			</dd>
 			<dt>Footnote 3</dt>
-			<dd id="fnb3">
+			<dd id="fn3">
 				<p>Example of a footnote containing multiple paragraphs (first paragraph).</p>
 				<p>Example of a footnote containing multiple paragraphs (second paragraph).</p>
 				<p>Example of a footnote containing multiple paragraphs (third paragraph).</p>
-				<p class="footnote-return">
-					<a href="#fnb3-ref"><span class="wb-invisible">Return to footnote </span>3<span class="wb-invisible"> referrer</span></a>
+				<p class="fn-rtn">
+					<a href="#fn3-rf"><span class="wb-invisible">Return to footnote </span>3<span class="wb-invisible"> referrer</span></a>
 				</p>
 			</dd>
 			<dt>Footnote *</dt>
-			<dd id="fnb*">
+			<dd id="fn*">
 				<p>Example of a standard footnote, denoted by a symbol.</p>
-				<p class="footnote-return">
-					<a href="#fnb*-ref"><span class="wb-invisible">Return to footnote </span>*<span class="wb-invisible"> referrer</span></a>
+				<p class="fn-rtn">
+					<a href="#fn*-rf"><span class="wb-invisible">Return to footnote </span>*<span class="wb-invisible"> referrer</span></a>
 				</p>
 			</dd>
 		</dl>

--- a/src/plugins/footnotes/footnotes-fr.hbs
+++ b/src/plugins/footnotes/footnotes-fr.hbs
@@ -5,59 +5,59 @@ en: footnotes
 ---
 <section>
 	<h2>Vue d'ensemble</h2>
-	<p>Le sous-projet Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section <a href="#fnb">Notes de bas de page</a>. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation<sup id="fnb1-ref"><a class="footnote-link" href="#fnb1"><span class="wb-invisible">Note de bas de page </span>1</a></sup>.</p>
+	<p>Le sous-projet Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section <a href="#fn">Notes de bas de page</a>. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation<sup id="fn1-rf"><a class="fn-lnk" href="#fn1"><span class="wb-invisible">Note de bas de page </span>1</a></sup>.</p>
 </section>
 
 <section>
 	<h2>Avantages</h2>
 	<ul>
-		<li>Conformes à WCAG 2.0 AA<sup id="fnb2a-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
+		<li>Conformes à WCAG 2.0 AA<sup id="fn2a-rf"><a class="fn-lnk" href="#fn2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
 		<li>Approche d'amélioration progressive</li>
-		<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fnb2b-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
+		<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fn2b-rf"><a class="fn-lnk" href="#fn2"><span class="wb-invisible">Note de bas de page </span>2</a></sup></li>
 		<li>Soutien pour l'anglais et le français</li>
-		<li>Mise en page et conception configurable<sup id="fnb2c-ref"><a class="footnote-link" href="#fnb2"><span class="wb-invisible">Note de bas de page </span>2</a></sup>&#160;<sup id="fnb3-ref"><a class="footnote-link" href="#fnb3"><span class="wb-invisible">Note de bas de page </span>3</a></sup></li>
+		<li>Mise en page et conception configurable<sup id="fn2c-rf"><a class="fn-lnk" href="#fn2"><span class="wb-invisible">Note de bas de page </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-invisible">Note de bas de page </span>3</a></sup></li>
 	</ul>
 </section>
 
 <section>
 	<h2>Utilisation recommandée</h2>
 		<ul>
-			<li>Exécuter les notes de bas de page dans les pages Web<sup id="fnb*-ref"><a class="footnote-link" href="#fnb*"><span class="wb-invisible">Note de bas de page </span>*</a></sup></li>
+			<li>Exécuter les notes de bas de page dans les pages Web<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-invisible">Note de bas de page </span>*</a></sup></li>
 		</ul>
 </section>
 
-<div class="wb-footnotes" role="note">
+<div class="wb-fnote" role="note">
 	<section>
-		<h2 id="fnb" class="wb-invisible">Notes de bas de page</h2>
+		<h2 id="fn" class="wb-invisible">Notes de bas de page</h2>
 		<dl>
 			<dt>Note de bas de page 1</dt>
-			<dd id="fnb1">
+			<dd id="fn1">
 				<p>Exemple de note de bas de page standard.</p>
-				<p class="footnote-return">
-					<a href="#fnb1-ref"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>1</a>
+				<p class="fn-rtn">
+					<a href="#fn1-rf"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>1</a>
 				</p>
 			</dd>
 			<dt>Note de bas de page 2</dt>
-			<dd id="fnb2">
+			<dd id="fn2">
 				<p>Exemple de note de bas de page qui comporte de nombreux liens.</p>
-				<p class="footnote-return">
-					<a href="#fnb2a-ref"><span class="wb-invisible">Retour à la <span>première</span> référence de la note de bas de page </span>2</a>
+				<p class="fn-rtn">
+					<a href="#fn2a-rf"><span class="wb-invisible">Retour à la <span>première</span> référence de la note de bas de page </span>2</a>
 				</p>
 			</dd>
 			<dt>Note de bas de page 3</dt>
-			<dd id="fnb3">
+			<dd id="fn3">
 				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (premier paragraphe).</p>
 				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).</p>
 				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).</p>
-				<p class="footnote-return">
-					<a href="#fnb3-ref"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>3</a>
+				<p class="fn-rtn">
+					<a href="#fn3-rf"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>3</a>
 				</p>
 			</dd>
 			<dt>Note de bas de page *</dt>
-			<dd id="fnb*">
+			<dd id="fn*">
 				<p>Exemple de note de bas de page standard, représentée par un symbole.</p>
-				<p class="footnote-return">
-					<a href="#fnb*-ref"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>*</a>
+				<p class="fn-rtn">
+					<a href="#fn*-rf"><span class="wb-invisible">Retour à la référence de la note de bas de page </span>*</a>
 				</p>
 			</dd>
 		</dl>

--- a/src/plugins/footnotes/footnotes-ie.scss
+++ b/src/plugins/footnotes/footnotes-ie.scss
@@ -3,64 +3,16 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 
-@import "../../variables";
-
-/*Default SCSS*/
-.ie7 {
-	.wb-footnotes {
-		display: inline-block;
-		dl {
-			dt {
-				position: relative;
-				float: left;
-				margin-bottom: -1px;
-			}
-		}
-	}
-}
-
-/*Screen SCSS*/
-@media screen {
-	.ie7 {
-		.wb-footnotes {
-			dd {
-				&.footnote-focus {
-					background-color: $clrLight;
-					border-color: $clrDark;
-					p {
-						&.footnote-return {
-							a {
-								color: $clrWhite !important;
-								background-color: $clrDark;
-								border-color: $clrDark;
-							}
-						}
-					}
-				}
-			}
-		}
-	}
-}
-
 /*Print SCSS*/
 @media print {
-	.ie7 {
-		.wb-footnotes {
-			dl {
-				dd {
-					overflow: auto;
-				}
-			}
-		}
-	}
 	.ie8 {
-		.wb-footnotes {
+		.wb-fnote {
 			dl {
 				dd {
 					display: block;
 					p {
 						display: inline-block;
-						&.footnote-return {
+						&.fn-rtn {
 							display: block;
 						}
 					}

--- a/src/plugins/footnotes/footnotes.js
+++ b/src/plugins/footnotes/footnotes.js
@@ -13,7 +13,7 @@
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
-var selector = ".wb-footnotes",
+var selector = ".wb-fnote",
 	$document = vapour.doc,
 
 	/*
@@ -43,7 +43,7 @@ var selector = ".wb-footnotes",
 		}
 
 		// Remove "first/premier/etc"-style text from certain footnote return links (via the child spans that hold those bits of text)
-		$returnLinks = $elm.find( "dd p.footnote-return a span span" ).remove();
+		$returnLinks = $elm.find( "dd p.fn-rtn a span span" ).remove();
 	};
 
 // Bind the init event of the plugin
@@ -54,7 +54,7 @@ $document.on( "timerpoke.wb", selector, function() {
 });
 
 // Listen for footnote reference links that get clicked
-$document.on( "click vclick", "main :not(.wb-footnotes) sup a.footnote-link", function( event ) {
+$document.on( "click vclick", "main :not(" + selector + ") sup a.fn-lnk", function( event ) {
 	var button = event.which,
 		refId, $refLinkDest;
 
@@ -63,7 +63,7 @@ $document.on( "click vclick", "main :not(.wb-footnotes) sup a.footnote-link", fu
 		refId = "#" + vapour.jqEscape( this.getAttribute( "href" ).substring( 1 ) );
 		$refLinkDest = $document.find( refId );
 	
-		$refLinkDest.find( "p.footnote-return a" )
+		$refLinkDest.find( "p.fn-rtn a" )
 					.attr( "href", "#" + this.parentNode.id );
 
 		// Assign focus to $refLinkDest
@@ -73,7 +73,7 @@ $document.on( "click vclick", "main :not(.wb-footnotes) sup a.footnote-link", fu
 } );
 
 // Listen for footnote return links that get clicked
-$document.on( "click.wb-footnotes vclick.wb-footnotes", selector + " dd p.footnote-return a", function( event ) {
+$document.on( "click vclick", selector + " dd p.fn-rtn a", function( event ) {
 	var button = event.which,
 		refId;
 

--- a/src/plugins/footnotes/footnotes.scss
+++ b/src/plugins/footnotes/footnotes.scss
@@ -5,55 +5,31 @@
 
 @import "../../variables";
  
-%footnote-link-highlight {
+%fnote-link-highlight {
 	color: $clrWhite !important;
 	background-color: $clrDark;
 	border-color: $clrDark;
 }
-%footnote-link-background-white {
+%fnote-link-background-white {
 	background-color: $clrWhite;
 }
-%footnote-link-background-light-border-medium-padding-whitespace {
+%fnote-link-background-light-border-medium-padding-whitespace {
 	background-color: $clrLight;
 	border: 1px solid $clrMedium;
 	padding: 0 4px 1px;
 	white-space: nowrap;
 	&:hover, &:focus {
-		@extend %footnote-link-highlight;
+		@extend %fnote-link-highlight;
 	}
 }
 sup {
 	a {
-		&.footnote-link {
-			@extend %footnote-link-background-light-border-medium-padding-whitespace;
+		&.fn-lnk {
+			@extend %fnote-link-background-light-border-medium-padding-whitespace;
 		}
 	}
 }
-.background-light {
-	sup {
-		a {
-			&.footnote-link {
-				@extend %footnote-link-background-white;
-				&:hover, &:focus {
-					@extend %footnote-link-highlight;
-				}
-			}
-		}
-	}
-}
-table {
-	th {
-		sup {
-			a {
-				&.footnote-link {
-					@extend %footnote-link-background-white;
-					text-shadow: none;
-				}
-			}
-		}
-	}
-}
-.wb-footnotes {
+.wb-fnote {
 	margin: 2em 10px 0 10px;
 	border-width: 1px 0 1px 0;
 	border-style: solid;
@@ -76,9 +52,9 @@ table {
 				background-color: $clrLight;
 				border-color: $clrDark;
 				p {
-					&.footnote-return {
+					&.fn-rtn {
 						a {
-							@extend %footnote-link-highlight;
+							@extend %fnote-link-highlight;
 						}
 					}
 				}
@@ -89,7 +65,7 @@ table {
 				&:first-child {
 					padding-top: $spacing;
 				}
-				&.footnote-return {
+				&.fn-rtn {
 					top: 0;
 					margin: 0;
 					padding-top: $spacing;
@@ -98,7 +74,7 @@ table {
 					width: $ddRtnWidth;
 					overflow: hidden;
 					a {
-						@extend %footnote-link-background-light-border-medium-padding-whitespace;
+						@extend %fnote-link-background-light-border-medium-padding-whitespace;
 						display: inline-block;
 						padding-bottom: 0;
 					}
@@ -110,7 +86,7 @@ table {
 
 /* Right to left (RTL) CSS */
 [dir="rtl"] {
-	.wb-footnotes {
+	.wb-fnote {
 		dl {
 			dd {
 				p {
@@ -118,7 +94,7 @@ table {
 					margin-right: 3.125em;
 					padding-left: 0;
 					padding-right: 0.375em;
-					&.footnote-return {
+					&.fn-rtn {
 						margin-right: 0;
 						padding-right: 0;
 					}
@@ -130,42 +106,22 @@ table {
 
 /*Print SCSS*/
 @media print {
-	%footnote-link-background-transparent {
+	%fnote-link-background-transparent {
 		background-color: transparent;
 	}
-	%footnote-print-link-background-transparent-border-0-padding-0 {
+	%fnote-print-link-background-transparent-border-0-padding-0 {
 		background-color: transparent;
 		border: 0;
 		padding: 0;
 	}
 	sup {
 		a {
-			&.footnote-link {
-				@extend %footnote-print-link-background-transparent-border-0-padding-0;
+			&.fn-lnk {
+				@extend %fnote-print-link-background-transparent-border-0-padding-0;
 			}
 		}
 	}
-	.background-light {
-		sup {
-			a {
-				&.footnote-link {
-					@extend %footnote-link-background-transparent;
-				}
-			}
-		}
-	}
-	table {
-		th {
-			sup {
-				a {
-					&.footnote-link {
-						@extend %footnote-link-background-transparent;
-					}
-				}
-			}
-		}
-	}
-	.wb-footnotes {
+	.wb-fnote {
 		border {
 			left: 0;
 			right: 0;
@@ -179,10 +135,10 @@ table {
 				width: 100%;
 				display: inline-block;
 				p {
-					&.footnote-return {
+					&.fn-rtn {
 						overflow: visible;
 						a {
-							@extend %footnote-print-link-background-transparent-border-0-padding-0;
+							@extend %fnote-print-link-background-transparent-border-0-padding-0;
 						}
 					}
 				}


### PR DESCRIPTION
Also dropped IE7-specific CSS and CSS related to the old grids.
