### PR TITLE
Renamed COA Class

### DIFF
--- a/src/theme-gcwu-fegc/sass/includes/_default-large-images-screen.scss
+++ b/src/theme-gcwu-fegc/sass/includes/_default-large-images-screen.scss
@@ -31,7 +31,7 @@
 	background-color: #406C93;
 }
 
-.ui-body-coa {
+.ui-head-in-coa {
 	background: {
 		position: center 5em !important;
 	}


### PR DESCRIPTION
This class needs to be applied to the wb-head-in div. It just makes more sense to have it called this.
