### PR TITLE
[Equal heights] Override specified height before calculating heights

### DIFF
--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -58,6 +58,9 @@ var selector = ".wb-equalheight",
 			// Ensure all children that are on the same baseline have the same 'top' value.
 			currentChild.style.verticalAlign = "top";
 
+			// Remove any previously set height
+			currentChild.style.height = "auto";
+
 			currentChildTop = currentChild.offsetTop;
 			currentChildHeight = currentChild.offsetHeight;
 


### PR DESCRIPTION
This ensures that changes to the content of the elements (e.g., text size) are considered when re-equalising the heights.
