### PR TITLE
Toggle: fix simple example for IE8

### DIFF
--- a/src/plugins/toggle/demo/toggle.scss
+++ b/src/plugins/toggle/demo/toggle.scss
@@ -2,12 +2,18 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
-.glyphicon {
+
+.box {
+	display: inline-block;
+	width: 30px;
+	height: 30px;
+	margin-right: 15px;
+
+	border-radius: 4px;
+	background-color: #d9edf7;
+	transition: background-color 0.5s;
 	&.on {
-		color: #d9534f !important;
-	}
-	&.off {
-		color: inherit;
+		background-color: #428bca;
 	}
 }
 details, .btn-group {

--- a/src/plugins/toggle/toggle-en.hbs
+++ b/src/plugins/toggle/toggle-en.hbs
@@ -9,6 +9,7 @@
 	"css": "demo/toggle"
 }
 ---
+
 <div class="alert alert-info">
 	<strong>Purpose:</strong> create an element that toggles elements between on and off states.
 </div>
@@ -81,24 +82,22 @@
 			<p>This simple example shows:</p>
 			<ul>
 				<li>a group of buttons that control the toggle state of multiple elements, and</li>
-				<li>a single element that controls its own toggle state (the down arrow).</li>
+				<li>a single element that controls its own toggle state (the last box).</li>
 			</ul>
 
 			<div class="btn-group">
-				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": ".glyphicon"}'>Toggle</button>
-				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": ".glyphicon", "type": "on"}'>On</button>
-				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": ".glyphicon", "type": "off"}'>Off</button>
+				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": ".box"}'>Toggle</button>
+				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": ".box", "type": "on"}'>On</button>
+				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": ".box", "type": "off"}'>Off</button>
 			</div>
 
 			<div class="mrgn-tp-lg mrgn-bttm-lg">
-				<span class="glyphicon glyphicon-adjust mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-align-center mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-align-justify mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-align-left mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-align-right mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-arrow-down wb-toggle mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-arrow-left mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-tower mrgn-rght-lg"></span>
+				<span class="box"></span>
+				<span class="box"></span>
+				<span class="box"></span>
+				<span class="box"></span>
+				<span class="box"></span>
+				<span class="box wb-toggle"></span>
 			</div>
 
 		</section>

--- a/src/plugins/toggle/toggle-fr.hbs
+++ b/src/plugins/toggle/toggle-fr.hbs
@@ -30,20 +30,18 @@
 			<h2 id="simple">Exemple simple</h2>
 
 			<div class="btn-group">
-				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": ".glyphicon"}'>Basculer</button>
-				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": ".glyphicon", "type": "on"}'>Activer</button>
-				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": ".glyphicon", "type": "off"}'>Désactiver</button>
+				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": ".box"}'>Basculer</button>
+				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": ".box", "type": "on"}'>Activer</button>
+				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": ".box", "type": "off"}'>Désactiver</button>
 			</div>
 
 			<div class="mrgn-tp-lg mrgn-bttm-lg">
-				<span class="glyphicon glyphicon-adjust mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-align-center mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-align-justify mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-align-left mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-align-right mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-arrow-down wb-toggle mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-arrow-left mrgn-rght-lg"></span>
-				<span class="glyphicon glyphicon-tower mrgn-rght-lg"></span>
+				<span class="box"></span>
+				<span class="box"></span>
+				<span class="box"></span>
+				<span class="box"></span>
+				<span class="box"></span>
+				<span class="box wb-toggle"></span>
 			</div>
 
 		</section>


### PR DESCRIPTION
There is an IE8 redraw issue with setting the colour of the Bootstrap `.glyphicons`.  This fixes it by changing the simple example to use a `<span>` element with a background colour.

Fixes #3829.
