### PR TITLE
added grouped functionality to toggle

### DIFF
--- a/src/plugins/toggle/toggle-en.hbs
+++ b/src/plugins/toggle/toggle-en.hbs
@@ -149,3 +149,108 @@
 	</div>
 
 </section>
+
+<section>
+<h3>Grouped Toggles</h3>
+<p>This parameter restricts grouped toggles to only have one of the elements active at a time much like the grouped checkbox behaviour</p>
+
+<div class="row">
+	<details id="toggle1" class="col-sm-12 grouped">
+		<summary>Example 1</summary>
+		<p>Example content that provides more details.</p>
+		<table>
+			<caption>Cups of coffee consumed by each delegate</caption>
+			<thead>
+				<tr>
+					<th scope="col">Name</th>
+					<th scope="col">Cups</th>
+					<th scope="col">Type of Coffee</th>
+					<th scope="col">Sugar?</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>T. Sexton</td>
+					<td>10</td>
+					<td>Espresso</td>
+					<td>No</td>
+				</tr>
+				<tr>
+					<td>J. Dinnen</td>
+					<td>5</td>
+					<td>Decaf</td>
+					<td>Yes</td>
+				</tr>
+			</tbody>
+		</table>
+	</details>
+</div>
+
+<div class="row">
+	<details id="toggle2" class="col-sm-6 grouped">
+		<summary>Example 2</summary>
+		<p>Example content that provides more details.</p>
+		<table>
+			<caption>Cups of coffee consumed by each delegate</caption>
+			<thead>
+			<tr>
+				<th scope="col">Name</th>
+				<th scope="col">Cups</th>
+				<th scope="col">Type of Coffee</th>
+				<th scope="col">Sugar?</th>
+			</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>T. Sexton</td>
+					<td>10</td>
+					<td>Espresso</td>
+					<td>No</td>
+				</tr>
+				<tr>
+					<td>J. Dinnen</td>
+					<td>5</td>
+					<td>Decaf</td>
+					<td>Yes</td>
+				</tr>
+			</tbody>
+		</table>
+	</details>
+
+	<details id="toggle3"  class="col-sm-6 grouped">
+		<summary>Example 3</summary>
+		<p>Example content that provides more details.</p>
+		<table>
+			<caption>Cups of coffee consumed by each delegate</caption>
+			<thead>
+			<tr>
+				<th scope="col">Name</th>
+				<th scope="col">Cups</th>
+				<th scope="col">Type of Coffee</th>
+				<th scope="col">Sugar?</th>
+			</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>T. Sexton</td>
+					<td>10</td>
+					<td>Espresso</td>
+					<td>No</td>
+				</tr>
+				<tr>
+					<td>J. Dinnen</td>
+					<td>5</td>
+					<td>Decaf</td>
+					<td>Yes</td>
+				</tr>
+			</tbody>
+		</table>
+	</details>
+</div>
+
+<div class="btn-group">
+	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle1", "group": "grouped"}'>Example 1</button>
+	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle2", "group": "grouped"}'>Example 2</button>
+	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle3", "group": "grouped"}'>Example 3</button>
+</div>
+</section>

--- a/src/plugins/toggle/toggle-fr.hbs
+++ b/src/plugins/toggle/toggle-fr.hbs
@@ -149,3 +149,109 @@
 	</div>
 
 </section>
