### PR TITLE
Added right padding to archived message heading to fix spacing issues in RTL mode

### DIFF
--- a/src/plugins/data-inview/archived-en.hbs
+++ b/src/plugins/data-inview/archived-en.hbs
@@ -32,7 +32,7 @@
 	background-color: #c00;
 	color: #fff;
 	margin: 0;
-	padding: 2px 0 2px 10px;
+	padding: 2px 10px 2px 10px;
 }
 </style>
 <p><span class="glyphicon glyphicon-warning-sign" title="Warning"></span> The <a href="http://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=24227">Standard on Web Usability</a> replaces this content. This content is archived because Common Look and Feel 2.0 Standards have been rescinded.</p>

--- a/src/plugins/data-inview/archived-fr.hbs
+++ b/src/plugins/data-inview/archived-fr.hbs
@@ -32,7 +32,7 @@
 	background-color: #c00;
 	color: #fff;
 	margin: 0;
-	padding: 2px 0 2px 10px;
+	padding: 2px 10px 2px 10px;
 }
 </style>
 <p><span class="glyphicon glyphicon-warning-sign" title="Avertissement"></span> La <a href="http://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=24227">Norme sur la facilité d'emploi des sites Web</a> remplace ce contenu. Cette page Web a été archivée parce que les Normes sur la normalisation des sites Internet 2.0 ont étés annulées.</p>


### PR DESCRIPTION
This fixes issue #3508.

Why is the CSS for the archived message demo in the `.hbs` file?
