### PR TITLE
[Equal height] Plugin optimisation

### DIFF
--- a/src/plugins/equalheight/demo/equalheight.scss
+++ b/src/plugins/equalheight/demo/equalheight.scss
@@ -1,0 +1,12 @@
+.wb-equalheight {
+	section {
+		display: inline-block;
+		width: 100%;
+		@media (min-width: 768px) {
+			width: 49%;
+		}
+		@media (min-width: 1200px) {
+			width: 33%;
+		}
+	}
+}

--- a/src/plugins/equalheight/equalheight-en.hbs
+++ b/src/plugins/equalheight/equalheight-en.hbs
@@ -1,0 +1,52 @@
+---
+{
+	"title": "Equal height",
+	"language": "en",
+	"category": "Plugin",
+	"description": "A plugin for responsive equal height.",
+	"tag": "equalheight",
+	"fr": "equalheight",
+	"css": "demo/equalheight"
+}
+---
+<div class="wb-equalheight">
+	<section>
+		<h2>Short container</h2>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vehicula mauris ipsum, nec facilisis sem eleifend eu. Donec fringilla dapibus massa ut tristique. In id nulla at purus vehicula vehicula. Morbi lacinia odio ut nulla euismod sagittis. Mauris interdum eu nibh in tincidunt. Praesent non tincidunt risus, et malesuada est. Mauris nisl nunc, pharetra sed dapibus vel, iaculis vitae lorem.</p>
+	</section>
+	<section>
+		<h2>Medium container</h2>
+		<p>In eget diam ac lectus consectetur accumsan et quis turpis. Nam vitae vulputate odio, vel posuere nunc. Mauris at pharetra lorem, ac commodo neque. Integer adipiscing luctus orci eu aliquet. Phasellus fermentum accumsan augue at dignissim. Proin malesuada leo quis ante ornare, vitae pellentesque lorem vulputate. Fusce fermentum, nibh sit amet interdum luctus, sapien magna tristique orci, in ultrices turpis mi lacinia quam. Etiam gravida velit id tempor vulputate. Maecenas aliquet pulvinar viverra. Quisque luctus viverra sem ut suscipit. Suspendisse et mi justo.</p>
+	</section>
+	<section>
+		<h2>Long container</h2>
+		<p>Vivamus felis erat, lobortis vel justo eu, blandit aliquam arcu. Nunc tempus dictum magna id consequat. Morbi sodales mi et ligula congue aliquet. Mauris sapien nibh, porta a interdum quis, vehicula eu nunc. Sed semper in mi sit amet vehicula. Maecenas placerat suscipit eleifend. Proin diam justo, vulputate ut hendrerit sit amet, faucibus non urna. Nulla placerat, quam ut vulputate faucibus, odio erat fermentum nisl, vitae tempus lectus orci vitae leo. Praesent cursus tellus nec mi fringilla, eu euismod quam egestas. Proin dolor dui, luctus a nibh id, accumsan vehicula metus. Cras venenatis felis vitae magna cursus, ut fringilla tortor imperdiet. Curabitur dictum posuere sem, a luctus turpis ultrices ac. Morbi semper consectetur massa in fringilla. Nulla ipsum tellus, dictum a commodo vel, sodales pulvinar eros. Donec mollis sapien a nunc lacinia, eu porta enim eleifend. Vivamus non feugiat felis, in sodales tellus.</p>
+	</section>
+</div>
+
+<div class="wb-equalheight">
+	<section>
+		<h2>Short container</h2>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vehicula mauris ipsum, nec facilisis sem eleifend eu. Donec fringilla dapibus massa ut tristique. In id nulla at purus vehicula vehicula. Morbi lacinia odio ut nulla euismod sagittis. Mauris interdum eu nibh in tincidunt. Praesent non tincidunt risus, et malesuada est. Mauris nisl nunc, pharetra sed dapibus vel, iaculis vitae lorem.</p>
+	</section>
+	<section>
+		<h2>Medium container</h2>
+		<p>In eget diam ac lectus consectetur accumsan et quis turpis. Nam vitae vulputate odio, vel posuere nunc. Mauris at pharetra lorem, ac commodo neque. Integer adipiscing luctus orci eu aliquet. Phasellus fermentum accumsan augue at dignissim. Proin malesuada leo quis ante ornare, vitae pellentesque lorem vulputate. Fusce fermentum, nibh sit amet interdum luctus, sapien magna tristique orci, in ultrices turpis mi lacinia quam. Etiam gravida velit id tempor vulputate. Maecenas aliquet pulvinar viverra. Quisque luctus viverra sem ut suscipit. Suspendisse et mi justo.</p>
+	</section>
+	<section>
+		<h2>Long container</h2>
+		<p>Vivamus felis erat, lobortis vel justo eu, blandit aliquam arcu. Nunc tempus dictum magna id consequat. Morbi sodales mi et ligula congue aliquet. Mauris sapien nibh, porta a interdum quis, vehicula eu nunc. Sed semper in mi sit amet vehicula. Maecenas placerat suscipit eleifend. Proin diam justo, vulputate ut hendrerit sit amet, faucibus non urna. Nulla placerat, quam ut vulputate faucibus, odio erat fermentum nisl, vitae tempus lectus orci vitae leo. Praesent cursus tellus nec mi fringilla, eu euismod quam egestas. Proin dolor dui, luctus a nibh id, accumsan vehicula metus. Cras venenatis felis vitae magna cursus, ut fringilla tortor imperdiet. Curabitur dictum posuere sem, a luctus turpis ultrices ac. Morbi semper consectetur massa in fringilla. Nulla ipsum tellus, dictum a commodo vel, sodales pulvinar eros. Donec mollis sapien a nunc lacinia, eu porta enim eleifend. Vivamus non feugiat felis, in sodales tellus.</p>
+	</section>
+	<section>
+		<h2>Short container</h2>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vehicula mauris ipsum, nec facilisis sem eleifend eu. Donec fringilla dapibus massa ut tristique. In id nulla at purus vehicula vehicula. Morbi lacinia odio ut nulla euismod sagittis. Mauris interdum eu nibh in tincidunt. Praesent non tincidunt risus, et malesuada est. Mauris nisl nunc, pharetra sed dapibus vel, iaculis vitae lorem.</p>
+	</section>
+	<section>
+		<h2>Medium container</h2>
+		<p>In eget diam ac lectus consectetur accumsan et quis turpis. Nam vitae vulputate odio, vel posuere nunc. Mauris at pharetra lorem, ac commodo neque. Integer adipiscing luctus orci eu aliquet. Phasellus fermentum accumsan augue at dignissim. Proin malesuada leo quis ante ornare, vitae pellentesque lorem vulputate. Fusce fermentum, nibh sit amet interdum luctus, sapien magna tristique orci, in ultrices turpis mi lacinia quam. Etiam gravida velit id tempor vulputate. Maecenas aliquet pulvinar viverra. Quisque luctus viverra sem ut suscipit. Suspendisse et mi justo.</p>
+	</section>
+	<section>
+		<h2>Long container</h2>
+		<p>Vivamus felis erat, lobortis vel justo eu, blandit aliquam arcu. Nunc tempus dictum magna id consequat. Morbi sodales mi et ligula congue aliquet. Mauris sapien nibh, porta a interdum quis, vehicula eu nunc. Sed semper in mi sit amet vehicula. Maecenas placerat suscipit eleifend. Proin diam justo, vulputate ut hendrerit sit amet, faucibus non urna. Nulla placerat, quam ut vulputate faucibus, odio erat fermentum nisl, vitae tempus lectus orci vitae leo. Praesent cursus tellus nec mi fringilla, eu euismod quam egestas. Proin dolor dui, luctus a nibh id, accumsan vehicula metus. Cras venenatis felis vitae magna cursus, ut fringilla tortor imperdiet. Curabitur dictum posuere sem, a luctus turpis ultrices ac. Morbi semper consectetur massa in fringilla. Nulla ipsum tellus, dictum a commodo vel, sodales pulvinar eros. Donec mollis sapien a nunc lacinia, eu porta enim eleifend. Vivamus non feugiat felis, in sodales tellus.</p>
+	</section>
+</div>

