### PR TITLE
Tabs: fix IE8 .tabs-roller in .tabs-style-2 (fixes #3695)

### DIFF
--- a/src/js/sass/includes/_tabbedinterface.scss
+++ b/src/js/sass/includes/_tabbedinterface.scss
@@ -304,7 +304,7 @@
 	.tabs {
 		border: none;
 		background: #eee;
-		@include opacity(0.95);
+		opacity: 0.95;
 		min-height: 24px;
 		position: absolute;
 		width: 100%;


### PR DESCRIPTION
Removed the opacity filter from the `.tabs-style-2 .tabs` element.  IE8 is unable to properly stack a parent and child  element that both have a filter applied.

Modern browsers that understand the `opacity` CSS rule will still get the 0.95 opacity.
