### PR TITLE
EQUALHEIGHT: change style property to minheight

### DIFF
--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -7,8 +7,8 @@
 (function( $, window, vapour ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
@@ -17,7 +17,7 @@ var selector = ".wb-equalheight",
 	$document = vapour.doc,
 
 	/*
-	 * Init runs once per plugin element on the page. There may be multiple elements. 
+	 * Init runs once per plugin element on the page. There may be multiple elements.
 	 * It will run more than once per plugin if you don't remove the selector from the timer.
 	 * @method init
 	 * @param {jQuery Event} event Event that triggered this handler
@@ -26,10 +26,10 @@ var selector = ".wb-equalheight",
 
 		// Filter out any events triggered by descendants
 		if ( event.currentTarget === event.target ) {
-		
+
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
 			window._timer.remove( selector );
-			
+
 			// Remove the event handler since only want init fired once per page (not per element)
 			$document.off( "timerpoke.wb", selector );
 
@@ -88,7 +88,7 @@ var selector = ".wb-equalheight",
 	 */
 	setRowHeight = function( row, height ) {
 		for ( var i = row.length - 1; i >= 0; i-- ) {
-			row[ i ].style.height = height + "px";
+			row[ i ].style.minHeight = height + "px";
 		}
 		row.length = 0;
 	};


### PR DESCRIPTION
- Changed `height` property setting to `min-height` to allows the container to grow so asynced children objects, img, etc can come in later and/or resize safety pushing the container it is in correctly since it is not restricted with the current fixed height.
- Corrects the text falling out of the container when text-size is increased by users, since it was setting the height, hence restricting the box from growing.
- It is IE8 safe, since a prior PR added the `auto` to the height attribute, which is in essence doing the same thing which allows the box the grow if needed.

Note: This fixes the current accessibility issues with presents itself by having the plugin add a value to the height property of the element which restricts any further growth of the element save triggering the resize() function. Using `min-height` offers the same functionality in terms of setting the baseline height of all boxes as children using min-height. To be more robust there will have to be some work done to explore triggering the resize() function as things come in.
