### PR TITLE
Toggle: plugin behaviour fixes

### DIFF
--- a/src/plugins/toggle/toggle-en.hbs
+++ b/src/plugins/toggle/toggle-en.hbs
@@ -139,7 +139,7 @@
 
 <section>
 <h2>Grouped Toggles</h2>
-<p>This parameter restricts grouped toggles to only have one of the elements active at a time much like the grouped checkbox behaviour</p>
+<p>This parameter restricts grouped toggles to only have one of the elements active at a time much like the grouped checkbox behaviour.</p>
 
 <div class="row">
 	<details id="toggle1" class="col-sm-12 grouped">
@@ -236,9 +236,9 @@
 </div>
 
 <div class="btn-group">
-	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle1", "group": ".grouped"}'>Example 1</button>
-	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle2", "group": ".grouped"}'>Example 2</button>
-	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle3", "group": ".grouped"}'>Example 3</button>
+	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle1", "group": ".grouped", "type": "on"}'>Example 1</button>
+	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle2", "group": ".grouped", "type": "on"}'>Example 2</button>
+	<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle3", "group": ".grouped", "type": "on"}'>Example 3</button>
 </div>
 </section>
 

--- a/src/plugins/toggle/toggle-fr.hbs
+++ b/src/plugins/toggle/toggle-fr.hbs
@@ -237,9 +237,9 @@
 	</div>
 
 	<div class="btn-group">
-		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle1", "group": ".grouped" }'>Exemple 1</button>
-		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector":  "#toggle2", "group": ".grouped" }'>Exemple 2</button>
-		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector":  "#toggle3", "group": ".grouped" }'>Exemple 3</button>
+		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle1", "group": ".grouped", "type": "on" }'>Exemple 1</button>
+		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle2", "group": ".grouped", "type": "on" }'>Exemple 2</button>
+		<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "#toggle3", "group": ".grouped", "type": "on" }'>Exemple 3</button>
 	</div>
 </section>
 

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -57,13 +57,14 @@ var selector = ".wb-toggle",
 		var i, len, $elm,
 			ariaControls = "",
 			link = event.target,
+			prefix = "wb-" + new Date().getTime(),
 			$elms =  getElements( link, data );
 
 		// Find the elements this link controls
 		for ( i = 0, len = $elms.length; i < len; i += 1 ) {
 			$elm = $elms.eq( i );
 			if ( $elm.attr( "id" ) === undefined ) {
-				$elm.attr( "id", "wb-toggle_" + i );
+				$elm.attr( "id", prefix + i );
 			}
 			ariaControls += $elm.attr( "id" ) + " ";
 		}
@@ -172,12 +173,12 @@ var selector = ".wb-toggle",
 	getState = function( link, data ) {
 		var parent = data.parent,
 			selector = data.selector,
-			type = data.group != null ? data.stateOn : data.type;
+			type = data.type;
 
 		// No toggle type: get the current on/off state of the elements specified by the selector and parent
 		if ( !type ) {
 			if( !selector ) {
-				return $( link ).data( "state" );
+				return $( link ).data( "state" ) || data.stateOff;
 
 			} else if ( states.hasOwnProperty( selector ) ) {
 				return states[ selector ].hasOwnProperty( parent ) ?


### PR DESCRIPTION
1. Fix first click on elements that toggle themselves.
2. Fix setAriaControls to set unique IDs on elements that don't have an ID defined.
3. Group toggle elements no longer default to `"type": "on"` (fixes #3711).  This allows the currently open section of an accordion to be closed.

**Breaking change**

Group toggle elements that you do not want to allow closed must specify their type as on:

``` html
data-toggle='{"group": ".grouped", "type": "on"}'
```

/cc @masterbee
