### PR TITLE
Slider: fixes IE javascript error and Chrome width

### DIFF
--- a/src/js/polyfills/slider.js
+++ b/src/js/polyfills/slider.js
@@ -367,13 +367,13 @@ var fdSlider = (function() {
 			if(!useDOMAttrModEvt || tagName == "select") {
 				return;
 			}
-			
+
 			var defs = getInputAttributes(inp);
 
 			if(defs.min == min && defs.max == max && defs.step == step) {
 				return;
 			}
-			
+
 			min		= +defs.min;
 			max		= +defs.max;
 			rMin		= min;
@@ -385,7 +385,7 @@ var fdSlider = (function() {
 			userSet	= false;
 			setSliderRange(min, max);
 		}
-		
+
 		function disableSlider(noCallback) {
 			if(disabled && !noCallback) {
 				return;
@@ -1042,7 +1042,6 @@ var fdSlider = (function() {
 				} catch (err) {}
 			} else {
 				if(val !== "" && !userInput) {
-				console.log("val:" + val + ", min:" + min + ", max:" + max + ", step:" + step);
 					val = (min + (Math.round((+val - min) / step) * step)).toFixed(precision);
 				}
 				if(inp.value === val) {
@@ -1165,7 +1164,7 @@ var fdSlider = (function() {
 				inp.setAttribute("fd-range-enabled", 1);
 				inp.stepUp	 = function(n) { increment(n||1); };
 				inp.stepDown = function(n) { increment(n||-1); };
-				
+
 				if(useDOMAttrModEvt) {
 					addEvent(inp, typeof(inp.onpropertychange) == "object" ? "propertychange" : "DOMAttrModified", rescanAttrs);
 				}

--- a/src/js/sass/includes/_slider.scss
+++ b/src/js/sass/includes/_slider.scss
@@ -6,6 +6,7 @@
 @import "compass/css3/images";
 @import "compass/css3/background-clip";
 @import "compass/css3/appearance";
+@import "compass/css3/box-sizing";
 
 .fd-form-element-hidden {
 	display: none
@@ -231,6 +232,7 @@ body {
 }
 input[type="range"] {
 	width: 100%;
+	@include box-sizing(border-box);
 }
 html {
 	&:not(.ui-mobile) {


### PR DESCRIPTION
1. `window.console` statement was bombing in IE.
2. Chrome slider was too wide because of default padding on `input` elements.
