### PR TITLE
Shortened keys that are used in the i18n JS files

### DIFF
--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -118,7 +118,7 @@
 	"%tmpl-toppage": "Top of Page",
 	"%tmpl-site-info": "Site Information",
 	"%lang-native": "English",
-	"%interword-space" : "&#32;",
+	"%space" : "&#32;",
 	"%current": "(current)",
 	"%cont-service" : "Services &amp; Information",
 	"%cont-dept" : "Department &amp; Agencies",

--- a/site/data/i18n/fr.json
+++ b/site/data/i18n/fr.json
@@ -119,7 +119,7 @@
   "%tmpl-toppage": "Haut de la page",
   "%tmpl-site-info": "Information du site",
   "%lang-native": "Français",
-  "%interword-space" : "&#32;",
+  "%space" : "&#32;",
   "%current": "(courant)",
   	"%cont-service" : "Services &amp; Information",
 	"%cont-dept" : "Department &amp; Agencies",

--- a/site/includes/languagetoggle.hbs
+++ b/site/includes/languagetoggle.hbs
@@ -9,7 +9,7 @@
 	{{/if}}
 {{/if_eq}}
 			<li class="current">
-				{{#i18n "%lang-native"}}{{/i18n}}{{#i18n "%interword-space"}}{{/i18n}}<span>{{#i18n "%current"}}{{/i18n}}</span>
+				{{#i18n "%lang-native"}}{{/i18n}}{{#i18n "%space"}}{{/i18n}}<span>{{#i18n "%current"}}{{/i18n}}</span>
 			</li>
 {{#unless_eq language compare="en"}}
 	{{#if page.en}}

--- a/src/i18n/base.js
+++ b/src/i18n/base.js
@@ -3,50 +3,51 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 /*
------ @%lang-eng@ dictionary (il8n) ---
+----- @%lang-en@ dictionary (il8n) ---
  */
 ( function( window ) {
 "use strict";
 /* main index */
 var ind = {
 	"%lang-code": "@%lang-code@",
-	"%lang-eng": "@%lang-eng@",
-	"%lang-fra": "@%lang-fra@",
-	"%lang-native": "@%lang-native@",
+	"%lang-en": "@%lang-en@",
+	"%lang-fr": "@%lang-fr@",
+	"%lang-nat": "@%lang-nat@",
 	"%all": "@%all@",
 	"%home": "@%home@",
 	"%main-page": "@%main-page@",
-	"%top-of-page": "@%top-of-page@",
+	"%tphp": "@%tphp@",
 	"%you-are-in": "@%you-are-in@",
 	"%welcome-to": "@%welcome-to@",
 	"%loading": "@%loading@",
 	"%processing": "@%processing@",
-	"%search": "@%search@",
-	"%search-for-terms": "@%search-for-terms@",
-	"%no-match-found": "@%no-match-found@",
-	"%matches-found": {
-		"mixin": "@%matches-found@"
+	"%srch": "@%srch@",
+	"%srch-terms": "@%srch-terms@",
+	"%no-match": "@%no-match@",
+	"%matches": {
+		"mixin": "@%matches@"
 	},
 	"%menu": "@%menu@",
 	"%settings": "@%settings@",
-	"%languages": "@%languages@",
+	"%langs": "@%langs@",
 	"%about": "@%about@",
-	"%current": "@%current@",
+	"%curr": "@%curr@",
 	"%hide": "@%hide@",
-	"%error": "@%error@",
+	"%err": "@%err@",
 	"%colon": "@%colon@",
 	"%hyphen": "@%hyphen@",
 	"%full-stop": "@%full-stop@",
-	"%list-comma-space": "@%list-comma-space@",
-	"%interword-space": "@%interword-space@",
+	"%comma-space": "@%comma-space@",
+	"%space": "@%space@",
 	"%start": "@%start@",
 	"%stop": "@%stop@",
 	"%back": "@%back@",
-	"%new-window": "@%new-window@",
-	"%minute-ago": "@%minute-ago@",
-	"%couple-of-minutes": "@%couple-of-minutes@",
-	"%minutes-ago": {
-		"mixin": "@%minutes-ago@"
+	"%cancel": "@%cancel@",
+	"%new-win": "@%new-win@",
+	"%min-ago": "@%min-ago@",
+	"%coup-mins": "@%coup-mins@",
+	"%mins-ago": {
+		"mixin": "@%mins-ago@"
 	},
 	"%hour-ago": "@%hour-ago@",
 	"%hours-ago": {
@@ -57,103 +58,102 @@ var ind = {
 	},
 	"%yesterday": "@%yesterday@",
 
-	"%next": "@%next@",
-	"%next-right": "@%next-right@",
-	"%previous": "@%previous@",
-	"%previous-left": "@%previous-left@",
+	"%nxt": "@%nxt@",
+	"%nxt-r": "@%nxt-r@",
+	"%prv": "@%prv@",
+	"%prv-l": "@%prv-l@",
 	"%first": "@%first@",
 	"%last": "@%last@",
 	"%close-esc": "@%close-esc@",
+	"%show": "@%show@",
 
 	/* Archived Web page template */
-	"%archived-page": "@%archived-page@",
+	"%arch-pg": "@%arch-pg@",
 	/* Menu bar */
-	"%sub-menu-help": "@%sub-menu-help@",
+	"%sm-hlp": "@%sm-hlp@",
 	/* Tabbed interface */
-	"%tab-rotation": {
-		"disable": "@%tab-rotation-disable@",
-		"enable": "@%tab-rotation-enable@"
+	"%tab-rot": {
+		"off": "@%tab-rot-off@",
+		"on": "@%tab-rot-on@"
 	},
 	"%tab-list": "@%tab-list@",
-	"%tab-panel-end-1": "@%tab-panel-end-1@",
-	"%tab-panel-end-2": "@%tab-panel-end-2@",
-	"%tab-panel-end-3": "@%tab-panel-end-3@",
+	"%tab-pnl-end1": "@%tab-pnl-end1@",
+	"%tab-pnl-end2": "@%tab-pnl-end2@",
+	"%tab-pnl-end3": "@%tab-pnl-end3@",
 	/* Multimedia player */
 	"%play": "@%play@",
 	"%pause": "@%pause@",
 	"%open": "@%open@",
 	"%close": "@%close@",
-	"%rewind": "@%rewind@",
-	"%fast-forward": "@%fast-forward@",
+	"%rew": "@%rew@",
+	"%ffwd": "@%ffwd@",
 	"%mute": {
-		"enable": "@%mute-enable@",
-		"disable": "@%mute-disable@"
+		"on": "@%mute-on@",
+		"off": "@%mute-off@"
 	},
-	"%closed-caption": {
-		"disable": "@%closed-caption-disable@",
-		"enable": "@%closed-caption-enable@"
+	"%cc": {
+		"off": "@%cc-off@",
+		"on": "@%cc-on@"
 	},
-	"%closed-caption-error": "@%closed-caption-error@",
-	"%audio-description": {
-		"enable": "@%audio-description-enable@",
-		"disable": "@%audio-description-disable@"
+	"%cc-err": "@%cc-err@",
+	"%adesc": {
+		"on": "@%adesc-on@",
+		"off": "@%adesc-off@"
 	},
-	"%progress-bar": "@%progress-bar@",
+	"%prog-bar": "@%prog-bar@",
 	"%no-video": "@%no-video@",
-	"%position": "@%position@",
-	"%percentage": "@%percentage@",
-	"%duration": "@%duration@",
-	"%buffered": "@%buffered@",
+	"%pos": "@%pos@",
+	"%perc": "@%perc@",
+	"%dur": "@%dur@",
+	"%buff": "@%buff@",
 	/* Share widget */
-	"%favourite": "@%favourite@",
+	"%fav": "@%fav@",
 	"%email": "@%email@",
-	"%share-text": "@%share-text@",
-	"%share-hint": "@%share-hint@",
-	"%share-email-subject": "@%share-email-subject@",
-	"%share-email-body": "@%share-email-body@",
-	"%share-fav-title": "@%share-fav-title@",
-	"%share-manual": "@%share-manual@",
-	"%share-showall": "@%share-showall@",
-	"%share-showall-title": "@%share-showall-title@",
-	"%share-disclaimer": "@%share-disclaimer@",
+	"%shr-txt": "@%shr-txt@",
+	"%shr-hnt": "@%shr-hnt@",
+	"%shr-email-sub": "@%shr-email-sub@",
+	"%shr-email-bd": "@%shr-email-bd@",
+	"%shr-fav-ttl": "@%shr-fav-ttl@",
+	"%shr-man": "@%shr-man@",
+	"%shr-all": "@%shr-all@",
+	"%shr-all-ttl": "@%shr-all-ttl@",
+	"%shr-disc": "@%shr-disc@",
 	/* Form validation */
-	"%form-not-submitted": "@%form-not-submitted@",
-	"%errors-found": "@%errors-found@",
-	"%error-found": "@%error-found@",
+	"%frm-nosubmit": "@%frm-nosubmit@",
+	"%errs-fnd": "@%errs-fnd@",
+	"%err-fnd": "@%err-fnd@",
 	/* Date picker */
-	"%datepicker-hide": "@%datepicker-hide@",
-	"%datepicker-show": "@%datepicker-show@",
-	"%datepicker-selected": "@%datepicker-selected@",
+	"%date-hide": "@%date-hide@",
+	"%date-show": "@%date-show@",
+	"%date-sel": "@%date-sel@",
 	/* Calendar */
-	"%calendar-weekDayNames": ["@%calendar-weekDayNames-1@", "@%calendar-weekDayNames-2@", "@%calendar-weekDayNames-3@", "@%calendar-weekDayNames-4@", "@%calendar-weekDayNames-5@", "@%calendar-weekDayNames-6@", "@%calendar-weekDayNames-7@"],
-	"%calendar-monthNames": ["@%calendar-monthNames-1@", "@%calendar-monthNames-2@", "@%calendar-monthNames-3@", "@%calendar-monthNames-4@", "@%calendar-monthNames-5@", "@%calendar-monthNames-6@", "@%calendar-monthNames-7@", "@%calendar-monthNames-8@", "@%calendar-monthNames-9@", "@%calendar-monthNames-10@", "@%calendar-monthNames-11@", "@%calendar-monthNames-12@"],
-	"%calendar": "@%calendar@",
-	"%calendar-currentDay": "@%calendar-currentDay@",
-	"%calendar-goToLink": "@%calendar-goToLink@",
-	"%calendar-goToTitle": "@%calendar-goToTitle@",
-	"%calendar-goToMonth": "@%calendar-goToMonth@",
-	"%calendar-goToYear": "@%calendar-goToYear@",
-	"%calendar-goToButton": "@%calendar-goToButton@",
-	"%calendar-cancelButton": "@%calendar-cancelButton@",
-	"%calendar-previousMonth": "@%calendar-previousMonth@",
-	"%calendar-nextMonth": "@%calendar-nextMonth@",
+	"%days": ["@%days-1@", "@%days-2@", "@%days-3@", "@%days-4@", "@%days-5@", "@%days-6@", "@%days-7@"],
+	"%mnths": ["@%mnths-1@", "@%mnths-2@", "@%mnths-3@", "@%mnths-4@", "@%mnths-5@", "@%mnths-6@", "@%mnths-7@", "@%mnths-8@", "@%mnths-9@", "@%mnths-10@", "@%mnths-11@", "@%mnths-12@"],
+	"%cal": "@%cal@",
+	"%currDay": "@%currDay@",
+	"%cal-goToLnk": "@%cal-goToLnk@",
+	"%cal-goToTtl": "@%cal-goToTtl@",
+	"%cal-goToMnth": "@%cal-goToMnth@",
+	"%cal-goToYr": "@%cal-goToYr@",
+	"%cal-goToBtn": "@%cal-goToBtn@",
+	"%prvMnth": "@%prvMnth@",
+	"%nxtMnth": "@%nxtMnth@",
 	/* Slideout */
 	"%show-toc": "@%show-toc@",
-	"%show-text": "@%show-text@",
-	"%hide-text": "@%hide-text@",
-	"%table-contents": "@%table-contents@",
+	"%hide-toc": "@%hide-toc@",
+	"%toc": "@%toc@",
 	/* Lightbox */
-	"%lb-current40": "@%lb-current40@",
-	"%lb-xhr-error": "@%lb-xhr-error@",
-	"%lb-img-error": "@%lb-img-error@",
+	"%lb-curr": "@%lb-curr@",
+	"%lb-xhr-err": "@%lb-xhr-err@",
+	"%lb-img-err": "@%lb-img-err@",
 	/* Charts widget */
 	"%table-mention": "@%table-mention@",
 	"%table-following": "@%table-following@",
 	/* Session timeout */
-	"%st-timeout-msg-bgn": "@%st-timeout-msg-bgn@",
-	"%st-timeout-msg-end": "@%st-timeout-msg-end@",
-	"%st-msgbox-title": "@%st-msgbox-title@",
-	"%st-already-timeout-msg": "@%st-already-timeout-msg@",
+	"%st-to-msg-bgn": "@%st-to-msg-bgn@",
+	"%st-to-msg-end": "@%st-to-msg-end@",
+	"%st-msgbx-ttl": "@%st-msgbx-ttl@",
+	"%st-alrdy-to-msg": "@%st-alrdy-to-msg@",
 	"%st-button-continue": "@%st-button-continue@",
 	"%st-button-end": "@%st-button-end@",
 	/* Toggle details */
@@ -163,14 +163,14 @@ var ind = {
 	"%td-ttl-open": "@%td-ttl-open@",
 	"%td-ttl-close": "@%td-ttl-close@",
 	/* Table enhancement */
-	"%sSortAscending": "@%sSortAscending@",
-	"%sSortDescending": "@%sSortDescending@",
-	"%sEmptyTable": "@%sEmptyTable@",
+	"%sortAsc": "@%sortAsc@",
+	"%sortDesc": "@%sortDesc@",
+	"%emptyTbl": "@%emptyTbl@",
 	"%sInfo": "@%sInfo@",
 	"%sInfoEmpty": "@%sInfoEmpty@",
-	"%sInfoFiltered": "@%sInfoFiltered@",
-	"%sInfoThousands": "@%sInfoThousands@",
-	"%sLengthMenu": "@%sLengthMenu@",
+	"%infoFilt": "@%infoFilt@",
+	"%info1000": "@%info1000@",
+	"%lenMenu": "@%lenMenu@",
 	/* Geomap */
 	"%geo-mapcontrol": "@%geo-mapcontrol@",
 	"%geo-zoomin": "@%geo-zoomin@",

--- a/src/plugins/calendar/calendar.js
+++ b/src/plugins/calendar/calendar.js
@@ -33,17 +33,17 @@ var $document = vapour.doc,
 		if ( !i18nText ) {
 			i18n = window.i18n;
 			i18nText = {
-				monthNames: i18n( "%calendar-monthNames" ),
-				prevMonth: i18n( "%calendar-previousMonth" ),
-				nextMonth: i18n( "%calendar-nextMonth" ),
-				goToTitle: i18n( "%calendar-goToTitle" ),
-				goToYear: i18n( "%calendar-goToYear" ),
-				goToMonth: i18n( "%calendar-goToMonth" ),
-				goToLink: i18n( "%calendar-goToLink" ),
-				goToBtn: i18n( "%calendar-goToButton" ),
-				cancelBtn: i18n( "%calendar-cancelButton" ),
-				dayNames: i18n( "%calendar-weekDayNames" ),
-				currDay: i18n( "%calendar-currentDay" )
+				monthNames: i18n( "%mnths" ),
+				prevMonth: i18n( "%prvMnth" ),
+				nextMonth: i18n( "%nxtMnth" ),
+				goToTitle: i18n( "%cal-goToTtl" ),
+				goToYear: i18n( "%cal-goToYr" ),
+				goToMonth: i18n( "%cal-goToMnth" ),
+				goToLink: i18n( "%cal-goToLnk" ),
+				goToBtn: i18n( "%cal-goToBtn" ),
+				cancelBtn: i18n( "%cancel" ),
+				dayNames: i18n( "%days" ),
+				currDay: i18n( "%currDay" )
 			};
 		}
 

--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -38,10 +38,10 @@ var selector = ".wb-formvalid",
 			i18nText = {
 				colon: i18n( "%colon" ),
 				hyphen: i18n( "%hyphen" ),
-				error: i18n( "%error" ),
-				errorFound: i18n( "%error-found" ),
-				errorsFound: i18n( "%errors-found" ),
-				formNotSubmitted: i18n( "%form-not-submitted" )
+				error: i18n( "%err" ),
+				errorFound: i18n( "%err-fnd" ),
+				errorsFound: i18n( "%errs-fnd" ),
+				formNotSubmitted: i18n( "%frm-nosubmit" )
 			};
 		}
 

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -38,15 +38,15 @@ var selector = ".wb-lightbox",
 				tClose: i18n( "%close-esc" ),
 				tLoading: i18n( "%loading" ),
 				gallery: {
-					tPrev: i18n( "%previous-left" ),
-					tNext: i18n( "%next-right" ),
-					tCounter: i18n( "%lb-current40" )
+					tPrev: i18n( "%prv-l" ),
+					tNext: i18n( "%nxt-r" ),
+					tCounter: i18n( "%lb-curr" )
 				},
 				image: {
-					tError: i18n( "%lb-img-error" ) + " (<a href=\"%url%\">)"
+					tError: i18n( "%lb-img-err" ) + " (<a href=\"%url%\">)"
 				},
 				ajax: {
-					tError: i18n( "%lb-xhr-error" ) + " (<a href=\"%url%\">)"
+					tError: i18n( "%lb-xhr-err" ) + " (<a href=\"%url%\">)"
 				}
 			};
 		}

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -302,17 +302,17 @@ $document.on( "timerpoke.wb", $selector, function() {
 	if ( !i18nText ) {
 		i18n = window.i18n;
 		i18nText = {
-			rewind: i18n( "%rewind" ),
-			ff: i18n( "%fast-forward" ),
+			rewind: i18n( "%rew" ),
+			ff: i18n( "%ffwd" ),
 			play: i18n( "%play" ),
 			pause: i18n( "%pause" ),
-			cc_on: i18n( "%closed-caption", "enable" ),
-			cc_off: i18n( "%closed-caption", "disable"),
-			cc_error: i18n ( "%closed-caption-error" ),
-			mute_on: i18n( "%mute", "enable"),
-			mute_off: i18n( "%mute", "disable"),
-			duration: i18n( "%duration"),
-			position: i18n( "%position")
+			cc_on: i18n( "%cc", "on" ),
+			cc_off: i18n( "%cc", "off"),
+			cc_error: i18n ( "%cc-err" ),
+			mute_on: i18n( "%mute", "on"),
+			mute_off: i18n( "%mute", "off"),
+			duration: i18n( "%dur"),
+			position: i18n( "%pos")
 		};
 	}
 

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -54,10 +54,10 @@ var selector = ".wb-session-timeout",
 				buttonContinue: i18n( "%st-button-continue" ),
 				buttonEnd: i18n( "%st-button-end" ),
 				buttonSignin: i18n( "%tmpl-signin" ),
-				timeoutBegin: i18n( "%st-timeout-msg-bgn" ),
-				timeoutEnd: i18n( "%st-timeout-msg-end" ),
-				timeoutTitle: i18n( "%st-msgbox-title" ),
-				timeoutAlready: i18n( "%st-already-timeout-msg" )
+				timeoutBegin: i18n( "%st-to-msg-bgn" ),
+				timeoutEnd: i18n( "%st-to-msg-end" ),
+				timeoutTitle: i18n( "%st-msgbx-ttl" ),
+				timeoutAlready: i18n( "%st-alrdy-to-msg" )
 			};
 		}
 

--- a/src/plugins/share/share.js
+++ b/src/plugins/share/share.js
@@ -131,7 +131,7 @@ var selector = ".wb-share",
 		if ( !i18nText ) {
 			i18n = window.i18n;
 			i18nText = {
-				disclaimer: i18n( "%share-disclaimer" )
+				disclaimer: i18n( "%shr-disc" )
 			};
 		}
 		

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -19,21 +19,21 @@
 						asStripeClasses : [],
 						oLanguage: {
 							oAria: {
-								sSortAscending: i18n( "%sSortAscending" ),
-								sSortDescending: i18n( "%sSortDescending" )
+								sSortAscending: i18n( "%sortAsc" ),
+								sSortDescending: i18n( "%sortDesc" )
 							},
 							oPaginate: {
 								sFirst: i18n( "%first" ),
 								sLast: i18n( "%last" ),
-								sNext: i18n( "%next" ),
-								sPrevious: i18n( "%previous" )
+								sNext: i18n( "%nxt" ),
+								sPrevious: i18n( "%prv" )
 							},
-							sEmptyTable: i18n( "%sEmptyTable" ),
+							sEmptyTable: i18n( "%emptyTbl" ),
 							sInfo: i18n( "%sInfo" ),
-							sInfoEmpty: i18n( "%sInfoEmpty" ),
+							sInfoEmpty: i18n( "%infoEmpty" ),
 							sInforFiltered: i18n( "%sInforFiltered" ),
-							sInfoThousands: i18n( "%sInfoThousands" ),
-							sLengthMenu: i18n( "%sLengthMenu" ),
+							sInfoThousands: i18n( "%info1000" ),
+							sLengthMenu: i18n( "%lenMenu" ),
 							sLoadingRecords: i18n( "%sLoadingRecords" ),
 							sProcessing: i18n( "%sProcessing" ),
 							sSearch: i18n( "%sSearch" ),

--- a/src/polyfills/datepicker/datepicker.js
+++ b/src/polyfills/datepicker/datepicker.js
@@ -43,9 +43,9 @@ var selector = "input[type=date]",
 		if ( !i18nText ) {
 			i18n = window.i18n;
 			i18nText = {
-				datepickerShow: i18n( "%datepicker-show" ) + i18n( "%interword-space" ),
-				datepickerHide: i18n( "%datepicker-hide" ),
-				datepickerSelected: i18n( "%datepicker-selected" )
+				datepickerShow: i18n( "%date-show" ) + i18n( "%space" ),
+				datepickerHide: i18n( "%date-hide" ),
+				datepickerSelected: i18n( "%date-sel" )
 			};
 		}
 


### PR DESCRIPTION
Looks like there may be some strings in there that are no longer used so should do a review later to determine what can be removed (some seem to duplicate the %templ-\* strings which are only used for templates and not JS).

Also did not shorten Charts and Geomap strings yet since they haven't been ported/merged in yet.

Should also consider splitting JS strings from template/theme strings.
