### PR TITLE
reworked menu system to deal with multiple imports

### DIFF
--- a/site/includes/mobimenu.hbs
+++ b/site/includes/mobimenu.hbs
@@ -4,7 +4,6 @@
 			<h2>{{#i18n "menu"}}{{/i18n}}</h2>
 			<ul class="list-inline text-right">
 				<li><a href="#wb-sm" title="{{#i18n "menu"}}{{/i18n}}" class="wb-trgt"><span class="glyphicon glyphicon-th-list"><span class="wb-inv">{{#i18n "menu"}}{{/i18n}}</span></span></a></li>
-				<li class="wb-trgt"><a href="#wb-srch" title="{{#i18n "tmpl-search"}}{{/i18n}}"><span class="glyphicon glyphicon-search"><span class="wb-inv">{{#i18n "tmpl-search"}}{{/i18n}}</span></span></a></li>
 			</ul>
 		</section>
 	</div>

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -31,11 +31,13 @@
 		</ul>
 		<header role="banner">
 			<div id="wb-bnr">
-				<div id="wb-bar" data-ajax-append="{{assets}}/ajax/mobmenu-{{language}}.html">
+
+				<div id="wb-bar">
 					<section id="wb-lng" class="visible-md visible-lg">
 						<h2>{{#i18n "tmpl-lang-select"}}{{/i18n}}</h2>
 						{{>languagetoggle}}
 					</section>
+					{{>mobimenu}}
 				</div>
 
 				<div class="container">
@@ -54,7 +56,7 @@
 				</div>
 			</div>
 
-			<nav role="navigation" id="wb-sm" data-ajax-fetch="{{assets}}/ajax/sitemenu-{{language}}.html" data-post-remove="remove after init" class="wb-menu remove after init" typeof="SiteNavigationElement">
+			<nav role="navigation" id="wb-sm" data-ajax-fetch="{{assets}}/ajax/sitemenu-{{language}}.html" data-import="wb-sec wb-srch" data-post-remove="remove after init" class="wb-menu remove after init" typeof="SiteNavigationElement">
 				{{>sitemenu}}
 			</nav>
 {{#unless_eq assets compare="."}}

--- a/src/plugins/menu/menu-en.hbs
+++ b/src/plugins/menu/menu-en.hbs
@@ -211,11 +211,11 @@
 		color: #eee;
 	}
 
-	#wb-imrpt-1 {
+	#wb-imprt-1 {
 		padding: 20px 30px;
 	}
 
-	#wb-imrpt-1 h2, label[for=wb-srch-q-imprt] { 
+	#wb-imprt-1 h2, label[for=wb-srch-q-imprt] { 
 	  position: absolute;
 	  width: 1px;
 	  height: 1px;

--- a/src/plugins/menu/menu-en.hbs
+++ b/src/plugins/menu/menu-en.hbs
@@ -21,10 +21,10 @@
 .menu-demo .menu > li > a {
 	color: #fff;
 	padding: 1em;
-	border-left: 2px ridge #284468;
+	border-left: 2px groove #284468;
 }
 .menu-demo .menu > li:last-child a {
-	border-right: 2px ridge #284468;
+	border-right: 2px groove #284468;
 }
 .menu-demo .sm.open {
 	box-shadow: 0 3px 3px -2px rgba(0, 0, 0, 0.3), 3px 3px 3px -2px rgba(0, 0, 0, 0.3), -3px 3px 3px -2px rgba(0, 0, 0, 0.3);
@@ -104,6 +104,128 @@
 }
 #menu-demo-2 .sm.open {
 	border-bottom: 5px solid #335075;
+}
+
+@media screen and (max-width:991px){
+	#wb-sm {
+	background: #114F7A;
+	}
+	#wb-sm .menu li a:hover, #wb-sm .menu li a:focus, #wb-sm .menu li a:active {
+		background: transparent;
+	}
+	#wb-sm .nav-close  {
+	    background: none repeat scroll 0 0 #305277;
+	    height: 44px;
+		margin-top:20px;
+		color:#fff;
+		text-decoration:none;
+		vertical-align:middle;
+		margin-left:-20px;
+		padding-top:10px;
+		text-transform:lowercase;
+	}
+
+	#wb-sm .nav-close span{
+	margin:-3px 10px 0;
+	font-size:1.5em;
+	vertical-align:middle;
+	}
+
+	#wb-sm .menu {
+	text-transform:none;
+	color:#fff;
+	}
+
+	#wb-sm .menu a{
+	color:#fff;
+	}
+
+	#wb-sm .expicon {
+	position:absolute;
+	top:.8em;
+	border-top-color:transparent;
+	border-left-color:#90a4b4;
+	border-bottom:5px solid transparent;
+	}
+
+	#wb-sm .sm.open {
+	border:none;
+	}
+
+	#wb-sm .menu li.active .expicon {
+	border-top-color:#fff !important;  /* note the !important is there to override the !important being used in base.css */
+	border-left-color:transparent;
+	top:1.1em;
+	}
+
+	#wb-sm .menu > li a {
+	padding-left:25px;
+	color:#fff;
+	}
+
+	#wb-sm .sm.open li a {
+	padding-left:35px;
+	color:#a5b5c2;
+	}
+
+	#wb-sm:target .wb-nav {
+	background:#1b3452;
+	padding:20px 0;
+	font-size:14px;
+	color:#90a4b4;
+	}
+
+	.wb-nav > ul > li {
+	padding:0 10px 0 25px;
+
+	}
+
+	.wb-nav a{
+	padding:5px 5px 5px 10px;
+	color:#fff;
+	text-decoration:none;
+	display:block;
+	}
+
+	#wb-sm .sm.open li a {
+		color: #fff;
+	}
+
+
+
+	#wb-sm .menu ul li, #wb-sm .menu .active, #wb-sm .menu > li.active > a, #wb-sm .menu > li.active > a , #wb-sm .menu .active:hover  {
+		background: transparent !important;
+		border: none !important;
+		color: #fff !important;
+	}
+
+	.wb-info .list-unstyled li, .wb-info .list-unstyled li a {
+		color: #fff;
+	}
+
+	#wb-sm .row ,#wb-sm .sm, #wb-sm .sm.open {
+		border: 0;
+	}
+
+	.wb-info .list-unstyled li ul li {
+		color: #eee;
+	}
+
+	#wb-imrpt-1 {
+		padding: 20px 30px;
+	}
+
+	#wb-imrpt-1 h2, label[for=wb-srch-q-imprt] { 
+	  position: absolute;
+	  width: 1px;
+	  height: 1px;
+	  margin: -1px;
+	  padding: 0;
+	  overflow: hidden;
+	  clip: rect(0 0 0 0);
+	  border: 0;
+	 }
+
 }
 </style>
 

