### PR TITLE
ResondJS: bump to 1.4.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
 		"magnific-popup": "0.9.8",
 		"jquery-pjax": "1.7.3",
 		"html5shiv": "3.7.0",
-		"respond": "1.3.0",
+		"respond": "1.4.0",
 		"selectivizr": "1.0.2",
 		"excanvas": "*",
 		"google-code-prettify": "1.0.0"


### PR DESCRIPTION
This will require a `bower install` by implementers
