### PR TITLE
Build: Remove QUnit reference

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -649,7 +649,7 @@ module.exports = (grunt) ->
 		watch:
 			lib_test:
 				files: "<%= jshint.lib_test.src %>"
-				tasks: ["jshint:lib_test", "qunit"]
+				tasks: "jshint:lib_test"
 
 			source:
 				files: "<%= jshint.lib_test.src %>"


### PR DESCRIPTION
Leftover boilerplate from initial scaffolding
