### PR TITLE
Gitignore: Added sprite naming patterns from v4.0's version of this file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ Thumbs.db
 /.project
 jshint.out.xml
 csslint.out.xml
+?sprite*.*css
+sprite*.png
 *.orig
 *.tmp
 *.log


### PR DESCRIPTION
Prevents generated sprite files from appearing as unversioned in non-v4.0 branches.
