### PR TITLE
Footnotes: Implemented HTML5 markup updates in HBS files...

### DIFF
--- a/src/plugins/footnotes/footnotes-en.hbs
+++ b/src/plugins/footnotes/footnotes-en.hbs
@@ -16,11 +16,11 @@
 <section>
 	<h2>Benefits</h2>
 	<ul>
-		<li>Conforms to WCAG 2.0 AA<sup id="fn2a-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
+		<li>Conforms to WCAG 2.0 AA<sup id="fn2-1-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
 		<li>Progressive enhancement approach</li>
-		<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fn2b-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
+		<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
 		<li>Support for English and French</li>
-		<li>Configurable layout and design<sup id="fn2c-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Footnote </span>3</a></sup></li>
+		<li>Configurable layout and design<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Footnote </span>3</a></sup></li>
 	</ul>
 </section>
 
@@ -31,40 +31,38 @@
 	</ul>
 </section>
 
-<div class="wb-fnote" role="note">
-	<section>
-		<h2 id="fn" class="wb-inv">Footnotes</h2>
-		<dl>
-			<dt>Footnote 1</dt>
-			<dd id="fn1">
-				<p>Example of a standard footnote.</p>
-				<p class="fn-rtn">
-					<a href="#fn1-rf"><span class="wb-inv">Return to footnote </span>1<span class="wb-inv"> referrer</span></a>
-				</p>
-			</dd>
-			<dt>Footnote 2</dt>
-			<dd id="fn2">
-				<p>Example of a footnote being referenced by multiple pieces of content.</p>
-				<p class="fn-rtn">
-					<a href="#fn2a-rf"><span class="wb-inv">Return to <span>first</span> footnote </span>2<span class="wb-inv"> referrer</span></a>
-				</p>
-			</dd>
-			<dt>Footnote 3</dt>
-			<dd id="fn3">
-				<p>Example of a footnote containing multiple paragraphs (first paragraph).</p>
-				<p>Example of a footnote containing multiple paragraphs (second paragraph).</p>
-				<p>Example of a footnote containing multiple paragraphs (third paragraph).</p>
-				<p class="fn-rtn">
-					<a href="#fn3-rf"><span class="wb-inv">Return to footnote </span>3<span class="wb-inv"> referrer</span></a>
-				</p>
-			</dd>
-			<dt>Footnote *</dt>
-			<dd id="fn*">
-				<p>Example of a standard footnote, denoted by a symbol.</p>
-				<p class="fn-rtn">
-					<a href="#fn*-rf"><span class="wb-inv">Return to footnote </span>*<span class="wb-inv"> referrer</span></a>
-				</p>
-			</dd>
-		</dl>
-	</section>
-</div>
+<section class="wb-fnote" role="note">
+	<h2 id="fn">Footnotes</h2>
+	<dl>
+		<dt>Footnote 1</dt>
+		<dd id="fn1">
+			<p>Example of a standard footnote.</p>
+			<p class="fn-rtn">
+				<a href="#fn1-rf"><span class="wb-inv">Return to footnote </span>1<span class="wb-inv"> referrer</span></a>
+			</p>
+		</dd>
+		<dt>Footnote 2</dt>
+		<dd id="fn2">
+			<p>Example of a footnote being referenced by multiple pieces of content.</p>
+			<p class="fn-rtn">
+				<a href="#fn2-1-rf"><span class="wb-inv">Return to <span>first</span> footnote </span>2<span class="wb-inv"> referrer</span></a>
+			</p>
+		</dd>
+		<dt>Footnote 3</dt>
+		<dd id="fn3">
+			<p>Example of a footnote containing multiple paragraphs (first paragraph).</p>
+			<p>Example of a footnote containing multiple paragraphs (second paragraph).</p>
+			<p>Example of a footnote containing multiple paragraphs (third paragraph).</p>
+			<p class="fn-rtn">
+				<a href="#fn3-rf"><span class="wb-inv">Return to footnote </span>3<span class="wb-inv"> referrer</span></a>
+			</p>
+		</dd>
+		<dt>Footnote *</dt>
+		<dd id="fn*">
+			<p>Example of a standard footnote, denoted by a symbol.</p>
+			<p class="fn-rtn">
+				<a href="#fn*-rf"><span class="wb-inv">Return to footnote </span>*<span class="wb-inv"> referrer</span></a>
+			</p>
+		</dd>
+	</dl>
+</section>

