### PR TITLE
Share: Switched columns to using column-count

### DIFF
--- a/src/base/views/_largeViewOver.scss
+++ b/src/base/views/_largeViewOver.scss
@@ -2,3 +2,12 @@
   WET-BOEW
   @title: Large view and over (screen only)
  */
+.colcount-lg-2 {
+	column-count: 2;
+}
+.colcount-lg-3 {
+	column-count: 3;
+}
+.colcount-lg-4 {
+	column-count: 4;
+}

--- a/src/base/views/_mediumViewOver.scss
+++ b/src/base/views/_mediumViewOver.scss
@@ -2,3 +2,12 @@
   WET-BOEW
   @title: Medium view and over (screen only)
  */
+.colcount-md-2 {
+	column-count: 2;
+}
+.colcount-md-3 {
+	column-count: 3;
+}
+.colcount-md-4 {
+	column-count: 4;
+}

--- a/src/base/views/_smallViewOver.scss
+++ b/src/base/views/_smallViewOver.scss
@@ -2,3 +2,9 @@
   WET-BOEW
   @title: Small view and over (screen only)
  */
+.colcount-sm-2 {
+	column-count: 2;
+}
+.colcount-sm-3 {
+	column-count: 3;
+}

--- a/src/base/views/_xSmallViewOver.scss
+++ b/src/base/views/_xSmallViewOver.scss
@@ -2,3 +2,6 @@
   WET-BOEW
   @title: Extra-small view and over (screen only)
  */
+.colcount-xs-2 {
+	column-count: 2;
+}

--- a/src/plugins/share/share.js
+++ b/src/plugins/share/share.js
@@ -147,7 +147,7 @@ var selector = ".wb-share",
 			panel = "<section id='shr-pg' class='shr-pg wb-panel-" +
 				( vapour.html.attr( "dir" ) === "rtl" ? "l" : "r" ) +
 				"'><div class='overlay-hd'><" + heading + ">" +
-				i18nText.shareText + "</" + heading + "></div><ul>";
+				i18nText.shareText + "</" + heading + "></div><ul class='colcount-xs-2 colcount-sm-3'>";
 
 			for ( site in sites ) {
 				siteProperties = sites[ site ];
@@ -156,7 +156,7 @@ var selector = ".wb-share",
 						.replace( /\{t\}/, pageTitle )
 						.replace( /\{i\}/, pageImage )
 						.replace( /\{d\}/, pageDescription );
-				panel += "<li class='col-md-4 col-sm-6'><a href='" + url + "' class='" + shareLink + " " + site + " btn btn-default' target='_blank'>" + siteProperties.name + "</a></li>";
+				panel += "<li><a href='" + url + "' class='" + shareLink + " " + site + " btn btn-default' target='_blank'>" + siteProperties.name + "</a></li>";
 			}
 
 			panel += "</ul><div class='clearfix'></div><p class='col-sm-12'>" + i18nText.disclaimer + "</p></section>";

--- a/src/plugins/share/share.scss
+++ b/src/plugins/share/share.scss
@@ -151,7 +151,7 @@
 	ul {
 		list-style-type: none;
 		padding-left: 0;
-		margin-top: 10px;
+		margin: 10px;
 	}
 }
 


### PR DESCRIPTION
Note that this doesn't work for IE9 and earlier but it does safely fall back to a single column for those browsers. Chose this approach because the previous approach of wrapping rows had usability issues (since people expect to read the links in columns not rows).