--- a/src/plugins/equalheight/equalheight-fr.hbs
+++ b/src/plugins/equalheight/equalheight-fr.hbs
@@ -1,0 +1,52 @@
+---
+{
+	"title": "Égalisation des hauteurs",
+	"language": "fr",
+	"category": "Plugiciel",
+	"description": "Un plugiel d'égalisation des hauteurs réactif.",
+	"tag": "equalheight",
+	"en": "equalheight",
+	"css": "demo/equalheight"
+}
+---
+<div class="wb-equalheight">
+	<section>
+		<h2>Contenant à basse hauteur</h2>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vehicula mauris ipsum, nec facilisis sem eleifend eu. Donec fringilla dapibus massa ut tristique. In id nulla at purus vehicula vehicula. Morbi lacinia odio ut nulla euismod sagittis. Mauris interdum eu nibh in tincidunt. Praesent non tincidunt risus, et malesuada est. Mauris nisl nunc, pharetra sed dapibus vel, iaculis vitae lorem.</p>
+	</section>
+	<section>
+		<h2>Contenant à hauteur moyenne</h2>
+		<p>In eget diam ac lectus consectetur accumsan et quis turpis. Nam vitae vulputate odio, vel posuere nunc. Mauris at pharetra lorem, ac commodo neque. Integer adipiscing luctus orci eu aliquet. Phasellus fermentum accumsan augue at dignissim. Proin malesuada leo quis ante ornare, vitae pellentesque lorem vulputate. Fusce fermentum, nibh sit amet interdum luctus, sapien magna tristique orci, in ultrices turpis mi lacinia quam. Etiam gravida velit id tempor vulputate. Maecenas aliquet pulvinar viverra. Quisque luctus viverra sem ut suscipit. Suspendisse et mi justo.</p>
+	</section>
+	<section>
+		<h2>Contenant à grande hauteur</h2>
+		<p>Vivamus felis erat, lobortis vel justo eu, blandit aliquam arcu. Nunc tempus dictum magna id consequat. Morbi sodales mi et ligula congue aliquet. Mauris sapien nibh, porta a interdum quis, vehicula eu nunc. Sed semper in mi sit amet vehicula. Maecenas placerat suscipit eleifend. Proin diam justo, vulputate ut hendrerit sit amet, faucibus non urna. Nulla placerat, quam ut vulputate faucibus, odio erat fermentum nisl, vitae tempus lectus orci vitae leo. Praesent cursus tellus nec mi fringilla, eu euismod quam egestas. Proin dolor dui, luctus a nibh id, accumsan vehicula metus. Cras venenatis felis vitae magna cursus, ut fringilla tortor imperdiet. Curabitur dictum posuere sem, a luctus turpis ultrices ac. Morbi semper consectetur massa in fringilla. Nulla ipsum tellus, dictum a commodo vel, sodales pulvinar eros. Donec mollis sapien a nunc lacinia, eu porta enim eleifend. Vivamus non feugiat felis, in sodales tellus.</p>
+	</section>
+</div>
+
+<div class="wb-equalheight">
+	<section>
+		<h2>Contenant à basse hauteur</h2>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vehicula mauris ipsum, nec facilisis sem eleifend eu. Donec fringilla dapibus massa ut tristique. In id nulla at purus vehicula vehicula. Morbi lacinia odio ut nulla euismod sagittis. Mauris interdum eu nibh in tincidunt. Praesent non tincidunt risus, et malesuada est. Mauris nisl nunc, pharetra sed dapibus vel, iaculis vitae lorem.</p>
+	</section>
+	<section>
+		<h2>Contenant à hauteur moyenne</h2>
+		<p>In eget diam ac lectus consectetur accumsan et quis turpis. Nam vitae vulputate odio, vel posuere nunc. Mauris at pharetra lorem, ac commodo neque. Integer adipiscing luctus orci eu aliquet. Phasellus fermentum accumsan augue at dignissim. Proin malesuada leo quis ante ornare, vitae pellentesque lorem vulputate. Fusce fermentum, nibh sit amet interdum luctus, sapien magna tristique orci, in ultrices turpis mi lacinia quam. Etiam gravida velit id tempor vulputate. Maecenas aliquet pulvinar viverra. Quisque luctus viverra sem ut suscipit. Suspendisse et mi justo.</p>
+	</section>
+	<section>
+		<h2>Contenant à grande hauteur</h2>
+		<p>Vivamus felis erat, lobortis vel justo eu, blandit aliquam arcu. Nunc tempus dictum magna id consequat. Morbi sodales mi et ligula congue aliquet. Mauris sapien nibh, porta a interdum quis, vehicula eu nunc. Sed semper in mi sit amet vehicula. Maecenas placerat suscipit eleifend. Proin diam justo, vulputate ut hendrerit sit amet, faucibus non urna. Nulla placerat, quam ut vulputate faucibus, odio erat fermentum nisl, vitae tempus lectus orci vitae leo. Praesent cursus tellus nec mi fringilla, eu euismod quam egestas. Proin dolor dui, luctus a nibh id, accumsan vehicula metus. Cras venenatis felis vitae magna cursus, ut fringilla tortor imperdiet. Curabitur dictum posuere sem, a luctus turpis ultrices ac. Morbi semper consectetur massa in fringilla. Nulla ipsum tellus, dictum a commodo vel, sodales pulvinar eros. Donec mollis sapien a nunc lacinia, eu porta enim eleifend. Vivamus non feugiat felis, in sodales tellus.</p>
+	</section>
+	<section>
+		<h2>Contenant à basse hauteur</h2>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc vehicula mauris ipsum, nec facilisis sem eleifend eu. Donec fringilla dapibus massa ut tristique. In id nulla at purus vehicula vehicula. Morbi lacinia odio ut nulla euismod sagittis. Mauris interdum eu nibh in tincidunt. Praesent non tincidunt risus, et malesuada est. Mauris nisl nunc, pharetra sed dapibus vel, iaculis vitae lorem.</p>
+	</section>
+	<section>
+		<h2>Contenant à hauteur moyenne</h2>
+		<p>In eget diam ac lectus consectetur accumsan et quis turpis. Nam vitae vulputate odio, vel posuere nunc. Mauris at pharetra lorem, ac commodo neque. Integer adipiscing luctus orci eu aliquet. Phasellus fermentum accumsan augue at dignissim. Proin malesuada leo quis ante ornare, vitae pellentesque lorem vulputate. Fusce fermentum, nibh sit amet interdum luctus, sapien magna tristique orci, in ultrices turpis mi lacinia quam. Etiam gravida velit id tempor vulputate. Maecenas aliquet pulvinar viverra. Quisque luctus viverra sem ut suscipit. Suspendisse et mi justo.</p>
+	</section>
+	<section>
+		<h2>Contenant à grande hauteur</h2>
+		<p>Vivamus felis erat, lobortis vel justo eu, blandit aliquam arcu. Nunc tempus dictum magna id consequat. Morbi sodales mi et ligula congue aliquet. Mauris sapien nibh, porta a interdum quis, vehicula eu nunc. Sed semper in mi sit amet vehicula. Maecenas placerat suscipit eleifend. Proin diam justo, vulputate ut hendrerit sit amet, faucibus non urna. Nulla placerat, quam ut vulputate faucibus, odio erat fermentum nisl, vitae tempus lectus orci vitae leo. Praesent cursus tellus nec mi fringilla, eu euismod quam egestas. Proin dolor dui, luctus a nibh id, accumsan vehicula metus. Cras venenatis felis vitae magna cursus, ut fringilla tortor imperdiet. Curabitur dictum posuere sem, a luctus turpis ultrices ac. Morbi semper consectetur massa in fringilla. Nulla ipsum tellus, dictum a commodo vel, sodales pulvinar eros. Donec mollis sapien a nunc lacinia, eu porta enim eleifend. Vivamus non feugiat felis, in sodales tellus.</p>
+	</section>
+</div>

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -40,8 +40,8 @@ var selector = ".wb-equalheight",
 	 * @method onResize
 	 */
 	onResize = function() {
-		var $elm = $( selector ),
-			$children = $elm.children(),
+		var $elms = $( selector ),
+			$children,
 			row = [ ],
 			rowTop = -1,
 			currentChild,
@@ -50,31 +50,35 @@ var selector = ".wb-equalheight",
 			tallestHeight = -1,
 			i;
 
-		for ( i = $children.length - 1; i >= 0; i-- ) {
-			currentChild = $children[ i ];
+		$elms.each( function() {
+			$children = $( this ).children();
 
-			// Ensure all children that are on the same baseline have the same 'top' value.
-			currentChild.style.verticalAlign = "top";
+			for ( i = $children.length - 1; i >= 0; i-- ) {
+				currentChild = $children[ i ];
 
-			// Remove any previously set min height
-			currentChild.style.minHeight = 0;
+				// Ensure all children that are on the same baseline have the same 'top' value.
+				currentChild.style.verticalAlign = "top";
 
-			currentChildTop = currentChild.offsetTop;
-			currentChildHeight = currentChild.offsetHeight;
+				// Remove any previously set min height
+				currentChild.style.minHeight = 0;
 
-			if ( currentChildTop !== rowTop ) {
-				setRowHeight( row, tallestHeight );
+				currentChildTop = currentChild.offsetTop;
+				currentChildHeight = currentChild.offsetHeight;
 
-				rowTop = currentChildTop;
-				tallestHeight = currentChildHeight;
-			} else {
-				tallestHeight = (currentChildHeight > tallestHeight) ? currentChildHeight : tallestHeight;
+				if ( currentChildTop !== rowTop ) {
+					setRowHeight( row, tallestHeight );
+
+					rowTop = currentChildTop;
+					tallestHeight = currentChildHeight;
+				} else {
+					tallestHeight = (currentChildHeight > tallestHeight) ? currentChildHeight : tallestHeight;
+				}
+
+				row.push( currentChild );
 			}
 
-			row.push( currentChild );
-		}
-
-		setRowHeight( row, tallestHeight );
+			setRowHeight( row, tallestHeight );
+		} );
 	},
 
 	/**

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -61,7 +61,7 @@ var selector = ".wb-equalheight",
 			i;
 
 		$elms.each( function() {
-			var $detachedChildren;
+			var $detachedChildren, minHeight;
 
 			$children = $( this ).children();
 
@@ -95,31 +95,41 @@ var selector = ".wb-equalheight",
 				currentChildHeight = currentChild.offsetHeight;
 
 				if ( currentChildTop !== rowTop ) {
-					setRowHeight( row, tallestHeight );
+					recordRowHeight( row, tallestHeight );
 
 					rowTop = currentChildTop;
 					tallestHeight = currentChildHeight;
 				} else {
-					tallestHeight = (currentChildHeight > tallestHeight) ? currentChildHeight : tallestHeight;
+					tallestHeight = ( currentChildHeight > tallestHeight ) ? currentChildHeight : tallestHeight;
 				}
 
-				row.push( currentChild );
+				row.push( $children.eq( i ) );
 			}
+			recordRowHeight( row, tallestHeight );
 
-			setRowHeight( row, tallestHeight );
+			$detachedChildren = $children.detach();
+			for ( i = $detachedChildren.length - 1; i >= 0; i-- ) {
+				minHeight = $detachedChildren.eq( i ).data( "min-height" );
+
+				if ( minHeight ) {
+					$detachedChildren[ i ].style.minHeight = minHeight;
+				}
+			}
+			$detachedChildren.appendTo( $(this) );
 		} );
 	},
 
 	/**
-	 * @method setRowHeight
-	 * @param {array} row The rows to be updated
-	 * @param {integer} height The new row height
+	 * @method recordRowHeight
+	 * @param {array} row The elements for which to record the height
+	 * @param {integer} height The height to record
 	 */
-	setRowHeight = function( row, height ) {
+	recordRowHeight = function( row, height ) {
+
 		// only set a height if more than one element exists in the row
 		if ( row.length > 1 ) {
 			for ( var i = row.length - 1; i >= 0; i-- ) {
-				row[ i ].style.minHeight = height + "px";
+				row[ i ].data( "min-height", height + "px" );
 			}
 		}
 		row.length = 0;

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -57,9 +57,10 @@ var selector = ".wb-equalheight",
 				rowTop = -1,
 				currentChildTop = -1,
 				currentChildHeight = -1,
-				tallestHeight = -1;
+				tallestHeight = -1,
+				$this = $( this );
 
-			$children = $( this ).children();
+			$children = $this.children();
 
 			$detachedChildren = $children.detach();
 			for ( i = $detachedChildren.length - 1; i >= 0; i-- ) {
@@ -82,7 +83,7 @@ var selector = ".wb-equalheight",
 
 				currentChild.style.cssText = childCSS;
 			}
-			$detachedChildren.appendTo( $(this) );
+			$detachedChildren.appendTo( $this );
 
 			for ( i = $children.length - 1; i >= 0; i-- ) {
 				currentChild = $children[ i ];
@@ -111,7 +112,7 @@ var selector = ".wb-equalheight",
 					$detachedChildren[ i ].style.minHeight = minHeight;
 				}
 			}
-			$detachedChildren.appendTo( $(this) );
+			$detachedChildren.appendTo( $this );
 		} );
 	},
 

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -74,9 +74,7 @@ var selector = ".wb-equalheight",
 			row.push( currentChild );
 		}
 
