### PR TITLE
optimized menu function to do the DOM manipulation in the document fragment

### DIFF
--- a/site/includes/fullmenu-en.hbs
+++ b/site/includes/fullmenu-en.hbs
@@ -1,7 +1,7 @@
 <!-- some mobile views -->
     <a href="#" class="nav-close visible-sm visible-xs"><span class="glyphicon glyphicon-remove"></span> Close menu</a>
 <!-- secondary navigation if enabled -->
-<div class="container visible-md visible-lg nvbar">
+<div class="pnl-strt container visible-md visible-lg nvbar">
     <h2>{{#i18n "%tmpl-site-menu"}}{{/i18n}}</h2>
     <div class="row">
         <ul class="list-inline menu" role="menubar">

--- a/site/includes/fullmenu-fr.hbs
+++ b/site/includes/fullmenu-fr.hbs
@@ -1,7 +1,7 @@
 <!-- some mobile views -->
     <a href="#" class="nav-close visible-sm visible-xs"><span class="glyphicon glyphicon-remove"></span> Fermer le menu</a>
 <!-- secondary navigation if enabled -->
-<div class="container visible-md visible-lg nvbar">
+<div class="pnl-strt container visible-md visible-lg nvbar">
 	<h2>{{#i18n "%tmpl-site-menu"}}{{/i18n}}</h2>
     <div class="row">
         <ul class="list-inline menu" role="menubar">

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -112,11 +112,13 @@ onAjaxLoaded = function( $elm, $ajaxed ) {
 	//Some hooks for post transformation
 	// - @data-post-remove : removes the space delimited class for the element. This is more a feature to fight the FOUC
 	var $menu = $ajaxed.find( "[role='menubar'] .item" ),
+		$panel,
 		$wbsec = $( "#wb-sec" );
 
 	// lets see if we need to add a dynamic navigation section ( secondary nav )
 	if ( $wbsec.length !== 0 ) {
-		$ajaxed.find( ".wb-nav" ).before( "<section class='dyn-nav container visible-sm visible-xs'>" + $wbsec.html() + "</section>" );
+		$panel = $ajaxed.find( ".wb-nav" );
+		$panel.before( "<section id='dyn-nvgtn' class='" + $panel.attr( "class" ) + "'>" + $wbsec.html() + "</section>" );
 	}
 
 	$ajaxed.find( ":discoverable" )
@@ -132,10 +134,6 @@ onAjaxLoaded = function( $elm, $ajaxed ) {
 	if ( $elm.has( "[data-post-remove]" ) ) {
 		$elm.removeClass( $elm.data( "post-remove" ) )
 			.removeAttr( "data-post-remove" );
-	}
-
-	if ( $wbsec.length !== 0 ) {
-		$( this ).find( ".nav-close" ).after(  );
 	}
 
 	// Replace elements

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -117,8 +117,8 @@ onAjaxLoaded = function( $elm, $ajaxed ) {
 
 	// lets see if we need to add a dynamic navigation section ( secondary nav )
 	if ( $wbsec.length !== 0 ) {
-		$panel = $ajaxed.find( ".wb-nav" );
-		$panel.before( "<section id='dyn-nvgtn' class='" + $panel.attr( "class" ) + "'>" + $wbsec.html() + "</section>" );
+		$panel = $ajaxed.find( ".pnl-strt" );
+		$panel.before( "<section id='dyn-nvgtn' class='" + $panel.siblings( ".wb-nav" ).eq( 0 ).attr( "class" ) + "'>" + $wbsec.html() + "</section>" );
 	}
 
 	$ajaxed.find( ":discoverable" )

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -111,7 +111,13 @@ onAjaxLoaded = function( $elm, $ajaxed ) {
 
 	//Some hooks for post transformation
 	// - @data-post-remove : removes the space delimited class for the element. This is more a feature to fight the FOUC
-	var $menu = $ajaxed.find( "[role='menubar'] .item" );
+	var $menu = $ajaxed.find( "[role='menubar'] .item" ),
+		$wbsec = $( "#wb-sec" );
+
+	// lets see if we need to add a dynamic navigation section ( secondary nav )
+	if ( $wbsec.length !== 0 ) {
+		$ajaxed.find( ".wb-nav" ).before( "<section class='dyn-nav container visible-sm visible-xs'>" + $wbsec.html() + "</section>" );
+	}
 
 	$ajaxed.find( ":discoverable" )
 		.attr( "tabindex", "-1" );
@@ -128,6 +134,10 @@ onAjaxLoaded = function( $elm, $ajaxed ) {
 			.removeAttr( "data-post-remove" );
 	}
 
+	if ( $wbsec.length !== 0 ) {
+		$( this ).find( ".nav-close" ).after(  );
+	}
+
 	// Replace elements
 	$elm.html( $ajaxed.html() );
 
@@ -138,19 +148,8 @@ onAjaxLoaded = function( $elm, $ajaxed ) {
 		items: $elm.find( ".sm" )
 	});
 
-	$elm.trigger( "loaded.wb-menu" );
 },
 
-/*
- * Adds the secondary menu to the medium view (and below) menu panel
- * @method onMenuLoaded
- */
-onMenuLoaded = function() {
-	var $wbsec = $( "#wb-sec" );
-	if ( $wbsec.length !== 0 ) {
-		$( this ).find( ".nav-close" ).after( $wbsec.clone().attr( "id", "wb-sec-p" ) );
-	}
-},
 
 /*
  * @method onSelect
@@ -330,8 +329,6 @@ $document.on( "timerpoke.wb mouseleave select.wb-menu ajax-fetched.wb increment.
 	return true;
 });
 
-// Post processing for the site menu once it's finished loading
-$document.on( "loaded.wb-menu", "#wb-sm", onMenuLoaded );
 
 // Panel clicks on menu items should open submenus
 $document.on( "click vclick", selector + " .item", onPanelClick );


### PR DESCRIPTION
- Removed need for event `loaded.wb` since the preprocessing task was rewritten to happen after the ajaxed in event
- Optimized the `.clone()` to a string variable since `.clone` copies events and data which is not required an introduces a bit of overhead that is not required since this function is simply copying the html
- Corrected the placement of the copied element to be above the `.wb-nav` instance instead of below the close indicator to allow for other elements to be placed before the copied element.
