### PR TITLE
Toggle: group toggle updates and accordion example

### DIFF
--- a/src/plugins/toggle/toggle-en.hbs
+++ b/src/plugins/toggle/toggle-en.hbs
@@ -138,7 +138,7 @@
 </section>
 
 <section>
-<h3>Grouped Toggles</h3>
+<h2>Grouped Toggles</h2>
 <p>This parameter restricts grouped toggles to only have one of the elements active at a time much like the grouped checkbox behaviour</p>
 
 <div class="row">
@@ -204,7 +204,7 @@
 		</table>
 	</details>
 
-	<details id="toggle3"  class="col-sm-6 grouped">
+	<details id="toggle3" class="col-sm-6 grouped">
 		<summary>Example 3</summary>
 		<p>Example content that provides more details.</p>
 		<table>
@@ -236,8 +236,110 @@
 </div>
 
 <div class="btn-group">
-	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle1", "group": "grouped"}'>Example 1</button>
-	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle2", "group": "grouped"}'>Example 2</button>
-	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle3", "group": "grouped"}'>Example 3</button>
+	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle1", "group": ".grouped"}'>Example 1</button>
+	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle2", "group": ".grouped"}'>Example 2</button>
+	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle3", "group": ".grouped"}'>Example 3</button>
 </div>
+</section>
+
+<section>
+<h2>Accordion</h2>
+<p>The group toggle feature of the plugin can also be used to create an accordion:</p>
+
+<div class="row">
+	<details class="col-sm-12 accordion wb-toggle" data-toggle='{"group": ".accordion"}'>
+		<summary>Example 1</summary>
+		<p>Example content that provides more details.</p>
+		<table>
+			<caption>Cups of coffee consumed by each delegate</caption>
+			<thead>
+				<tr>
+					<th scope="col">Name</th>
+					<th scope="col">Cups</th>
+					<th scope="col">Type of Coffee</th>
+					<th scope="col">Sugar?</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>T. Sexton</td>
+					<td>10</td>
+					<td>Espresso</td>
+					<td>No</td>
+				</tr>
+				<tr>
+					<td>J. Dinnen</td>
+					<td>5</td>
+					<td>Decaf</td>
+					<td>Yes</td>
+				</tr>
+			</tbody>
+		</table>
+	</details>
+</div>
+
+<div class="row">
+	<details class="col-sm-12 accordion wb-toggle" data-toggle='{"group": ".accordion"}'>
+		<summary>Example 2</summary>
+		<p>Example content that provides more details.</p>
+		<table>
+			<caption>Cups of coffee consumed by each delegate</caption>
+			<thead>
+			<tr>
+				<th scope="col">Name</th>
+				<th scope="col">Cups</th>
+				<th scope="col">Type of Coffee</th>
+				<th scope="col">Sugar?</th>
+			</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>T. Sexton</td>
+					<td>10</td>
+					<td>Espresso</td>
+					<td>No</td>
+				</tr>
+				<tr>
+					<td>J. Dinnen</td>
+					<td>5</td>
+					<td>Decaf</td>
+					<td>Yes</td>
+				</tr>
+			</tbody>
+		</table>
+	</details>
+</div>
+
+<div class="row">
+	<details class="col-sm-12 accordion wb-toggle" data-toggle='{"group": ".accordion"}'>
+		<summary>Example 3</summary>
+		<p>Example content that provides more details.</p>
+		<table>
+			<caption>Cups of coffee consumed by each delegate</caption>
+			<thead>
+			<tr>
+				<th scope="col">Name</th>
+				<th scope="col">Cups</th>
+				<th scope="col">Type of Coffee</th>
+				<th scope="col">Sugar?</th>
+			</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>T. Sexton</td>
+					<td>10</td>
+					<td>Espresso</td>
+					<td>No</td>
+				</tr>
+				<tr>
+					<td>J. Dinnen</td>
+					<td>5</td>
+					<td>Decaf</td>
+					<td>Yes</td>
+				</tr>
+			</tbody>
+		</table>
+	</details>
+</div>
+
 </section>

--- a/src/plugins/toggle/toggle-fr.hbs
+++ b/src/plugins/toggle/toggle-fr.hbs
@@ -237,8 +237,110 @@
 	</div>
 
 	<div class="btn-group">
-		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle1", "group": "grouped" }'>Exemple 1</button>
-		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector":  "#toggle2", "group": "grouped" }'>Exemple 2</button>
-		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector":  "#toggle3", "group": "grouped" }'>Exemple 3</button>
+		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle1", "group": ".grouped" }'>Exemple 1</button>
+		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector":  "#toggle2", "group": ".grouped" }'>Exemple 2</button>
+		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector":  "#toggle3", "group": ".grouped" }'>Exemple 3</button>
 	</div>
