### PR TITLE
WET theme: Aligned with site menu and footer work from other repo (adds i18n and framework for mega menus)

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -147,6 +147,7 @@ module.exports = (grunt) ->
 			"assemble:site"
 			"assemble:plugins"
 			"assemble:polyfills"
+			"assemble:ajax"
 		]
 	)
 
@@ -290,6 +291,18 @@ module.exports = (grunt) ->
 				cwd: "src/polyfills"
 				src: ["**/*.hbs"]
 				dest: "dist/demos"
+
+			ajax:
+				options:
+					layout: "ajax.hbs"
+					ext: ".txt"
+				cwd: "site/pages/ajax"
+				src: [
+					"*.hbs"
+				]
+				dest: "dist/ajax/"
+				expand: true
+				flatten: true
 
 			tests:
 				options:

--- a/site/includes/footer-en.hbs
+++ b/site/includes/footer-en.hbs
@@ -1,0 +1,26 @@
+<section class="col-sm-3 col-lg-3">
+	<h3>About</h3>
+	<ul class="list-unstyled">
+		<li><a href="{{rooturl}}/index-en.html#about">About the Web Experience Toolkit</a></li>
+                <li><a href="http://www.tbs-sct.gc.ca/ws-nw/index-eng.asp">About the Web Standards</a></li>
+	</ul>
+</section>
+<section class="col-sm-3 col-lg-3">
+	<h3>Contact us</h3>
+	<ul class="list-unstyled">
+		<li><a href="https://github.com/wet-boew/wet-boew/issues/new">Questions or comments?</a></li>
+	</ul>
+</section>
+<section class="col-sm-3 col-lg-3">
+	<h3>News</h3>
+	<ul class="list-unstyled">
+		<li><a href="https://github.com/wet-boew/wet-boew/pulse">Recent project activity</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/graphs">Project statistics</a></li>
+	</ul>
+</section>
+<section class="col-sm-3 col-lg-3">
+	<h3>Stay connected</h3>
+	<ul class="list-unstyled">
+		<li><a href="https://twitter.com/WebExpToolkit">Twitter</a></li>
+	</ul>
+</section>

--- a/site/includes/footer-fr.hbs
+++ b/site/includes/footer-fr.hbs
@@ -1,0 +1,26 @@
+<section class="col-sm-3 col-lg-3">
+	<h3>À propos</h3>
+	<ul class="list-unstyled">
+		<li><a href="{{rooturl}}/index-fr.html#apropos">À propos de la Boîte à outils de l’expérience Web</a></li>
+		<li><a href="http://www.tbs-sct.gc.ca/ws-nw/index-fra.asp">À propos des normes Web</a></li>
+	</ul>
+</section>
+<section class="col-sm-3 col-lg-3">
+	<h3>Contactez-nous</h3>
+	<ul class="list-unstyled">
+		<li><a href="https://github.com/wet-boew/wet-boew/issues/new">Questions ou commentaires?</a></li>
+	</ul>
+</section>
+<section class="col-sm-3 col-lg-3">
+	<h3>Nouvelles</h3>
+	<ul class="list-unstyled">
+		<li><a href="https://github.com/wet-boew/wet-boew/pulse">Activité du projet récente</a></li>
+		<li><a href="https://github.com/wet-boew/wet-boew/graphs">Statistiques du projet</a></li>
+	</ul>
+</section>
+<section class="col-sm-3 col-lg-3">
+	<h3>Restez branchés</h3>
+	<ul class="list-unstyled">
+		<li><a href="https://twitter.com/BoiteExpWeb">Twitter</a></li>
+	</ul>
+</section>

