### PR TITLE
Tables: Added 'pg-scrlltp' classed based option

### DIFF
--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -73,6 +73,14 @@ var selector = ".wb-tables",
 			Modernizr.load([{
 				load: [ "site!deps/jquery.dataTables" + vapour.getMode() + ".js" ],
 				complete: function() {
+
+					// lets introduce a scrolltotop of table function if required by implementers
+					if ( $elm.hasClass( "pg-scrlltp") ) {
+						$elm.on( "page" , function() {
+							$( "html , body" ).scrollTop( $(this).prev().offset().top  );
+						});
+					}
+
 					$elm.dataTable( $.extend( true, defaults, vapour.getData( $elm, "wet-boew" ) ) );
 
 					// Disable role="dialog" on table wrapper since it is


### PR DESCRIPTION
- Up for review to add in if it makes sense
- Created a new setting that allows for the implementor to program the behaviour of what happens when you use the pagination function.
- Potential Usability issue: Next/Previous links do not nothing more than increment the counters and page results. Since these tables are dynamic in nature, there can be cases where the table is longer than the viewport, so the user would not see any changes to the table.
- Corrected this with an scrollTo function bound to the listen to the custom event "page" triggered by data tables when   there Next and Prev functions are fired. 

/cc @thomasgohard 
