### PR TITLE
Tables & Inview: leveraged Inview plugin to hook in scrollTop functionality for Tables

### DIFF
--- a/src/plugins/data-inview/data-inview.js
+++ b/src/plugins/data-inview/data-inview.js
@@ -7,8 +7,8 @@
 (function( $, window, vapour ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
@@ -19,7 +19,7 @@ var selector = ".wb-inview",
 	$window = vapour.win,
 
 	/*
-	 * Init runs once per plugin element on the page. There may be multiple elements. 
+	 * Init runs once per plugin element on the page. There may be multiple elements.
 	 * It will run more than once per plugin if you don't remove the selector from the timer.
 	 * @method init
 	 * @param {jQuery DOM element} $elm The plugin element being initialized
@@ -47,16 +47,23 @@ var selector = ".wb-inview",
 			x2 = x1 + elementWidth,
 			y1 = $elm.offset().top,
 			y2 = y1 + elementHeight,
-			inView = ( scrollBottom < y1 || scrollTop > y2 ) || ( scrollRight < x1 || scrollRight > x2 );
+			inView = ( scrollBottom < y1 || scrollTop > y2 ) || ( scrollRight < x1 || scrollRight > x2 ),
 
-		$elm
+			// this is a bit of a play on true/false to get the desired effect. In short this variable depicts
+			// the view state of the element
+			// all - the whole element is in the viewport
+			// partial - part of the element is in the viewport
+			// none - no part of the element is in the viewport
+			viewstate = ( scrollBottom > y2 && scrollTop < y1 ) ? "all" : ( inView ) ? "none" : "partial";
+
+		$elm.attr( "data-inviewstate", viewstate )
 			.find( ".pg-banner, .pg-panel" )
-				.attr({
-					"role": "toolbar",
-					"aria-hidden": !inView
-				})
-				.toggleClass( "in", !inView )
-				.toggleClass( "out", inView );
+			.attr({
+				"role": "toolbar",
+				"aria-hidden": !inView
+			})
+			.toggleClass( "in", !inView )
+			.toggleClass( "out", inView );
 	};
 
 // Bind the init event of the plugin
@@ -80,7 +87,7 @@ $document.on( "timerpoke.wb scroll.wb-inview", selector, function( event ) {
 	}
 
 	/*
-	 * Since we are working with events we want to ensure that we are being passive about our control, 
+	 * Since we are working with events we want to ensure that we are being passive about our control,
 	 * so returning true allows for events to always continue
 	 */
 	return true;

--- a/src/plugins/index-en.hbs
+++ b/src/plugins/index-en.hbs
@@ -5,7 +5,7 @@
 	"fr": "index"
 }
 ---
-<table id="components" class="wb-prettify wb-tables table table-striped table-hover" data-wet-boew='{"aoColumnDefs": [ { "bVisible": false, "aTargets": [ 3 ] } ], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1, "aaSorting": [[ 0, "asc" ]]}'>
+<table id="components" class="wb-prettify wb-tables table table-striped table-hover wb-inview" data-wet-boew='{"aoColumnDefs": [ { "bVisible": false, "aTargets": [ 3 ] } ], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1, "aaSorting": [[ 0, "asc" ]]}'>
 	<thead>
 		<tr>
 			<th>Name</th>

--- a/src/plugins/index-fr.hbs
+++ b/src/plugins/index-fr.hbs
@@ -5,7 +5,7 @@
 	"en": "index"
 }
 ---
-<table id="components" class="wb-prettify wb-tables table table-striped table-hover" data-wet-boew='{"aoColumnDefs": [ { "bVisible": false, "aTargets": [ 3 ] } ], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1, "aaSorting": [[ 0, "asc" ]]}'>
+<table id="components" class="wb-prettify wb-tables table table-striped table-hover wb-inview" data-wet-boew='{"aoColumnDefs": [ { "bVisible": false, "aTargets": [ 3 ] } ], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1, "aaSorting": [[ 0, "asc" ]]}'>
 	<thead>
 		<tr>
 			<th>Nom</th>

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -65,6 +65,11 @@ var selector = ".wb-tables",
 				asStripeClasses : [],
 				oLanguage: i18nText,
 				fnDrawCallback: function() {
+
+					if ( $elm.data( "inviewstate" ) === "partial" ){
+						$( "html, body" ).scrollTop( $elm.prev().offset().top );
+					}
+
 					$elm.trigger( "tables-draw.wb" );
 				}
 			};


### PR DESCRIPTION
- Leveraged `wb-inview` plugin that allows for the implementor to program the behaviour of what happens when you use the pagination function if the table is not completely in view.
- **Potential Usability issue**: Next/Previous links do not nothing more than increment the counters and page results. Since these tables are dynamic in nature, there can be cases where the table is longer than the viewport, so the user would not see any changes to the table.
- Corrected this with an scrollTo function bound to the listen to the custom event "fnDrawTable" triggered by data tables when the table is redrawn ( via paging, etc ).
- Modified `wb-inview` slightly to report a state of all/partial/none on elements that require their viewport visiblity to be known.
- **For Consideration**: At a future state we may want to review the `wb-inview` to see if the new `data-inviewstate` is sufficient instead of having `.pg-banner`, etc targeted via JS

/cc @thomasgohard 