+<section>
+	<h2>Basculer groupées</h2>
+	<p>
+		Cette paramètre <code> group </code> restreint bascule groupées d'avoir un seul des éléments actifs à un moment un peu comme le comportement de case à cocher groupées.
+	</p>
+
+	<div class="row">
+		<details id="toggle1" class="col-sm-12 grouped">
+			<summary>Exemple 1</summary>
+			<p>Le contenu d'exemple qui fournit plus de détails.</p>
+			<table>
+				<caption>Tasses de café bues par chaque député</caption>
+				<thead>
+				<tr>
+					<th scope="col">Nom</th>
+					<th scope="col">Tasses</th>
+					<th scope="col">Type de café</th>
+					<th scope="col">Sucre?</th>
+				</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>T. Sexton</td>
+						<td>10</td>
+						<td>Expresso</td>
+						<td>Non</td>
+					</tr>
+					<tr>
+						<td>J. Dinnen</td>
+						<td>5</td>
+						<td>Déca</td>
+						<td>Oui</td>
+					</tr>
+				</tbody>
+			</table>
+		</details>
+	</div>
+
+	<div class="row">
+		<details id="toggle2" class="col-sm-6 grouped">
+			<summary>Exemple 2</summary>
+			<p>Le contenu d'exemple qui fournit plus de détails.</p>
+			<table>
+				<caption>Tasses de café bues par chaque député</caption>
+				<thead>
+				<tr>
+					<th scope="col">Nom</th>
+					<th scope="col">Tasses</th>
+					<th scope="col">Type de café</th>
+					<th scope="col">Sucre?</th>
+				</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>T. Sexton</td>
+						<td>10</td>
+						<td>Expresso</td>
+						<td>Non</td>
+					</tr>
+					<tr>
+						<td>J. Dinnen</td>
+						<td>5</td>
+						<td>Déca</td>
+						<td>Oui</td>
+					</tr>
+				</tbody>
+			</table>
+		</details>
+
+		<details id="toggle3" class="col-sm-6 grouped">
+			<summary>Exemple 3</summary>
+			<p>Le contenu d'exemple qui fournit plus de détails.</p>
+			<table>
+				<caption>Tasses de café bues par chaque député</caption>
+				<thead>
+				<tr>
+					<th scope="col">Nom</th>
+					<th scope="col">Tasses</th>
+					<th scope="col">Type de café</th>
+					<th scope="col">Sucre?</th>
+				</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>T. Sexton</td>
+						<td>10</td>
+						<td>Expresso</td>
+						<td>Non</td>
+					</tr>
+					<tr>
+						<td>J. Dinnen</td>
+						<td>5</td>
+						<td>Déca</td>
+						<td>Oui</td>
+					</tr>
+				</tbody>
+			</table>
+		</details>
+	</div>
+
+	<div class="btn-group">
+		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle1", "group": "grouped" }'>Exemple 1</button>
+		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector":  "#toggle2", "group": "grouped" }'>Exemple 2</button>
+		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector":  "#toggle3", "group": "grouped" }'>Exemple 3</button>
+	</div>
+</section>

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -93,11 +93,17 @@ var selector = ".wb-toggle",
 			$elms = getElements( link, data ),
 			stateFrom = getState( link, data ),
 			isToggleOn = stateFrom === data.stateOff,
-			stateTo = isToggleOn ? data.stateOn : data.stateOff;
+			stateTo = isToggleOn ? data.stateOn : data.stateOff,
+			$grouped;
 
-		// Update the element state and store the new state
 		setState( link, data, stateTo );
 		$elms.wb( "toggle", stateTo, stateFrom );
+
+		// Update the states of the toggles first since grouped only allows for one of the toggles to be active at once
+		if ( data.group !== undefined ) {
+			$grouped = getGroupedElements( link, data );
+			$grouped.trigger( "toggled.wb-toggle", { isOn: false } );
+		}
 		$elms.trigger( "toggled.wb-toggle", { isOn: isToggleOn } );
 	},
 
@@ -111,7 +117,7 @@ var selector = ".wb-toggle",
 
 		// Native details support
 		$detail.prop( "open", data.isOn );
-		
+
 		// Polyfill details support
 		if ( !Modernizr.details ) {
 			$detail.attr( "open", data.isOn ? null : "open" );
@@ -127,6 +133,20 @@ var selector = ".wb-toggle",
 	 */
 	getElements = function( link, data ) {
 		var selector = data.selector !== undefined ? data.selector : link,
+			parent = data.parent !== undefined ? data.parent : null;
+
+		return parent !== null ? $( parent ).find( selector ) : $( selector );
+	},
+
+
+	/*
+	 * Returns the grouped elements a given toggle element controls.
+	 * @param {DOM element} link Toggle element that was clicked
+	 * @param {Object} data Simple key/value data object passed when the event was triggered
+	 * @returns {jQuery Object} DOM elements the toggle link controls
+	 */
+	getGroupedElements = function( link, data ) {
+		var selector = data.group !== undefined ? "." + data.group : link,
 			parent = data.parent !== undefined ? data.parent : null;
 
 		return parent !== null ? $( parent ).find( selector ) : $( selector );


### PR DESCRIPTION
- Introduced new parameter called "group" to allow for grouped behaviour in toggling
  - The new behaviour allows for web developers to pass a group class or selector to identify the toggle grouping and to allow for only one of the toggled elements to hold a state.
  - Similar to the behaviour of a group checkbox list that only allows one element to be selected at a time.
  - @patheard I know you will probably play with this function a bit since it does the trick but not as flushed out as it should be. If you have a moment to play with it, that would be ideal

/cc @patheard
