### PR TITLE
Focus: Changed folder name to resolve click handler issue

### DIFF
--- a/src/plugins/wb-focus/focus.js
+++ b/src/plugins/wb-focus/focus.js
@@ -40,7 +40,9 @@ $document.on( clickEvents, linkSelector, function( event ) {
 	var testHref = event.currentTarget.getAttribute( "href" );
 
 	// Same page links only
-	if ( testHref.charAt( 0 ) === "#" && ( $linkTarget = $( testHref ) ).length !== 0 ) {
+	if ( testHref.charAt( 0 ) === "#" && !event.isDefaultPrevented() &&
+		( $linkTarget = $( testHref ) ).length !== 0 ) {
+
 		$linkTarget.trigger( setFocusEvent );
 	}
 });


### PR DESCRIPTION
Changed from "focus" to "wb-focus" to ensure it is later in the concatenated JS file than other plugins so it can respect the event.preventDefault() of other plugins. It is important that it is later in the JS file so that its click handler is called later than the click handlers of the plugins files (otherwise it will never see the event.preventDefault()).

This was needed to fix issue in Chrome and IE10 where it didn't detect the event.preventDefault() used by Tabs or Menu.
