### PR TITLE
Overlays: Changed hover/focus colour of close button to medium grey

### DIFF
--- a/src/plugins/overlays/overlays.scss
+++ b/src/plugins/overlays/overlays.scss
@@ -110,4 +110,7 @@
 	text-decoration: none;
 	top: 7px;
 	width: 1.5em;
+	&:hover, &:focus {
+		color: #999;
+	}
 }


### PR DESCRIPTION
Improves contrast and visual aesthetics over the medium/dark blue hover/focus colour.
