### PR TITLE
[Equal height] Restore height override before height calculations

### DIFF
--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -58,8 +58,8 @@ var selector = ".wb-equalheight",
 			// Ensure all children that are on the same baseline have the same 'top' value.
 			currentChild.style.verticalAlign = "top";
 
-			// Remove any previously set height
-			currentChild.style.height = "auto";
+			// Remove any previously set min height
+			currentChild.style.minHeight = 0;
 
 			currentChildTop = currentChild.offsetTop;
 			currentChildHeight = currentChild.offsetHeight;


### PR DESCRIPTION
Restores the fix from https://github.com/wet-boew/wet-boew/pull/3675 that was undone when the `min-height` property was substituted for the `height` property in https://github.com/wet-boew/wet-boew/pull/3705.
