### PR TITLE
WET theme: Added mega menu and mobile menu support

### DIFF
--- a/site/includes/fullmenu-en.hbs
+++ b/site/includes/fullmenu-en.hbs
@@ -1,8 +1,8 @@
 <!-- some mobile views -->
     <a href="#" class="nav-close visible-sm visible-xs"><span class="glyphicon glyphicon-remove"></span> Close menu</a>
 <!-- secondary navigation if enabled -->
-<section class="container visible-md visible-lg nvbar">
-    <h2 class="wb-inv">Site menu</h2>
+<div class="container visible-md visible-lg nvbar">
+    <h2>{{#i18n "%tmpl-site-menu"}}{{/i18n}}</h2>
     <div class="row">
         <ul class="list-inline menu" role="menubar">
             <li><a href="#project" class="item">WET project</a>
@@ -38,7 +38,7 @@
             </li>
         </ul>
     </div>
-</section>
+</div>
 
 <section class="wb-nav container visible-sm visible-xs">
     <h2 class="wb-inv">Site Information</h2>

--- a/site/includes/fullmenu-fr.hbs
+++ b/site/includes/fullmenu-fr.hbs
@@ -1,8 +1,8 @@
 <!-- some mobile views -->
     <a href="#" class="nav-close visible-sm visible-xs"><span class="glyphicon glyphicon-remove"></span> Fermer le menu</a>
 <!-- secondary navigation if enabled -->
-<section class="container visible-md visible-lg nvbar">
-    <h2 class="wb-inv">Menu du site</h2>
+<div class="container visible-md visible-lg nvbar">
+	<h2>{{#i18n "%tmpl-site-menu"}}{{/i18n}}</h2>
     <div class="row">
         <ul class="list-inline menu" role="menubar">
             <li><a href="#projet" class="item">Projet de la BOEW</a>
@@ -38,7 +38,7 @@
             </li>
         </ul>
     </div>
-</section>
+</div>
 
 <section class="wb-nav container visible-sm visible-xs">
     <h2 class="wb-inv">Information du site</h2>

--- a/site/includes/sitemenu-en.hbs
+++ b/site/includes/sitemenu-en.hbs
@@ -1,4 +1,5 @@
 <div class="container visible-md visible-lg nvbar">
+	<h2>{{#i18n "%tmpl-site-menu"}}{{/i18n}}</h2>
     <div class="row">
         <ul class="list-inline menu">
 			<li><a href="{{rooturl}}/index-en.html">WET project</a></li>

--- a/site/includes/sitemenu-fr.hbs
+++ b/site/includes/sitemenu-fr.hbs
@@ -1,4 +1,5 @@
 <div class="container visible-md visible-lg nvbar">
+	<h2>{{#i18n "%tmpl-site-menu"}}{{/i18n}}</h2>
     <div class="row">
         <ul class="list-inline menu">
 			<li><a href="{{rooturl}}/index-fr.html">Projet de la BOEW</a></li>

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -56,9 +56,7 @@
 				</div>
 			</div>
 
-			<!-- <nav role="navigation" id="wb-sm" class="wb-menu" data-ajax-fetch="{{assets}}/ajax/sitemenu-{{language}}.html" typeof="SiteNavigationElement"> -->
-			<nav role="navigation" id="wb-sm" typeof="SiteNavigationElement">
-				<h2>{{#i18n "%tmpl-site-menu"}}{{/i18n}}</h2>
+			<nav role="navigation" id="wb-sm" data-ajax-fetch="{{assets}}/ajax/sitemenu-{{language}}.html" data-post-remove="remove after init" class="wb-menu remove after init" typeof="SiteNavigationElement">
 				{{>sitemenu}}
 			</nav>
 {{#unless_eq assets compare="."}}

--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -12,3 +12,8 @@ $clrWhite: #FFF;
 $clrLight: #EEE;
 $clrMedium: #CCC;
 $clrDark: #555;
+
+// Views
+$mobile: 991px;
+$desktop: 992px;
+$largescreen: 1200px;

--- a/src/core/vapour.js
+++ b/src/core/vapour.js
@@ -282,7 +282,7 @@ window._timer = {
 
 	touch: function() {
 
-		var elms = this._elms,
+		var elms = this._elms.slice( 0 ),
 			len = elms.length,
 			$elm, i;
 		for ( i = 0; i !== len; i += 1 ) {

--- a/src/plugins/menu/menu-en.hbs
+++ b/src/plugins/menu/menu-en.hbs
@@ -14,7 +14,7 @@
 	margin: 0;
 	padding: 0;
 }
-.menu-demo .menu > li a {
+.menu-demo .menu > li > a {
 	color: #fff;
 	padding: 1em;
 	border-left: 2px ridge #284468;
@@ -26,12 +26,12 @@
 	box-shadow: 0 3px 3px -2px rgba(0, 0, 0, 0.3), 3px 3px 3px -2px rgba(0, 0, 0, 0.3), -3px 3px 3px -2px rgba(0, 0, 0, 0.3);
 	border-left: none;
 	border-right: none;
-	border-bottom: 5px solid #243850;
 	padding: 0;
 	background: #ccc;
 	min-width: 200px;
 }
 .menu-demo .sm.open li a {
+	font-size: 0.95em;
 	color: #444;
 	border-left: none;
 	border-right: none;
@@ -49,6 +49,15 @@
 	text-shadow: none;
 	background: #335075;
 }
+#menu-demo-1 .menu a {
+	text-decoration: none;
+}
+#menu-demo-1 .menu > li > a {
+	padding: 0.8em;
+}
+#menu-demo-1 .menu > li > a:hover, #menu-demo-1 .menu > li > a:focus {
+	text-decoration: underline;
+}
 #menu-demo-1 .sm.open li a:hover, #menu-demo-1 .sm.open li a:focus {
 	background: #243850;
 	color: #fff;
@@ -62,6 +71,9 @@
 #menu-demo-1 .sm.open {
 	border-bottom: 5px solid #243850;
 }
+#menu-demo-1 .expicon {
+	margin-right: 5px;
+}
 
 
 #menu-demo-2 {
@@ -73,6 +85,9 @@
 #menu-demo-2 .menu .active {
 	text-shadow: none;
 	background: #0B3048;
+}
+#menu-demo-2 .menu > li > a {
+	padding: 1.0em;
 }
 #menu-demo-2 .sm.open li a:hover, #menu-demo-2 .sm.open li a:focus {
 	background: #243850;
@@ -110,5 +125,3 @@
 		<li><a href="http://www.ec.gc.ca" class="item">Section 4</a></li>
 	</ul>
 </nav>
-<!-- DataAjaxFragmentEnd -->
-</html>

--- a/src/plugins/menu/menu-fr.hbs
+++ b/src/plugins/menu/menu-fr.hbs
@@ -14,9 +14,8 @@
 	margin: 0;
 	padding: 0;
 }
-.menu-demo .menu > li a {
+.menu-demo .menu > li > a {
 	color: #fff;
-	padding: 1em;
 	border-left: 2px ridge #284468;
 }
 .menu-demo .menu > li:last-child a {
@@ -26,12 +25,12 @@
 	box-shadow: 0 3px 3px -2px rgba(0, 0, 0, 0.3), 3px 3px 3px -2px rgba(0, 0, 0, 0.3), -3px 3px 3px -2px rgba(0, 0, 0, 0.3);
 	border-left: none;
 	border-right: none;
-	border-bottom: 5px solid #243850;
 	padding: 0;
 	background: #ccc;
 	min-width: 200px;
 }
 .menu-demo .sm.open li a {
+	font-size: 0.95em;
 	color: #444;
 	border-left: none;
 	border-right: none;
@@ -49,6 +48,15 @@
 	text-shadow: none;
 	background: #335075;
 }
+#menu-demo-1 .menu a {
+	text-decoration: none;
+}
+#menu-demo-1 .menu > li > a {
+	padding: 0.8em;
+}
+#menu-demo-1 .menu > li > a:hover, #menu-demo-1 .menu > li > a:focus {
+	text-decoration: underline;
+}
 #menu-demo-1 .sm.open li a:hover, #menu-demo-1 .sm.open li a:focus {
 	background: #243850;
 	color: #fff;
@@ -62,7 +70,9 @@
 #menu-demo-1 .sm.open {
 	border-bottom: 5px solid #243850;
 }
-
+#menu-demo-1 .expicon {
+	margin-right: 5px;
+}
 
 #menu-demo-2 {
 	background: #335075;
@@ -73,6 +83,9 @@
 #menu-demo-2 .menu .active {
 	text-shadow: none;
 	background: #0B3048;
+}
+#menu-demo-2 .menu > li > a {
+	padding: 1.0em;
 }
 #menu-demo-2 .sm.open li a:hover, #menu-demo-2 .sm.open li a:focus {
 	background: #243850;
@@ -110,5 +123,3 @@
 		<li><a href="http://www.ec.gc.ca" class="item">Section 4</a></li>
 	</ul>
 </nav>
-<!-- DataAjaxFragmentEnd -->
-</html>

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -102,6 +102,7 @@ drizzleAria = function( $elements ){
 		}
 	}
 },