--- a/src/plugins/menu/menu-fr.hbs
+++ b/src/plugins/menu/menu-fr.hbs
@@ -213,11 +213,11 @@
 		color: #eee;
 	}
 
-	#wb-imrpt-1 {
+	#wb-imprt-1 {
 		padding: 20px 30px;
 	}
 
-	#wb-imrpt-1 h2, label[for=wb-srch-q-imprt] { 
+	#wb-imprt-1 h2, label[for=wb-srch-q-imprt] { 
 	  position: absolute;
 	  width: 1px;
 	  height: 1px;

--- a/src/plugins/menu/menu-fr.hbs
+++ b/src/plugins/menu/menu-fr.hbs
@@ -105,6 +105,130 @@
 #menu-demo-2 .sm.open {
 	border-bottom: 5px solid #335075;
 }
+
+@media screen and (max-width:991px){
+
+	#wb-sm {
+		background: #114F7A;
+	}
+
+	#wb-sm .menu li a:hover, #wb-sm .menu li a:focus, #wb-sm .menu li a:active {
+		background: transparent;
+	}
+
+	#wb-sm .nav-close  {
+	    background: none repeat scroll 0 0 #305277;
+	    height: 44px;
+		margin-top:20px;
+		color:#fff;
+		text-decoration:none;
+		vertical-align:middle;
+		margin-left:-20px;
+		padding-top:10px;
+		text-transform:lowercase;
+	}
+
+	#wb-sm .nav-close span{
+		margin:-3px 10px 0;
+		font-size:1.5em;
+		vertical-align:middle;
+	}
+
+	#wb-sm .menu {
+		text-transform:none;
+		color:#fff;
+	}
+
+	#wb-sm .menu a{
+		color:#fff;
+	}
+
+	#wb-sm .expicon {
+		position:absolute;
+		top:.8em;
+		border-top-color:transparent;
+		border-left-color:#90a4b4;
+		border-bottom:5px solid transparent;
+	}
+
+	#wb-sm .sm.open {
+		border:none;
+	}
+
+	#wb-sm .menu li.active .expicon {
+		border-top-color:#fff !important;  /* note the !important is there to override the !important being used in base.css */
+		border-left-color:transparent;
+		top:1.1em;
+	}
+
+	#wb-sm .menu > li a {
+		padding-left:25px;
+		color:#fff;
+	}
+
+	#wb-sm .sm.open li a {
+		padding-left:35px;
+		color:#a5b5c2;
+	}
+
+	#wb-sm:target .wb-nav {
+		background:#1b3452;
+		padding:20px 0;
+		font-size:14px;
+		color:#90a4b4;
+	}
+
+	.wb-nav > ul > li {
+		padding:0 10px 0 25px;
+	}
+
+	.wb-nav a{
+		padding:5px 5px 5px 10px;
+		color:#fff;
+		text-decoration:none;
+		display:block;
+	}
+
+	#wb-sm .sm.open li a {
+		color: #fff;
+	}
+
+	#wb-sm .menu ul li, #wb-sm .menu .active, #wb-sm .menu > li.active > a, #wb-sm .menu > li.active > a , #wb-sm .menu .active:hover  {
+		background: transparent !important;
+		border: none !important;
+		color: #fff !important;
+	}
+
+	.wb-info .list-unstyled li, .wb-info .list-unstyled li a {
+		color: #fff;
+		padding-left: 10px;
+    	text-decoration: none;
+	}
+
+	#wb-sm .row ,#wb-sm .sm, #wb-sm .sm.open {
+		border: 0;
+	}
+
+	.wb-info .list-unstyled li ul li {
+		color: #eee;
+	}
+
+	#wb-imrpt-1 {
+		padding: 20px 30px;
+	}
+
+	#wb-imrpt-1 h2, label[for=wb-srch-q-imprt] { 
+	  position: absolute;
+	  width: 1px;
+	  height: 1px;
+	  margin: -1px;
+	  padding: 0;
+	  overflow: hidden;
+	  clip: rect(0 0 0 0);
+	  border: 0;
+	 }
+
+}
 </style>
 
 <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione, minima deleniti autem tenetur odit nostrum sunt eligendi quasi maiores veritatis voluptate tempore dolorem animi libero!</p>

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -112,19 +112,36 @@ var selector = ".wb-menu",
 	 */
 	onAjaxLoaded = function( $elm, $ajaxed ) {
 		var $menu = $ajaxed.find( "[role='menubar'] .item" ),
-			$wbsec = $( "#wb-sec" ),
-			$panel;
 
-		// lets see if we need to add a dynamic navigation section ( secondary nav )
-		if ( $wbsec.length !== 0 ) {
+			// Optimized the code block to look to see if we need to import anything instead
+			// of just doing a query with which could result in no result
+			imports = $elm.data( "import" ) ? $elm.data( "import" ).split( " " ) : 0,
+			$panel, i, cClass, $iElement;
 
-			// Trigger the navcurrent plugin
-			$wbsec.trigger( "navcurrent.wb", breadcrumb );
-		
+		// lets see if there is anything to import into our panel
+		if ( imports !== 0 ) {
 			$panel = $ajaxed.find( ".pnl-strt" );
-			$panel.before( "<section id='dyn-nvgtn' class='" +
-				$panel.siblings( ".wb-info" ).eq( 0 ).attr( "class" ) +
-				"'>" + $wbsec.html() + "</section>" );
+			cClass = $panel.siblings( ".wb-info" ).eq( 0 ).attr( "class" );
+
+			for ( i = imports.length - 1; i >= 0; i-- ) {
+				$iElement = $( "#" + imports[i] );
+
+				// lets only deal with elements that exist since there are possibilites where templates
+				// could add into a header and footer and the content areas change depending on levels
+				// in the site
+				if ( $iElement.length === 0 ){
+					continue;
+				}
+
+				// Lets DomInsert since we are complete all our safeguards and pre-processing
+				// ** note we need to ensure our content is ID safe since this will invalidate the DOM
+				$panel.before( "<section id='wb-imrpt-" + i + "' class='" +
+				cClass + "'>" + 
+				$iElement.html().replace( /\b(id|for)="([^"]+)"/g , "\$1=\"\$2-imprt\"" ) +
+				"</section>" );
+				
+			};
+			
 		}
 
 		$ajaxed.find( ":discoverable" )

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -135,7 +135,7 @@ var selector = ".wb-menu",
 
 				// Lets DomInsert since we are complete all our safeguards and pre-processing
 				// ** note we need to ensure our content is ID safe since this will invalidate the DOM
