### PR TITLE
Overlay: Added overflow: auto and max-height: 100% to resolve issue with overlay being taller than the viewport

### DIFF
--- a/src/plugins/overlays/overlays.scss
+++ b/src/plugins/overlays/overlays.scss
@@ -17,6 +17,8 @@
 		display: block;
 		visibility: visible;
 		z-index: 999;
+		overflow: auto;
+		max-height: 100%;
 	}
 }
 

--- a/src/plugins/share/share.scss
+++ b/src/plugins/share/share.scss
@@ -152,6 +152,10 @@
 		list-style-type: none;
 		padding-left: 0;
 	}
+
+	p {
+		margin: 5px 10px;
+	}
 }
 
 #shr-pg {


### PR DESCRIPTION
Issue was that when the overlay was taller than the viewport, it wasn't possible to reach the part outside of the viewport.