--- a/site/includes/footer.hbs
+++ b/site/includes/footer.hbs
@@ -1,39 +1,5 @@
-<div class="container">
-	<div class="row">
-		<section class="col-sm-3 col-lg-3">
-			<h3>About</h3>
-			<ul class="list-unstyled">
-				<li>
-					<a href="#">About the Web Experience Toolkit</a>
-				</li>
-				<li>
-					<a href="#">About the Web Standards</a>
-				</li>
-			</ul>
-		</section>
-		<section class="col-sm-3 col-lg-3">
-			<h3>Contact us</h3>
-			<ul class="list-unstyled">
-				<li>
-					<a href="#">Questions or comments?</a>
-				</li>
-			</ul>
-		</section>
-		<section class="col-sm-3 col-lg-3">
-			<h3>News</h3>
-			<ul class="list-unstyled">
-				<li>
-					<a href="#">Recent project activity</a>
-				</li>
-			</ul>
-		</section>
-		<section class="col-sm-3 col-lg-3">
-			<h3>Stay Connected</h3>
-			<ul class="list-unstyled">
-				<li>
-					<a href="#">Twitter</a>
-				</li>
-			</ul>
-		</section>
-	</div>
-</div>
+{{#startsWith "en" language }}
+{{>footer-en}}
+ {{else}}
+ {{>footer-fr}}
+{{/startsWith}}

--- a/site/includes/fullmenu-en.hbs
+++ b/site/includes/fullmenu-en.hbs
@@ -1,0 +1,69 @@
+<!-- some mobile views -->
+    <a href="#" class="nav-close visible-sm visible-xs"><span class="glyphicon glyphicon-remove"></span> Close menu</a>
+<!-- secondary navigation if enabled -->
+<section class="container visible-md visible-lg nvbar">
+    <h2 class="wb-inv">Site menu</h2>
+    <div class="row">
+        <ul class="list-inline menu" role="menubar">
+            <li><a href="#project" class="item">WET project</a>
+                <ul class="sm list-unstyled" id="project" role="menu">
+                    <li><a href="{{rooturl}}/index-en.html#about">About WET</a></li>
+                    <li><a href="{{rooturl}}/index-en.html#benefits">Benefits</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Accolades">Accolades for WET</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/">Main project</a></li>
+					<li><a href="{{rooturl}}/License-en.html">Terms and conditions of use</a></li>
+					<li><a href="https://github.com/wet-boew/wet-boew/wiki/Roadmap">Roadmap of past and future releases</a></li>
+					<li><a href="{{rooturl}}/index-en.html#version-history">Version history</a></li>
+					<li><a href="http://www.tbs-sct.gc.ca/ws-nw/index-eng.asp">About the Web Standards</a></li>
+                </ul>
+            </li>
+            <li><a href="#implement" class="item">Implement WET</a>
+                <ul class="sm list-unstyled" id="implement" role="menu">
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Getting-Started-with-WET">Getting started with WET</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Using-Github-for-WET">Using Github for WET</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Downloads">Download WET</a></li>
+                    <li><a href="{{rooturl}}/demos/index-en.html">Working examples</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki#reference">Documentation</a></li>
+                </ul>
+            </li>
+            <li><a href="#contribute" class="item">Contribute to WET</a>
+                <ul class="sm list-unstyled" id="contribute" role="menu">
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Contributor-guidelines">Contributor guidelines</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Contributor-guidelines#wiki-Filing_a_bug_or_an_Issue">Filing a bug or an issue</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Contributor-guidelines#wiki-Creating_a_Pull_Request">Creating a pull request</a></li>
+					<li><a href="https://github.com/wet-boew/wet-boew/wiki/Contributor-guidelines#testing-you-pr-before-submitting">Testing your code</a></li>
+					<li><a href="https://github.com/wet-boew/wet-boew/wiki/Developing-for-WET">Developing for WET</a></li>
+					<li><a href="https://github.com/wet-boew/wet-boew/wiki/Creating-Documentation">Creating documentation</a></li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+</section>
+
+<section class="wb-nav container visible-sm visible-xs">
+    <h2 class="wb-inv">Site Information</h2>
+    <ul class="list-unstyled">
+        <li>About
+            <ul class="list-unstyled">
+                <li><a href="{{rooturl}}/index-en.html#about">About the Web Experience Toolkit</a></li>
+                <li><a href="http://www.tbs-sct.gc.ca/ws-nw/index-eng.asp">About the Web Standards</a></li>
+            </ul>
+        </li>
+        <li>Contact us
+			<ul class="list-unstyled">
+				<li><a href="https://github.com/wet-boew/wet-boew/issues/new">Questions or comments?</a></li>
+			</ul>
+        </li>
+        <li>News
+            <ul class="list-unstyled">
+                <li><a href="https://github.com/wet-boew/wet-boew/pulse">Recent project activity</a></li>
+				<li><a href="https://github.com/wet-boew/wet-boew/graphs">Project statistics</a></li>
+            </ul>
+        </li>
+        <li>Stay connected
+            <ul class="list-unstyled">
+				<li><a href="https://twitter.com/WebExpToolkit">Twitter</a></li>
+            </ul>
+        </li>
+    </ul>
+</section>

--- a/site/includes/fullmenu-fr.hbs
+++ b/site/includes/fullmenu-fr.hbs
@@ -1,0 +1,69 @@
+<!-- some mobile views -->
+    <a href="#" class="nav-close visible-sm visible-xs"><span class="glyphicon glyphicon-remove"></span> Fermer le menu</a>
+<!-- secondary navigation if enabled -->
+<section class="container visible-md visible-lg nvbar">
+    <h2 class="wb-inv">Menu du site</h2>
+    <div class="row">
+        <ul class="list-inline menu" role="menubar">
+            <li><a href="#projet" class="item">Projet de la BOEW</a>
+                <ul class="sm list-unstyled" id="projet" role="menu">
+                    <li><a href="{{rooturl}}/index-fr.html#apropos">À propos de la BOEW</a></li>
+                    <li><a href="{{rooturl}}index-fr.html#avantages">Avantages</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Distinctions">Distinctions pour la BOEW</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/">Projet principal</a></li>
+					<li><a href="{{rooturl}}/Licence-fr.html">Conditions régissant l'utilisation</a></li>
+					<li><a href="https://github.com/wet-boew/wet-boew/wiki/Feuille-de-route">Feuille de route pour les versions passées et futures</a></li>
+					<li><a href="{{rooturl}}/index-fr.html#historique-des-versions">Historique des versions</a></li>
+					<li><a href="http://www.tbs-sct.gc.ca/ws-nw/index-fra.asp">À propos des normes Web</a></li>
+                </ul>
+            </li>
+            <li><a href="#miseenoeuvre" class="item">Mise en œuvre de la BOEW</a>
+                <ul class="sm list-unstyled" id="miseenoeuvre" role="menu">
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Comment-d%C3%A9marrer-avec-la-BOEW">Comment démarrer avec la BOEW</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Guide-d%27utilisation-de-GitHub-pour-la-BOEW">Guide d'utilisation de GitHub pour la BOEW</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/T%C3%A9l%C3%A9chargements">Télécharger la BOEW</a></li>
+                    <li><a href="{{rooturl}}/demos/index-fr.html">Exemples pratiques</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/Accueil#rfrence">Documentation</a></li>
+                </ul>
+            </li>
+            <li><a href="#contribue" class="item">Contribuer à la BOEW</a>
+                <ul class="sm list-unstyled" id="contribue" role="menu">
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Lignes-directrices-pour-les-contributeurs">Lignes directrices pour les contributeurs</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Lignes-directrices-pour-les-contributeurs#filing-a-bug-or-an-issue">Soumettre un bogue ou un problème</a></li>
+                    <li><a href="https://github.com/wet-boew/wet-boew/wiki/Lignes-directrices-pour-les-contributeurs#wiki-Creating_a_Pull_Request">Créer un &#171;&#160;<span lang="en">pull request</span>&#160;&#187;</a></li>
+					<li><a href="https://github.com/wet-boew/wet-boew/wiki/Lignes-directrices-pour-les-contributeurs#testing-you-pr-before-submitting">Essayer votre code</a></li>
+					<li><a href="https://github.com/wet-boew/wet-boew/wiki/D%C3%A9velopper-pour-la-BOEW">Développer pour la BOEW</a></li>
+					<li><a href="https://github.com/wet-boew/wet-boew/wiki/Cr%C3%A9er-des-documents">Créer des documents</a></li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+</section>
+
+<section class="wb-nav container visible-sm visible-xs">
+    <h2 class="wb-inv">Information du site</h2>
+    <ul class="list-unstyled">
+        <li>À propos
+            <ul class="list-unstyled">
+				<li><a href="{{rooturl}}/index-fr.html#apropos">À propos de la Boîte à outils de l’expérience Web</a></li>
+				<li><a href="http://www.tbs-sct.gc.ca/ws-nw/index-fra.asp">À propos des normes Web</a></li>
+            </ul>
+        </li>
+        <li>Contactez-nous
+            <ul class="list-unstyled">
+                <li><a href="https://github.com/wet-boew/wet-boew/issues/new">Questions ou commentaires?</a></li>
+            </ul>
+        </li>
+        <li>Nouvelles
+            <ul class="list-unstyled">
+				<li><a href="https://github.com/wet-boew/wet-boew/pulse">Activité du projet récente</a></li>
+				<li><a href="https://github.com/wet-boew/wet-boew/graphs">Statistiques du projet</a></li>
+            </ul>
+        </li>
+        <li>Restez branchés
+            <ul class="list-unstyled">
+				<li><a href="https://twitter.com/BoiteExpWeb">Twitter</a></li>
+            </ul>
+        </li>
+    </ul>
+</section>

--- a/site/includes/languagetoggle.hbs
+++ b/site/includes/languagetoggle.hbs
@@ -1,6 +1,6 @@
 <div class="container">
 	<div class="row text-right">
-		<ul data-ajax-before="{{assets}}/js/assets/mobmenu-{{language}}.html" class="visible-md visible-lg">
+		<ul data-ajax-before="{{assets}}/ajax/mobmenu-{{language}}.txt" class="visible-md visible-lg">
 {{#if_eq language compare="en"}}
 	{{#if page.fr}}
 			<li>

--- a/site/includes/mobimenu.hbs
+++ b/site/includes/mobimenu.hbs
@@ -1,0 +1,6 @@
+<section class="wb-mb-links col-xs-12 visible-sm visible-xs" id="wb-glb-mn" >
+	<ul class="list-inline text-right">
+		<li><a href="#wb-sm" title="Menu" class="wb-target"><span class="glyphicon glyphicon-th-list"><i class="wb-inv">Menu</i></span></a></li>
+		<li class="wb-target"><a href="#wb-srch" title="{{#i18n "%tmpl-search"}}{{/i18n}}"><span class="glyphicon glyphicon-search"><i class="wb-inv">{{#i18n "%tmpl-search"}}{{/i18n}}</i></span></a></li>
+	</ul>
+</section>

--- a/site/includes/sitemenu-en.hbs
+++ b/site/includes/sitemenu-en.hbs
@@ -1,0 +1,9 @@
+<div class="container visible-md visible-lg nvbar">
+    <div class="row">
+        <ul class="list-inline menu">
+			<li><a href="{{rooturl}}/index-en.html">WET project</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/wiki/Implementing-WET">Implement WET</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/wiki/Contributor-guidelines">Contribute to WET</a></li>
+        </ul>
+    </div>
+</div>

--- a/site/includes/sitemenu-fr.hbs
+++ b/site/includes/sitemenu-fr.hbs
@@ -1,0 +1,9 @@
+<div class="container visible-md visible-lg nvbar">
+    <div class="row">
+        <ul class="list-inline menu">
+			<li><a href="{{rooturl}}/index-fr.html">Projet de la BOEW</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/wiki/Mise-en-%C5%93uvre-de-la-BOEW">Mise en œuvre de la BOEW</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/wiki/Lignes-directrices-pour-les-contributeurs">Contribuer à la BOEW</a></li>
+        </ul>
+    </div>
+</div>

--- a/site/includes/sitemenu.hbs
+++ b/site/includes/sitemenu.hbs
@@ -1,13 +1,5 @@
-<div class="container">
-		<ul class="wb-menu">
-			<li>
-				<a href="http://wet-boew.github.io/wet-boew/index-en.html">WET project</a>
-			</li>
-			<li>
-				<a href="https://github.com/wet-boew/wet-boew/wiki/Implementing-WET">Implement WET</a>
-			</li>
-			<li>
-				<a href="https://github.com/wet-boew/wet-boew/wiki/Contributor-guidelines">Contribute to WET</a>
-			</li>
-		</ul>
-</div>
+{{#startsWith "en" language }}
+{{>sitemenu-en}}
+ {{else}}
+ {{>sitemenu-fr}}
+{{/startsWith}}

--- a/site/layouts/ajax.hbs
+++ b/site/layouts/ajax.hbs
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="{{language}}">
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+<!-- DataAjaxFragmentStart -->
+{{>body}}
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -33,7 +33,7 @@
 		</ul>
 		<header role="banner">
 			<div id="wb-bnr">
-				<section data-ajax-after="{{assets}}/assets/mobmenu-{{language}}.html" id="wb-lng">
+				<section id="wb-lng">
 					<h2>{{#i18n "%tmpl-lang-select"}}{{/i18n}}</h2>
 					{{>languagetoggle}}
 				</section>
@@ -54,6 +54,7 @@
 				</div>
 			</div>
 
+			<!-- <nav role="navigation" id="wb-sm" class="wb-menu" data-ajax-fetch="{{assets}}/ajax/sitemenu-{{language}}.txt" typeof="SiteNavigationElement"> -->
 			<nav role="navigation" id="wb-sm" typeof="SiteNavigationElement">
 				<h2>{{#i18n "%tmpl-site-menu"}}{{/i18n}}</h2>
 				{{>sitemenu}}

--- a/site/pages/ajax/mobmenu-en.hbs
+++ b/site/pages/ajax/mobmenu-en.hbs
@@ -1,0 +1,5 @@
+---
+language: "en"
+---
+{{>mobimenu}}
+

--- a/site/pages/ajax/mobmenu-fr.hbs
+++ b/site/pages/ajax/mobmenu-fr.hbs
@@ -1,0 +1,4 @@
+---
+language: "fr"
+---
+{{>mobimenu}}

--- a/site/pages/ajax/sitemenu-en.hbs
+++ b/site/pages/ajax/sitemenu-en.hbs
@@ -1,0 +1,4 @@
+---
+language: "en"
+---
+{{>fullmenu-en}}

--- a/site/pages/ajax/sitemenu-fr.hbs
+++ b/site/pages/ajax/sitemenu-fr.hbs
@@ -1,0 +1,4 @@
+---
+language: "fr"
+---
+{{>fullmenu-fr}}

--- a/src/plugins/index-en.hbs
+++ b/src/plugins/index-en.hbs
@@ -9,7 +9,7 @@ fr: index
 			<th>Name</th>
 			<th>Category</th>
 			<th>Description</th>
-			<th>Keywords</th>
+			<th class="wb-inv">Keywords</th>
 		</tr>
 	</thead>
 	<tbody>

--- a/src/plugins/index-fr.hbs
+++ b/src/plugins/index-fr.hbs
@@ -9,7 +9,7 @@ en: index
 			<th>Nom</th>
 			<th>Catégorie</th>
 			<th>Description</th>
-			<th>Mots clés</th>
+			<th class="wb-inv">Mots clés</th>
 		</tr>
 	</thead>
 	<tbody>

--- a/theme/layouts/theme.hbs
+++ b/theme/layouts/theme.hbs
@@ -54,6 +54,7 @@
 				</div>
 			</div>
 
+			<!-- <nav role="navigation" id="wb-sm" class="wb-menu" data-ajax-fetch="{{assets}}/ajax/sitemenu-{{language}}.txt" typeof="SiteNavigationElement"> -->
 			<nav role="navigation" id="wb-sm" typeof="SiteNavigationElement">
 				<h2>{{#i18n "%tmpl-site-menu"}}{{/i18n}}</h2>
 				{{>sitemenu}}

--- a/theme/sass/parts/_breadcrumb.scss
+++ b/theme/sass/parts/_breadcrumb.scss
@@ -21,7 +21,6 @@
 	}
 	li {
 		background: url("data:image/gif;base64,R0lGODlhBgAGAMQAAAAAAP///5aWlpCQkI+Pj42NjYyMjImJiYiIiIaGhoCAgHh4eHNzc25ubmxsbGhoaGdnZ2VlZWRkZFFRUQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAEAABMALAAAAAAGAAYAAAUa4MEsQmAiTjOYARFFiVlAkhIYknQESfSsgRAAOw==") no-repeat scroll 0 50%;
-		float: left;
 		margin-right: 5px;
 		padding-left: 11px;
 		white-space: nowrap;

--- a/theme/sass/parts/_search.scss
+++ b/theme/sass/parts/_search.scss
@@ -10,3 +10,11 @@
 		width: 70%;
 	}
 }
+
+[lang=fr] {
+	#wb-srch {
+		.form-group {
+			width: 60%;
+		}
+	}
+}


### PR DESCRIPTION
Notes:
- Ajaxing in of site menu is commented out since mega menus not working correctly (TODO: Fix mega menus)
- Ports most of the English and French site menu and site footer content from master branch (v3.1)
- Happens to fix the duplication issue in #3405
- Has known semantic issues with mobile menu include as described in #3405 (TODO: Deal with this issue in a separate PR when proper approach is found)
