### PR TITLE
Demos: add support for querystrings in table link

### DIFF
--- a/site/pages/demos/index-en.hbs
+++ b/site/pages/demos/index-en.hbs
@@ -19,7 +19,7 @@
 			{{#is data.language "en"}}
 				{{#if data.category}}
 					<tr>
-						<td><a href="{{relative dirname dest}}">{{data.title}}</a></td>
+						<td><a href="{{relative dirname dest}}{{#if data.querystring}}?{{data.querystring}}{{/if}}">{{data.title}}</a></td>
 						<td>{{data.category}}</td>
 						<td>{{data.description}}</td>
 						<td>{{data.tag}}</td>

--- a/site/pages/demos/index-fr.hbs
+++ b/site/pages/demos/index-fr.hbs
@@ -19,7 +19,7 @@
 			{{#is data.language "fr"}}
 				{{#if data.category}}
 					<tr>
-						<td><a href="{{relative dirname dest}}">{{data.title}}</a></td>
+						<td><a href="{{relative dirname dest}}{{#if data.querystring}}?{{data.querystring}}{{/if}}">{{data.title}}</a></td>
 						<td>{{data.category}}</td>
 						<td>{{data.description}}</td>
 						<td>{{data.tag}}</td>

--- a/src/plugins/texthighlight/texthighlight-en.hbs
+++ b/src/plugins/texthighlight/texthighlight-en.hbs
@@ -4,6 +4,7 @@
 	"language": "en",
 	"category": "Plugin",
 	"description": "Automatically highlights certain words on a Web page. The highlighted words can be selected via the query string.",
+	"querystring": "texthighlight=avian%20influenza+world+cook+flu-like%20symptoms+Don't%20Forget...+causes%20sickness%20in%20birds,%20it%20can%20also%20infect%20people.",
 	"tag": "texthighlight",
 	"fr": "texthighlight"
 }

--- a/src/plugins/texthighlight/texthighlight-fr.hbs
+++ b/src/plugins/texthighlight/texthighlight-fr.hbs
@@ -4,6 +4,7 @@
 	"language": "fr",
 	"category": "Plugiciel",
 	"description": "Met en surbrillance sur une page Web les mots choisis.",
+	"querystring": "texthighlight=influenza%20aviaire+monde+suffis+symptômes%20semblables%20à%20ceux%20de%20l'influenza+À%20titre%20de%20rappel...+À%20de%20rares%20occasions,%20des%20humains%20ont%20été%20infectés%20par%20ce%20virus.",
 	"tag": "texthighlight",
 	"en": "texthighlight"
 }


### PR DESCRIPTION
As requested at the meeting today, but the language switch link still ignores the querystring.
