### PR TITLE
Added png compression task

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -42,6 +42,7 @@ module.exports = (grunt) ->
 			"assets"
 			"js"
 			"css"
+			"pngmin"
 		]
 	)
 
@@ -114,7 +115,6 @@ module.exports = (grunt) ->
 			"autoprefixer"
 			"concat:css"
 			"cssmin"
-			"copy:sprites"
 		]
 	)
 
@@ -615,6 +615,7 @@ module.exports = (grunt) ->
 					"!**/*.scss"
 					"!**/*.hbs"
 					"!**/assets/*"
+					"!**/sprites/*"
 				]
 				dest: "dist/unmin/demos"
 				expand: true
@@ -676,13 +677,6 @@ module.exports = (grunt) ->
 				dest: "dist/unmin/demos/"
 				expand: true
 
-			sprites:
-				cwd: "src/assets/"
-				src: "*.*"
-				dest: "dist/unmin/assets"
-				expand: true
-				flatten: true
-
 			themeAssets:
 				cwd: "theme/"
 				src: "**/assets/*.*"
@@ -708,6 +702,7 @@ module.exports = (grunt) ->
 					"!**/*.scss"
 					"!**/*.hbs"
 					"!**/assets/*"
+					"!**/sprites/*"
 				]
 				dest: "dist/demos"
 				expand: true
@@ -719,6 +714,10 @@ module.exports = (grunt) ->
 				]
 				dest: "dist"
 				expand: true
+
+		pngmin:
+			src: 'dist/unmin/assets/*.png'
+			dest: 'dist'
 
 		clean:
 			dist: ["dist", "src/base/partials/*sprites*"]

--- a/script/setup
+++ b/script/setup
@@ -1,2 +1,2 @@
 #!/bin/sh
-npm install -g bower grunt-cli
+npm install -g bower grunt-cli node-advpng


### PR DESCRIPTION
```
Running "pngmin" task
>> Compressed 8 files
>> Uncompressed size: 186kb, Compressed size: 25.76kb, Savings: 86.15%
```

Please note that you need to run `npm install -g node-advpng` for this task to work
