### PR TITLE
keep id="base-fullhd" and id="base-fullhd-in" within <p> scope

### DIFF
--- a/demos/theme-base/cont-en.html
+++ b/demos/theme-base/cont-en.html
@@ -45,9 +45,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-head"><div id="wb-head-in"><header>
 <!-- HeaderStart -->
 <section><div id="base-fullhd"><h2>Header bar</h2>
-<p class="mobile-hide">id="base-fullhd"</p>
+<p class="mobile-hide" id="base-fullhd"></p>
 <div id="base-fullhd-in">
-<p class="mobile-hide">id="base-fullhd-in"</p>
+<p class="mobile-hide" id="base-fullhd-in"></p>
 <ul>
 <li id="base-fullhd-lang"><a href="es/cont-es.html" lang="es">Español</a></li>
 <li id="base-fullhd-lang-2"><a href="cont-fr.html" lang="fr">Français</a></li>


### PR DESCRIPTION
id="base-fullhd" and id="base-fullhd-in" declared outside of their parent <p>, thus showing in demos (intentional?)