+</section>
+
+<section>
+<h2>Accordéon</h2>
+<p>La fonction de basculement de groupe du plugin peut également être utilisé pour créer un accordéon:</p>
+
+<div class="row">
+	<details class="col-sm-12 accordion wb-toggle" data-toggle='{"group": ".accordion"}'>
+		<summary>Exemple 1</summary>
+		<p>Le contenu d'exemple qui fournit plus de détails.</p>
+		<table>
+			<caption>Tasses de café bues par chaque député</caption>
+			<thead>
+			<tr>
+				<th scope="col">Nom</th>
+				<th scope="col">Tasses</th>
+				<th scope="col">Type de café</th>
+				<th scope="col">Sucre?</th>
+			</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>T. Sexton</td>
+					<td>10</td>
+					<td>Expresso</td>
+					<td>Non</td>
+				</tr>
+				<tr>
+					<td>J. Dinnen</td>
+					<td>5</td>
+					<td>Déca</td>
+					<td>Oui</td>
+				</tr>
+			</tbody>
+		</table>
+	</details>
+</div>
+
+<div class="row">
+	<details class="col-sm-12 accordion wb-toggle" data-toggle='{"group": ".accordion"}'>
+		<summary>Exemple 2</summary>
+		<p>Le contenu d'exemple qui fournit plus de détails.</p>
+		<table>
+			<caption>Tasses de café bues par chaque député</caption>
+			<thead>
+			<tr>
+				<th scope="col">Nom</th>
+				<th scope="col">Tasses</th>
+				<th scope="col">Type de café</th>
+				<th scope="col">Sucre?</th>
+			</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>T. Sexton</td>
+					<td>10</td>
+					<td>Expresso</td>
+					<td>Non</td>
+				</tr>
+				<tr>
+					<td>J. Dinnen</td>
+					<td>5</td>
+					<td>Déca</td>
+					<td>Oui</td>
+				</tr>
+			</tbody>
+		</table>
+	</details>
+</div>
+
+<div class="row">
+	<details class="col-sm-12 accordion wb-toggle" data-toggle='{"group": ".accordion"}'>
+		<summary>Exemple 3</summary>
+		<p>Le contenu d'exemple qui fournit plus de détails.</p>
+		<table>
+			<caption>Tasses de café bues par chaque député</caption>
+			<thead>
+			<tr>
+				<th scope="col">Nom</th>
+				<th scope="col">Tasses</th>
+				<th scope="col">Type de café</th>
+				<th scope="col">Sucre?</th>
+			</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>T. Sexton</td>
+					<td>10</td>
+					<td>Expresso</td>
+					<td>Non</td>
+				</tr>
+				<tr>
+					<td>J. Dinnen</td>
+					<td>5</td>
+					<td>Déca</td>
+					<td>Oui</td>
+				</tr>
+			</tbody>
+		</table>
+	</details>
+</div>
+
 </section>

--- a/src/polyfills/details/details.js
+++ b/src/polyfills/details/details.js
@@ -7,15 +7,15 @@
 (function( window, vapour ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the polyfill - meaning that they will be initialized once per page.
  */
 var selector = "details",
 	$document = vapour.doc,
 
 	/*
-	 * Init runs once per polyfill element on the page. There may be multiple elements. 
+	 * Init runs once per polyfill element on the page. There may be multiple elements.
 	 * It will run more than once if you don't remove the selector from the timer.
 	 * @method init
 	 * @param {DOM element} _input The input field to be polyfilled
@@ -38,14 +38,14 @@ $document.on( "timerpoke.wb", selector, function( event ) {
 	init( event.target );
 
 	/*
-	 * Since we are working with events we want to ensure that we are being passive about our control, 
+	 * Since we are working with events we want to ensure that we are being passive about our control,
 	 * so returning true allows for events to always continue
 	 */
 	return true;
 });
 
 // Bind the init event of the plugin
-$document.on( "click vclick touchstart keydown", selector + " summary", function( event ) {
+$document.on( "click vclick touchstart keydown toggle.wb-details", selector + " summary", function( event ) {
 	var which = event.which,
 		details, isClosed;
 
@@ -53,7 +53,7 @@ $document.on( "click vclick touchstart keydown", selector + " summary", function
 	if ( !which || which === 1 || which === 13 || which === 32 ) {
 		details = event.currentTarget.parentNode;
 		isClosed = ( details.getAttribute( "open" ) === null );
-		
+
 		if ( isClosed ) {
 			details.setAttribute( "open", "open" );
 			details.className += " open";
@@ -62,12 +62,10 @@ $document.on( "click vclick touchstart keydown", selector + " summary", function
 			details.className = details.className.replace( " open", "" );
 		}
 		details.setAttribute( "aria-expanded", isClosed );
-
-		return false;
 	}
 
 	/*
-	 * Since we are working with events we want to ensure that we are being passive about our control, 
+	 * Since we are working with events we want to ensure that we are being passive about our control,
 	 * so returning true allows for events to always continue
 	 */
 	return true;


### PR DESCRIPTION
**Toggle**
- Group toggle code  now sets on/off CSS classes and data states on the grouped elements.
- event.target for details element clicks was referencing the nested summary element.  Fixed by passing reference to clicked details element.
- Added Accordion example using group toggle

**Details**
- New `toggle.wb-details` event allows toggle plugin to open/close polyfilled details elements without triggering a summary click.
- Events that open/close details elements are now allowed to propagate.

**Breaking change**
The group toggle `data.group` property now expects a full CSS selector:

``` html
<!-- note the dot in .grouped -->
<button type="button" class="wb-toggle" data-toggle='{"group": ".grouped"}'>Example 1</button> 
```

/cc @masterbee
