### PR TITLE
Focus: Changed event to setfocus.wb and added test and helper for same page link focus changes

### DIFF
--- a/src/plugins/cal-events/cal-events.js
+++ b/src/plugins/cal-events/cal-events.js
@@ -288,7 +288,7 @@ var selector = ".wb-cal-evt",
 			$children = $this.closest( "ul" ).children( "li" );
 			length = $children.length;
 			$children.eq( ( $this.closest( "li" ).index() - 1 ) % length )
-				.children( "a" ).trigger( "focus.wb" );
+				.children( "a" ).trigger( "setfocus.wb" );
 			return false;
 
 		// Down arrow
@@ -296,26 +296,26 @@ var selector = ".wb-cal-evt",
 			$children = $this.closest( "ul" ).children( "li" );
 			length = $children.length;
 			$children.eq( ( $this.closest( "li" ).index() + 1 ) % length )
-				.children( "a" ).trigger( "focus.wb" );
+				.children( "a" ).trigger( "setfocus.wb" );
 			return false;
 
 		// Left arrow
 		case 37:
 			$this.closest( "ol" )
 				.children( "li:lt(" + $this.closest( "li[id^=cal-]" ).index() + ")" )
-				.children( "a" ).last().trigger( "focus.wb" );
+				.children( "a" ).last().trigger( "setfocus.wb" );
 			return false;
 
 		// Right arrow
 		case 39:
 			$this.closest( "ol" )
 				.children( "li:gt(" + $this.closest( "li[id^=cal-]" ).index() + ")" )
-				.children( "a" ).first().trigger( "focus.wb" );
+				.children( "a" ).first().trigger( "setfocus.wb" );
 			return false;
 
 		// Escape
 		case 27:
-			$this.closest( "li[id^=cal-]" ).children( ".cal-event" ).trigger( "focus.wb" );
+			$this.closest( "li[id^=cal-]" ).children( ".cal-event" ).trigger( "setfocus.wb" );
 			return false;
 		}
 	},

--- a/src/plugins/calendar/calendar.js
+++ b/src/plugins/calendar/calendar.js
@@ -217,9 +217,9 @@ var $document = vapour.doc,
 			]);
 
 			if ( $btn.hasClass( "wb-inv" ) ) {
-				$container.find( ".cal-goto-lnk a" ).trigger( "focus.wb" );
+				$container.find( ".cal-goto-lnk a" ).trigger( "setfocus.wb" );
 			} else {
-				$btn.trigger( "focus.wb" );
+				$btn.trigger( "setfocus.wb" );
 			}
 		}
 	},
@@ -421,7 +421,7 @@ var $document = vapour.doc,
 		// TODO: Replace with CSS animation
 		link.stop().slideUp( 0 );
 		form.stop().slideDown( 0 ).queue(function() {
-			$( this ).find( ":input:eq(0)" ).trigger( "focus.wb" );
+			$( this ).find( ":input:eq(0)" ).trigger( "setfocus.wb" );
 		});
 
 		link
@@ -475,7 +475,7 @@ var $document = vapour.doc,
 			// Go to the first day to avoid having to tab over the navigation again.
 			$( "#cal-" + calendarId + "-days a" )
 				.eq( 0 )
-				.trigger( "focus.wb" );
+				.trigger( "setfocus.wb" );
 		}
 	},
 	
@@ -601,7 +601,7 @@ $document.on( "keydown", ".cal-days a", function ( event ) {
 		);
 		return false;
 	} else if ( currDay !== date.getDate() ) {
-		$( days[ date.getDate() - 1 ] ).trigger( "focus.wb" );
+		$( days[ date.getDate() - 1 ] ).trigger( "setfocus.wb" );
 		return false;
 	}
 });

