### PR TITLE
Added init event to all plugins and polyfills to support manual (non-timerpoke) initialization

### DIFF
--- a/src/plugins/cal-events/cal-events.js
+++ b/src/plugins/cal-events/cal-events.js
@@ -461,7 +461,8 @@ var selector = ".wb-cal-evt",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, function() {
+$document.on( "timerpoke.wb init.wb-cal-evt", selector, function( event ) {
+window.console.log( event.type + ", " + event.namespace );
 	init( $( this ) );
 
 	/*
@@ -472,6 +473,6 @@ $document.on( "timerpoke.wb", selector, function() {
 });
 
 // Add the timer poke to initialize the plugin
-wb.add( ".wb-cal-evt" );
+wb.add( selector );
 
 })( jQuery, window, wb );

--- a/src/plugins/country-content/country-content.js
+++ b/src/plugins/country-content/country-content.js
@@ -80,7 +80,7 @@ var $document = wb.doc,
 		return dfd.promise();
 	};
 
-$document.on( "timerpoke.wb", selector, function( event ) {
+$document.on( "timerpoke.wb init.wb-country-content", selector, function( event ) {
 	var eventTarget = event.target;
 
 	// Filter out any events triggered by descendants

--- a/src/plugins/data-ajax/data-ajax.js
+++ b/src/plugins/data-ajax/data-ajax.js
@@ -42,7 +42,7 @@ var $document = wb.doc,
 		});
 	};
 
-$document.on( "timerpoke.wb ajax-fetched.wb", selector, function( event ) {
+$document.on( "timerpoke.wb init.wb-data-ajax ajax-fetched.wb", selector, function( event ) {
 	var eventTarget = event.target,
 		eventType = event.type,
 		ajaxTypes = [
@@ -66,9 +66,14 @@ $document.on( "timerpoke.wb ajax-fetched.wb", selector, function( event ) {
 			}
 		}
 
-		if ( eventType === "timerpoke" ) {
+		switch ( eventType ) {
+
+		case "timerpoke":
+		case "init":
 			init( $elm, ajaxType );
-		} else {
+			break;
+
+		default:
 
 			// ajax-fetched event
 			content = event.pointer.html();

--- a/src/plugins/data-inview/data-inview.js
+++ b/src/plugins/data-inview/data-inview.js
@@ -17,6 +17,7 @@ var selector = ".wb-inview",
 	$elms = $( selector ),
 	$document = wb.doc,
 	$window = wb.win,
+	scrollEvent = "scroll.wb-inview",
 
 	/**
 	 * Init runs once per plugin element on the page. There may be multiple elements.
@@ -29,7 +30,7 @@ var selector = ".wb-inview",
 		// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
 		wb.remove( selector );
 
-		$elm.trigger( "scroll.wb-inview" );
+		$elm.trigger( scrollEvent );
 	},
 
 	/**
@@ -86,7 +87,7 @@ var selector = ".wb-inview",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb scroll.wb-inview", selector, function( event ) {
+$document.on( "timerpoke.wb init.wb-inview " + scrollEvent, selector, function( event ) {
 	var eventTarget = event.target,
 		eventType = event.type,
 		$elm;
@@ -97,6 +98,7 @@ $document.on( "timerpoke.wb scroll.wb-inview", selector, function( event ) {
 
 		switch ( eventType ) {
 		case "timerpoke":
+		case "init":
 			init( $elm );
 			break;
 		case "scroll":
@@ -113,11 +115,11 @@ $document.on( "timerpoke.wb scroll.wb-inview", selector, function( event ) {
 });
 
 $window.on( "scroll scrollstop", function() {
-	$elms.trigger( "scroll.wb-inview" );
+	$elms.trigger( scrollEvent );
 });
 
 $document.on( "text-resize.wb window-resize-width.wb window-resize-height.wb", function() {
-	$elms.trigger( "scroll.wb-inview" );
+	$elms.trigger( scrollEvent );
 });
 
 // Add the timer poke to initialize the plugin

--- a/src/plugins/data-picture/data-picture.js
+++ b/src/plugins/data-picture/data-picture.js
@@ -15,6 +15,7 @@
  */
 var selector = "[data-picture]",
 	$document = wb.doc,
+	picturefillEvent = "picturefill.wb-data-picture",
 
 	/**
 	 * Init runs once per plugin element on the page. There may be multiple elements.
@@ -27,7 +28,7 @@ var selector = "[data-picture]",
 		// All plugins need to remove their reference from the timer in the init sequence unless they have a requirement to be poked every 0.5 seconds
 		wb.remove( selector );
 
-		$elm.trigger( "picturefill.wb-data-picture" );
+		$elm.trigger( picturefillEvent );
 	},
 
 	/**
@@ -67,7 +68,7 @@ var selector = "[data-picture]",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb picturefill.wb-data-picture", selector, function( event ) {
+$document.on( "timerpoke.wb init.wb-data-picture " + picturefillEvent, selector, function( event ) {
 	var eventTarget = event.target,
 		eventType = event.type;
 
@@ -75,6 +76,7 @@ $document.on( "timerpoke.wb picturefill.wb-data-picture", selector, function( ev
 	if ( event.currentTarget === eventTarget ) {
 		switch ( eventType ) {
 		case "timerpoke":
+		case "init":
 			init( $( eventTarget ) );
 			break;
 		case "picturefill":
@@ -86,7 +88,7 @@ $document.on( "timerpoke.wb picturefill.wb-data-picture", selector, function( ev
 
 // Handles window resize so images can be updated as new media queries match
 $document.on( "text-resize.wb window-resize-width.wb window-resize-height.wb", function() {
-	$( selector ).trigger( "picturefill.wb-data-picture" );
+	$( selector ).trigger( picturefillEvent );
 });
 
 // Add the timer poke to initialize the plugin

--- a/src/plugins/data-picture/test.js
+++ b/src/plugins/data-picture/test.js
@@ -24,7 +24,7 @@ describe( "[data-picture] test suite", function() {
 		spy = sinon.spy( $.prototype, "trigger" );
 
 		// Trigger the plugin's initialization
-		$( "[data-picture]" ).trigger( "timerpoke.wb" );
+		$( "[data-picture]" ).trigger( "init.wb-data-picture" );
 	});
 
 	/*

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -94,7 +94,7 @@ var selector = ".wb-equalheight",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-equalheight", selector, init );
 
 // Handle text and window resizing
 $document.on( "text-resize.wb window-resize-width.wb window-resize-height.wb tables-draw.wb", onResize );

--- a/src/plugins/favicon/favicon.js
+++ b/src/plugins/favicon/favicon.js
@@ -109,13 +109,14 @@ var selector = "link[rel='shortcut icon']",
 	};
 
 // Bind the plugin events
-$document.on( "timerpoke.wb mobile.wb-favicon icon.wb-favicon", selector, function( event, data ) {
+$document.on( "timerpoke.wb init.wb-favicon mobile.wb-favicon icon.wb-favicon", selector, function( event, data ) {
 	var eventTarget = event.target;
 
 	// Filter out any events triggered by descendants
 	if ( event.currentTarget === eventTarget ) {
 		switch ( event.type ) {
 		case "timerpoke":
+		case "init":
 			init( $( eventTarget ) );
 			break;
 		case "mobile":

--- a/src/plugins/favicon/test.js
+++ b/src/plugins/favicon/test.js
@@ -114,7 +114,7 @@ describe( "Favicon test suite", function() {
 				sizes: "57x57",
 				path: "foo/",
 				filename: "bar"
-			}).trigger( "timerpoke.wb" );
+			}).trigger( "init.wb-favicon" );
 
 		});
 

--- a/src/plugins/feedback/feedback.js
+++ b/src/plugins/feedback/feedback.js
@@ -117,7 +117,7 @@ var selector = ".wb-fdbck",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-fdbck", selector, init );
 
 // Show/hide form areas when certain form fields are changed
 $document.on( "keydown click change", "#fbrsn, #fbaxs, #fbcntc1, #fbcntc2", function( event ) {

--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -133,7 +133,7 @@ var selector = ".wb-feeds",
 		return $elm.empty().append( result );
 	};
 
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-feeds", selector, init );
 
 // Add the timer poke to initialize the plugin
 wb.add( selector );

--- a/src/plugins/focus/focus.js
+++ b/src/plugins/focus/focus.js
@@ -10,11 +10,12 @@
 var $document = wb.doc,
 	hash = wb.pageUrlParts.hash,
 	clickEvents = "click.wb-focus vclick.wb-focus",
+	setFocusEvent = "setfocus.wb",
 	linkSelector = "a[href]",
 	$linkTarget;
 
 // Bind the setfocus event
-$document.on( "setfocus.wb", function( event ) {
+$document.on( setFocusEvent, function( event ) {
 	var $elm = $( event.target );
 
 	// Set the tabindex to -1 (as needed) to ensure the element is focusable
@@ -31,7 +32,7 @@ $document.on( "setfocus.wb", function( event ) {
 // Set focus to the target of a deep link from a different page
 // (helps browsers that can't set the focus on their own)
 if ( hash && ( $linkTarget = $( hash ) ).length !== 0 ) {
-	$linkTarget.trigger( "setfocus.wb" );
+	$linkTarget.trigger( setFocusEvent );
 }
 
 // Helper for browsers that can't change keyboard and/or event focus on a same page link click
@@ -40,7 +41,7 @@ $document.on( clickEvents, linkSelector, function( event ) {
 
 	// Same page links only
 	if ( testHref.charAt( 0 ) === "#" && ( $linkTarget = $( testHref ) ).length !== 0 ) {
-		$linkTarget.trigger( "setfocus.wb" );
+		$linkTarget.trigger( setFocusEvent );
 	}
 });
 

--- a/src/plugins/footnotes/footnotes.js
+++ b/src/plugins/footnotes/footnotes.js
@@ -52,7 +52,7 @@ var selector = ".wb-fnote",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-fnote", selector, init );
 
 // Listen for footnote reference links that get clicked
 $document.on( "click vclick", "main :not(" + selector + ") sup a.fn-lnk", function( event ) {

--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -258,7 +258,7 @@ var selector = ".wb-formvalid",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-formvalid", selector, init );
 
 // Move the focus to the associated input when an error message link is clicked
 // and scroll to the top of the label or legend that contains the error

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -176,7 +176,7 @@ var selector = ".wb-lightbox",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-lightbox", selector, init );
 
 $document.on( "keydown", ".mfp-wrap", function( event ) {
 	var $elm, $focusable, index, length;

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -326,7 +326,7 @@ var selector = ".wb-menu",
 	};
 
 // Bind the events of the plugin
-$document.on( "timerpoke.wb select.wb-menu ajax-fetched.wb increment.wb-menu display.wb-menu", selector, function( event ) {
+$document.on( "timerpoke.wb init.wb-menu select.wb-menu ajax-fetched.wb increment.wb-menu display.wb-menu", selector, function( event ) {
 	var elm = event.target,
 		eventType = event.type,
 		$elm = $( elm );
@@ -345,6 +345,7 @@ $document.on( "timerpoke.wb select.wb-menu ajax-fetched.wb increment.wb-menu dis
 		break;
 
 	case "timerpoke":
+	case "init":
 
 		// Filter out any events triggered by descendants
 		if ( event.currentTarget === elm ) {

--- a/src/plugins/modal/modal.js
+++ b/src/plugins/modal/modal.js
@@ -117,7 +117,7 @@ var selector = ".wb-modal",
 
 // Bind the plugin events
 $document
-	.on( "timerpoke.wb", selector, init )
+	.on( "timerpoke.wb init.wb-modal", selector, init )
 	.on( "build.wb-modal show.wb-modal hide.wb-modal", function( event, settings ) {
 		var eventType = event.type;
 

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -398,7 +398,7 @@ youTubeEvents = function( event ) {
 	}
 };
 
-$document.on( "timerpoke.wb", selector, function() {
+$document.on( "timerpoke.wb init.wb-mltmd", selector, function() {
 	wb.remove( selector );
 
 	// Only initialize the i18nText once

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -88,7 +88,7 @@ var selector = ".wb-overlay",
 		}
 	};
 
-$document.on( "timerpoke.wb keydown open.wb-overlay close.wb-overlay", selector, function( event ) {
+$document.on( "timerpoke.wb init.wb-overlay keydown open.wb-overlay close.wb-overlay", selector, function( event ) {
 	var eventType = event.type,
 		which = event.which,
 		overlayId = event.currentTarget.id,
@@ -96,6 +96,7 @@ $document.on( "timerpoke.wb keydown open.wb-overlay close.wb-overlay", selector,
 
 	switch ( eventType ) {
 	case "timerpoke":
+	case "init":
 		init( event );
 		break;
 

--- a/src/plugins/prettify/prettify.js
+++ b/src/plugins/prettify/prettify.js
@@ -118,7 +118,7 @@ var selector = ".wb-prettify",
 
 // Bind the plugin events
 $document
-	.on( "timerpoke.wb", selector, init )
+	.on( "timerpoke.wb init.wb-prettify", selector, init )
 	.on( "prettyprint.wb-prettify", prettyprint );
 
 // Add the timer poke to initialize the plugin

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -381,11 +381,12 @@ var selector = ".wb-session-timeout",
 	};
 
 // Bind the plugin events
-$document.on( "timerpoke.wb keepalive.wb-session-timeout inactivity.wb-session-timeout reset.wb-session-timeout", selector, function( event, settings ) {
+$document.on( "timerpoke.wb init.wb-session-timeout keepalive.wb-session-timeout inactivity.wb-session-timeout reset.wb-session-timeout", selector, function( event, settings ) {
 	var eventType = event.type;
 
 	switch ( eventType ) {
 	case "timerpoke":
+	case "init":
 		init( event );
 		break;
 

--- a/src/plugins/session-timeout/test.js
+++ b/src/plugins/session-timeout/test.js
@@ -186,7 +186,7 @@ describe( "Session Timeout test suite", function() {
 				.on( "reset.wb-session-timeout", function() {
 					done();
 				})
-				.trigger( "timerpoke.wb" );
+				.trigger( "init.wb-session-timeout" );
 		});
 
 		it( "should trigger keepalive.wb-session-timeout after 5000ms", function() {

--- a/src/plugins/share/share.js
+++ b/src/plugins/share/share.js
@@ -167,12 +167,12 @@ var selector = ".wb-share",
 
 			$elm.append( $share );
 
-			$share.trigger( "timerpoke" );
+			$share.trigger( "init.wb-share" );
 		}
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-share", selector, init );
 
 $document.on( "click vclick", "." + shareLink, function( event) {
 	var which = event.which;

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -84,7 +84,7 @@ var selector = ".wb-tables",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-tables", selector, init );
 
 // Add the timer poke to initialize the plugin
 wb.add( selector );

--- a/src/plugins/texthighlight/texthighlight.js
+++ b/src/plugins/texthighlight/texthighlight.js
@@ -51,7 +51,7 @@ var selector = ".wb-texthighlight",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-texthighlight", selector, init );
 
 // Add the timer poke to initialize the plugin
 wb.add( selector );

--- a/src/plugins/twitter/twitter.js
+++ b/src/plugins/twitter/twitter.js
@@ -37,7 +37,7 @@ var selector = ".wb-twitter",
 		}
 	};
 
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-twitter", selector, init );
 
 // Add the timer poke to initialize the plugin
 wb.add( selector );

--- a/src/polyfills/datalist/datalist.js
+++ b/src/polyfills/datalist/datalist.js
@@ -298,13 +298,14 @@ var selector = "input[list]",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb keydown click vclick touchstart", selector, function( event ) {
+$document.on( "timerpoke.wb init.wb-datalist keydown click vclick touchstart", selector, function( event ) {
 	var input = event.target,
 		eventType = event.type,
 		which = event.which;
 
 	switch ( eventType ) {
 	case "timerpoke":
+	case "init":
 		init( event );
 		break;
 	case "keydown":

--- a/src/polyfills/datepicker/datepicker.js
+++ b/src/polyfills/datepicker/datepicker.js
@@ -258,7 +258,7 @@ var selector = "input[type=date]",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-datepicker", selector, init );
 
 $document.on( "click vclick touchstart focusin", "body", function( event ) {
 	var which = event.which,

--- a/src/polyfills/details/details.js
+++ b/src/polyfills/details/details.js
@@ -32,7 +32,7 @@ var selector = "summary",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, function( event ) {
+$document.on( "timerpoke.wb init.wb-details", selector, function( event ) {
 	init( event.currentTarget );
 
 	/*

--- a/src/polyfills/mathml/mathml.js
+++ b/src/polyfills/mathml/mathml.js
@@ -28,7 +28,7 @@ var selector = "math",
 	};
 
 // Bind the init event of the plugin
-wb.doc.on( "timerpoke.wb", selector, init );
+wb.doc.on( "timerpoke.wb init.wb-math", selector, init );
 wb.add( selector );
 
 })( wb );

--- a/src/polyfills/meter/meter.js
+++ b/src/polyfills/meter/meter.js
@@ -108,7 +108,7 @@ var selector = "meter",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-meter", selector, init );
 
 // Add the timer poke to initialize the plugin
 wb.add( selector );

--- a/src/polyfills/progress/progress.js
+++ b/src/polyfills/progress/progress.js
@@ -78,7 +78,7 @@ var selector = "progress",
 	};
 
 // Bind the init event of the plugin
-$document.on( "timerpoke.wb", selector, init );
+$document.on( "timerpoke.wb init.wb-progress", selector, init );
 
 // Add the timer poke to initialize the plugin
 wb.add( selector );


### PR DESCRIPTION
Necessary since can crash browsers if you manually fire a timerpoke event on an element that has more than one plugin trigger, or plugin triggers on the ancestors (creates forever loop). The init event provides a safe namespaced way to do the same thing without any risk of the forever loop
