### PR TITLE
Changed the archived message colour to yellow

### DIFF
--- a/src/other/archived/archived-en.hbs
+++ b/src/other/archived/archived-en.hbs
@@ -13,24 +13,24 @@
 	display: none;
 }
 .pg-banner.out {
-	background-color: #c00;
+	background-color: #fd0;
 }
 .pg-banner.out a {
-	color: #fff;
+	color: #000;
 	text-decoration: underline;
 	font-weight: 700;
 }
 #archived {
 	background-color: #ffc;
-	border: 1px solid #c00;
+	border: 1px solid #fd0;
 }
 #archived p {
 	padding-top: 10px;
 	padding-bottom: 10px;
 }
 #archived h2 {
-	background-color: #c00;
-	color: #fff;
+	background-color: #fd0;
+	color: #000;
 	margin: 0;
 	padding: 2px 10px 2px 10px;
 }

--- a/src/other/archived/archived-fr.hbs
+++ b/src/other/archived/archived-fr.hbs
@@ -13,24 +13,24 @@
 	display: none;
 }
 .pg-banner.out {
-	background-color: #c00;
+	background-color: #fd0;
 }
 .pg-banner.out a {
-	color: #fff;
+	color: #000;
 	text-decoration: underline;
 	font-weight: 700;
 }
 #archived {
 	background-color: #ffc;
-	border: 1px solid #c00;
+	border: 1px solid #fd0;
 }
 #archived p {
 	padding-top: 10px;
 	padding-bottom: 10px;
 }
 #archived h2 {
-	background-color: #c00;
-	color: #fff;
+	background-color: #fd0;
+	color: #000;
 	margin: 0;
 	padding: 2px 10px 2px 10px;
 }


### PR DESCRIPTION
Red should only be used for errors or things that pose a danger, not warnings. Yellow and black are traditionally used for warnings.

Associated issue: #3591.