+
 /*
  * @method onAjaxLoaded
  * @param {jQuery DOM elements} element The plugin element
@@ -115,7 +116,7 @@ onAjaxLoaded = function( $elm, $ajaxed ) {
 	$ajaxed.find( ":discoverable" )
 		.attr( "tabindex", "-1" );
 
-	$menu.eq(0).attr( "tabindex", "0" );
+	$menu.eq( 0 ).attr( "tabindex", "0" );
 	$menu.filter( "[href^=#]" )
 		.append( "<span class='expicon'></span>" );
 
@@ -234,14 +235,17 @@ onHoverFocus = function( event ) {
 		$container = ref[ 0 ],
 		$elm = ref[ 3 ];
 
-	// Clear the any timeouts for open/closing menus
-	clearTimeout( globalTimeout[ $container.attr( "id" ) ] );
+	if ( $container ) {
+	
+		// Clear the any timeouts for open/closing menus
+		clearTimeout( globalTimeout[ $container.attr( "id" ) ] );
 
-	$container.trigger({
-		type: "display.wb-menu",
-		ident: $elm.parent(),
-		cancelDelay: event.type === "focusin"
-	});
+		$container.trigger({
+			type: "display.wb-menu",
+			ident: $elm.parent(),
+			cancelDelay: event.type === "focusin"
+		});
+	}
 };
 
 // Bind the events of the plugin

--- a/src/plugins/menu/menu.scss
+++ b/src/plugins/menu/menu.scss
@@ -1,6 +1,8 @@
 /*
  Menu Sass
  */
