### PR TITLE
Build: Add demos target to watch and widen source

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -729,8 +729,19 @@ module.exports = (grunt) ->
 				tasks: "jshint:lib_test"
 
 			source:
-				files: "<%= jshint.lib_test.src %>"
-				tasks: ["dist"]
+				files: "src/**.*"
+				tasks: "dist"
+				options:
+					interval: 5007
+					livereload: true
+
+			demos:
+				files: [
+					"**/*.hbs"
+				]
+				tasks: [
+					"assemble"
+				]
 				options:
 					interval: 5007
 					livereload: true


### PR DESCRIPTION
This watch task makes it easier to iterate on the examples and corrects the `source` tasks to actually point to the full "scr" directory.
