### PR TITLE
Removed Bootstrap outline overrides

### DIFF
--- a/src/base/partials/_bootstrap-overrides.scss
+++ b/src/base/partials/_bootstrap-overrides.scss
@@ -8,9 +8,6 @@
  */
 a {
 	color: #295376;
-	&:focus {
-		outline: invert dotted thin;
-	}
 }
 
 /*

--- a/src/plugins/lightbox/lightbox.scss
+++ b/src/plugins/lightbox/lightbox.scss
@@ -21,20 +21,20 @@
 
 .mfp-close {
 	font-weight: 700;
-	/* Should fix upstream rather than overriding in WET */
+	/* Should fix upstream in Magnific Popup rather than overriding in WET */
 	&:focus {
 		@extend %lightbox-button-outline;
 	}
 }
 
-/* Should fix upstream rather than overriding in WET */
+/* Should fix upstream in Magnific Popup rather than overriding in WET */
 .mfp-arrow {
 	&:focus {
 		@extend %lightbox-button-outline;
 	}
 }
 
-/* Should fix upstream rather than overriding in WET */
+/* Should fix upstream in Magnific Popup rather than overriding in WET */
 .mfp-bottom-bar {
 	.mfp-title {
 		width: 75%;

--- a/src/plugins/multimedia/multimedia.scss
+++ b/src/plugins/multimedia/multimedia.scss
@@ -47,11 +47,6 @@
 		border: 0;
 		color: #fff;
 	}
-	progress, .btn {
-		&:focus {
-			outline: #fff thin dotted;
-		}
-	}
 
 	.display {
 		position: relative;


### PR DESCRIPTION
Removed since no longer necessary in Bootstrap 3.0.3.
