### PR TITLE
SauceLabs: Disable IE testing

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -5,14 +5,6 @@
     "browserName": "chrome",
     "platform": "Windows 7"
 },{
-    "browserName": "internet explorer",
-    "version": "9",
-    "platform": "Windows 7"
-},{
-    "browserName": "internet explorer",
-    "version": "8",
-    "platform": "Windows XP"
-},{
     "browserName": "safari",
     "platform": "OS X 10.8"
 },{


### PR DESCRIPTION
Fixes #3565
Remaining browsers pass correctly, but I don't have time to properly diagnose the IE tests right now. @patheard I think they just need to be separated out and use a longer testTimeout value.