+@import "../../variables";
+
 %menu-text-decoration-none {
 	text-decoration: none;
 }
@@ -66,4 +68,55 @@
 			border-color: transparent !important;
 		}
 	}
+
+    /*
+	Mobile view
+	*/
+    @media screen and (max-width: $mobile) {
+        position: absolute;
+        z-index: 1000;
+        top: 0;
+        right: -100%;
+        display: block !important;
+
+        &:target {
+            width: 75%;
+            right: 0;
+            .container {
+                display: block !important;
+            }
+        }
+        .nav-close {
+            text-align: right;
+            margin-bottom: 5px;
+            padding: 5px 10px;
+        }
+        .menu {
+            display: block;
+        }
+        .menu {
+			> {
+				li {
+					display: block;
+					a {
+						text-align: left;
+					}
+				}
+			}
+        }
+		%menu-sm-mobile {
+			display: block;
+            position: relative;
+            z-index: auto;
+            text-transform: none;
+            top: auto;
+            min-width: 0;
+		}
+        .sm {
+            @extend %menu-sm-mobile;
+            &.open {
+                @extend %menu-sm-mobile;
+            }
+        }
+    }
 }

--- a/theme/sass/parts/_sitenav.scss
+++ b/theme/sass/parts/_sitenav.scss
@@ -1,58 +1,150 @@
 /*
  Site menu
  */
+@import "../../../src/variables";
 
 #wb-sm {
