### PR TITLE
Share: output sprite and SCSS inside plug-in dir

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -368,10 +368,9 @@ module.exports = (grunt) ->
 			share:
 				src: [
 					"src/plugins/share/sprites/*.png"
-					"!src/plugins/share/sprites/sprites_*.png"
 				]
-				css: "src/plugins/share/_sprites.scss"
-				map: "src/plugins/assets/sprites_share.png"
+				css: "src/plugins/share/sprites/_sprites.scss"
+				map: "src/plugins/share/assets/sprites_share.png"
 				output: "scss"
 
 		# Compiles the Sass files

--- a/src/plugins/share/share.scss
+++ b/src/plugins/share/share.scss
@@ -2,7 +2,7 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
-@import "sprites";
+@import "sprites/sprites";
 
 .wb-share {
 	.shr-lnk {


### PR DESCRIPTION
Outputs the sprite image under the `share/assets` and the Sass under `share/sprites`

@LaurentGoderre this is pretty subjective, but I wanted to remove the root `src/assets` folder. Feel free to close if you don't agree :wink: 