-				$panel.before( "<section id='wb-imrpt-" + i + "' class='" +
+				$panel.before( "<section id='wb-imprt-" + i + "' class='" +
 					classList + "'>" +
 					$iElement.html().replace( /\b(id|for)="([^"]+)"/g , "$1='$2-imprt'" ) +
 				"</section>" );

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -135,12 +135,12 @@ var selector = ".wb-menu",
 
 				// Lets DomInsert since we are complete all our safeguards and pre-processing
 				// ** note we need to ensure our content is ID safe since this will invalidate the DOM
-				$panel.before( "<section id='wb-imrpt-" + i + "' class='" + 
-					classList + "'>" + 
-					$iElement.html().replace( /\b(id|for)="([^"]+)"/g , "\$1=\"\$2-imprt\"" ) +
+				$panel.before( "<section id='wb-imrpt-" + i + "' class='" +
+					classList + "'>" +
+					$iElement.html().replace( /\b(id|for)="([^"]+)"/g , "$1='$2-imprt'" ) +
 				"</section>" );
 				
-			};
+			}
 			
 		}
 

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -116,28 +116,28 @@ var selector = ".wb-menu",
 			// Optimized the code block to look to see if we need to import anything instead
 			// of just doing a query with which could result in no result
 			imports = $elm.data( "import" ) ? $elm.data( "import" ).split( " " ) : 0,
