### PR TITLE
Vapour: rename to "wb"

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -14,7 +14,7 @@
 	"unused": true,
 
 	"globals": {
-		"vapour": true,
+		"wb": true,
 		"Modernizr": true,
 		"yepnope": true
 	},

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -186,7 +186,7 @@ module.exports = (grunt) ->
 					stripBanners: false
 				src: [
 					"lib/modernizr/modernizr-custom.js"
-					"src/core/vapour.js"
+					"src/core/wb.js"
 					"src/core/helpers.js"
 					"src/plugins/**/*.js"
 					"!src/plugins/**/test.js"
@@ -204,7 +204,7 @@ module.exports = (grunt) ->
 					"lib/excanvas/excanvas.js"
 					"lib/html5shiv/dist/html5shiv.js"
 					"lib/selectivizr/selectivizr.js"
-					"src/core/vapour.js"
+					"src/core/wb.js"
 					"!src/plugins/**/test.js"
 					"!src/plugins/**/assets/*.js"
 					"!src/plugins/**/demo/*.js"
@@ -241,7 +241,7 @@ module.exports = (grunt) ->
 						methods = if grunt.file.exists methodsPath then grunt.file.read( methodsPath ) else ""
 
 						if methods != "" or messages != ""
-							src += "\nvapour.doc.one( \"formLanguages.wb\", function() {\n"
+							src += "\nwb.doc.one( \"formLanguages.wb\", function() {\n"
 							src += messages
 							src += "\n"
 							src += methods
@@ -815,7 +815,7 @@ module.exports = (grunt) ->
 								testHtml += "<script src='/" + path.dirname( path.relative(__dirname, require.resolve( "sinon" ) ) ) + "/../pkg/sinon.js'></script>"
 								testHtml += "<!--[if lt IE 9]><script src='/" + path.dirname( path.relative(__dirname, require.resolve( "sinon" ) ) ) + "/../pkg/sinon-ie.js'></script><![endif]-->"
 
-								testHtml += "<script>mocha.setup( 'bdd' ); vapour.doc.on( 'ready', function() { mocha.run(); } );</script>"
+								testHtml += "<script>mocha.setup( 'bdd' ); wb.doc.on( 'ready', function() { mocha.run(); } );</script>"
 
 								testHtml += "<script src='/" + testFile + "'></script>"
 

--- a/site/includes/test.hbs
+++ b/site/includes/test.hbs
@@ -11,7 +11,7 @@
 
 <script>
 	mocha.setup( "bdd" );
-	vapour.doc.on( "ready", function() {
+	wb.doc.on( "ready", function() {
 		mocha.run();
 	});
 </script>

--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -5,8 +5,8 @@
  * @author WET Community
  * Credits: http://kaibun.net/blog/2013/04/19/a-fully-fledged-coffeescript-boilerplate-for-jquery-plugins/
  */
-(function( $, vapour ) {
-	vapour.getData = function( element, dataName ) {
+(function( $, wb ) {
+	wb.getData = function( element, dataName ) {
 		var elm = !element.jquery ? element : element[ 0 ],
 			dataAttr = elm.getAttribute( "data-" + dataName ),
 			dataObj;
@@ -22,24 +22,24 @@
 		$.data( elm, dataName, dataObj );
 		return dataObj;
 	};
-})( jQuery, vapour );
+})( jQuery, wb );
 
-(function( vapour ) {
+(function( wb ) {
 	"use strict";
 
 	// Escapes the characters in a string for use in a jQuery selector
 	// Based on http://totaldev.com/content/escaping-characters-get-valid-jquery-id
-	vapour.jqEscape = function( selector ) {
+	wb.jqEscape = function( selector ) {
 		return selector.replace( /([;&,\.\+\*\~':"\!\^#$%@\[\]\(\)=>\|])/g, "\\$1" );
 	};
 
 	/*
-	 * @namespace vapour.string
+	 * @namespace wb.string
 	 */
-	vapour.string = {
+	wb.string = {
 		/*
 		 * Left-pads a number with zeros.
-		 * @memberof vapour.string
+		 * @memberof wb.string
 		 * @param {number} number The original number to pad.
 		 * @param {number} length The width of the resulting padded number, not the number of zeros to add to the front of the string.
 		 * @return {string} The padded string
@@ -57,9 +57,9 @@
 
 	/*
 	 * A suite of date related functions for easier parsing of dates
-	 * @namespace vapour.date
+	 * @namespace wb.date
 	 */
-	vapour.date = {
+	wb.date = {
 		/*
 		 * Converts the date to a date-object. The input can be:
 		 * <ul>
@@ -69,7 +69,7 @@
 		 * <li>a string: Any format supported by the javascript engine, like 'YYYY/MM/DD', 'MM/DD/YYYY', 'Jan 31 2009' etc.</li>
 		 * <li>an object: Interpreted as an object with year, month and date attributes. **NOTE** month is 0-11.</li>
 		 * </ul>
-		 * @memberof vapour.date
+		 * @memberof wb.date
 		 * @param {Date | number[] | number | string | object} dateValue
 		 * @return {Date | NaN}
 		 */
@@ -91,7 +91,7 @@
 
 		/*
 		 * Compares two dates (input can be any type supported by the convert function).
-		 * @memberof vapour.date
+		 * @memberof wb.date
 		 * @param {Date | number[] | number | string | object} dateValue1
 		 * @param {Date | number[] | number | string | object} dateValue2
 		 * @return {number | NaN}
@@ -102,7 +102,7 @@
 		 * NaN if dateValue1 or dateValue2 is an illegal date
 		 */
 		compare: function( dateValue1, dateValue2 ) {
-			var convert = vapour.date.convert;
+			var convert = wb.date.convert;
 
 			if ( isFinite( dateValue1 = convert( dateValue1 ).valueOf() ) && isFinite( dateValue2 = convert( dateValue2 ).valueOf() ) ) {
 				return ( dateValue1 > dateValue2 ) - ( dateValue1 < dateValue2 );
@@ -112,7 +112,7 @@
 
 		/*
 		 * Cross-browser safe way of translating a date to ISO format
-		 * @memberof vapour.date
+		 * @memberof wb.date
 		 * @param {Date | number[] | number | string | object} dateValue
 		 * @param {boolean} withTime Optional. Whether to include the time in the result, or just the date. False if blank.
 		 * @return {string}
@@ -123,8 +123,8 @@
 		 * returns "2012-04-27 13:46"
 		 */
 		toDateISO: function( dateValue, withTime ) {
-			var date = vapour.date.convert( dateValue ),
-				pad = vapour.string.pad;
+			var date = wb.date.convert( dateValue ),
+				pad = wb.string.pad;
 
 			return date.getFullYear() + "-" + pad( date.getMonth() + 1, 2, "0" ) + "-" + pad( date.getDate(), 2, "0" ) +
 				( withTime ? " " + pad( date.getHours(), 2, "0" ) + ":" + pad( date.getMinutes(), 2, "0" ) : "" );
@@ -132,7 +132,7 @@
 
 		/*
 		 * Cross-browser safe way of creating a date object from a date string in ISO format
-		 * @memberof vapour.date
+		 * @memberof wb.date
 		 * @param {string} dateISO Date string in ISO format
 		 * @return {Date}
 		 */
@@ -147,7 +147,7 @@
 		}
 	};
 
-})( vapour );
+})( wb );
 
 (function( $, undef ) {
 	"use strict";

--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -118,28 +118,6 @@ var getUrlParts = function( url ) {
 		return ( typeof disabled === "string" ) ? ( disabled.toLowerCase() === "true" ) : Boolean( disabled );
 	}()),
 
-	i18n = function( key, state, mixin ) {
-		var truthiness,
-			ind = window.i18nObj;
-
-		truthiness = ( typeof key === "string" && key !== "" ) | // eg. 000 or 001 ie. 0 or 1
-		( typeof state === "string" && state !== "" ) << 1 | // eg. 000 or 010 ie. 0 or 2
-		( typeof mixin === "string" && mixin !== "" ) << 2; // eg. 000 or 100 ie. 0 or 4
-
-		switch ( truthiness ) {
-			case 1:
-				// only key was provided
-				return ind[ key ];
-			case 3:
-				// key and state were provided
-				return ind[ key ][ state ];
-			case 7:
-				// key, state, and mixin were provided
-				return ind[ key ][ state ].replace( "[MIXIN]", mixin );
-			default:
-				return "";
-		}
-	},
 	/*-----------------------------
 	 * Core Library Object
 	 *-----------------------------
@@ -208,10 +186,32 @@ var getUrlParts = function( url ) {
 				wb.nodes.trigger( "timerpoke.wb" );
 			}, 500 );
 
+		},
+		i18nDict: {},
+		i18n: function( key, state, mixin ) {
+			var truthiness,
+				dictionary = wb.i18nDict;
+
+			truthiness = ( typeof key === "string" && key !== "" ) | // eg. 000 or 001 ie. 0 or 1
+			( typeof state === "string" && state !== "" ) << 1 | // eg. 000 or 010 ie. 0 or 2
+			( typeof mixin === "string" && mixin !== "" ) << 2; // eg. 000 or 100 ie. 0 or 4
+
+			switch ( truthiness ) {
+				case 1:
+					// only key was provided
+					return dictionary[ key ];
+				case 3:
+					// key and state were provided
+					return dictionary[ key ][ state ];
+				case 7:
+					// key, state, and mixin were provided
+					return dictionary[ key ][ state ].replace( "[MIXIN]", mixin );
+				default:
+					return "";
+			}
 		}
 	};
 
-window.i18n = i18n;
 window.wb = wb;
 
 /*-----------------------------

--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -52,7 +52,7 @@ var getUrlParts = function( url ) {
 
 	/*
 	 * @variable $src
-	 * @return {jQuery Element} of vapour script element
+	 * @return {jQuery Element} of wb script element
 	 */
 	$src = $( "script[src$='wet-boew.js'],script[src$='wet-boew.min.js']" )
 		.last(),
@@ -118,44 +118,6 @@ var getUrlParts = function( url ) {
 		return ( typeof disabled === "string" ) ? ( disabled.toLowerCase() === "true" ) : Boolean( disabled );
 	}()),
 
-	/*-----------------------------
-	 * Vapour Core Object
-	 *-----------------------------*/
-	vapour = {
-		"/": $homepath,
-		"/assets": "" + $homepath + "/../assets",
-		"/templates": "" + $homepath + "/assets/templates",
-		"/deps": "" + $homepath + "/deps",
-		mode: $mode,
-		doc: $( document ),
-		win: $( window ),
-		html: $( "html" ),
-		pageUrlParts: currentpage,
-		getUrlParts: getUrlParts,
-		isDisabled : disabled,
-
-		getPath: function( property ) {
-			return this.hasOwnProperty( property ) ? this[ property ] : undef;
-		},
-
-		getMode: function() {
-			return this.mode;
-		},
-
-		// Lets load some variables into vapour for IE detection
-		other:  !oldie,
-		desktop: ( window.orientation === undefined ),
-		ie:     !!oldie,
-		ie6:    ( oldie === 6 ),
-		ie7:    ( oldie === 7 ),
-		ie8:    ( oldie === 8 ),
-		ie9:    ( oldie === 9 ),
-		ielt7:  ( oldie < 7 ),
-		ielt8:  ( oldie < 8 ),
-		ielt9:  ( oldie < 9 ),
-		ielt10: ( oldie < 10 )
-	},
-
 	i18n = function( key, state, mixin ) {
 		var truthiness,
 			ind = window.i18nObj;
@@ -177,10 +139,80 @@ var getUrlParts = function( url ) {
 			default:
 				return "";
 		}
+	},
+	/*-----------------------------
+	 * Core Library Object
+	 *-----------------------------
+	 */
+	wb = {
+		"/": $homepath,
+		"/assets": "" + $homepath + "/../assets",
+		"/templates": "" + $homepath + "/assets/templates",
+		"/deps": "" + $homepath + "/deps",
+		mode: $mode,
+		doc: $( document ),
+		win: $( window ),
+		html: $( "html" ),
+		pageUrlParts: currentpage,
+		getUrlParts: getUrlParts,
+		isDisabled : disabled,
+
+		getPath: function( property ) {
+			return this.hasOwnProperty( property ) ? this[ property ] : undef;
+		},
+
+		getMode: function() {
+			return this.mode;
+		},
+
+		// Lets load some variables into wb for IE detection
+		other:  !oldie,
+		desktop: ( window.orientation === undefined ),
+		ie:     !!oldie,
+		ie6:    ( oldie === 6 ),
+		ie7:    ( oldie === 7 ),
+		ie8:    ( oldie === 8 ),
+		ie9:    ( oldie === 9 ),
+		ielt7:  ( oldie < 7 ),
+		ielt8:  ( oldie < 8 ),
+		ielt9:  ( oldie < 9 ),
+		ielt10: ( oldie < 10 ),
+
+		nodes: $(),
+
+		add: function( selector ) {
+
+			// Lets ensure we are not running if things are disabled
+			if ( this.isDisabled && selector !== "#wb-tphp" ) {
+				return 0;
+			}
+
+			this.nodes = this.nodes.add( selector );
+		},
+
+		// Remove nodes referenced by the selector
+		remove: function( selector ) {
+			this.nodes = this.nodes.not( selector );
+		},
+
+		start: function() {
+
+			/* Lets start our clock right away. We we need to test to ensure that there will not be any
+			 * instances on Mobile were the DOM is not ready before the timer starts. That is why 0.5 seconds
+			 * was used as a buffer.
+			 */
+			this.nodes.trigger( "timerpoke.wb" );
+
+			// lets keep it ticking after
+			setInterval(function() {
+				wb.nodes.trigger( "timerpoke.wb" );
+			}, 500 );
+
+		}
 	};
 
 window.i18n = i18n;
-window.vapour = vapour;
+window.wb = wb;
 
 /*-----------------------------
  * Yepnope Prefixes
@@ -230,44 +262,6 @@ yepnope.addPrefix( "i18n", function( resourceObj ) {
 	resourceObj.url = $homepath + "/" + resourceObj.url + lang + $mode + ".js";
 	return resourceObj;
 });
-
-/*-----------------------------
- * Base Timer
- *-----------------------------*/
-window._timer = {
-
-	nodes: $(),
-
-	add: function( selector ) {
-
-		// Lets ensure we are not running if things are disabled
-		if ( vapour.isDisabled && selector !== "#wb-tphp" ) {
-			return 0;
-		}
-
-		this.nodes = this.nodes.add( selector );
-	},
-
-	// Remove nodes referenced by the selector
-	remove: function( selector ) {
-		this.nodes = this.nodes.not( selector );
-	},
-
-	start: function() {
-
-		/* Lets start our clock right away. We we need to test to ensure that there will not be any
-		 * instances on Mobile were the DOM is not ready before the timer starts. That is why 0.5 seconds
-		 * was used as a buffer.
-		 */
-		this.nodes.trigger( "timerpoke.wb" );
-
-		// lets keep it ticking after
-		setInterval(function() {
-			window._timer.nodes.trigger( "timerpoke.wb" );
-		}, 500 );
-
-	}
-};
 
 /*-----------------------------
  * Modernizr Polyfill Loading
@@ -323,7 +317,7 @@ Modernizr.load([
 	}, {
 		load: "i18n!i18n/",
 		complete: function() {
-			window._timer.start();
+			wb.start();
 		}
 	}
 ]);

--- a/src/i18n/base.js
+++ b/src/i18n/base.js
@@ -5,10 +5,10 @@
 /*
 ----- @lang-en@ dictionary (il8n) ---
  */
-( function( window ) {
+( function( wb ) {
 "use strict";
 /* main index */
-var ind = {
+wb.i18nDict = {
 	"lang-code": "@lang-code@",
 	"lang-nat": "@lang-nat@",
 	"all": "@all@",
@@ -168,6 +168,4 @@ var ind = {
 	"tmpl-signin": "@tmpl-signin@"
 };
 
-window.i18nObj = ind;
-
-})( window );
+})( wb );

--- a/src/plugins/ajax-fetch/ajax-fetch.js
+++ b/src/plugins/ajax-fetch/ajax-fetch.js
@@ -4,16 +4,16 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author WET Community
  */
-(function( $, vapour ) {
+(function( $, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
-var $document = vapour.doc,
+var $document = wb.doc,
 
 	/*
 	 * @method generateSerial
@@ -62,4 +62,4 @@ $document.on( "ajax-fetch.wb", function( event ) {
 	}
 });
 
-})( jQuery, vapour );
+})( jQuery, wb );

--- a/src/plugins/cal-events/cal-events.js
+++ b/src/plugins/cal-events/cal-events.js
@@ -22,7 +22,7 @@ var selector = ".wb-cal-evt",
 
 		// Only initialize the i18nText once
 		if ( !i18nText ) {
-			i18n = window.i18n;
+			i18n = wb.i18n;
 			i18nText = {
 				monthNames: i18n( "calendar-monthNames" ),
 				calendar: i18n( "calendar" )

--- a/src/plugins/cal-events/cal-events.js
+++ b/src/plugins/cal-events/cal-events.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author WET Community
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -14,11 +14,11 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-cal-evt",
-	$document = vapour.doc,
+	$document = wb.doc,
 	i18n, i18nText,
 
 	init = function( $elm ) {
-		window._timer.remove( selector );
+		wb.remove( selector );
 
 		// Only initialize the i18nText once
 		if ( !i18nText ) {
@@ -99,8 +99,8 @@ var selector = ".wb-cal-evt",
 
 	daysBetween = function ( dateLow, dateHigh ) {
 		// Simplified conversion to date object
-		var date1 = vapour.date.convert( dateLow ),
-			date2 = vapour.date.convert( dateHigh ),
+		var date1 = wb.date.convert( dateLow ),
+			date2 = wb.date.convert( dateHigh ),
 			dstAdjust = 0,
 			oneMinute = 1000 * 60,
 			oneDay = oneMinute * 60 * 24,
@@ -168,7 +168,7 @@ var selector = ".wb-cal-evt",
 					 * Fixes IE tabbing error:
 					 * http://www.earthchronicle.com/ECv1point8/Accessibility01IEAnchoredKeyboardNavigation.aspx
 					 */
-					if ( vapour.ie ) {
+					if ( wb.ie ) {
 						event.attr( "tabindex", "-1" );
 					}
 					link = "#" + linkId;
@@ -215,7 +215,7 @@ var selector = ".wb-cal-evt",
 						date = new Date( date.setDate( date.getDate() + 1 ) );
 
 						// Add a viewfilter
-						className = "filter-" + ( date.getFullYear() ) + "-" + vapour.string.pad( date.getMonth() + 1, 2 );
+						className = "filter-" + ( date.getFullYear() ) + "-" + wb.string.pad( date.getMonth() + 1, 2 );
 						if ( !objTitle.hasClass( className ) ) {
 							objTitle.addClass( className );
 						}
@@ -236,7 +236,7 @@ var selector = ".wb-cal-evt",
 					events.list[ events.iCount ] = {"title" : title, "date" : date, "href" : link};
 
 					// Add a viewfilter
-					className = "filter-" + ( date.getFullYear() ) + "-" + vapour.string.pad( date.getMonth() + 1, 2 );
+					className = "filter-" + ( date.getFullYear() ) + "-" + wb.string.pad( date.getMonth() + 1, 2 );
 					if ( !objTitle.hasClass( className ) ) {
 						objTitle.addClass( className );
 					}
@@ -444,7 +444,7 @@ var selector = ".wb-cal-evt",
 		$( "." + calendarId + " li.calendar-display-onshow" )
 			.addClass( "wb-inv" )
 			.has( ":header[class*=filter-" + year + "-" +
-				vapour.string.pad( parseInt( month, 10 ) + 1, 2 ) + "]" )
+				wb.string.pad( parseInt( month, 10 ) + 1, 2 ) + "]" )
 			.removeClass( "wb-inv" );
 	};
 
@@ -460,7 +460,7 @@ $document.on( "timerpoke.wb", selector, function() {
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( ".wb-cal-evt" );
+wb.add( ".wb-cal-evt" );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );
 

--- a/src/plugins/calendar/calendar.js
+++ b/src/plugins/calendar/calendar.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
 /*
@@ -14,7 +14,7 @@
  * place to define variables that are common to all instances of the plugin on a
  * page.
  */
-var $document = vapour.doc,
+var $document = wb.doc,
 	i18n, i18nText,
 
 	/*
@@ -25,7 +25,7 @@ var $document = vapour.doc,
 		var calendar = document.getElementById( calendarId ),
 			$calendar = $( calendar ),
 			objCalendarId = "#cal-" + calendarId + "-cnt",
-			fromDateISO = vapour.date.fromDateISO,
+			fromDateISO = wb.date.fromDateISO,
 			$objCalendar, $calendarHeader, $oldCalendarHeader, $days, $daysList,
 			maxDateYear, maxDateMonth, minDateYear, minDateMonth;
 
@@ -98,7 +98,7 @@ var $document = vapour.doc,
 		if ( shownav ) {
 			$calendarHeader.append( createMonthNav( calendarId, year, month, mindate, maxdate, minDateYear, maxDateYear ) );
 		}
-		
+
 		$oldCalendarHeader = $objCalendar.prev( ".cal-hd" );
 		if ( $oldCalendarHeader.length === 0 ) {
 			$objCalendar.before( $calendarHeader );
@@ -144,7 +144,7 @@ var $document = vapour.doc,
 		if ( $monthNav.length === 0 ) {
 			$monthNav = $( "<div id='cal-" + calendarId + "-mnthnav'></div>" );
 		}
-		
+
 		// Create the go to form if one doesn't already exist
 		if ( $( "#" + calendarId + " .cal-goto" ).length === 0 ) {
 			$monthNav.append( createGoToForm( calendarId, year, month, minDate, maxDate ) );
@@ -170,7 +170,7 @@ var $document = vapour.doc,
 			);
 			alt = buttonSpec[ 2 ] + monthNames[ newMonth ] + " " + newYear;
 			$btn = $monthNav.find( ".cal-" + buttonClass );
-			
+
 			if ( $btn.length !== 0 ) {
 				$btn
 					.off()
@@ -208,7 +208,7 @@ var $document = vapour.doc,
 
 		// Ignore middle/right mouse buttons
 		if ( !which || which === 1 ) {
-		
+
 			if ( typeof eventData !== "undefined" ) {
 				$document.trigger( "create.wb-cal", [
 					eventData.calID,
@@ -296,7 +296,7 @@ var $document = vapour.doc,
 
 		// Update the list of available months when changing the year
 		$yearField.on( "change", {minDate: minDate, maxDate: maxDate, $monthField: $monthField}, yearChanged );
-		
+
 		// Populate initial month list
 		$yearField.trigger( "change" );
 
@@ -380,11 +380,11 @@ var $document = vapour.doc,
 		for ( week = 1; week < 7; week += 1 ) {
 			cells += "<tr>";
 			for ( day = 0; day < 7; day += 1 ) {
-				
+
 				id = "cal-" + calendarId + "-w" + week + "d" + ( day + 1 );
 				className = ( day === 0 || day === 6 ? "cal-we " : "" ) +
 					"cal-w" + week + "d" + ( day + 1 ) + " cal-index-" + ( dayCount + 1 );
-				
+
 				if ( ( week === 1 && day < firstDay ) || ( dayCount > lastDay ) ) {
 
 					// Creates empty cells | Cree les cellules vides
@@ -400,7 +400,7 @@ var $document = vapour.doc,
 						( frenchLang ? ( " </span>" + dayCount + "<span class='wb-inv'> " + textMonthNames[ month ].toLowerCase() + " " ) :
 						( " " + textMonthNames[ month ] + " </span>" + dayCount + "<span class='wb-inv'> " ) ) + year +
 						( isCurrentDate ?  textCurrentDay : "" ) + "</span></time></div></td>";
-						
+
 					if ( dayCount > lastDay ) {
 						breakAtEnd = true;
 					}
@@ -475,7 +475,7 @@ var $document = vapour.doc,
 				.trigger( "setfocus.wb" );
 		}
 	},
-	
+
 	setFocus = function( event, calendarId, year, month, minDate, maxDate, targetDate ) {
 		var time = targetDate.getTime();
 
@@ -511,7 +511,7 @@ $document.on( "keydown", ".cal-days a", function ( event ) {
 		calendarId = $container.attr( "id" ),
 		fieldId = $container.attr( "aria-controls" ),
 		which = event.which,
-		fromDateISO = vapour.date.fromDateISO,
+		fromDateISO = wb.date.fromDateISO,
 		date = fromDateISO( elm.getElementsByTagName( "time" )[ 0 ].getAttribute( "datetime" ) ),
 		currYear = date.getFullYear(),
 		currMonth = date.getMonth(),
@@ -531,7 +531,7 @@ $document.on( "keydown", ".cal-days a", function ( event ) {
 
 	minDate = fromDateISO( ( minDate ? minDate : "1800-01-01" ) );
 	maxDate = fromDateISO( ( maxDate ? maxDate : "2100-01-01" ) );
-	
+
 	if ( !event.altKey && !event.metaKey && which > 31 && which < 41 ) {
 		switch ( which ) {
 
@@ -608,4 +608,4 @@ $document.on( "setFocus.wb-cal", setFocus );
 
 $document.on( "click", ".cal-prvmnth, .cal-nxtmnth", changeMonth );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/calendar/calendar.js
+++ b/src/plugins/calendar/calendar.js
@@ -31,7 +31,7 @@ var $document = wb.doc,
 
 		// Only initialize the i18nText once
 		if ( !i18nText ) {
-			i18n = window.i18n;
+			i18n = wb.i18n;
 			i18nText = {
 				monthNames: i18n( "mnths" ),
 				prevMonth: i18n( "prvMnth" ),

--- a/src/plugins/country-content/country-content.js
+++ b/src/plugins/country-content/country-content.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @nschonni
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -14,7 +14,7 @@
  * place to define variables that are common to all instances of the plugin on a
  * page.
  */
-var $document = vapour.doc,
+var $document = wb.doc,
 	selector = "[data-country-content]",
 
 	/**
@@ -30,7 +30,7 @@ var $document = vapour.doc,
 
 		// All plugins need to remove their reference from the timer in the init
 		// sequence unless they have a requirement to be poked every 0.5 seconds
-		window._timer.remove( selector );
+		wb.remove( selector );
 
 		$.when( getCountry() ).then( function( countryCode ) {
 
@@ -97,6 +97,6 @@ $document.on( "timerpoke.wb", selector, function( event ) {
 } );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/data-ajax/data-ajax.js
+++ b/src/plugins/data-ajax/data-ajax.js
@@ -5,7 +5,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author WET Community
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -15,7 +15,7 @@
  * place to define variables that are common to all instances of the plugin on a
  * page.
  */
-var $document = vapour.doc,
+var $document = wb.doc,
 	selector = "[data-ajax-after], [data-ajax-append], [data-ajax-before], " +
 		"[data-ajax-prepend], [data-ajax-replace]",
 
@@ -33,7 +33,7 @@ var $document = vapour.doc,
 
 		// All plugins need to remove their reference from the timer in the init
 		// sequence unless they have a requirement to be poked every 0.5 seconds
-		window._timer.remove( selector );
+		wb.remove( selector );
 
 		$document.trigger({
 			type: "ajax-fetch.wb",
@@ -94,6 +94,6 @@ $document.on( "timerpoke.wb ajax-fetched.wb", selector, function( event ) {
 } );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/data-inview/data-inview.js
+++ b/src/plugins/data-inview/data-inview.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author WET Community
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -15,8 +15,8 @@
  */
 var selector = ".wb-inview",
 	$elms = $( selector ),
-	$document = vapour.doc,
-	$window = vapour.win,
+	$document = wb.doc,
+	$window = wb.win,
 
 	/*
 	 * Init runs once per plugin element on the page. There may be multiple elements.
@@ -27,7 +27,7 @@ var selector = ".wb-inview",
 	init = function( $elm ) {
 
 		// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-		window._timer.remove( selector );
+		wb.remove( selector );
 
 		$elm.trigger( "scroll.wb-inview" );
 	},
@@ -119,6 +119,6 @@ $document.on( "text-resize.wb window-resize-width.wb window-resize-height.wb", f
 
 // Add the timer poke to initialize the plugin
 
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/data-picture/data-picture.js
+++ b/src/plugins/data-picture/data-picture.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @patheard
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -14,7 +14,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = "[data-picture]",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
 	 * Init runs once per plugin element on the page. There may be multiple elements.
@@ -25,7 +25,7 @@ var selector = "[data-picture]",
 	init = function( $elm ) {
 
 		// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-		window._timer.remove( selector );
+		wb.remove( selector );
 
 		$elm.trigger( "picturefill.wb-data-picture" );
 	},
@@ -70,7 +70,7 @@ var selector = "[data-picture]",
 $document.on( "timerpoke.wb picturefill.wb-data-picture", selector, function( event ) {
 	var eventTarget = event.target,
 		eventType = event.type;
-		
+
 	// Filter out any events triggered by descendants
 	if ( event.currentTarget === eventTarget ) {
 		switch ( eventType ) {
@@ -90,6 +90,6 @@ $document.on( "text-resize.wb window-resize-width.wb window-resize-height.wb", f
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/data-picture/test.js
+++ b/src/plugins/data-picture/test.js
@@ -6,7 +6,7 @@
  */
 /* global jQuery, describe, it, expect, before, after, sinon */
 /* jshint unused:vars */
-(function( $, vapour ) {
+(function( $, wb ) {
 
 /*
  * Create a suite of related test cases using `describe`. Test suites can also be
@@ -63,17 +63,17 @@ describe( "[data-picture] test suite", function() {
 	describe( "resize events", function() {
 
 		it( "should have text-resize.wb event handler", function() {
-			vapour.doc.trigger( "text-resize.wb" );
+			wb.doc.trigger( "text-resize.wb" );
 			expect( spy.calledWith( "picturefill.wb-data-picture" ) ).to.equal( true );
 		});
 
 		it( "should have window-resize-width.wb event handler", function() {
-			vapour.doc.trigger( "window-resize-width.wb" );
+			wb.doc.trigger( "window-resize-width.wb" );
 			expect( spy.calledWith( "picturefill.wb-data-picture" ) ).to.equal( true );
 		});
 
 		it( "should have window-resize-height.wb event handler", function() {
-			vapour.doc.trigger( "window-resize-height.wb" );
+			wb.doc.trigger( "window-resize-height.wb" );
 			expect( spy.calledWith( "picturefill.wb-data-picture" ) ).to.equal( true );
 		});
 	});
@@ -107,7 +107,7 @@ describe( "[data-picture] test suite", function() {
 					"<span data-picture data-alt='foo' class='test'>" +
 					"<span data-src='bar.jpg'></span>" +
 					"</span>" );
-				$img = $img.appendTo( vapour.doc.find( "body" ) );
+				$img = $img.appendTo( wb.doc.find( "body" ) );
 
 			// Sanity check
 			expect( $img.find( "img" ) ).to.have.length( 0 );
@@ -123,7 +123,7 @@ describe( "[data-picture] test suite", function() {
 					"<span data-src='baz.jpg' data-media='screen'></span>" +
 					"<span data-src='bar.jpg' data-media='print'></span>" +
 					"</span>" );
-				$img = $img.appendTo( vapour.doc.find( "body" ) );
+				$img = $img.appendTo( wb.doc.find( "body" ) );
 
 			$img.trigger( "picturefill.wb-data-picture" );
 			expect( $img.find( "img" ) ).to.have.length( 1 );
@@ -135,7 +135,7 @@ describe( "[data-picture] test suite", function() {
 					"<span data-picture data-alt='foo' class='test'>" +
 					"<span data-src='bar.jpg' data-media='print'></span>" +
 					"</span>" );
-				$img = $img.appendTo( vapour.doc.find( "body" ) );
+				$img = $img.appendTo( wb.doc.find( "body" ) );
 
 			$img.trigger( "picturefill.wb-data-picture" );
 			expect( $img.find( "img" ) ).to.have.length( 0 );
@@ -143,7 +143,7 @@ describe( "[data-picture] test suite", function() {
 
 		it( "should not create a responsive image when no span[data-src]", function() {
 			var $img = $( "<span data-picture data-alt='foo' class='test'>" );
-				$img = $img.appendTo( vapour.doc.find( "body" ) );
+				$img = $img.appendTo( wb.doc.find( "body" ) );
 
 			$img.trigger( "picturefill.wb-data-picture" );
 			expect( $img.find( "img" ) ).to.have.length( 0 );
@@ -152,4 +152,4 @@ describe( "[data-picture] test suite", function() {
 
 });
 
-}( jQuery, vapour ));
+}( jQuery, wb ));

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @thomasgohard
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -14,7 +14,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-equalheight",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
 	 * Init runs once per plugin element on the page. There may be multiple elements.
@@ -28,7 +28,7 @@ var selector = ".wb-equalheight",
 		if ( event.currentTarget === event.target ) {
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Remove the event handler since only want init fired once per page (not per element)
 			$document.off( "timerpoke.wb", selector );
@@ -100,6 +100,6 @@ $document.on( "timerpoke.wb", selector, init );
 $document.on( "text-resize.wb window-resize-width.wb window-resize-height.wb tables-draw.wb", onResize );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/favicon/favicon.js
+++ b/src/plugins/favicon/favicon.js
@@ -17,17 +17,17 @@
  *
  *     <link href="favion.ico" rel="shortcut icon" data-rel="apple-touch-icon-precomposed" data-filename="my-mobile-favicon.ico">
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = "link[rel='shortcut icon']",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
 	 * Plugin users can override these defaults by setting attributes on the html elements that the
@@ -42,7 +42,7 @@ var selector = "link[rel='shortcut icon']",
 	},
 
 	/*
-	 * Init runs once per plugin element on the page. There may be multiple elements. 
+	 * Init runs once per plugin element on the page. There may be multiple elements.
 	 * It will run more than once per plugin if you don't remove the selector from the timer.
 	 * @method init
 	 * @param {jQuery DOM element} $favicon The plugin element being initialized
@@ -52,7 +52,7 @@ var selector = "link[rel='shortcut icon']",
 		var settings = $.extend( {}, defaults, $favicon.data() );
 
 		// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-		window._timer.remove( selector );
+		wb.remove( selector );
 
 		$favicon.trigger( "mobile.wb-favicon", settings );
 	},
@@ -111,7 +111,7 @@ var selector = "link[rel='shortcut icon']",
 // Bind the plugin events
 $document.on( "timerpoke.wb mobile.wb-favicon icon.wb-favicon", selector, function( event, data ) {
 	var eventTarget = event.target;
-	
+
 	// Filter out any events triggered by descendants
 	if ( event.currentTarget === eventTarget ) {
 		switch ( event.type ) {
@@ -128,13 +128,13 @@ $document.on( "timerpoke.wb mobile.wb-favicon icon.wb-favicon", selector, functi
 	}
 
 	/*
-	 * Since we are working with events we want to ensure that we are being passive about our control, 
+	 * Since we are working with events we want to ensure that we are being passive about our control,
 	 * so returning true allows for events to always continue
 	 */
 	return true;
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/favicon/test.js
+++ b/src/plugins/favicon/test.js
@@ -7,7 +7,7 @@
  */
 /* global jQuery, describe, it, expect, before, after, sinon */
 /* jshint unused:vars */
-(function( $, vapour ) {
+(function( $, wb ) {
 
 /*
  * Create a suite of related test cases using `describe`. Test suites can also be
@@ -25,7 +25,7 @@ describe( "Favicon test suite", function() {
 		// Spy on jQuery's trigger methods
 		spies.trigger = sinon.spy( $.prototype, "trigger" );
 
-		vapour.doc.on( "mobile.wb-favicon", "link[rel='shortcut icon']", function() {
+		wb.doc.on( "mobile.wb-favicon", "link[rel='shortcut icon']", function() {
 			done();
 		});
 	});
@@ -103,7 +103,7 @@ describe( "Favicon test suite", function() {
 		before(function( done ) {
 			$( ".wb-favicon" ).remove();
 
-			vapour.doc.on( "mobile.wb-favicon", "link[rel='shortcut icon']", function() {
+			wb.doc.on( "mobile.wb-favicon", "link[rel='shortcut icon']", function() {
 				$faviconMobile = $( ".wb-favicon" );
 				done();
 			});
@@ -161,4 +161,4 @@ describe( "Favicon test suite", function() {
 	});
 });
 
-}( jQuery, vapour ));
+}( jQuery, wb ));

--- a/src/plugins/feedback/feedback.js
+++ b/src/plugins/feedback/feedback.js
@@ -4,21 +4,21 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-fdbck",
-	$document = vapour.doc,
+	$document = wb.doc,
 	fbrsn, fbaxs, fbcntc1, fbcntc2, $fbweb, $fbmob, $fbcomp, $fbinfo,
 
 	/*
-	 * Init runs once per plugin element on the page. There may be multiple elements. 
+	 * Init runs once per plugin element on the page. There may be multiple elements.
 	 * It will run more than once per plugin if you don't remove the selector from the timer.
 	 * @method init
 	 * @param {jQuery Event} event Event that triggered this handler
@@ -32,7 +32,7 @@ var selector = ".wb-fdbck",
 		if ( event.currentTarget === eventTarget ) {
 			$elm = $( eventTarget );
 			$fbrsn = $elm.find( "#fbrsn" );
-			urlParams = vapour.pageUrlParts.params;
+			urlParams = wb.pageUrlParts.params;
 
 			// Cache the form areas
 			fbrsn = $fbrsn[ 0 ];
@@ -43,9 +43,9 @@ var selector = ".wb-fdbck",
 			$fbmob = $fbweb.find( "#fbmob" );
 			$fbcomp = $fbweb.find( "#fbcomp" );
 			$fbinfo = $elm.find( "#fbinfo" );
-				
+
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Set the initial value for the fbrsn field based on the query string
 			if ( !urlParams.submit && urlParams.fbrsn ) {
@@ -55,7 +55,7 @@ var selector = ".wb-fdbck",
 			// Set aria-controls
 			fbrsn.setAttribute( "aria-controls", "fbweb" );
 			fbaxs.setAttribute( "aria-controls", "fbmob fbcomp" );
-		
+
 			// Set the initial show/hide state of the form
 			showHide( fbrsn );
 			showHide( fbaxs );
@@ -102,7 +102,7 @@ var selector = ".wb-fdbck",
 			}
 			break;
 		}
-				
+
 		// Element to show
 		if ( $show ) {
 			// TODO: Use CSS transitions instead
@@ -143,6 +143,6 @@ $document.on( "click", selector + " input[type=reset]", function( event ) {
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -4,20 +4,20 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-feeds",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
-	 * Init runs once per plugin element on the page. There may be multiple elements. 
+	 * Init runs once per plugin element on the page. There may be multiple elements.
 	 * It will run more than once per plugin if you don't remove the selector from the timer.
 	 * @method init
 	 * @param {jQuery Event} event Event that triggered this handler
@@ -28,7 +28,7 @@ var selector = ".wb-feeds",
 		if ( event.currentTarget === event.target ) {
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			var elm = event.target,
 				$content = $( elm ).find( ".feeds-cont" ),
@@ -87,7 +87,7 @@ var selector = ".wb-feeds",
 		}
 		return Number( count[ 0 ].replace( /limit-/i, "" ) );
 	},
-	
+
 	/*
 	 * Builds the URL for the JSON request
 	 * @method jsonRequest
@@ -97,7 +97,7 @@ var selector = ".wb-feeds",
 	 */
 	jsonRequest = function( url, limit ) {
 		var requestURL = "http://ajax.googleapis.com/ajax/services/feed/load?v=1.0&callback=?&q=" + encodeURIComponent( decodeURIComponent( url ) );
-		
+
 		// API returns a maximum of 4 entries by default so only override if more entries should be returned
 		if ( limit > 4 ) {
 			requestURL += "&num=" + limit;
@@ -116,10 +116,10 @@ var selector = ".wb-feeds",
 	parseEntries = function( entries, limit, $elm ) {
 		var cap = ( limit > 0 && limit < entries.length ? limit : entries.length ),
 			result = "",
-			toDateISO = vapour.date.toDateISO,
-			compare = vapour.date.compare,
+			toDateISO = wb.date.toDateISO,
+			compare = wb.date.compare,
 			i, sorted, sortedEntry;
-		
+
 		sorted = entries.sort( function( a, b ) {
 			return compare( b.publishedDate, a.publishedDate );
 		});
@@ -136,6 +136,6 @@ var selector = ".wb-feeds",
 $document.on( "timerpoke.wb", selector, init );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/focus/focus.js
+++ b/src/plugins/focus/focus.js
@@ -4,11 +4,11 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, vapour ) {
+(function( $, wb ) {
 "use strict";
 
-var $document = vapour.doc,
-	hash = vapour.pageUrlParts.hash,
+var $document = wb.doc,
+	hash = wb.pageUrlParts.hash,
 	clickEvents = "click.wb-focus vclick.wb-focus",
 	linkSelector = "a[href]",
 	$linkTarget;
@@ -34,7 +34,7 @@ $document.on( "setfocus.wb", function ( event ) {
 if ( hash && ( $linkTarget = $( hash ) ).length !== 0 ) {
 	$linkTarget.trigger( "setfocus.wb" );
 }
-	
+
 // Helper for browsers that can't change keyboard and/or event focus on a same page link click
 $document.on( clickEvents, linkSelector, function( event ) {
 	var testHref = event.currentTarget.getAttribute( "href" );
@@ -45,4 +45,4 @@ $document.on( clickEvents, linkSelector, function( event ) {
 	}
 });
 
-})( jQuery, vapour );
+})( jQuery, wb );

--- a/src/plugins/footnotes/footnotes.js
+++ b/src/plugins/footnotes/footnotes.js
@@ -4,20 +4,20 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @EricDunsworth
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-fnote",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
-	 * Init runs once per plugin element on the page. There may be multiple elements. 
+	 * Init runs once per plugin element on the page. There may be multiple elements.
 	 * It will run more than once per plugin if you don't remove the selector from the timer.
 	 * @method init
 	 * @param {jQuery Event} event Event that triggered this handler
@@ -31,9 +31,9 @@ var selector = ".wb-fnote",
 			$elm = $( elm );
 			footnoteDd = elm.getElementsByTagName( "dd" );
 			footnoteDt = elm.getElementsByTagName( "dt" );
-		
+
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Apply aria-labelledby and set initial event handlers for return to referrer links
 			len = footnoteDd.length;
@@ -62,9 +62,9 @@ $document.on( "click vclick", "main :not(" + selector + ") sup a.fn-lnk", functi
 
 	// Ignore middle/right mouse button
 	if ( !which || which === 1 ) {
-		refId = "#" + vapour.jqEscape( eventTarget.getAttribute( "href" ).substring( 1 ) );
+		refId = "#" + wb.jqEscape( eventTarget.getAttribute( "href" ).substring( 1 ) );
 		$refLinkDest = $document.find( refId );
-	
+
 		$refLinkDest.find( "p.fn-rtn a" )
 					.attr( "href", "#" + eventTarget.parentNode.id );
 
@@ -81,7 +81,7 @@ $document.on( "click vclick", selector + " dd p.fn-rtn a", function( event ) {
 
 	// Ignore middle/right mouse button
 	if ( !which || which === 1 ) {
-		refId = "#" + vapour.jqEscape( event.target.getAttribute( "href" ).substring( 1 ) );
+		refId = "#" + wb.jqEscape( event.target.getAttribute( "href" ).substring( 1 ) );
 
 		// Assign focus to the link
 		$document.find( refId + " a" ).trigger( "setfocus.wb" );
@@ -90,6 +90,6 @@ $document.on( "click vclick", selector + " dd p.fn-rtn a", function( event ) {
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
 /*
@@ -14,7 +14,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-formvalid",
-	$document = vapour.doc,
+	$document = wb.doc,
 	i18n, i18nText,
 
 	/*
@@ -31,11 +31,11 @@ var selector = ".wb-formvalid",
 		if ( event.currentTarget === eventTarget ) {
 
 			// read the selector node for parameters
-			modeJS = vapour.getMode() + ".js";
+			modeJS = wb.getMode() + ".js";
 			$elm = $( eventTarget );
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
@@ -87,7 +87,7 @@ var selector = ".wb-formvalid",
 
 					// Change form attributes and values that interfere with validation in IE7/8
 					// TODO: Need better way of dealing with this rather than browser sniffing
-					if ( vapour.ieVersion > 0 && vapour.ieVersion < 9 ) {
+					if ( wb.ieVersion > 0 && wb.ieVersion < 9 ) {
 						len = $required.length;
 						$required.removeAttr( "required" );
 						for ( i = 0; i !== len; i += 1) {
@@ -285,6 +285,6 @@ $document.on( "click vclick", selector + " .errCnt a", function( event ) {
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -39,7 +39,7 @@ var selector = ".wb-formvalid",
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
-				i18n = window.i18n;
+				i18n = wb.i18n;
 				i18nText = {
 					colon: i18n( "colon" ),
 					hyphen: i18n( "hyphen" ),

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
 /*
@@ -14,7 +14,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-lightbox",
-	$document = vapour.doc,
+	$document = wb.doc,
 	i18n, i18nText,
 	extendedGlobal = false,
 
@@ -32,11 +32,11 @@ var selector = ".wb-lightbox",
 		if ( event.currentTarget === elm ) {
 
 			// read the selector node for parameters
-			modeJS = vapour.getMode() + ".js";
+			modeJS = wb.getMode() + ".js";
 			$elm = $( elm );
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
@@ -158,17 +158,17 @@ var selector = ".wb-lightbox",
 					} else {
 						settings.type = "image";
 					}
-					
+
 					if ( elm.className.indexOf( "lb-modal" ) !== -1 ) {
 						settings.modal = true;
 					}
 
-					// Extend the settings with data-wet-boew then 
+					// Extend the settings with data-wet-boew then
 					$elm.magnificPopup(
 						$.extend(
 							true,
 							settings,
-							vapour.getData( $elm, "wet-boew" )
+							wb.getData( $elm, "wet-boew" )
 						)
 					);
 				}
@@ -211,6 +211,6 @@ $(document).on( "click", ".popup-modal-dismiss", function ( event ) {
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -40,7 +40,7 @@ var selector = ".wb-lightbox",
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
-				i18n = window.i18n;
+				i18n = wb.i18n;
 				i18nText = {
 					tClose: i18n( "overlay-close" ) + i18n( "space" ) + i18n( "esc-key" ),
 					tLoading: i18n( "load" ),

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -5,7 +5,7 @@
  * @author WET community
  */
 
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
 /*
@@ -15,7 +15,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-menu",
-	$document = vapour.doc,
+	$document = wb.doc,
 	breadcrumb = document.getElementById( "wb-bc" ),
 
 	// Used for half second delay on showing/hiding menus because of mouse hover
@@ -47,7 +47,7 @@ var selector = ".wb-menu",
 
 		// All plugins need to remove their reference from the timer in the init
 		// sequence unless they have a requirement to be poked every 0.5 seconds
-		window._timer.remove( selector );
+		wb.remove( selector );
 
 		// Ensure the container has an id attribute
 		if ( !$elm.attr( "id" ) ) {
@@ -538,6 +538,6 @@ $document.on( "keydown", selector + " [role=menu]", function( event ) {
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/modal/modal.js
+++ b/src/plugins/modal/modal.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @patheard
  */
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
 /*
@@ -14,7 +14,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-modal",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
 	 * Plugin users can override these defaults by setting attributes on the html elements that the
@@ -39,11 +39,11 @@ var selector = ".wb-modal",
 		if ( event.currentTarget === event.target ) {
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Load the magnific popup dependency
 			Modernizr.load({
-				load: "site!deps/jquery.magnific-popup" + vapour.getMode() + ".js",
+				load: "site!deps/jquery.magnific-popup" + wb.getMode() + ".js",
 				complete: function() {
 					$document.trigger( "ready.wb-modal" );
 				}
@@ -141,6 +141,6 @@ $document
 	});
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -5,11 +5,11 @@
  * @author WET Community
  */
 /* globals YT */
-(function( $, window, vapour, undef ) {
+(function( $, window, wb, undef ) {
 "use strict";
 
 /* Local scoped variables*/
-var $document = vapour.doc,
+var $document = wb.doc,
 	selector = ".wb-mltmd",
 	seed = 0,
 	templatetriggered = false,
@@ -401,7 +401,7 @@ youTubeEvents = function ( event ) {
 
 
 $document.on( "timerpoke.wb", selector, function() {
-	window._timer.remove( selector );
+	wb.remove( selector );
 
 	// Only initialize the i18nText once
 	if ( !i18nText ) {
@@ -426,7 +426,7 @@ $document.on( "timerpoke.wb", selector, function() {
 		$document.trigger({
 			type: "ajax-fetch.wb",
 			element: $( selector ),
-			fetch: vapour.getPath( "/assets" ) + "/mediacontrols.html"
+			fetch: wb.getPath( "/assets" ) + "/mediacontrols.html"
 		});
 	}
 });
@@ -470,7 +470,7 @@ $document.on( "init.multimedia.wb", selector, function() {
 
 	if ( $media.find( "[type='video/youtube']" ).length > 0 ){
 		// lets tweak some variables and start the load sequence
-		url = vapour.getUrlParts( $this.find( "[type='video/youtube']").attr( "src") );
+		url = wb.getUrlParts( $this.find( "[type='video/youtube']").attr( "src") );
 
 		// lets set the flag for the call back
 		$this.data( "youtube", url.params.v );
@@ -513,17 +513,17 @@ $document.on( "fallback.multimedia.wb", selector, function() {
 
 
 	$data.flashvars = "id=" + $data.mId;
-	$playerresource = vapour.getPath( "/assets" ) + "/multimedia.swf?" + $data.flashvars;
+	$playerresource = wb.getPath( "/assets" ) + "/multimedia.swf?" + $data.flashvars;
 	$data.poster = "";
 	if ( $data.type === "video" ) {
 		$data.poster = "<img src='" + $poster + " class='img-responsive' height='" +
 			$data.height + "' width='" + $data.width + "' alt='" + $media.attr( "title" ) + "'/>";
 		$data.flashvars += "&height=" + $media.height() + "&width=" +
 			$media.width() + "&posterimg=" +
-			encodeURI( vapour.getUrlParts( $poster ).absolute ) + "&media=" +
-			encodeURI( vapour.getUrlParts( $source.filter( "[type='video/mp4']" ).attr( "src" ) ).absolute );
+			encodeURI( wb.getUrlParts( $poster ).absolute ) + "&media=" +
+			encodeURI( wb.getUrlParts( $source.filter( "[type='video/mp4']" ).attr( "src" ) ).absolute );
 	} else {
-		$data.flashvars += "&media=" + encodeURI( vapour.getUrlParts( $source.filter( "[type='audio/mp3']" ).attr( "src" ) ).absolute );
+		$data.flashvars += "&media=" + encodeURI( wb.getUrlParts( $source.filter( "[type='audio/mp3']" ).attr( "src" ) ).absolute );
 	}
 	$this.find( "video, audio" ).replaceWith( "<object id='" + $data.mId + "' width='" + $data.width +
 		"' height='" + $data.height + "' class='" + $data.type +
@@ -557,7 +557,7 @@ $document.on( "youtube.multimedia.wb", selector, function() {
 		playerVars: {
 			autoplay: 0,
 			controls: 0,
-			origin: vapour.pageUrlParts.host,
+			origin: wb.pageUrlParts.host,
 			modestbranding: 1,
 			rel: 0,
 			showinfo: 0
@@ -616,8 +616,8 @@ $document.on( "renderui.multimedia.wb", selector, function( event, type ) {
 		$this = ref[ 0 ],
 		$data = ref[ 1 ],
 		$player,
-		captionsUrl = vapour.getUrlParts( $data.captions ),
-		currentUrl = vapour.getUrlParts( window.location.href ),
+		captionsUrl = wb.getUrlParts( $data.captions ),
+		currentUrl = wb.getUrlParts( window.location.href ),
 		media = $this.find( "video, audio, iframe, object" );
 
 	media.after( window.tmpl( $this.data( "template" ), $data ) );
@@ -858,6 +858,6 @@ $document.on( "durationchange play pause ended volumechange timeupdate captionsl
 	}
 });
 
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -405,7 +405,7 @@ $document.on( "timerpoke.wb", selector, function() {
 
 	// Only initialize the i18nText once
 	if ( !i18nText ) {
-		i18n = window.i18n;
+		i18n = wb.i18n;
 		i18nText = {
 			rewind: i18n( "rew" ),
 			ff: i18n( "ffwd" ),

--- a/src/plugins/navcurrent/navcurrent.js
+++ b/src/plugins/navcurrent/navcurrent.js
@@ -4,22 +4,22 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
-var $document = vapour.doc,
+var $document = wb.doc,
 	breadcrumbLinksArray, breadcrumbLinksUrlArray,
 	navClass = "wb-navcurr",
 
 	/*
 	 * We start the logic for what the plugin truly does
-	 * For demonstration purposes lets display some text with an alert 
+	 * For demonstration purposes lets display some text with an alert
 	 * @method otherEvent
 	 * @param {jQuery Event} event The event that triggered this method call
 	 * @param {jQuery DOM element | DOM element} breadcrumb Optional breadcrumb element
@@ -76,7 +76,7 @@ var $document = vapour.doc,
 						localBreadcrumbLinksUrlArray.push( link.hostname + link.pathname.replace( /^([^\/])/, "/$1" ) );
 					}
 				}
-				
+
 				// Cache the data in case of more than one execution (e.g., site menu + secondary navigation)
 				breadcrumbLinksArray = localBreadcrumbLinksArray;
 				breadcrumbLinksUrlArray = localBreadcrumbLinksUrlArray;
@@ -86,7 +86,7 @@ var $document = vapour.doc,
 				localBreadcrumbLinksArray = breadcrumbLinksArray;
 				localBreadcrumbLinksUrlArray = breadcrumbLinksUrlArray;
 			}
-		
+
 			// Try to match each breadcrumb link
 			len = menuLinksArray.length;
 			for ( j = localBreadcrumbLinksArray.length - 1; j !== -1; j -= 1 ) {
@@ -121,4 +121,4 @@ var $document = vapour.doc,
 // Bind the navcurrent event of the plugin
 $document.on( "navcurrent.wb", navCurrent );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/overlay/demo/overlay.js
+++ b/src/plugins/overlay/demo/overlay.js
@@ -3,13 +3,13 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 /*jshint unused: false*/
-(function( $, vapour ) {
+(function( $, wb ) {
 "use strict";
 
-vapour.doc.on( "click vclick", ".modal-close", function( event ) {
+wb.doc.on( "click vclick", ".modal-close", function( event ) {
 	$( event.currentTarget )
 			.closest( ".wb-overlay" )
 				.trigger( "close.wb-overlay" );
 });
 
-})( jQuery, vapour );
+})( jQuery, wb );

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -39,7 +39,7 @@ var selector = ".wb-overlay",
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
-				i18n = window.i18n;
+				i18n = wb.i18n;
 				i18nText = {
 					close: i18n( "overlay-close" ) + i18n( "space" ) + i18n( "esc-key" )
 				};

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -4,11 +4,11 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @thomasgohard, @pjackson28
  */
-(function ( $, window, document, vapour ) {
+(function ( $, window, document, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
@@ -18,7 +18,7 @@ var selector = ".wb-overlay",
 	linkClass = "overlay-lnk",
 	ignoreOutsideClass = "outside-off",
 	sourceLinks = {},
-	$document = vapour.doc,
+	$document = wb.doc,
 	i18n, i18nText,
 
 	/*
@@ -35,7 +35,7 @@ var selector = ".wb-overlay",
 		if ( event.currentTarget === event.target ) {
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
@@ -199,6 +199,6 @@ $document.on( "click vclick touchstart focusin", "body", function ( event ) {
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/prettify/prettify-en.hbs
+++ b/src/plugins/prettify/prettify-en.hbs
@@ -116,11 +116,11 @@ div#gcwu-headlines ul li,div#gcwu-headlines ul{
 init = function() {
 	var cssClass, cssClasses, i, len, $pre,
 		$elm = $( this ),
-		modeJS = vapour.getMode() + ".js",
+		modeJS = wb.getMode() + ".js",
 		deps = [ "site!deps/prettify" + modeJS ],
 		settings = $.extend( {}, defaults, $elm.data() );
 
-	window._timer.remove( selector );
+	wb.remove( selector );
 
 	// Check the element for `lang-*` syntax CSS classes
 	cssClasses = typeof $elm[0].className === "string" ? $elm[0].className.split( " " ) : [];
@@ -150,7 +150,7 @@ init = function() {
 	Modernizr.load({
 		load: deps,
 		complete: function() {
-			vapour.doc.trigger( "prettyprint.wb-prettify" );
+			wb.doc.trigger( "prettyprint.wb-prettify" );
 		}
 	});
 }</code></pre>

--- a/src/plugins/prettify/prettify-fr.hbs
+++ b/src/plugins/prettify/prettify-fr.hbs
@@ -116,11 +116,11 @@ div#gcwu-headlines ul li,div#gcwu-headlines ul{
 init = function() {
 	var cssClass, cssClasses, i, len, $pre,
 		$elm = $( this ),
-		modeJS = vapour.getMode() + ".js",
+		modeJS = wb.getMode() + ".js",
 		deps = [ "site!deps/prettify" + modeJS ],
 		settings = $.extend( {}, defaults, $elm.data() );
 
-	window._timer.remove( selector );
+	wb.remove( selector );
 
 	// Check the element for `lang-*` syntax CSS classes
 	cssClasses = typeof $elm[0].className === "string" ? $elm[0].className.split( " " ) : [];
@@ -150,7 +150,7 @@ init = function() {
 	Modernizr.load({
 		load: deps,
 		complete: function() {
-			vapour.doc.trigger( "prettyprint.wb-prettify" );
+			wb.doc.trigger( "prettyprint.wb-prettify" );
 		}
 	});
 }</code></pre>

--- a/src/plugins/prettify/prettify.js
+++ b/src/plugins/prettify/prettify.js
@@ -30,7 +30,7 @@
  *    - lang-xq
  *    - lang-yaml
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -40,7 +40,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-prettify",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
 	 * Plugin users can override these defaults by setting attributes on the html elements that the
@@ -59,7 +59,7 @@ var selector = ".wb-prettify",
 	 */
 	init = function( event ) {
 		var elm = event.target,
-			modeJS = vapour.getMode() + ".js",
+			modeJS = wb.getMode() + ".js",
 			deps = [ "site!deps/prettify" + modeJS ],
 			$elm, classes, settings, i, len, $pre;
 
@@ -67,12 +67,12 @@ var selector = ".wb-prettify",
 		if ( event.currentTarget === elm ) {
 			$elm = $( elm );
 			classes = elm.className.split( " " );
-	
+
 			// Merge default settings with overrides from the selected plugin element. There may be more than one, so don't override defaults globally!
 			settings = $.extend( {}, defaults, $elm.data() );
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Check the element for `lang-*` syntax CSS classes
 			for ( i = 0, len = classes.length; i !== len; i += 1 ) {
@@ -122,6 +122,6 @@ $document
 	.on( "prettyprint.wb-prettify", prettyprint );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/prettify/test.js
+++ b/src/plugins/prettify/test.js
@@ -6,7 +6,7 @@
  */
 /* global jQuery, describe, it, expect, before, after, sinon */
 /* jshint unused:vars */
-(function( $, vapour ) {
+(function( $, wb ) {
 
 /*
  * Create a suite of related test cases using `describe`. Test suites can also be
@@ -25,7 +25,7 @@ describe( "Prettify test suite", function() {
 
 		// Start the tests once the plugin has been initialized
 		$( ".wb-prettify" ).removeClass( "all-pre" );
-		vapour.doc.on( "prettyprint.wb-prettify", function() {
+		wb.doc.on( "prettyprint.wb-prettify", function() {
 			done();
 		});
 	});
@@ -107,7 +107,7 @@ describe( "Prettify test suite", function() {
 				.addClass("all-pre")
 				.addClass("linenums")
 				.trigger("timerpoke.wb");
-			vapour.doc.on( "prettyprint.wb-prettify", function() {
+			wb.doc.on( "prettyprint.wb-prettify", function() {
 				done();
 			});
 		});
@@ -143,7 +143,7 @@ describe( "Prettify test suite", function() {
 					"linenums": true
 				})
 				.trigger("timerpoke.wb");
-			vapour.doc.on( "prettyprint.wb-prettify", function() {
+			wb.doc.on( "prettyprint.wb-prettify", function() {
 				done();
 			});
 		});
@@ -162,4 +162,4 @@ describe( "Prettify test suite", function() {
 	});
 });
 
-}( jQuery, vapour ));
+}( jQuery, wb ));

--- a/src/plugins/resize/resize.js
+++ b/src/plugins/resize/resize.js
@@ -4,19 +4,19 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
 var id = "wb-resize",
 	selector = "#" + id,
-	$window = vapour.win,
-	$document = vapour.doc,
+	$window = wb.win,
+	$document = wb.doc,
 	sizes = [],
 	events = [
 		"text-resize.wb",
@@ -83,7 +83,7 @@ var id = "wb-resize",
 		if ( viewName !== currentView ) {
 
 			// Change the breakpoint class on the html element
-			vapour.html
+			wb.html
 				.removeClass( currentView )
 				.addClass( viewName );
 
@@ -124,7 +124,7 @@ var id = "wb-resize",
 			return;
 		}
 	};
-	
+
 // Re-test on each timerpoke
 $document.on( "timerpoke.wb", selector, test );
 
@@ -132,6 +132,6 @@ $document.on( "timerpoke.wb", selector, test );
 init();
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @patheard
  */
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
 /*
@@ -14,7 +14,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-session-timeout",
-	$document = vapour.doc,
+	$document = wb.doc,
 	i18n, i18nText,
 
 	/*
@@ -41,7 +41,7 @@ var selector = ".wb-session-timeout",
 	init = function( event ) {
 		var elm = event.target,
 			$elm, settings;
-	
+
 		// Filter out any events triggered by descendants
 		if ( event.currentTarget === elm ) {
 			$elm = $( elm );
@@ -50,7 +50,7 @@ var selector = ".wb-session-timeout",
 			settings = $.extend( {}, defaults, $elm.data( "wet-boew" ) );
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
@@ -406,6 +406,6 @@ $document.on( "timerpoke.wb keepalive.wb-session-timeout inactivity.wb-session-t
 $document.on( "click", ".wb-session-timeout-confirm", confirm );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -54,7 +54,7 @@ var selector = ".wb-session-timeout",
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
-				i18n = window.i18n;
+				i18n = wb.i18n;
 				i18nText = {
 					buttonContinue: i18n( "st-btn-cont" ),
 					buttonEnd: i18n( "st-btn-end" ),

--- a/src/plugins/session-timeout/test.js
+++ b/src/plugins/session-timeout/test.js
@@ -7,7 +7,7 @@
  */
 /* global jQuery, describe, it, expect, before, after, sinon */
 /* jshint unused:vars */
-(function( $, vapour ) {
+(function( $, wb ) {
 
 /*
  * Create a suite of related test cases using `describe`. Test suites can also be
@@ -46,7 +46,7 @@ describe( "Session Timeout test suite", function() {
 				done();
 			});
 
-		vapour.doc.on( "show.wb-modal", function() {
+		wb.doc.on( "show.wb-modal", function() {
 			$( ".wb-session-timeout-confirm.btn-primary" ).trigger( "click" );
 		});
 	});
@@ -144,7 +144,7 @@ describe( "Session Timeout test suite", function() {
 
 		it( "should trigger keepalive.wb-session-timeout on document click", function() {
 			clock.tick( 42010 );
-			vapour.doc.trigger( "click" );
+			wb.doc.trigger( "click" );
 			expect( spies.trigger.calledWith( "keepalive.wb-session-timeout" ) ).to.equal( true );
 		});
 
@@ -159,7 +159,7 @@ describe( "Session Timeout test suite", function() {
 		it( "should not trigger keepalive.wb-session-timeout on document click (refresh limit prevents)", function() {
 			spies.trigger.reset();
 
-			vapour.doc.trigger( "click" );
+			wb.doc.trigger( "click" );
 			expect( spies.trigger.calledWith( "keepalive.wb-session-timeout" ) ).to.equal( false );
 		});
 
@@ -167,7 +167,7 @@ describe( "Session Timeout test suite", function() {
 			spies.trigger.reset();
 			clock.tick( 42010 );
 
-			vapour.doc.trigger( "click" );
+			wb.doc.trigger( "click" );
 			expect( spies.trigger.calledWith( "keepalive.wb-session-timeout" ) ).to.equal( true );
 		});
 	});
@@ -210,4 +210,4 @@ describe( "Session Timeout test suite", function() {
 
 });
 
-}( jQuery, vapour ));
+}( jQuery, wb ));

--- a/src/plugins/share/share.js
+++ b/src/plugins/share/share.js
@@ -137,7 +137,7 @@ var selector = ".wb-share",
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
-				i18n = window.i18n;
+				i18n = wb.i18n;
 				i18nText = {
 					shareText: i18n( "shr-txt" ),
 					disclaimer: i18n( "shr-disc" )

--- a/src/plugins/share/share.js
+++ b/src/plugins/share/share.js
@@ -4,18 +4,18 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-share",
 	shareLink = "shr-lnk",
-	$document = vapour.doc,
+	$document = wb.doc,
 	i18n, i18nText,
 
 	/*
@@ -109,7 +109,7 @@ var selector = ".wb-share",
 	},
 
 	/*
-	* Init runs once per plugin element on the page. There may be multiple elements. 
+	* Init runs once per plugin element on the page. There may be multiple elements.
 	* It will run more than once per plugin if you don't remove the selector from the timer.
 	* @method init
 	* @param {jQuery Event} event `timerpoke.wb` event that triggered the function call
@@ -122,10 +122,10 @@ var selector = ".wb-share",
 		// Filter out any events triggered by descendants
 		if ( event.currentTarget === elm ) {
 			$elm = $( elm );
-			settings = $.extend( true, defaults, vapour.getData( $elm, "wet-boew" ) );
+			settings = $.extend( true, defaults, wb.getData( $elm, "wet-boew" ) );
 			sites = settings.sites;
 			heading = settings.heading;
-			pageHref = vapour.pageUrlParts.href;
+			pageHref = wb.pageUrlParts.href;
 			pageTitle = encodeURIComponent( document.title || $document.find( "h1:first" ).text() );
 
 			// Placeholders until source(s) can be determined and implemented
@@ -133,7 +133,7 @@ var selector = ".wb-share",
 			pageDescription = encodeURIComponent( "" );
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
@@ -145,7 +145,7 @@ var selector = ".wb-share",
 			}
 
 			panel = "<section id='shr-pg' class='shr-pg wb-overlay modal-content overlay-def wb-panel-" +
-				( vapour.html.attr( "dir" ) === "rtl" ? "l" : "r" ) +
+				( wb.html.attr( "dir" ) === "rtl" ? "l" : "r" ) +
 				"'><header class='modal-header'><" + heading + " class='modal-title'>" +
 				i18nText.shareText + "</" + heading + "></header><ul class='colcount-xs-2'>";
 
@@ -162,7 +162,7 @@ var selector = ".wb-share",
 			panel += "</ul><div class='clearfix'></div><p class='col-sm-12'>" + i18nText.disclaimer + "</p></section>";
 			link = "<a href='#shr-pg' aria-controls='shr-pg' class='shr-opn overlay-lnk'><span class='glyphicon glyphicon-share'></span> " +
 				i18nText.shareText + "</a>";
-			
+
 			$share = $( panel + link );
 
 			$elm.append( $share );
@@ -186,6 +186,6 @@ $document.on( "click vclick", "." + shareLink, function( event) {
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -36,7 +36,7 @@ var selector = ".wb-tables",
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
-				i18n = window.i18n;
+				i18n = wb.i18n;
 				i18nText = {
 					oAria: {
 						sSortAscending: i18n( "sortAsc" ),

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @jeresiv
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -14,7 +14,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-tables",
-	$document = vapour.doc,
+	$document = wb.doc,
 	i18n, i18nText, defaults,
 
 	/*
@@ -32,7 +32,7 @@ var selector = ".wb-tables",
 			$elm = $( elm );
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
@@ -76,9 +76,9 @@ var selector = ".wb-tables",
 
 
 			Modernizr.load([{
-				load: [ "site!deps/jquery.dataTables" + vapour.getMode() + ".js" ],
+				load: [ "site!deps/jquery.dataTables" + wb.getMode() + ".js" ],
 				complete: function() {
-					$elm.dataTable( $.extend( true, defaults, vapour.getData( $elm, "wet-boew" ) ) );
+					$elm.dataTable( $.extend( true, defaults, wb.getData( $elm, "wet-boew" ) ) );
 				}
 			}]);
 		}
@@ -88,6 +88,6 @@ var selector = ".wb-tables",
 $document.on( "timerpoke.wb", selector, init );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/tabs/tabs.js
+++ b/src/plugins/tabs/tabs.js
@@ -129,7 +129,7 @@
 
 		// Only initialize the i18nText once
 		if ( !i18nText ) {
-			i18n = window.i18n;
+			i18n = wb.i18n;
 			i18nText = {
 				prev: i18n( "prv" ),
 				next: i18n( "nxt" ),

--- a/src/plugins/tabs/tabs.js
+++ b/src/plugins/tabs/tabs.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author WET Community
  */
- (function( $, window, vapour ) {
+ (function( $, window, wb ) {
  "use strict";
 
  /*
@@ -14,7 +14,7 @@
   * variables that are common to all instances of the plugin on a page.
   */
  var selector = ".wb-tabs",
-	$document = vapour.doc,
+	$document = wb.doc,
 	i18n, i18nText,
 	controls = selector + " [role=tablist] a",
 
@@ -97,7 +97,7 @@
 		for ( ; tabCounter !== -1; tabCounter -= 1 ) {
 			item = tabs[ tabCounter ];
 			isActive = item.className.indexOf( "in" ) !== -1;
-			
+
 			item.tabIndex = isActive ? "0" : "-1";
 			item.setAttribute( "aria-hidden", isActive ? "false" : "true" );
 			item.setAttribute( "aria-expanded", isActive ? "true" : "false" );
@@ -312,7 +312,7 @@
 		$sldr = $elm
 			.parents( ".wb-tabs" )
 			.attr( "data-ctime", 0 );
-			
+
 		// Spacebar
 		if ( which > 36 ) {
 			onCycle( $elm, which < 39 ? -1 : 1 );
@@ -327,7 +327,7 @@
 
 				text = elm.getElementsByTagName( "i" )[ 0 ];
 				text.innerHTML = text.innerHTML === playText ? i18nText.pause : playText;
-				
+
 				inv = $elm.find( ".wb-inv" )[ 0 ];
 				inv.innerHTML = inv.innerHTML === rotStopText ? i18nText.rotStart : rotStopText;
 			} else {
@@ -344,6 +344,6 @@
  });
 
  // Add the timer poke to initialize the plugin
- window._timer.add( ".wb-tabs" );
+ wb.add( ".wb-tabs" );
 
- })( jQuery, window, vapour );
+ })( jQuery, window, wb );

--- a/src/plugins/texthighlight/texthighlight.js
+++ b/src/plugins/texthighlight/texthighlight.js
@@ -4,20 +4,20 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-texthighlight",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
-	 * Init runs once per plugin element on the page. There may be multiple elements. 
+	 * Init runs once per plugin element on the page. There may be multiple elements.
 	 * It will run more than once per plugin if you don't remove the selector from the timer.
 	 * @method init
 	 * @param {jQuery Event} event `timerpoke.wb` event that triggered the function call
@@ -29,10 +29,10 @@ var selector = ".wb-texthighlight",
 		// Filter out any events triggered by descendants
 		if ( event.currentTarget === elm ) {
 			$elm = $( elm );
-			searchCriteria = vapour.pageUrlParts.params.texthighlight;
+			searchCriteria = wb.pageUrlParts.params.texthighlight;
 
 			// all plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			if ( searchCriteria ) {
 				// clean up the search criteria and OR each value
@@ -54,6 +54,6 @@ var selector = ".wb-texthighlight",
 $document.on( "timerpoke.wb", selector, init );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @patheard
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -14,8 +14,8 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-toggle",
-	$document = vapour.doc,
-	$window = vapour.win,
+	$document = wb.doc,
+	$window = wb.win,
 	states = {},
 	defaults = {
 		stateOn: "on",
@@ -36,7 +36,7 @@ var selector = ".wb-toggle",
 		if ( event.currentTarget === link ) {
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			// Merge the elements settings with the defaults
 			$link = $( link );
@@ -310,6 +310,6 @@ $document.on( "timerpoke.wb aria.wb-toggle toggle.wb-toggle toggled.wb-toggle cl
 $document.on( "toggled.wb-toggle", "details", toggleDetails );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/twitter/twitter.js
+++ b/src/plugins/twitter/twitter.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -14,7 +14,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var selector = ".wb-twitter",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
 	 * Init runs once per plugin element on the page. There may be multiple elements.
@@ -26,10 +26,10 @@ var selector = ".wb-twitter",
 
 		// Filter out any events triggered by descendants
 		if ( event.currentTarget === event.target ) {
-			var protocol = vapour.pageUrlParts.protocol;
+			var protocol = wb.pageUrlParts.protocol;
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			Modernizr.load( {
 				load: ( protocol.indexOf( "http" ) === -1 ? "http:" : protocol ) + "//platform.twitter.com/widgets.js"
@@ -40,6 +40,6 @@ var selector = ".wb-twitter",
 $document.on( "timerpoke.wb", selector, init );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/plugins/wb-disable/disable.js
+++ b/src/plugins/wb-disable/disable.js
@@ -24,7 +24,7 @@ var selector = "#wb-tphp",
 		var elm = event.target,
 			nQuery = "?",
 			$html = wb.html,
-			i18n = window.i18n,
+			i18n = wb.i18n,
 			pageUrl = wb.pageUrlParts,
 			li, param;
 

--- a/src/plugins/wb-disable/disable.js
+++ b/src/plugins/wb-disable/disable.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @gc
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -13,7 +13,7 @@
  * not once per instance of event on the page.
  */
 var selector = "#wb-tphp",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
 	 * createOffer runs once per plugin element on the page.
@@ -23,16 +23,16 @@ var selector = "#wb-tphp",
 	createOffer = function( event ) {
 		var elm = event.target,
 			nQuery = "?",
-			$html = vapour.html,
+			$html = wb.html,
 			i18n = window.i18n,
-			pageUrl = vapour.pageUrlParts,
+			pageUrl = wb.pageUrlParts,
 			li, param;
 
 		// Filter out any events triggered by descendants
 		if ( event.currentTarget === elm ) {
 
 			// Let remove ourselves from the queue we only run once
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			li = document.createElement( "li" );
 			li.className = "wb-slc";
@@ -44,7 +44,7 @@ var selector = "#wb-tphp",
 				}
 			}
 
-			if ( vapour.isDisabled || ( vapour.ie && vapour.ielt7 ) ) {
+			if ( wb.isDisabled || ( wb.ie && wb.ielt7 ) ) {
 				$html.addClass( "no-js wb-disable" );
 				if ( localStorage ) {
 
@@ -74,6 +74,6 @@ var selector = "#wb-tphp",
 $document.on( "timerpoke.wb", selector, createOffer );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/polyfills/datalist/datalist.js
+++ b/src/polyfills/datalist/datalist.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
 /*
@@ -12,7 +12,7 @@
  * These are global to the polyfill - meaning that they will be initialized once per page.
  */
 var selector = "input[list]",
-	$document = vapour.doc,
+	$document = wb.doc,
 	initialized = false,
 
 	/*
@@ -33,9 +33,9 @@ var selector = "input[list]",
 			datalist = document.getElementById( input.getAttribute( "list" ) );
 			options = datalist.getElementsByTagName( "option" );
 			len = options.length;
-		
+
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			input.setAttribute( "autocomplete", "off" );
 			input.setAttribute( "role", "textbox" );
@@ -396,6 +396,6 @@ $document.on( "focusin text-resize.wb window-resize-width.wb window-resize-heigh
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/polyfills/datepicker/datepicker.js
+++ b/src/polyfills/datepicker/datepicker.js
@@ -43,7 +43,7 @@ var selector = "input[type=date]",
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
-				i18n = window.i18n;
+				i18n = wb.i18n;
 				i18nText = {
 					show: i18n( "date-show" ) + i18n( "space" ),
 					hide: i18n( "date-hide" ),

--- a/src/polyfills/datepicker/datepicker.js
+++ b/src/polyfills/datepicker/datepicker.js
@@ -5,7 +5,7 @@
  * @author @pjackson28
  */
 
-(function( $, window, document, vapour ) {
+(function( $, window, document, wb ) {
 "use strict";
 
 /*
@@ -13,7 +13,7 @@
  * These are global to the polyfill - meaning that they will be initialized once per page.
  */
 var selector = "input[type=date]",
-	$document = vapour.doc,
+	$document = wb.doc,
 	date = new Date(),
 	month = date.getMonth(),
 	year = date.getFullYear(),
@@ -35,7 +35,7 @@ var selector = "input[type=date]",
 		if ( event.currentTarget === elm ) {
 
 			// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-			window._timer.remove( selector );
+			wb.remove( selector );
 
 			if ( elm.className.indexOf( "picker-field" ) !== -1 ) {
 				return;
@@ -96,7 +96,7 @@ var selector = "input[type=date]",
 		var field = document.getElementById( fieldId ),
 			minDate = field.getAttribute( "min" ),
 			maxDate = field.getAttribute( "max" ),
-			fromDateISO = vapour.date.fromDateISO,
+			fromDateISO = wb.date.fromDateISO,
 			len = $days.length,
 			// $parent = $days.parent(),
 			focusDay = ( targetDay ? targetDay - 1 : 0 ),
@@ -161,7 +161,7 @@ var selector = "input[type=date]",
 			$field = $( field ),
 			minDate = field.getAttribute( "min" ),
 			maxDate = field.getAttribute( "max" ),
-			fromDateISO = vapour.date.fromDateISO,
+			fromDateISO = wb.date.fromDateISO,
 			targetDate = fromDateISO( field.value );
 
 		if ( !minDate ) {
@@ -247,7 +247,7 @@ var selector = "input[type=date]",
 	},
 
 	formatDate = function( year, month, day, format ) {
-		var pad = vapour.string.pad;
+		var pad = wb.string.pad;
 		return format
 			.replace( "DD", pad( day, 2 ) )
 			.replace( "D", day)
@@ -336,7 +336,7 @@ $document.on( "click", ".cal-days a", function ( event ) {
 	if ( !which || which === 1 ) {
 		fieldId = document.getElementById( "wb-picker" )
 			.getAttribute( "aria-controls" );
-		date = vapour.date.fromDateISO( this.getElementsByTagName( "time" )[ 0 ]
+		date = wb.date.fromDateISO( this.getElementsByTagName( "time" )[ 0 ]
 			.getAttribute( "datetime" ) );
 		year = date.getFullYear();
 		month = date.getMonth();
@@ -355,6 +355,6 @@ $document.on( "click", ".cal-days a", function ( event ) {
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, document, vapour );
+})( jQuery, window, document, wb );

--- a/src/polyfills/details/details.js
+++ b/src/polyfills/details/details.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( window, vapour ) {
+(function( window, wb ) {
 "use strict";
 
 /*
@@ -12,7 +12,7 @@
  * These are global to the polyfill - meaning that they will be initialized once per page.
  */
 var selector = "details",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
 	 * Init runs once per polyfill element on the page. There may be multiple elements.
@@ -24,7 +24,7 @@ var selector = "details",
 		var summary;
 
 		// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-		window._timer.remove( selector );
+		wb.remove( selector );
 
 		_elm.setAttribute( "aria-expanded", ( _elm.getAttribute( "open" ) === null ) );
 		summary = _elm.getElementsByTagName( "summary" );
@@ -72,6 +72,6 @@ $document.on( "click vclick touchstart keydown toggle.wb-details", selector + " 
 });
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( window, vapour );
+})( window, wb );

--- a/src/polyfills/meter/meter.js
+++ b/src/polyfills/meter/meter.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @nschonni
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -12,7 +12,7 @@
  * These are global to the polyfill - meaning that they will be initialized once per page.
  */
 var selector = "meter",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
 	 * Init runs once per polyfill element on the page. There may be multiple elements.
@@ -23,7 +23,7 @@ var selector = "meter",
 	init = function( event ) {
 
 		// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-		window._timer.remove( selector );
+		wb.remove( selector );
 
 		meter( event.target );
 	},
@@ -111,6 +111,6 @@ var selector = "meter",
 $document.on( "timerpoke.wb", selector, init );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/src/polyfills/progress/demo/progress.js
+++ b/src/polyfills/progress/demo/progress.js
@@ -3,10 +3,10 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 /*jshint unused: false*/
-(function( $, vapour ) {
+(function( $, wb ) {
 "use strict";
 
-vapour.doc.on( "click vclick", "#updateProgress", function() {
+wb.doc.on( "click vclick", "#updateProgress", function() {
 	var $elm = $( "#updateTest" ),
 		valuenow = parseInt( $elm.attr( "value" ), 10 ),
 		newValue = valuenow === parseInt( $elm.attr( "max" ) ) ? 0 : valuenow + 1;
@@ -15,4 +15,4 @@ vapour.doc.on( "click vclick", "#updateProgress", function() {
 	$elm.find( "span" ).text( newValue + "%" );
 });
 
-})( jQuery, vapour );
+})( jQuery, wb );

--- a/src/polyfills/progress/progress.js
+++ b/src/polyfills/progress/progress.js
@@ -4,18 +4,18 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( $, window, vapour ) {
+(function( $, window, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the polyfill - meaning that they will be initialized once per page.
  */
 var selector = "progress",
-	$document = vapour.doc,
+	$document = wb.doc,
 
 	/*
-	 * Init runs once per polyfill element on the page. There may be multiple elements. 
+	 * Init runs once per polyfill element on the page. There may be multiple elements.
 	 * It will run more than once if you don't remove the selector from the timer.
 	 * @method init
 	 * @param {jQuery Event} event `timerpoke.wb` event that triggered the function call
@@ -23,7 +23,7 @@ var selector = "progress",
 	init = function( event ) {
 
 		// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
-		window._timer.remove( selector );
+		wb.remove( selector );
 
 		progress( event.target );
 	},
@@ -62,7 +62,7 @@ var selector = "progress",
 					"aria-valuemax": ariaValueMax,
 					"aria-valuenow": ariaValueNow
 				});
-				
+
 			$span.detach();
 			$span.appendTo( $progressbar );
 
@@ -81,6 +81,6 @@ var selector = "progress",
 $document.on( "timerpoke.wb", selector, init );
 
 // Add the timer poke to initialize the plugin
-window._timer.add( selector );
+wb.add( selector );
 
-})( jQuery, window, vapour );
+})( jQuery, window, wb );

--- a/test/demo.html
+++ b/test/demo.html
@@ -18,7 +18,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <!--[if gte IE 9 | !IE ]><!-->
 <script src="../dist/js/jquery.min.js"></script>
 <!--<![endif]-->
-<script src="../dist/js/vapour.min.js"></script>
+<script src="../dist/js/wb.min.js"></script>
 <link rel="stylesheet" href="../dist/css/base.css">
 <link rel="stylesheet" href="../dist/css/bootstrap.min.css">
 </head>

--- a/theme/js/theme.js
+++ b/theme/js/theme.js
@@ -2,16 +2,16 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
-(function ( $, vapour ) {
+(function ( $, wb ) {
 "use strict";
 
-/* 
- * Variable and function definitions. 
+/*
+ * Variable and function definitions.
  * These are global to the plugin - meaning that they will be initialized once per page,
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
-var $document = vapour.doc,
+var $document = wb.doc,
 
 	onXXSmallView = function() {
 		return;
@@ -60,4 +60,4 @@ $document.on( "xxsmallview.wb xsmallview.wb smallview.wb mediumview.wb largeview
 	}
 });
 
-})( jQuery, vapour );
+})( jQuery, wb );


### PR DESCRIPTION
I did this as a discussion point, but I think the window._timer should be merged with vapour/wb either way.
- Rename vapour to better align with the library
- Move timer code internal to wb and remove the separate global object