--- a/src/plugins/focus/focus.js
+++ b/src/plugins/focus/focus.js
@@ -7,19 +7,74 @@
 (function( $, vapour ) {
 "use strict";
 
-// Bind the focus event
-vapour.doc.on( "focus.wb", function ( event ) {
-	var eventTarget = event.target;
+var $document = vapour.doc,
+	linkFocusTested = false,
+	clickEvents = "click.wb-focus vclick.wb-focus",
+	focusOutEvent = "focusout.wb-focus",
+	linkSelector = "a[href]",
+	testHref = "",
+	testTimeout;
 
-	// Ignore focus events that are not in the wb namespace and
-	// filter out any events triggered by descendants
-	if ( event.namespace === "wb" && event.currentTarget === eventTarget ) {
+// Test and helper for browsers that can't change focus on a same page link click
+$document.on( clickEvents, linkSelector, function( event ) {
+	var testElm = event.target,
+		$linkTarget;
 
-		// Assigns focus to an element
-		setTimeout(function () {
-			return $( eventTarget ).focus();
-		}, 0 );
+	testHref = testElm.getAttribute( "href" );
+
+	// Same page links only
+	if ( testHref.charAt( 0 ) === "#" &&
+		( $linkTarget = $( testHref ) ).length !== 0 ) {
+
+		// Ensure the test is run only once
+		if ( linkFocusTested ) {
+			$linkTarget.trigger( "setfocus.wb" );
+		} else {
+
+			// If the focus changes before the timeout expires, then the
+			// browser can change focus on a same page link click
+			$document.one( focusOutEvent, testHref, function() {
+
+				// Browser can change focus on a same page link click so disable help
+				clearTimeout( testTimeout );
+				$document.off( clickEvents, linkSelector );
+			});
+
+			// If the timeout expires before focus changes, then the browser
+			// can't change focus on a same page link click
+			testTimeout = setTimeout(function() {
+
+				// Browser can't change focus on a same page link click so enable help
+				$document.off( focusOutEvent, testHref );
+				linkFocusTested = true;
+
+				$linkTarget.trigger( "setfocus.wb" );
+			}, 10 );
+		}
 	}
+});
+
+
+// Bind the setfocus event
+$document.on( "setfocus.wb", function ( event ) {
+	var $elm = $( event.target );
+
+	// If link focus test is underway and hasn't been completed then stop the test
+	if ( !linkFocusTested && testHref.length !== 0 ) {
+		clearTimeout( testTimeout );
+		$document.off( focusOutEvent, testHref );
+		testHref = "";
+	}
+	
+	// Set the tabindex to -1 (as needed) to ensure the element is focusable
+	$elm
+		.filter( ":not([tabindex], a, button, input, textarea, select)" )
+			.attr( "tabindex", "-1" );
+
+	// Assigns focus to an element
+	setTimeout(function () {
+		return $elm.focus();
+	}, 0 );
 });
 
 })( jQuery, vapour );

--- a/src/plugins/footnotes/footnotes.js
+++ b/src/plugins/footnotes/footnotes.js
@@ -69,7 +69,7 @@ $document.on( "click vclick", "main :not(" + selector + ") sup a.fn-lnk", functi
 					.attr( "href", "#" + eventTarget.parentNode.id );
 
 		// Assign focus to $refLinkDest
-		$refLinkDest.trigger( "focus.wb" );
+		$refLinkDest.trigger( "setfocus.wb" );
 		return false;
 	}
 } );
@@ -84,7 +84,7 @@ $document.on( "click vclick", selector + " dd p.fn-rtn a", function( event ) {
 		refId = "#" + vapour.jqEscape( event.target.getAttribute( "href" ).substring( 1 ) );
 
 		// Assign focus to the link
-		$document.find( refId + " a" ).trigger( "focus.wb" );
+		$document.find( refId + " a" ).trigger( "setfocus.wb" );
 		return false;
 	}
 });

