### PR TITLE
JSCS: Disallow unnecessary quoting in objects

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -93,6 +93,7 @@
 		"!=",
 		"!=="
 	],
+	"disallowQuotedKeysInObjects": "allButReserved",
 	"requireLineFeedAtFileEnd": true,
 	"validateJSDoc": {
 		"checkParamNames": true,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "grunt-gh-pages": "~0.8.0",
     "grunt-htmlcompressor": "~0.1.9",
     "grunt-imagine": "http://github.com/LaurentGoderre/grunt-imagine/tarball/custom",
-    "grunt-jscs-checker": "~0.2.5",
+    "grunt-jscs-checker": "~0.2.6",
     "grunt-mocha": "~0.4.1",
     "grunt-modernizr": "~0.4.0",
     "grunt-sass": "~0.8.0",

--- a/src/plugins/tabs/tabs.js
+++ b/src/plugins/tabs/tabs.js
@@ -87,7 +87,7 @@ var pluginName = "wb-tabs",
 
 			// Determine the current view
 			isSmallView = document.documentElement.className.indexOf( smallViewPattern ) !== -1;
-				
+
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
 				i18n = wb.i18n;
@@ -155,8 +155,8 @@ var pluginName = "wb-tabs",
 						}
 					} else {
 						$panel.attr({
-							"role": "tabpanel",
-							"open": "open"
+							role: "tabpanel",
+							open: "open"
 						});
 						$panel.addClass( ( Modernizr.details ? "" :  "open " ) +
 							"fade " + ( isOpen ? "in" : "out" ) );
@@ -203,10 +203,10 @@ var pluginName = "wb-tabs",
 			}
 
 			$elm.data({
-				"panels": $panels,
-				"tablist": $tablist,
-				"delay": interval,
-				"ctime": 0
+				panels: $panels,
+				tablist: $tablist,
+				delay: interval,
+				ctime: 0
 			});
 
 			initialized = true;
@@ -334,7 +334,7 @@ var pluginName = "wb-tabs",
 				"aria-hidden": "false",
 				"aria-expanded": "true"
 			});
-			
+
 		$controls
 			.find( ".active" )
 				.removeClass( "active" )
@@ -361,7 +361,7 @@ var pluginName = "wb-tabs",
 		} catch ( error ) {
 		}
 	},
-	
+
 	/*
 	 * @method onPick
 	 * @param {jQuery DOM element} $sldr The plugin element
@@ -438,7 +438,7 @@ var pluginName = "wb-tabs",
 			$elm = $( selector );
 			$details = $elm.children( "details" );
 			$tablist = $elm.children( "ul" );
-			
+
 			// Disable equal heights for small view and enable for large view
 			if ( $elm.attr( "class" ).indexOf( equalHeightClass ) !== -1 ) {
 				$elm.toggleClass( equalHeightClass + " " + equalHeightOffClass );
@@ -446,7 +446,7 @@ var pluginName = "wb-tabs",
 
 			if ( isSmallView ) {
 
-				// Switch to small view			
+				// Switch to small view
 				$active = $tablist.find( ".active a" );
 				$openDetails = $details.filter( "#" + $active.attr( "href" ).substring( 1 ) );
 				$nonOpenDetails = $details
@@ -475,8 +475,8 @@ var pluginName = "wb-tabs",
 
 				$details
 					.attr({
-						"role": "tabpanel",
-						"open": "open"
+						role: "tabpanel",
+						open: "open"
 					})
 					.not( $openDetails )
 						.addClass( "fade out" );
@@ -550,14 +550,14 @@ var pluginName = "wb-tabs",
 			$plypause = $sldr.find( "a.plypause" );
 			$plypause.find( ".glyphicon" ).toggleClass( "glyphicon-play glyphicon-pause" );
 			$sldr.toggleClass( "playing" );
-			
+
 			text = $plypause[ 0 ].getElementsByTagName( "i" )[ 0 ];
 			text.innerHTML = text.innerHTML === playText ? i18nText.pause : playText;
-				
+
 			inv = $plypause.find( ".wb-inv" )[ 0 ];
 			inv.innerHTML = inv.innerHTML === rotStopText ? i18nText.rotStart : rotStopText;
 		}
-			
+
 		if ( which > 36 ) {
 			onCycle( $elm, which < 39 ? -1 : 1 );
 			$sldr.find( ".active a" ).trigger( setFocusEvent );


### PR DESCRIPTION
This was mostly fixed in the original JSCS cleanup, but couldn't be enforced till the fix to make it compatible with ES3/IE8 keywords
