### PR TITLE
WET theme: Added hidden comma between site title and tagline

### DIFF
--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -119,6 +119,7 @@
 	"%tmpl-site-info": "Site Information",
 	"%lang-native": "English",
 	"%space" : "&#32;",
+	"%comma-space": ", ",
 	"%current": "(current)",
 	"%menu": "Menu",
 	"%menu-close": "Close menu",

--- a/site/data/i18n/fr.json
+++ b/site/data/i18n/fr.json
@@ -119,6 +119,7 @@
 	"%tmpl-site-info": "Informations sur le site",
 	"%lang-native": "Français",
 	"%space" : "&#32;",
+	"%comma-space": ", ",
 	"%current": "(courant)",
 	"%menu": "Menu",
 	"%menu-close": "Fermer le menu",

--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -1,4 +1,4 @@
 <a href="index-{{language}}.html">
 	<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/assets/logo.svg" aria-label="{{#i18n "%site.title"}}{{/i18n}}"></object>
-	<span>{{#i18n "%site.title"}}{{/i18n}} <small>{{#i18n "%site.tagline"}}{{/i18n}}</small></span>
+	<span>{{#i18n "%site.title"}}{{/i18n}}<span class="wb-inv">{{#i18n "%comma-space"}}{{/i18n}}</span><small>{{#i18n "%site.tagline"}}{{/i18n}}</small></span>
 </a>


### PR DESCRIPTION
Gives screen reader users a natural pause between the site title and tagline.

Thank you for the suggestion @sbahram!