-		if ( row.length !== 0 ) {
-			setRowHeight( row, tallestHeight );
-		}
+		setRowHeight( row, tallestHeight );
 	},
 
 	/**
@@ -85,8 +83,11 @@ var selector = ".wb-equalheight",
 	 * @param {integer} height The new row height
 	 */
 	setRowHeight = function( row, height ) {
-		for ( var i = row.length - 1; i >= 0; i-- ) {
-			row[ i ].style.minHeight = height + "px";
+		// only set a height if more than one element exists in the row
+		if ( row.length > 1 ) {
+			for ( var i = row.length - 1; i >= 0; i-- ) {
+				row[ i ].style.minHeight = height + "px";
+			}
 		}
 		row.length = 0;
 	};

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -61,10 +61,13 @@ var selector = ".wb-equalheight",
 			i;
 
 		$elms.each( function() {
+			var $detachedChildren;
+
 			$children = $( this ).children();
 
-			for ( i = $children.length - 1; i >= 0; i-- ) {
-				currentChild = $children[ i ];
+			$detachedChildren = $children.detach();
+			for ( i = $detachedChildren.length - 1; i >= 0; i-- ) {
+				currentChild = $detachedChildren[ i ];
 				childCSS = currentChild.style.cssText;
 
 				// Ensure all children that are on the same baseline have the same 'top' value.
@@ -82,6 +85,11 @@ var selector = ".wb-equalheight",
 				}
 
 				currentChild.style.cssText = childCSS;
+			}
+			$detachedChildren.appendTo( $(this) );
+
+			for ( i = $children.length - 1; i >= 0; i-- ) {
+				currentChild = $children[ i ];
 
 				currentChildTop = currentChild.offsetTop;
 				currentChildHeight = currentChild.offsetHeight;

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -49,19 +49,15 @@ var selector = ".wb-equalheight",
 	 * @method onResize
 	 */
 	onResize = function() {
-		var $elms = $( selector ),
-			$children,
-			row = [ ],
-			rowTop = -1,
-			currentChild,
-			childCSS,
-			currentChildTop = -1,
-			currentChildHeight = -1,
-			tallestHeight = -1,
-			i;
+		var $elms = $( selector );
 
 		$elms.each( function() {
-			var $detachedChildren, minHeight;
+			var $children, $detachedChildren, currentChild, childCSS, minHeight, i,
+				row = [ ],
+				rowTop = -1,
+				currentChildTop = -1,
+				currentChildHeight = -1,
+				tallestHeight = -1;
 
 			$children = $( this ).children();
 

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -63,7 +63,7 @@ var selector = ".wb-equalheight",
 			$children = $this.children();
 
 			$detachedChildren = $children.detach();
-			for ( i = $detachedChildren.length - 1; i >= 0; i-- ) {
+			for ( i = $detachedChildren.length - 1; i !== -1; i -= 1 ) {
 				currentChild = $detachedChildren[ i ];
 				childCSS = currentChild.style.cssText;
 
@@ -85,7 +85,7 @@ var selector = ".wb-equalheight",
 			}
 			$detachedChildren.appendTo( $this );
 
-			for ( i = $children.length - 1; i >= 0; i-- ) {
+			for ( i = $children.length - 1; i !== -1; i -= 1 ) {
 				currentChild = $children[ i ];
 
 				currentChildTop = currentChild.offsetTop;
@@ -105,7 +105,7 @@ var selector = ".wb-equalheight",
 			recordRowHeight( row, tallestHeight );
 
 			$detachedChildren = $children.detach();
-			for ( i = $detachedChildren.length - 1; i >= 0; i-- ) {
+			for ( i = $detachedChildren.length - 1; i !== -1; i -= 1 ) {
 				minHeight = $detachedChildren.eq( i ).data( "min-height" );
 
 				if ( minHeight ) {
@@ -125,7 +125,7 @@ var selector = ".wb-equalheight",
 
 		// only set a height if more than one element exists in the row
 		if ( row.length > 1 ) {
-			for ( var i = row.length - 1; i >= 0; i-- ) {
+			for ( var i = row.length - 1; i !== -1; i -= 1 ) {
 				row[ i ].data( "min-height", height + "px" );
 			}
 		}

--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -15,6 +15,15 @@
  */
 var selector = ".wb-equalheight",
 	$document = wb.doc,
+	vAlignCSS = "vertical-align",
+	vAlignDefault = "top",
+	minHeightCSS = "min-height",
+	minHeightDefault = "0",
+	cssValueSeparator = ":",
+	cssPropertySeparator = ";",
+	regexCSSValue = " ?[^;]+",
+	regexVAlign = new RegExp( vAlignCSS + cssValueSeparator + regexCSSValue + cssPropertySeparator ),
+	regexMinHeight = new RegExp( minHeightCSS + cssValueSeparator + regexCSSValue + cssPropertySeparator ),
 
 	/**
 	 * Init runs once per plugin element on the page. There may be multiple elements.
@@ -45,6 +54,7 @@ var selector = ".wb-equalheight",
 			row = [ ],
 			rowTop = -1,
 			currentChild,
+			childCSS,
 			currentChildTop = -1,
 			currentChildHeight = -1,
 			tallestHeight = -1,
@@ -55,12 +65,23 @@ var selector = ".wb-equalheight",
 
 			for ( i = $children.length - 1; i >= 0; i-- ) {
 				currentChild = $children[ i ];
+				childCSS = currentChild.style.cssText;
 
 				// Ensure all children that are on the same baseline have the same 'top' value.
-				currentChild.style.verticalAlign = "top";
+				if ( childCSS.indexOf( vAlignCSS ) !== -1 ) {
+					childCSS = childCSS.replace( regexVAlign, vAlignCSS + cssValueSeparator + vAlignDefault + cssPropertySeparator );
+				} else {
+					childCSS += " " + vAlignCSS + cssValueSeparator + vAlignDefault + cssPropertySeparator;
+				}
 
 				// Remove any previously set min height
-				currentChild.style.minHeight = 0;
+				if ( childCSS.indexOf( minHeightCSS ) !== -1 ) {
+					childCSS = childCSS.replace( regexMinHeight, minHeightCSS + cssValueSeparator + minHeightDefault + cssPropertySeparator );
+				} else {
+					childCSS += " " + minHeightCSS + cssValueSeparator + minHeightDefault + cssPropertySeparator;
+				}
+
+				currentChild.style.cssText = childCSS;
 
 				currentChildTop = currentChild.offsetTop;
 				currentChildHeight = currentChild.offsetHeight;


### PR DESCRIPTION
First round of optimisations to this plugin.

This should reduce the number of reflows/repaints from
- 5 per container to equalise

to
- 2 per container to equalise plus 2 per group of containers to equalise.

What's the best way to do performance testing on these changes?
