### PR TITLE
Meter Polyfill: Move to JEP model

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,3 +1,2 @@
 src/polyfills/slider/slider.js
-src/polyfills/meter/meter.js
 src/polyfills/events/mobile.js


### PR DESCRIPTION
Move the meter polyfill to the JEP model. The old/current implementation leaks functions into the global scope.

TODO:
- [ ] Figure out a default for the `optimal` value http://dev.w3.org/html5/markup/aria/meter.html
- [ ] Add optimal CSS
- [ ] Re-add form attribute