-			$panel, i, cClass, $iElement;
+			$panel, i, classList, $iElement;
 
 		// lets see if there is anything to import into our panel
 		if ( imports !== 0 ) {
 			$panel = $ajaxed.find( ".pnl-strt" );
-			cClass = $panel.siblings( ".wb-info" ).eq( 0 ).attr( "class" );
+			classList = $panel.siblings( ".wb-info" ).eq( 0 ).attr( "class" );
 
 			for ( i = imports.length - 1; i >= 0; i-- ) {
-				$iElement = $( "#" + imports[i] );
+				$iElement = $( "#" + imports[ i ] );
 
 				// lets only deal with elements that exist since there are possibilites where templates
 				// could add into a header and footer and the content areas change depending on levels
 				// in the site
-				if ( $iElement.length === 0 ){
+				if ( $iElement.length === 0 ) {
 					continue;
 				}
 
 				// Lets DomInsert since we are complete all our safeguards and pre-processing
 				// ** note we need to ensure our content is ID safe since this will invalidate the DOM
-				$panel.before( "<section id='wb-imrpt-" + i + "' class='" +
-				cClass + "'>" + 
-				$iElement.html().replace( /\b(id|for)="([^"]+)"/g , "\$1=\"\$2-imprt\"" ) +
+				$panel.before( "<section id='wb-imrpt-" + i + "' class='" + 
+					classList + "'>" + 
+					$iElement.html().replace( /\b(id|for)="([^"]+)"/g , "\$1=\"\$2-imprt\"" ) +
 				"</section>" );
 				
 			};


### PR DESCRIPTION
- Added an improved detection algorithm through `data-import` attribute to streamline menu loading
- Removed redundant `navcurrent.wb` trigger since it was called at the end of the function after all HTML has been injected and available
- Added comments for logic to help code review
- Removed the `data-ajax-append` from base layout for mobimenu.html since it is now only one glyph and too much overhead with ajax for such a small code block [ reducing the ajax requests by 1 for templates ]
- Added base styling for mobile panel which will still require some designer treatment since it is still very simple, but better than the flat gray that was there.
