### PR TITLE
Vapour: Remove sDisabled with inlined string

### DIFF
--- a/src/core/vapour.js
+++ b/src/core/vapour.js
@@ -131,7 +131,6 @@ var getUrlParts = function( url ) {
 		doc: $( document ),
 		win: $( window ),
 		html: $( "html" ),
-		sDisabled: "#wb-tphp",
 		pageUrlParts: currentpage,
 		getUrlParts: getUrlParts,
 		isDisabled : disabled,
@@ -241,9 +240,9 @@ window._timer = {
 	nodes: $(),
 
 	add: function( selector ) {
-	
+
 		// Lets ensure we are not running if things are disabled
-		if ( vapour.isDisabled && selector !== vapour.sDisabled ) {
+		if ( vapour.isDisabled && selector !== "#wb-tphp" ) {
 			return 0;
 		}
 

--- a/src/plugins/wb-disable/disable.js
+++ b/src/plugins/wb-disable/disable.js
@@ -12,7 +12,7 @@
  * These are global to the event - meaning that they will be initialized once per page,
  * not once per instance of event on the page.
  */
-var selector = vapour.sDisabled,
+var selector = "#wb-tphp",
 	$document = vapour.doc,
 
 	/*


### PR DESCRIPTION
Inlined disabled selector since it is single use and is still shorter than the minified result.

As discussed in #3476
