### PR TITLE
Build: Bump grunt-sass for partials fix

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -368,7 +368,6 @@ module.exports = (grunt) ->
 					cwd: "src/base"
 					src: [
 						"**/*.scss"
-						"!**/_*.scss"
 						"!**/demo/*.scss"
 					]
 					dest: "dist/unmin/css/"
@@ -378,7 +377,6 @@ module.exports = (grunt) ->
 					cwd: "theme/sass"
 					src: [
 						"**/*.scss"
-						"!**/_*.scss"
 					]
 					dest: "dist/unmin/css/"
 					ext: ".css"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-jscs-checker": "~0.2.5",
     "grunt-mocha": "~0.4.1",
     "grunt-modernizr": "~0.4.0",
-    "grunt-sass": "~0.8.0",
+    "grunt-sass": "~0.9.0",
     "grunt-saucelabs": "~4.1.2",
     "mocha": "~1.13.0",
     "sinon": "~1.7.3"


### PR DESCRIPTION
- "_" partial files are excluded now by default
- Remove "Other" regular SCSS compiling since it is for demos only
