### PR TITLE
WET theme: Switched breadcrumb icons from right angle brackets to right arrows

### DIFF
--- a/theme/sass/parts/_breadcrumb.scss
+++ b/theme/sass/parts/_breadcrumb.scss
@@ -11,12 +11,11 @@
 	li {
 		&:before, &:after {
 			font-family: "Glyphicons Halflings";
-			font-size: 0.5em;
+			font-size: 0.7em;
 			color: #333;
-			vertical-align: 15%;
 		}
 		&:before {
-			content: "\e080";
+			content: "\e092";
 		}
 		white-space: nowrap;
 		&:first-child {


### PR DESCRIPTION
Switches away from the right angle bracket that is discouraged in the HTML 5.1 draft: http://www.w3.org/html/wg/drafts/html/master/common-idioms.html#rel-up
