### PR TITLE
WET theme: shrink logo and add top/bottom margin on splash

### DIFF
--- a/site/layouts/splashpage.hbs
+++ b/site/layouts/splashpage.hbs
@@ -21,6 +21,11 @@
 		<script src="{{assets}}/js/ie8-vapour{{environment.suffix}}.js"></script>
 		<![endif]-->
 
+		<style>
+			.mrg-top { margin-top: 2em; }
+			.mrg-btm { margin-bottom: 2em; }
+		</style>
+
 		<noscript><link rel="stylesheet" href="{{assets}}/css/noscript{{environment.suffix}}.css" /></noscript>
 
 	</head>
@@ -28,8 +33,8 @@
 		<header role="banner">
 			<div id="wb-bnr">
 				<div class="container">
-					<div class="row">
-						<section class="full-hd">
+					<div class="row mrg-top mrg-btm">
+						<section class="col-md-8 col-md-offset-2">
 							<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/assets/logo.svg" aria-label="{{site.sitetitle}}"></object>
 						</section>
 					</div>
@@ -37,7 +42,7 @@
 			</div>
 		</header>
 		<main role="main" property="mainContentOfPage" class="container">
-			<div class="row">
+			<div class="row mrg-top">
 				<div class="col-md-12">
 					{{>body}}
 				</div>


### PR DESCRIPTION
Visual tweak to the splash page:
- Adds top/bottom margin around logo and buttons.
- Reduces size of the WET logo.

CSS has been added as an inline `<style>` block because I wasn't sure if 4.0 was going to have utility margin classes.

![wet-splash](https://f.cloud.github.com/assets/2110107/1484372/389b202a-4706-11e3-8a29-6cab7bb155ba.png)
