### PR TITLE
Build: Remove Form Validation localization files

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -512,7 +512,6 @@ module.exports = (grunt) ->
 					"jquery-pjax/jquery.pjax.js"
 					"jquery.validation/jquery.validate.js"
 					"jquery.validation/additional-methods.js"
-					"jquery.validation/localization/*.js"
 					"magnific-popup/dist/jquery.magnific-popup.js"
 					"google-code-prettify/src/*.js"
 					"DataTables/media/js/jquery.dataTables.js"


### PR DESCRIPTION
The new dictionary reads the values from "lib" so there is no need to copy them to the dist folder.
