### PR TITLE
Modernizr: Move meter/progressbar tests build

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -519,7 +519,10 @@ module.exports = (grunt) ->
 				hasevents: true
 				prefixes: true
 				domprefixes: true
-			tests: ["elem_details"]
+			tests: [
+				"elem_details"
+				"elem_progress_meter"
+			]
 			parseFiles: false
 			matchCommunityTests: false
 

--- a/src/core/vapour.js
+++ b/src/core/vapour.js
@@ -266,13 +266,6 @@ window._timer = {
 	}
 };
 
-// @TODO: Upstream Modernizr Tests to remove after Modernizr v3.0 release
-// Tests for progressbar-support. All browsers that don't support progressbar returns undefined =)
-Modernizr.addTest( "progressbar", document.createElement( "progress" ).max !== undef );
-
-// Tests for meter-support. All browsers that don't support meters returns undefined =)
-Modernizr.addTest( "meter", document.createElement( "meter" ).max !== undef );
-
 /*-----------------------------
  * Modernizr Polyfill Loading
  *-----------------------------*/


### PR DESCRIPTION
Adds the extra element to the grunt-modernizr custom build

Undoes part of #3522, but will require implementers to run `grunt init`to get an updated copy of the Modernizr build
