### PR TITLE
Session modal: use init.wb-modal event to initialize modal dialog

### DIFF
--- a/src/plugins/prettify/test.js
+++ b/src/plugins/prettify/test.js
@@ -106,7 +106,7 @@ describe( "Prettify test suite", function() {
 				.addClass("lang-sql")
 				.addClass("all-pre")
 				.addClass("linenums")
-				.trigger("timerpoke.wb");
+				.trigger( "init.wb-prettify" );
 			wb.doc.on( "prettyprint.wb-prettify", function() {
 				done();
 			});
@@ -137,12 +137,12 @@ describe( "Prettify test suite", function() {
 		before(function( done ) {
 
 			$( "body" ).append( "<pre class='test'>" );
-			$(".wb-prettify")
+			$( ".wb-prettify" )
 				.data({
 					allpre: true,
 					linenums: true
 				})
-				.trigger("timerpoke.wb");
+				.trigger( "init.wb-prettify" );
 			wb.doc.on( "prettyprint.wb-prettify", function() {
 				done();
 			});

--- a/src/plugins/session-timeout/session-timeout-en.hbs
+++ b/src/plugins/session-timeout/session-timeout-en.hbs
@@ -9,12 +9,12 @@
 }
 ---
 
-<span class="wb-session-timeout wb-modal" data-wet-boew='{"inactivity": 30000, "logouturl": "../index-en.html"}'></span>
+<span class="wb-session-timeout" data-wet-boew='{"inactivity": 30000, "logouturl": "../index-en.html"}'></span>
 <section>
 	<h2>Overview</h2>
 	<p>This sub project will help web asset owners provide session timeout and inactivity timeout functionality. When a user requests a page with this plugin implemented their session will begin. After the specified session period, they will be notified that their session is about to timeout. At this point, they will have the option to remain logged in by clicking "OK", or logging out by clicking "Cancel". At anytime during the session, if the user remains idle for a specified amount of time, they will be notified that they're session is about to time out. In either case, if the user does not respond to the timeout notification within a specified amount of time, once they click either "OK" or "Cancel" they will be automatically redirected to the log out page.</p>
 	<p>The code you're allowed to edit (within the page) is:</p>
-	<p><code>&lt;span class="wb-session-timeout wb-modal" data-wet-boew='{"inactivity": 1200000, "reactionTime": 30000, "sessionalive": 1200000, "logouturl": "./", "refreshCallbackUrl": "./"}'&gt;&lt;/span&gt;</code></p>
+	<p><code>&lt;span class="wb-session-timeout" data-wet-boew='{"inactivity": 1200000, "reactionTime": 30000, "sessionalive": 1200000, "logouturl": "./", "refreshCallbackUrl": "./"}'&gt;&lt;/span&gt;</code></p>
 	<p>This allows you to configure the plugin:</p>
 	<ul>
 		<li><strong>inactivity:</strong> This is the inactivity period of time after which the dialog message will appear.</li>
@@ -24,7 +24,7 @@
 		<li><strong>refreshCallbackUrl:</strong> This is the URL to perform an ajax refresh, must return true/false.</li>
 	</ul>
 	<p>The only required parameter is logouturl, all other fields are optional. The default code would be:</p>
-	<p><code>&lt;span class="wb-session-timeout wb-modal"&gt; data-wet-boew='{logouturl: "./"}'&gt;&lt;/span&gt;</code></p>
+	<p><code>&lt;span class="wb-session-timeout"&gt; data-wet-boew='{logouturl: "./"}'&gt;&lt;/span&gt;</code></p>
 	<p><strong>IMPORTANT NOTE:</strong> The inactivity, reactionTime and sessionalive parameters are set in milliseconds. The only required parameter is the logouturl. The default inactivity and sessionalive is set to 20 minutes with a 30 second confirmation time with the dialog message. The refreshCallbackUrl must not be a page containing the timeout function again as a loop will be created, it should be simply a viewless page that refreshes the session.</p>
 	<p>Need help with the conversion? See: <a href="http://www.calculateme.com/Time/Minutes/ToMilliseconds.htm" rel="external">http://www.calculateme.com/Time/Minutes/ToMilliseconds.htm</a></p>
 	<p><strong>IMPORTANT NOTE</strong>: Your sessionalive and inactivity parameters should be equal to your web server session alive time minus the reactionTime time. If you set your sessionalive time and inactivity time to the same as your web server without taking into consideration the reactionTime time then the session will have ended by the server as soon as the popup appears to extend the session.</p>
@@ -32,7 +32,7 @@
 <section>
 	<h2>How do I use it?</h2>
 	<p>Add the following to the page:</p>
-	<p><code>&lt;span class="wb-session-timeout wb-modal" data-wet-boew='{logouturl: "./"}'&gt;&lt;/span&gt;</code></p>
+	<p><code>&lt;span class="wb-session-timeout" data-wet-boew='{logouturl: "./"}'&gt;&lt;/span&gt;</code></p>
 </section>
 <section>
 	<h2>Try it out!</h2>

--- a/src/plugins/session-timeout/session-timeout-fr.hbs
+++ b/src/plugins/session-timeout/session-timeout-fr.hbs
@@ -9,12 +9,12 @@
 }
 ---
 
-<span class="wb-session-timeout wb-modal" data-wet-boew='{"inactivity": 30000, "logouturl": "../index-fr.html"}'></span>
+<span class="wb-session-timeout" data-wet-boew='{"inactivity": 30000, "logouturl": "../index-fr.html"}'></span>
 <section>
 	<h2>Aperçu</h2>
 	<p>Ce sous-projet aidera les propriétaires d'actifs Web à configurer leurs actifs avec une fonction «&#160;Expiration de la session&#160;». Celle-ci sera activée en deux circonstances&#160;: après une période de temps spécifique ou lors d'inactivité. Par exemple, si l'utilisateur demeure trop longtemps sur la même page, la fonction sera activée. De même, si l’utilisateur demeure inactif, la fonction sera activée. Le fureteur affichera alors une boîte de dialogue proposant deux options à l'utilisateur ; s’il souhaite rester connecté il devra sélectionner « OK » et ce, dans un laps de temps précis et s’il souhaite mettre fin à sa session, il n’aura qu’à choisir «&#160;Annuler&#160;». Advenant que l'utilisateur tarde trop à faire son choix, ce sera le paramètre de déconnexion qui s’affichera.</p>
 	<p>Le code que vous êtes autorisés à modifier (dans la page) est&#160;:</p>
-	<p><code>&lt;span class="wb-session-timeout wb-modal" data-wet-boew='{"inactivity": 1200000, "reactionTime": 30000, "sessionalive": 1200000, "logouturl": "./", "refreshCallbackUrl": "./"'}"&gt;&lt;/span&gt;</code></p>
+	<p><code>&lt;span class="wb-session-timeout" data-wet-boew='{"inactivity": 1200000, "reactionTime": 30000, "sessionalive": 1200000, "logouturl": "./", "refreshCallbackUrl": "./"'}"&gt;&lt;/span&gt;</code></p>
 	<p>Les paramètres suivants vous permettent de configurer la fonction&#160;:</p>
 	<ul>
 		<li><strong>inactivity&#160;:</strong> période de temps d'inactivité après laquelle la boîte de dialogue apparaîtra.</li>
@@ -24,14 +24,14 @@
 		<li><strong>refreshCallbackUrl&#160;:</strong> Ceci est l'URL pour effectuer une actualisation ajax, doit retourner true/false.</li>
 	</ul>
 	<p>Le seul paramètre requis est logouturl, tous les autres champs sont facultatifs. Le JavaScript par défaut serait&#160;:</p>
-	<p><code>&lt;span class="wb-session-timeout wb-modal" data-wet-boew='{"logouturl": "./"}'&gt;&lt;/span&gt;</code></p>
+	<p><code>&lt;span class="wb-session-timeout" data-wet-boew='{"logouturl": "./"}'&gt;&lt;/span&gt;</code></p>
 	<p><strong>NOTE IMPORTANTE&#160;:</strong> Les paramètres inactivity, reactionTime et sessionAlive sont mis en millisecondes. Le seule paramètre obligatoire est le logouturl. Les paramètres inactivity et sessionalive est fixé à 20 minutes par défaut avec un temps de 30 secondes pour la confirmation du message de dialogue. Le paramètre refreshCallbackUrl ne doit pas être une page contenant la fonction d'expiration de la session de nouveau sinon une boucle sera créé, il devrait être tout simplement une page qui rafraîchit la session.</p>
 	<p>Voici un outil qui vous aidera a convertir des minutes en millisecondes (disponible en anglais seulement)&#160;: <a href="http://www.calculateme.com/Time/Minutes/ToMilliseconds.htm" rel="external">http://www.calculateme.com/Time/Minutes/ToMilliseconds.htm</a></p>
 	<p><strong>NOTE IMPORTANTE&#160;:</strong> Les paramètres sessionalive et inactivity devrait être égal à votre session sur le serveur web moins le temps de reactionTime. Si vous définissez paramètres sessionalive et inactivity avec le même temps que la session sur le serveur web, sans prendre en considération le temps reactionTime, alors la session sur le serveur sera fini dès que la fenêtre contextuelle apparaît pour prolonger la session.</p>
 </section>
 <section><h2>Configuration</h2>
 	<p>Ajoutez les lignes suivantes à la page&#160;:</p>
-	<p><code>&lt;span class="wb-session-timeout wb-modal" data-wet-boew='{logouturl: "./"}'&gt;&lt;/span&gt;</code></p>
+	<p><code>&lt;span class="wb-session-timeout" data-wet-boew='{logouturl: "./"}'&gt;&lt;/span&gt;</code></p>
 </section>
 <section><h2>Faites un essai</h2>
 	<p>Cette page a été configurée pour expirer dans 30 secondes. Après ce délai, vous aurez 30 secondes pour choisir de la garder active ou non. Veuillez svp attendre que la boîte de dialogue apparaisse.</p>

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -67,6 +67,9 @@ var selector = ".wb-session-timeout",
 			}
 
 			// Setup the modal dialog behaviour
+			$elm
+				.addClass( "wb-modal" )
+				.trigger( "init.wb-modal" );
 			$document.one( "ready.wb-modal", function() {
 				// Initialize the keepalive and inactive timeouts of the plugin
 				$elm.trigger( "reset.wb-session-timeout", settings );

--- a/src/plugins/session-timeout/test.js
+++ b/src/plugins/session-timeout/test.js
@@ -186,7 +186,7 @@ describe( "Session Timeout test suite", function() {
 				.on( "reset.wb-session-timeout", function() {
 					done();
 				})
-				.trigger( "timerpoke.wb" );
+				.trigger( "init.wb-session-timeout" );
 		});
 
 		it( "should trigger keepalive.wb-session-timeout after 5000ms", function() {


### PR DESCRIPTION
1. Removes requirement to specify `wb-modal` CSS class on session timeout element.
2. Removes the manual `trigger( "timerpoke.wb" )` calls in the Mocha tests (requested in #3881).
