### PR TITLE
Overlays: Fixed keyboard handling for second time panel is opened

### DIFF
--- a/src/plugins/focus/focus.js
+++ b/src/plugins/focus/focus.js
@@ -9,33 +9,23 @@
 
 var $document = vapour.doc,
 	hash = vapour.pageUrlParts.hash,
-	linkFocusTested = false,
 	clickEvents = "click.wb-focus vclick.wb-focus",
-	focusOutEvent = "focusout.wb-focus",
 	linkSelector = "a[href]",
-	testHref = "",
-	$linkTarget, testTimeout;
+	$linkTarget;
 
 // Bind the setfocus event
 $document.on( "setfocus.wb", function ( event ) {
 	var $elm = $( event.target );
 
-	// If link focus test is underway and hasn't been completed then stop the test
-	if ( !linkFocusTested && testHref.length !== 0 ) {
-		clearTimeout( testTimeout );
-		$document.off( focusOutEvent, testHref );
-		testHref = "";
-	}
-	
 	// Set the tabindex to -1 (as needed) to ensure the element is focusable
 	$elm
 		.filter( ":not([tabindex], a, button, input, textarea, select)" )
 			.attr( "tabindex", "-1" );
 
-	// Assigns focus to an element
+	// Assigns focus to an element (delay allows for revealing of hidden content)
 	setTimeout(function () {
 		return $elm.focus();
-	}, 0 );
+	}, 1 );
 });
 
 
@@ -45,39 +35,13 @@ if ( hash && ( $linkTarget = $( hash ) ).length !== 0 ) {
 	$linkTarget.trigger( "setfocus.wb" );
 }
 	
-// Test and helper for browsers that can't change focus on a same page link click
+// Helper for browsers that can't change keyboard and/or event focus on a same page link click
 $document.on( clickEvents, linkSelector, function( event ) {
 	var testHref = event.currentTarget.getAttribute( "href" );
 
 	// Same page links only
-	if ( testHref.charAt( 0 ) === "#" &&
-		( $linkTarget = $( testHref ) ).length !== 0 ) {
-
-		// Ensure the test is run only once
-		if ( linkFocusTested ) {
-			$linkTarget.trigger( "setfocus.wb" );
-		} else {
-
-			// If the focus changes before the timeout expires, then the
-			// browser can change focus on a same page link click
-			$document.one( focusOutEvent, testHref, function() {
-
-				// Browser can change focus on a same page link click so disable help
-				clearTimeout( testTimeout );
-				$document.off( clickEvents, linkSelector );
-			});
-
-			// If the timeout expires before focus changes, then the browser
-			// can't change focus on a same page link click
-			testTimeout = setTimeout(function() {
-
-				// Browser can't change focus on a same page link click so enable help
-				$document.off( focusOutEvent, testHref );
-				linkFocusTested = true;
-
-				$linkTarget.trigger( "setfocus.wb" );
-			}, 20 );
-		}
+	if ( testHref.charAt( 0 ) === "#" && ( $linkTarget = $( testHref ) ).length !== 0 ) {
+		$linkTarget.trigger( "setfocus.wb" );
 	}
 });
 

--- a/src/plugins/overlays/overlays.js
+++ b/src/plugins/overlays/overlays.js
@@ -82,20 +82,25 @@ $document.on( "timerpoke.wb keydown", selector, function( event ) {
 	if ( event.type === "timerpoke" ) {
 		init( event );
 	} else if ( event.which === 27 ) {
+
+		// Hides the overlay
 		window.location.hash += "_0";
+
+		// Returns focus to the source link for the overlay
 		$( sourceLinks[ event.currentTarget.id ] ).trigger( "setfocus.wb" );
 	}
 });
 
+// Returns focus to the source link for the overlay
 $document.on( "click vclick", "." + closeClass, function( event ) {
 	$( sourceLinks[ event.currentTarget.parentNode.parentNode.id ] ).trigger( "setfocus.wb" );
 });
 
+// Stores the source link for the overlay
 $document.on( "click vclick", "." + linkClass, function( event ) {
 	var sourceLink = event.target,
 		hash = sourceLink.hash;
 
-	// Store the source link
 	sourceLinks[ hash.substring( 1 ) ] = sourceLink;
 });
 


### PR DESCRIPTION
Had to remove focus test from focus.js since Firefox needs the focus delay to be able to shift event focus to overlays since otherwise it tries unsuccessfully to shift event focus before the overlay is revealed (which causes event focus to fall back to the body element).
