### PR TITLE
Switched jQuery script references to Google CDN

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -88,7 +88,6 @@ module.exports = (grunt) ->
 		"js"
 		"INTERNAL: Copies all third party JS to the dist folder"
 		[
-			"copy:jquery"
 			"copy:polyfills"
 			"copy:other"
 			"copy:deps"
@@ -117,7 +116,6 @@ module.exports = (grunt) ->
 		"assets-dist"
 		"INTERNAL: Process non-CSS/JS assets to dist"
 		[
-			"copy:jquery_min"
 			"copy:assets_min"
 			"copy:misc_min"
 		]
@@ -190,7 +188,6 @@ module.exports = (grunt) ->
 				options:
 					stripBanners: false
 				src: [
-					"lib/jquery-ie/jquery.js"
 					"lib/respond/respond.src.js"
 					"lib/excanvas/excanvas.js"
 					"lib/html5shiv/dist/html5shiv.js"
@@ -510,7 +507,7 @@ module.exports = (grunt) ->
 				teststyles: true
 				testprops: true
 				testallprops: true
-				hasevent: true
+				hasevents: true
 				prefixes: true
 				domprefixes: true
 			tests: [
@@ -519,15 +516,8 @@ module.exports = (grunt) ->
 			]
 			parseFiles: false
 			matchCommunityTests: false
-			uglify: false
 
 		copy:
-			jquery:
-				cwd: "lib/jquery"
-				src: "jquery.js"
-				dest: "dist/unmin/js"
-				expand: true
-
 			bootstrap:
 				cwd: "lib/bootstrap/fonts"
 				src: "*.*"
@@ -590,15 +580,6 @@ module.exports = (grunt) ->
 				cwd: "theme/"
 				src: "**/assets/*.*"
 				dest: "dist/unmin"
-				expand: true
-
-			jquery_min:
-				cwd: "lib/jquery"
-				src: [
-					"jquery.min.js"
-					"jquery.min.map"
-				]
-				dest: "dist/js"
 				expand: true
 
 			assets_min:
@@ -763,6 +744,7 @@ module.exports = (grunt) ->
 						src = src.replace( ".hbs", ".html" )
 						return "http://localhost:8000/" + src
 					)
+					tunnelTimeout: 5
 					build: process.env.TRAVIS_BUILD_NUMBER
 					concurrency: 3
 					browsers: grunt.file.readJSON "browsers.json"
@@ -771,8 +753,6 @@ module.exports = (grunt) ->
 						process.env.TRAVIS_BRANCH,
 						process.env.TRAVIS_COMMIT
 					]
-					testReadyTimeout: 15000
-					testTimeout: 60000
 
 		"gh-pages":
 			options:

--- a/bower.json
+++ b/bower.json
@@ -1,44 +1,42 @@
 {
-  "name": "wet-boew",
-  "version": "v4.0-a1-development",
-  "homepage": "https://github.com/wet-boew/wet-boew",
-  "authors": [
-    "WET-BOEW Team"
-  ],
-  "description": "Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)",
-  "keywords": [
-    "i18n",
-    "a11y",
-    "wet-boew",
-    "bootstrap"
-  ],
-  "license": "MIT",
-  "private": true,
-  "ignore": [
-    ".git*",
-    ".travis.yml",
-    ".editorconfig",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
-  ],
-  "dependencies": {
-    "jquery.validation": "1.11.1",
-    "bootstrap": "3.0.1",
-    "jquery": "2.0.3",
-    "flot": "0.8.1",
-    "DataTables": "1.9.4",
-    "magnific-popup": "0.9.8",
-    "jquery-pjax": "1.7.3",
-    "html5shiv": "3.7.0",
-    "jquery-ie": "jquery#1.10.2",
-    "respond": "1.3.0",
-    "selectivizr": "1.0.2",
-    "excanvas": "*",
-    "google-code-prettify": "1.0.0"
-  },
-  "resolutions": {
-    "jquery": ">= 1.9.0"
-  }
+	"name": "wet-boew",
+	"version": "v4.0-a1-development",
+	"homepage": "https://github.com/wet-boew/wet-boew",
+	"authors": [
+		"WET-BOEW Team"
+	],
+	"description": "Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)",
+	"keywords": [
+		"i18n",
+		"a11y",
+		"wet-boew",
+		"bootstrap"
+	],
+	"license": "MIT",
+	"private": true,
+	"ignore": [
+		".git*",
+		".travis.yml",
+		".editorconfig",
+		"node_modules",
+		"bower_components",
+		"test",
+		"tests"
+	],
+	"dependencies": {
+		"jquery.validation": "1.11.1",
+		"bootstrap": "3.0.1",
+		"flot": "0.8.1",
+		"DataTables": "1.9.4",
+		"magnific-popup": "0.9.8",
+		"jquery-pjax": "1.7.3",
+		"html5shiv": "3.7.0",
+		"respond": "1.3.0",
+		"selectivizr": "1.0.2",
+		"excanvas": "*",
+		"google-code-prettify": "1.0.0"
+	},
+	"resolutions": {
+		"jquery": ">= 1.9.0"
+	}
 }

--- a/site/includes/footerresources.hbs
+++ b/site/includes/footerresources.hbs
@@ -1,5 +1,5 @@
 <!--[if gte IE 9 | !IE ]><!-->
-<script src="{{assets}}/js/jquery{{environment.suffix}}.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.0.3/jquery{{environment.suffix}}.js"></script>
 <script src="{{assets}}/js/vapour{{environment.suffix}}.js"></script>
 <!--<![endif]-->
 <script src="{{assets}}/js/wet-boew{{environment.suffix}}.js"></script>

--- a/site/includes/headresources.hbs
+++ b/site/includes/headresources.hbs
@@ -3,6 +3,7 @@
 
 <!--[if lt IE 9]>
 <link rel="stylesheet" href="{{assets}}/css/ie8{{environment.suffix}}.css" />
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery{{environment.suffix}}.js"></script>
 <script src="{{assets}}/js/ie8-vapour{{environment.suffix}}.js"></script>
 <![endif]-->
 


### PR DESCRIPTION
Note the following downsides:
- No plugins or polyfills will work when pages run through file protocol (since can't find jQuery)
- jQuery version is now hardcoded in markup so takes a markup change to change versions of jQuery
