### PR TITLE
Build: run an npm install as part of setup script

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -1,2 +1,2 @@
 #!/bin/sh
-npm install -g bower grunt-cli
+npm install -g bower grunt-cli && npm install

--- a/script/setup.cmd
+++ b/script/setup.cmd
@@ -1,1 +1,1 @@
-npm install -g bower grunt-cli
+npm install -g bower grunt-cli && npm install


### PR DESCRIPTION
Simplifies setup since the devs won't need to run a separate install after the setup script.