--- a/src/plugins/footnotes/footnotes-fr.hbs
+++ b/src/plugins/footnotes/footnotes-fr.hbs
@@ -16,11 +16,11 @@
 <section>
 	<h2>Avantages</h2>
 	<ul>
-		<li>Conformes à WCAG 2.0 AA<sup id="fn2a-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
+		<li>Conformes à WCAG 2.0 AA<sup id="fn2-1-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
 		<li>Approche d'amélioration progressive</li>
-		<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fn2b-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
+		<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
 		<li>Soutien pour l'anglais et le français</li>
-		<li>Mise en page et conception configurable<sup id="fn2c-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Note de bas de page </span>3</a></sup></li>
+		<li>Mise en page et conception configurable<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Note de bas de page </span>3</a></sup></li>
 	</ul>
 </section>
 
@@ -31,40 +31,38 @@
 		</ul>
 </section>
 
-<div class="wb-fnote" role="note">
-	<section>
-		<h2 id="fn" class="wb-inv">Notes de bas de page</h2>
-		<dl>
-			<dt>Note de bas de page 1</dt>
-			<dd id="fn1">
-				<p>Exemple de note de bas de page standard.</p>
-				<p class="fn-rtn">
-					<a href="#fn1-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>1</a>
-				</p>
-			</dd>
-			<dt>Note de bas de page 2</dt>
-			<dd id="fn2">
-				<p>Exemple de note de bas de page qui comporte de nombreux liens.</p>
-				<p class="fn-rtn">
-					<a href="#fn2a-rf"><span class="wb-inv">Retour à la <span>première</span> référence de la note de bas de page </span>2</a>
-				</p>
-			</dd>
-			<dt>Note de bas de page 3</dt>
-			<dd id="fn3">
-				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (premier paragraphe).</p>
-				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).</p>
-				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).</p>
-				<p class="fn-rtn">
-					<a href="#fn3-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>3</a>
-				</p>
-			</dd>
-			<dt>Note de bas de page *</dt>
-			<dd id="fn*">
-				<p>Exemple de note de bas de page standard, représentée par un symbole.</p>
-				<p class="fn-rtn">
-					<a href="#fn*-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>*</a>
-				</p>
-			</dd>
-		</dl>
-	</section>
-</div>
+<section class="wb-fnote" role="note">
+	<h2 id="fn">Notes de bas de page</h2>
+	<dl>
+		<dt>Note de bas de page 1</dt>
+		<dd id="fn1">
+			<p>Exemple de note de bas de page standard.</p>
+			<p class="fn-rtn">
+				<a href="#fn1-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>1</a>
+			</p>
+		</dd>
+		<dt>Note de bas de page 2</dt>
+		<dd id="fn2">
+			<p>Exemple de note de bas de page qui comporte de nombreux liens.</p>
+			<p class="fn-rtn">
+				<a href="#fn2-1-rf"><span class="wb-inv">Retour à la <span>première</span> référence de la note de bas de page </span>2</a>
+			</p>
+		</dd>
+		<dt>Note de bas de page 3</dt>
+		<dd id="fn3">
+			<p>Exemple de note de bas de page qui compte plusieurs paragraphes (premier paragraphe).</p>
+			<p>Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).</p>
+			<p>Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).</p>
+			<p class="fn-rtn">
+				<a href="#fn3-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>3</a>
+			</p>
+		</dd>
+		<dt>Note de bas de page *</dt>
+		<dd id="fn*">
+			<p>Exemple de note de bas de page standard, représentée par un symbole.</p>
+			<p class="fn-rtn">
+				<a href="#fn*-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>*</a>
+			</p>
+		</dd>
+	</dl>
+</section>


### PR DESCRIPTION
- Removed container div element and moved its class/role attributes to the section element.
- Removed "wb-inv" class from h2 element (fixes gh-2707).
- Replaced letters with dashes+numbers in the IDs of multi-referenced footnotes (fixes gh-3257).
