### PR TITLE
Bumped html-compressor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-gh-pages": "~0.8.0",
-    "grunt-htmlcompressor": "~0.1.8",
+    "grunt-htmlcompressor": "~0.1.9",
     "grunt-mocha": "~0.4.1",
     "grunt-modernizr": "~0.3.0",
     "grunt-sass": "~0.8.0",


### PR DESCRIPTION
Version prior to this one are known to cause instability issues
