### PR TITLE
Build: fix demo asset copying and minification

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -113,7 +113,7 @@ module.exports = (grunt) ->
 			"autoprefixer"
 			"csslint:unmin"
 			"concat:css"
-			"cssmin"
+			"cssmin:dist"
 		]
 	)
 
@@ -140,6 +140,7 @@ module.exports = (grunt) ->
 		"INTERNAL: Create minified demos"
 		[
 			"copy:demos_min"
+			"cssmin:demos_min"
 			"assemble:demos_min"
 			"htmlcompressor"
 		]
@@ -572,17 +573,15 @@ module.exports = (grunt) ->
 				cwd: "dist/unmin/css"
 				src: [
 					"**/*.css"
-					"!**/*.min.css"
 				]
 				dest: "dist/css"
 				ext: ".min.css"
 
-			demo:
+			demos_min:
 				expand: true
 				cwd: "dist/unmin/demos/"
 				src: [
 					"**/demo/*.css"
-					"!**/demo/*.min.css"
 				]
 				dest: "dist/demos/"
 				ext: ".min.css"
@@ -717,7 +716,6 @@ module.exports = (grunt) ->
 					"assets/*"
 					"fonts/*"
 					"js/assets/*"
-					"!**/assets/*.js"
 				]
 				dest: "dist"
 				expand: true
@@ -729,6 +727,8 @@ module.exports = (grunt) ->
 					"**/demo/*.*"
 					"**/ajax/*.*"
 					"**/img/*.*"
+					# CSS is copied by the cssmin:demos_min task
+					"!**/*.css"
 				]
 				dest: "dist/demos/"
 				expand: true

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -689,6 +689,7 @@ module.exports = (grunt) ->
 						"**/ajax/*.*"
 						"**/img/*.*"
 						"!**/assets/*.*"
+						"!**/*.scss"
 					]
 					dest: "dist/unmin/demos/"
 					expand: true
@@ -722,13 +723,12 @@ module.exports = (grunt) ->
 				expand: true
 
 			demos_min:
-				cwd: "dist/unmin"
+				cwd: "dist/unmin/demos"
 				src: [
 					"**/*.{jpg,html,xml}"
 					"**/demo/*.*"
 					"**/ajax/*.*"
 					"**/img/*.*"
-					"!**/assets/*.*"
 				]
 				dest: "dist/demos/"
 				expand: true


### PR DESCRIPTION
- Don't copy SCSS files to unmin
- Use better scope for copying umnin assets to minfied
- Fix CSS minification so that the unminified copies aren't left in the production folder

Fixes gh-3867
