### PR TITLE
Build: Switch advpng for grunt-contrib-imagemin

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -40,9 +40,9 @@ module.exports = (grunt) ->
 		[
 			"clean:dist"
 			"assets"
+			"images"
 			"js"
 			"css"
-			"pngmin"
 		]
 	)
 
@@ -110,11 +110,19 @@ module.exports = (grunt) ->
 		"css"
 		"INTERNAL: Compiles Sass and copies third party CSS to the dist folder"
 		[
-			"sprites"
 			"sass"
 			"autoprefixer"
 			"concat:css"
 			"cssmin"
+		]
+	)
+
+	@registerTask(
+		"images"
+		"INTERNAL: Compiles sprites and optimized images"
+		[
+			"sprites"
+			"imagemin"
 		]
 	)
 
@@ -695,9 +703,12 @@ module.exports = (grunt) ->
 				dest: "dist"
 				expand: true
 
-		pngmin:
-			src: 'dist/unmin/assets/*.png'
-			dest: 'dist'
+		imagemin:
+			sprites:
+				cwd: "src"
+				src: "**/sprites_*.png"
+				dest: "src"
+				expand: true
 
 		clean:
 			dist: ["dist", "src/base/partials/*sprites*"]
@@ -887,6 +898,7 @@ module.exports = (grunt) ->
 	@loadNpmTasks "grunt-contrib-connect"
 	@loadNpmTasks "grunt-contrib-copy"
 	@loadNpmTasks "grunt-contrib-cssmin"
+	@loadNpmTasks "grunt-contrib-imagemin"
 	@loadNpmTasks "grunt-contrib-jshint"
 	@loadNpmTasks "grunt-contrib-uglify"
 	@loadNpmTasks "grunt-contrib-watch"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-cssmin": "~0.7.0",
+    "grunt-contrib-imagemin": "~0.4.0",
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",

--- a/script/setup
+++ b/script/setup
@@ -1,2 +1,2 @@
 #!/bin/sh
-npm install -g bower grunt-cli node-advpng
+npm install -g bower grunt-cli


### PR DESCRIPTION
- Restricted to sprites at this time
- No settings tweaking have been done
- Creates a new image target and combines with the spriting task
