### PR TITLE
Secondary menu and mobile view

### DIFF
--- a/src/plugins/menu/menu-secondary-en.hbs
+++ b/src/plugins/menu/menu-secondary-en.hbs
@@ -1,0 +1,26 @@
+---
+{
+	"title": "Secondary Menu",
+	"language": "en",
+	"fr": "menu-secondary"
+}
+---
+
+<div class="row">
+
+	<nav role="navigation" id="wb-sec" typeof="SiteNavigationElement" class="col-md-3">
+		<h2>Secondary menu</h2>
+		<ul class="list-unstyled">
+			<li><a href="#">Lorem ipsum dolor sit amet.</a></li>
+			<li><a href="#">Officia, molestiae praesentium.</a></li>
+			<li><a href="#">Officiis, dolorem ut sunt?</a></li>
+			<li><a href="#">Harum, aliquam cupiditate!</a></li>
+			<li><a href="#">Quos voluptates quisquam alias.</a></li>
+		</ul>
+	</nav>
+	
+	<div class="col-md-9">
+		<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione, minima deleniti autem tenetur odit nostrum sunt eligendi quasi maiores veritatis voluptate tempore dolorem animi libero!</p>
+	</div>
+
+</div>

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -60,9 +60,9 @@ onInit = function( $elm ) {
 			element: $elm,
 			fetch: $elm.data( "ajax-fetch" )
 		});
+	} else {
+		$elm.trigger( "loaded.wb-menu" );
 	}
-
-	//anything else
 },
 
 /*
@@ -138,6 +138,18 @@ onAjaxLoaded = function( $elm, $ajaxed ) {
 		items: $elm.find( ".sm" )
 	});
 
+	$elm.trigger( "loaded.wb-menu" );
+},
+
+/*
+ * Adds the secondary menu to the medium view (and below) menu panel
+ * @method onMenuLoaded
+ */
+onMenuLoaded = function() {
+	var $wbsec = $( "#wb-sec" );
+	if ( $wbsec.length !== 0 ) {
+		$( this ).find( ".nav-close" ).after( $wbsec.clone().attr( "id", "wb-sec-p" ) );
+	}
 },
 
 /*
@@ -236,7 +248,7 @@ onHoverFocus = function( event ) {
 		$elm = ref[ 3 ];
 
 	if ( $container ) {
-	
+
 		// Clear the any timeouts for open/closing menus
 		clearTimeout( globalTimeout[ $container.attr( "id" ) ] );
 
@@ -253,7 +265,7 @@ $document.on( "timerpoke.wb mouseleave select.wb-menu ajax-fetched.wb increment.
 	var elm = event.target,
 		eventType = event.type,
 		$elm = $( elm );
-	
+
 	switch ( eventType ) {
 	case "ajax-fetched":
 
@@ -280,7 +292,7 @@ $document.on( "timerpoke.wb mouseleave select.wb-menu ajax-fetched.wb increment.
 		break;
 
 	case "mouseleave":
-	
+
 		// Make sure we are dealing with the top level container
 		if ( !$elm.hasClass( "wb-menu" ) ) {
 			$elm = $elm.closest( ".wb-menu" );
@@ -306,6 +318,8 @@ $document.on( "timerpoke.wb mouseleave select.wb-menu ajax-fetched.wb increment.
 	return true;
 });
 
+// Post processing for the site menu once it's finished loading
+$document.on( "loaded.wb-menu", "#wb-sm", onMenuLoaded );
 
 /*
  * Menu Keyboard bindings
@@ -333,7 +347,7 @@ $document.on( "keydown", selector + " .item", function( event ) {
 			$parent = $elm.parent();
 			$subMenu = $parent.find( ".sm" );
 			$goto = $subMenu.find( "a" ).first();
-			
+
 			// Open the submenu if it is not already open
 			if ( !$subMenu.hasClass( "open" ) ) {
 				$container.trigger({

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -258,6 +258,18 @@ onHoverFocus = function( event ) {
 			cancelDelay: event.type === "focusin"
 		});
 	}
+},
+
+/*
+ * Causes virtual clicks on menu items to open submenus
+ * @method onVirtualClick
+ * @param {jQuery event} event The current event
+ */
+onVirtualClick = function( event ) {
+	if ( $( "#wb-sm" ).find( ".nav-close:visible" ) ) {
+		event.preventDefault();
+		$( this ).trigger( "focusin" );
+	}
 };
 
 // Bind the events of the plugin
@@ -320,6 +332,9 @@ $document.on( "timerpoke.wb mouseleave select.wb-menu ajax-fetched.wb increment.
 
 // Post processing for the site menu once it's finished loading
 $document.on( "loaded.wb-menu", "#wb-sm", onMenuLoaded );
+
+// Virtual clicks on menu items should open submenus
+$document.on( "vclick", selector + " .item", onVirtualClick );
 
 /*
  * Menu Keyboard bindings

--- a/theme/sass/parts/_sitenav.scss
+++ b/theme/sass/parts/_sitenav.scss
@@ -70,6 +70,9 @@
 	.expicon {
 		margin-right: 5px;
 	}
+	#wb-sec-p {
+		display: none;
+	}
 
 	/*
 	Mobile view
@@ -152,5 +155,13 @@
 				}
 			}
 		}
+		#wb-sec-p {
+			display: block;
+		}
+	}
+}
+@media screen and (max-width: $mobile) {
+	#wb-sec {
+		display: none;
 	}
 }


### PR DESCRIPTION
1. If `#wb-sec` exists in the DOM, it is prepended to the #wb-sm panel menu once the menu as finished loading (loaded.wb-menu event).
2. Allows menus with hidden submenu items to be opened on virtual click (triggers `onHoverFocus` processing).

/cc @masterbee
