### PR TITLE
Build: Use tarball for grunt-imagemin dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-gh-pages": "~0.8.0",
     "grunt-htmlcompressor": "~0.1.9",
-    "grunt-imagine": "git://github.com/LaurentGoderre/grunt-imagine.git#custom",
+    "grunt-imagine": "http://github.com/LaurentGoderre/grunt-imagine/tarball/custom",
     "grunt-mocha": "~0.4.1",
     "grunt-modernizr": "~0.4.0",
     "grunt-sass": "~0.8.0",


### PR DESCRIPTION
HTTP has better proxy support