--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -186,7 +186,7 @@ var selector = ".wb-formvalid",
 								if ( submitted ) {
 
 									// Assign focus to $summaryContainer
-									$summaryContainer.trigger( "focus.wb" );
+									$summaryContainer.trigger( "setfocus.wb" );
 								} else {
 
 									// Update the aria-live region as necessary
@@ -275,7 +275,7 @@ $document.on( "click vclick", selector + " .errCnt a", function( event ) {
 		errorTop = $label.length !== 0 ? $label.offset().top : ( $legend.length !== 0 ? $legend.offset().top : -1 );
 
 		// Assign focus to $input
-		$input.trigger( "focus.wb" );
+		$input.trigger( "setfocus.wb" );
 
 		if ( errorTop !== -1 ) {
 			window.scroll( 0, errorTop );

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -183,12 +183,12 @@ $document.on( "keydown", ".mfp-wrap", function( event ) {
 
 		if ( event.shiftKey ) {
 			if ( event.currentTarget === eventTarget ) {
-				$elm.find( ":focusable" ).last().trigger( "focus.wb" );
+				$elm.find( ":focusable" ).last().trigger( "setfocus.wb" );
 				return false;
 			}
 		} else {
 			if ( $elm.find( ":focusable" ).last()[ 0 ] === eventTarget ) {
-				$elm.trigger( "focus.wb" );
+				$elm.trigger( "setfocus.wb" );
 				return false;
 			}
 		}

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -165,7 +165,7 @@ var selector = ".wb-menu",
 		var $goto = event.goto,
 			special = event.special;
 
-		$goto.trigger( "focus.wb" );
+		$goto.trigger( "setfocus.wb" );
 		if ( special || ( $goto.hasClass( "item" ) && !$goto.attr( "aria-haspopup" ) ) ) {
 			onReset( $goto.parents( selector ), true, special );
 		}

--- a/src/plugins/navcurrent/navcurrent.js
+++ b/src/plugins/navcurrent/navcurrent.js
@@ -43,7 +43,7 @@ var $document = vapour.doc,
 			link = menuLinks[ i ];
 			linkHref = link.getAttribute( "href" );
 			if ( linkHref !== null ) {
-				if ( linkHref.length !== 0 && linkHref.slice( 0, 1 ) !== "#" ) {
+				if ( linkHref.length !== 0 && linkHref.charAt( 0 ) !== "#" ) {
 					linkUrl = link.hostname + link.pathname.replace( /^([^\/])/, "/$1" );
 					linkQuery = link.search;
 					linkQueryLen = linkQuery.length;
@@ -71,7 +71,7 @@ var $document = vapour.doc,
 				for ( i = 0; i !== len; i += 1) {
 					link = localBreadcrumbLinks[ i ];
 					linkHref = link.getAttribute( "href" );
-					if ( linkHref.length !== 0 && linkHref.slice( 0, 1 ) !== "#" ) {
+					if ( linkHref.length !== 0 && linkHref.charAt( 0 ) !== "#" ) {
 						localBreadcrumbLinksArray.push( link );
 						localBreadcrumbLinksUrlArray.push( link.hostname + link.pathname.replace( /^([^\/])/, "/$1" ) );
 					}

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -233,7 +233,7 @@ var selector = ".wb-session-timeout",
 						clearInterval( countdownInterval );
 
 						// Assign focus to activeElement
-						$( activeElement ).trigger( "focus.wb" );
+						$( activeElement ).trigger( "setfocus.wb" );
 					}
 				}
 			});

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -80,7 +80,7 @@ var selector = ".wb-toggle",
 		event.preventDefault();
 
 		// Assign focus to eventTarget
-		$link.trigger( "focus.wb" );
+		$link.trigger( "setfocus.wb" );
 	},
 
 	/*

--- a/src/polyfills/datalist/datalist.js
+++ b/src/polyfills/datalist/datalist.js
@@ -168,7 +168,7 @@ var selector = "input[list]",
 			input.setAttribute( "aria-activedescendent", dest.parentNode.getAttribute( "id" ) );
 
 			// Assign focus to dest
-			$( dest ).trigger( "focus.wb" );
+			$( dest ).trigger( "setfocus.wb" );
 
 			return false;
 		}
@@ -200,7 +200,7 @@ var selector = "input[list]",
 			( which > 187 && which < 223 ) ) {
 
 			input.value += String.fromCharCode( which );
-			$input.trigger( "focus.wb" );
+			$input.trigger( "setfocus.wb" );
 			showOptions( input, input.value );
 
 			return false;
@@ -216,7 +216,7 @@ var selector = "input[list]",
 				showOptions( input, input.value );
 			}
 
-			$input.trigger( "focus.wb" );
+			$input.trigger( "setfocus.wb" );
 
 			return false;
 		}
@@ -235,7 +235,7 @@ var selector = "input[list]",
 			}
 
 			input.value = value;
-			$input.trigger( "focus.wb" );
+			$input.trigger( "setfocus.wb" );
 			closeOptions( input );
 
 			return false;
@@ -243,7 +243,7 @@ var selector = "input[list]",
 
 		// Tab or Escape key
 		else if ( which === 9 || which === 27 ) {
-			$input.trigger( "focus.wb" );
+			$input.trigger( "setfocus.wb" );
 			closeOptions( input );
 
 			return false;
@@ -271,7 +271,7 @@ var selector = "input[list]",
 			dest = dest.getElementsByTagName( "a" )[ 0 ];
 
 			input.setAttribute( "aria-activedescendent", dest.parentNode.getAttribute( "id" ) );
-			$( dest ).trigger( "focus.wb" );
+			$( dest ).trigger( "setfocus.wb" );
 
 			return false;
 		}
@@ -303,7 +303,7 @@ var selector = "input[list]",
 		}
 
 		input.value = value;
-		$input.trigger( "focus.wb" );
+		$input.trigger( "setfocus.wb" );
 		closeOptions( input );
 
 		return false;

--- a/src/polyfills/datepicker/datepicker.js
+++ b/src/polyfills/datepicker/datepicker.js
@@ -125,7 +125,7 @@ var selector = "input[type=date]",
 
 		if ( targetDay ) {
 			links = $days.find( "a" );
-			( targetDay === 1 ? links.first() : links.last() ).trigger( "focus.wb" );
+			( targetDay === 1 ? links.first() : links.last() ).trigger( "setfocus.wb" );
 		}
 	},
 
@@ -220,17 +220,17 @@ var selector = "input[type=date]",
 				if ( $prevMonthLink.hasClass( "wb-inv" ) ) {
 					$nextMonthLink = $container.find( ".cal-nxtmnth" );
 					if ( $nextMonthLink.hasClass( "wb-inv" ) ) {
-						$container.find( ".cal-goto a" ).trigger( "focus.wb" );
+						$container.find( ".cal-goto a" ).trigger( "setfocus.wb" );
 					} else {
-						$nextMonthLink.trigger( "focus.wb" );
+						$nextMonthLink.trigger( "setfocus.wb" );
 					}
 				} else {
-					$prevMonthLink.trigger( "focus.wb" );
+					$prevMonthLink.trigger( "setfocus.wb" );
 				}
 			}
 		} else {
 			hide( fieldId );
-			$field.trigger( "focus.wb" );
+			$field.trigger( "setfocus.wb" );
 		}
 	},
 
@@ -298,7 +298,7 @@ $document.on( "keydown displayed.wb-cal", "#wb-picker", function ( event, year, 
 		// Escape key to close overlay
 		if ( which === 27 ) {
 			hideAll();
-			$( "#" + fieldId ).trigger( "focus.wb" );
+			$( "#" + fieldId ).trigger( "setfocus.wb" );
 		}
 		break;
 


### PR DESCRIPTION
Had to change to setfocus.wb because triggering focus.wb was also triggering the native focus event which interfered with focus change fixes for screen readers and Chrome/Safari.

This test and helper approach only tests once and deregisters if not needed.

TODO: Handling of deep linking from a different page (since Chrome/Safari have same bug for deep links as for same page links... to be handled in separate PR)