-	background: none repeat scroll 0 0 #0E4164;
-	border-top: 1px solid #0B3048;
-	ul {
-		width: 100%;
-		list-style: none;
-		padding: 0;
-		li {
-			display: inline;
-			float: left;
-			a {
-				border-left: 1px solid #0B3048;
-				border-right: 1px solid #135480;
-				color: #fff;
-				display: block;
-				padding: 0.8em;
-				font-size: 1em;
-				font-weight: 400;
-				line-height: normal;
-				margin: 0;
-				text-decoration: none;
-				&:focus, &:hover {
-					text-decoration: underline;
-				}
-			}
-		}
-	}
+	background: #0E4164;
 	.menu {
-		display: table;
-		width: 100%;
-		margin: 0;
-		> li {
-			display: table-cell;
-			padding: 0;
-		}
-		li {
-			a {
-				&:hover, &:focus, &:active {
+		text-shadow: 1px 1px 1px #222;
+		margin-bottom: 0;
+		> {
+			li {
+				margin: 0;
+				padding: 0;
+				> {
+					a {
+						color: #fff;
+						padding: 0.8em;
+						border-left: 1px solid #0B3048;
+						text-decoration: none;
+						&:hover, &:focus {
+							text-decoration: underline;
+						}
+					}
+				}
+				&:last-child a {
+					border-right: 1px solid #135480;
+				}
+				&.active {
 					background: #243850;
 				}
 			}
+		}
+	}
+	.sm {
+		&.open {
+			box-shadow: 0 3px 3px -2px rgba(0, 0, 0, 0.3), 3px 3px 3px -2px rgba(0, 0, 0, 0.3), -3px 3px 3px -2px rgba(0, 0, 0, 0.3);
+			border-left: none;
+			border-right: none;
+			border-bottom: 5px solid #243850;
+			padding: 0;
+			background: #ccc;
+			min-width: 200px;
 			li {
 				a {
-					&:hover, &:focus, &:active {
-						background: none;
+					font-size: 0.95em;
+					color: #444;
+					border-left: none;
+					border-right: none;
+					text-shadow: none;
+					padding: 5px 10px;
+					text-decoration: none;
+					&:hover, &:focus {
+						background: #243850;
+						color: #fff;
 					}
 				}
 			}
+			.slflnk {
+				background: #bbb;
+			}
 		}
-		.expicon {
-			border-top-color: #bbb;
+		.row {
+			background: transparent;
+			a {
+				color: #6e6e6e;
+			}
 		}
 	}
+	.expicon {
+		margin-right: 5px;
+	}
+
+    /*
+	Mobile view
+	*/
+    @media screen and (max-width: $mobile) {
+        .menu {
+            li {
+				a {
+					&:hover, &:focus, &:active {
+						background: #eee;
+					}
+				}
+            }
+            .active {
+                background: #ddd !important;
+            }
+            li {
+				li {
+					a {
+						&:hover, &:focus, &:active {
+							background: none;
+						}
+					}
+                }
+            }
+        }
+        background: #ddd;
+
+        &:target {
+            .container {
+                display: block !important;
+            }
+        }
+        .row {
+            border-bottom: 1px solid #bbb;
+            padding-bottom: 10px;
+        }
+        .menu {
+			> {
+				li {
+					a {
+						text-shadow: none;
+						color: #333;
+						border: none;
+						padding: .5em;
+					}
+				}
+			}
+        }
+		%theme-menu-sm-mobile {
+			-webkit-box-shadow: none;
+            box-shadow: none;
+            border-left: none;
+            border-right: none;
+            border-top: 1px solid #ddd;
+            padding: 0;
+            background: transparent;
+		}
+        .sm {
+            @extend %theme-menu-sm-mobile;
+            &.open {
+                @extend %theme-menu-sm-mobile;
+            }
+        }
+        .menu {
+            > li:last-child a {
+                border: none;
+            }
+            ul {
+				li {
+					border-bottom: 1px solid #ddd;
+					border-top: 1px solid #fff;
+					background: #eee;
+				}
+            }
+        }
+    }
 }


### PR DESCRIPTION
Also fixes timerpoke race condition that prevented multiple menus from being loaded (made clone of the timerpoke array to ensure that selectors weren't being removed from the array while trying to fire events).

@masterbee I moved more structural menu CSS to menu.scss core so you can probably remove more from the theme. Only a first cut so would be good to get agreement on what goes in menu.scss versus theme so there is consistency across themes (and no duplication).
