### PR TITLE
Reset the a:focus outline property to the default value

### DIFF
--- a/src/base/partials/_bootstrap-overrides.scss
+++ b/src/base/partials/_bootstrap-overrides.scss
@@ -4,6 +4,16 @@
  */
 
 /*
+ *	Anchor outline
+ */
+a {
+	&:focus {
+		outline: invert none medium;
+		outline-offset: 0;
+	}
+}
+
+/*
  *	Table stripes and hover -- Increased the contrast for the table stripes
  *	and hover
  */


### PR DESCRIPTION
@masterbee As requested. Although, I'm not sure that it's what you want: This disables the focus outline.
