### PR TITLE
Overlay: Added escape handling

### DIFF
--- a/src/plugins/overlays/overlays.js
+++ b/src/plugins/overlays/overlays.js
@@ -75,8 +75,14 @@ var selector = ".wb-panel-left, .wb-panel-right, .wb-bar-top, .wb-bar-bottom, .w
 		}
 	};
 
-// Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb keydown", selector, function( event ) {
+	if ( event.type === "timerpoke" ) {
+		init( event );
+	} else if ( event.which === 27 ) {
+		window.location.hash += "_0";
+		$( "[href='#" + event.currentTarget.id + "']" ).trigger( "setfocus.wb" );
+	}
+});
 
 // Add the timer poke to initialize the plugin
 window._timer.add( selector );


### PR DESCRIPTION
Overlay TODO:
- Set focus to the link that opened the overlay when hitting escape (currently goes to the last link)
- Handle escape on overlay open after first time. First time escape works fine. Second time it doesn't until tab into the container (almost as if focus is moved but jQuery doesn't recognize it).
- Need to add appropriate WAI-ARIA
- Handle focusout (needs to close)
