### PR TITLE
Tables: Removed role='grid' override

### DIFF
--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -79,12 +79,6 @@ var selector = ".wb-tables",
 				load: [ "site!deps/jquery.dataTables" + vapour.getMode() + ".js" ],
 				complete: function() {
 					$elm.dataTable( $.extend( true, defaults, vapour.getData( $elm, "wet-boew" ) ) );
-
-					// Disable role="dialog" on table wrapper since it is
-					// causing issues with screen readers and is also
-					// implemented incorrectly
-					// TODO: Remove role="grid" upstream
-					$elm.parent().removeAttr( "role" );
 				}
 			}]);
 		}


### PR DESCRIPTION
Didn't end up making a difference for screen reader users.
