### PR TITLE
Session: revert to displaying time that session expires

### DIFF
--- a/src/js/i18n/base.js
+++ b/src/js/i18n/base.js
@@ -146,8 +146,7 @@
 		'%table-mention': '@%table-mention@',
 		'%table-following': '@%table-following@',
 		/* Session timeout */
-		'%st-timeout-msg-bgn': '@%st-timeout-msg-bgn@',
-		'%st-timeout-msg-end': '@%st-timeout-msg-end@',
+		'%st-timeout-msg': '@%st-timeout-msg@',
 		'%st-msgbox-title': '@%st-msgbox-title@',
 		'%st-already-timeout-msg': '@%st-already-timeout-msg@',
 		/* Disable/enable PE */

--- a/src/js/i18n/i18n.csv
+++ b/src/js/i18n/i18n.csv
@@ -121,10 +121,9 @@ jQuery Mobile,%jqm-expand, click to expand contents, cliquer pour afficher le co
 ,%jqm-filter,Filter items…,Filtrer des articles...,filtrar artículos…
 Charts widget,%table-mention,Table,Tableau,Tabla
 ,%table-following,Chart. Details in the following table.,Graphique. Plus de détails dans le tableau suivant.,Cuadro. Los detalles aparecen en la siguiente tabla.
-Session timeout,%st-timeout-msg-bgn,Your session will expire automatically in #min# min #sec# sec.,Votre session expirera automatiquement dans #min# min #sec# sec.,Su sesión expirará automáticamente en #min# min #sec# sec.
-,%st-timeout-msg-end,"Select ""OK"" to extend your session.",Sélectionner « OK » pour prolonger votre session.,"Seleccione ""OK"" para prolongar tu sesión."
+Session timeout,%st-timeout-msg,"Your session will expire automatically at #expireTime#. Select ""OK"" to extend your session.",Votre session expirera automatiquement à #expireTime#. Sélectionner « OK » pour prolonger votre session.,"Su sesión expirará automáticamente en #expireTime#. Seleccione ""OK"" para prolongar tu sesión."
 ,%st-msgbox-title,Session timeout warning,Avertissement d\'expiration de la session,Aviso de finalización de sesión
-,%st-already-timeout-msg,"Sorry your session has already expired. Please login again.","Désolé, votre session a déjà expiré. S\'il vous plaît vous connecter à nouveau.","Lamentablemente su sesión ha expirado. Por favor ingrese nuevamente."
+,%st-already-timeout-msg,"Sorry your session has already expired. Please sign in again.","Désolé, votre session a déjà expiré. S\'il vous plaît ouvrir une nouvelle session.","Lamentablemente su sesión ha expirado. Por favor ingrese nuevamente."
 Toggle details,%td-toggle,Toggle all,Basculer tout,Alternar todo
 ,%td-open,Expand all,Afficher tout,Expandir todo
 ,%td-close,Collapse all,Réduire tout,Colapsar todo

--- a/src/js/workers/sessiontimeout.js
+++ b/src/js/workers/sessiontimeout.js
@@ -31,8 +31,7 @@
 				timeParse,
 				getExpireTime,
 				alreadyTimeoutMsg = _pe.dic.get('%st-already-timeout-msg'),
-				timeoutMsgBegin = _pe.dic.get('%st-timeout-msg-bgn'),
-				timeoutMsgEnd = _pe.dic.get('%st-timeout-msg-end'),
+				timeoutMsg = _pe.dic.get('%st-timeout-msg'),
 				lastActivity,
 				lastAjaxCall = 0;
 
@@ -90,13 +89,11 @@
 
 			// code to display the alert message
 			displayTimeoutMessage = function () {
-				var expireTime = getExpireTime(opts.reactionTime),
-					timeoutMsg = timeoutMsgBegin.replace('#min#', expireTime.minutes).replace('#sec#', expireTime.seconds) + ' ' + timeoutMsgEnd,
-					$where_was_i = document.activeElement, // Grab where the focus in the page was BEFORE the modal dialog appears
+				var $where_was_i = document.activeElement, // Grab where the focus in the page was BEFORE the modal dialog appears
 					result;
 
 				$(document.body).append(overLay);
-				result = confirm(timeoutMsg);
+				result = confirm(timeoutMsg.replace('#expireTime#', getExpireTime()));
 				$where_was_i.focus();
 				$('.jqmOverlay').detach();
 				return result;
@@ -146,20 +143,24 @@
 				}
 			};
 
-			/*
-			 * Converts a millisecond value into minutes and seconds
-			 * @function getExpireTime
-			 * @param {integer} milliseconds The time value in milliseconds
-			 * @returns {Object} An object with a seconds and minutes property
-			 */
-			getExpireTime = function( milliseconds ) {
-				var time = { minutes: "", seconds: "" };
+			getExpireTime = function () {
+				var expire = new Date(getCurrentTimeMs() + opts.reactionTime),
+					hours = expire.getHours(),
+					minutes = expire.getMinutes(),
+					seconds = expire.getSeconds(),
+					timeformat = hours < 12 ? ' AM' : ' PM';
 
-				if ( milliseconds != null ) {
-					time.minutes = parseInt( ( milliseconds / ( 1000 * 60 ) ) % 60, 10 );
-					time.seconds = parseInt( ( milliseconds / 1000 ) % 60, 10 );
+				hours = hours % 12;
+				if (hours === 0) {
+					hours = 12;
 				}
-				return time;
+
+				// Add a zero if needed in the time
+				hours = hours < 10 ? '0' + hours : hours;
+				minutes = minutes < 10 ? '0' + minutes : minutes;
+				seconds = seconds < 10 ? '0' + seconds : seconds;
+
+				return hours + ':' + minutes + ':' + seconds + timeformat;
 			};
 
 			start_liveTimeout();


### PR DESCRIPTION
- Updating the Google Doc now and will have a new i18n.csv for 3.1 once this lands.
- Usability improvement to `%st-already-timeout-msg` from #3190 (changed "login" to "sign in").

Fixes #3426.
