### PR TITLE
Menu: Switched to details/summary for expand/collapse

### DIFF
--- a/site/includes/languagetoggle.hbs
+++ b/site/includes/languagetoggle.hbs
@@ -1,23 +1,19 @@
-<div class="container">
-	<div class="row text-right">
-		<ul>
+<ul class="text-right">
 {{#if_eq language compare="en"}}
 	{{#if page.fr}}
-			<li>
-				<a lang="fr" href="{{page.fr}}-fr.html">Français</a>
-			</li>
+	<li>
+		<a lang="fr" href="{{page.fr}}-fr.html">Français</a>
+	</li>
 	{{/if}}
 {{/if_eq}}
-			<li class="curr">
-				{{#i18n "lang-native"}}{{/i18n}}{{#i18n "space"}}{{/i18n}}<span>{{#i18n "current"}}{{/i18n}}</span>
-			</li>
+	<li class="curr">
+		{{#i18n "lang-native"}}{{/i18n}}{{#i18n "space"}}{{/i18n}}<span>{{#i18n "current"}}{{/i18n}}</span>
+	</li>
 {{#unless_eq language compare="en"}}
 	{{#if page.en}}
-			<li>
-				<a lang="en" href="{{page.en}}-en.html">English</a>
-			</li>
+	<li>
+		<a lang="en" href="{{page.en}}-en.html">English</a>
+	</li>
 	{{/if}}
 {{/unless_eq}}
-		</ul>
-	</div>
-</div>
+</ul>

--- a/site/includes/mobimenu.hbs
+++ b/site/includes/mobimenu.hbs
@@ -1,11 +1,4 @@
-<div class="container">
-	<div class="row">
-		<section class="wb-mb-links col-xs-12 visible-sm visible-xs" id="wb-glb-mn">
-			<h2>{{#i18n "menu"}}{{/i18n}}</h2>
-			<ul class="list-inline text-right">
-				<li><a href="#mb-pnl" title="{{#i18n "menu"}}{{/i18n}}" aria-controls="mb-pnl" class="overlay-lnk" role="button"><span class="glyphicon glyphicon-th-list"><span class="wb-inv">{{#i18n "menu"}}{{/i18n}}</span></span></a></li>
-			</ul>
-			<div id="mb-pnl"></div>
-		</section>
-	</div>
-</div>
+<ul class="pnl-btn list-inline text-right">
+	<li><a href="#mb-pnl" title="{{#i18n "menu"}}{{/i18n}}" aria-controls="mb-pnl" class="overlay-lnk" role="button"><span class="glyphicon glyphicon-th-list"><span class="wb-inv">{{#i18n "menu"}}{{/i18n}}</span></span></a></li>
+</ul>
+<div id="mb-pnl"></div>

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -32,11 +32,21 @@
 		<header role="banner">
 			<div id="wb-bnr">
 				<div id="wb-bar">
-					<section id="wb-lng" class="visible-md visible-lg">
-						<h2>{{#i18n "tmpl-lang-select"}}{{/i18n}}</h2>
-						{{>languagetoggle}}
-					</section>
-					{{>mobimenu}}
+					<div class="container">
+						<div class="row">
+
+							<section id="wb-lng" class="visible-md visible-lg">
+								<h2>{{#i18n "tmpl-lang-select"}}{{/i18n}}</h2>
+								{{>languagetoggle}}
+							</section>
+
+							<section class="wb-mb-links col-xs-12 visible-sm visible-xs" id="wb-glb-mn">
+								<h2>{{#i18n "menu"}}{{/i18n}}</h2>
+								{{>mobimenu}}
+							</section>
+
+						</div>
+					</div>
 				</div>
 
 				<div class="container">

--- a/src/base/partials/_accessibility.scss
+++ b/src/base/partials/_accessibility.scss
@@ -29,6 +29,12 @@
 	}
 }
 
+#wb-lng {
+	h2 {
+		@extend %accessible-invisible;
+	}
+}
+
 #wb-glb-mn {
 	h2 {
 		@extend %accessible-invisible;

--- a/src/plugins/menu/menu.scss
+++ b/src/plugins/menu/menu.scss
@@ -97,38 +97,23 @@
 }
 
 #mb-pnl {
-	a {
-		position: relative;
-		.expicon {
-			position: absolute;
-			top: 0.5em;
-			left: -1em;
-			transform: rotate(270deg);
-		}
-		&:focus {
-			outline-offset: 0;
-		}
-	}
-	.active {
-		a {
-			.expicon {
-				transform: none !important;
-			}
-		}
-	}
 	ul {
-		float: none !important;
-		padding-left: 0;
+		margin-bottom: 0;
 		li {
-			float: none !important;
-			border: none !important;
-			ul {
-				@extend %global-display-none;
-				&.open {
-					@extend %global-display-block;
-				}
+			padding: 6px 0;
+			&.no-sect {
+				padding-left: 1.27em;
 			}
 		}
+	}
+	details {
+		ul {
+			padding-left: 2em;
+		}
+	}
+
+	%menu-mb-pnl-margin-bottom-5px {
+		margin-bottom: 5px;
 	}
 	.srch-pnl {
 		form {
@@ -137,8 +122,18 @@
 		label {
 			@extend %accessible-invisible;
 		}
-		.form-group, button {
-			margin-bottom: 5px;
+		.form-group {
+			display: inline-block;
+			margin-bottom: 0;
+			vertical-align: auto;
+		}
+		input {
+			display: inline-block;
+			width: auto;
+			@extend %menu-mb-pnl-margin-bottom-5px;
+		}
+		button {
+			@extend %menu-mb-pnl-margin-bottom-5px;
 		}
 	}
 	.modal-body {
@@ -150,11 +145,10 @@
 
 [dir=rtl] {
 	#mb-pnl {
-		a {
-			.expicon {
-				left: auto;
-				right: -1em;
-				transform: rotate(90deg);
+		details {
+			ul {
+				padding-left: 0;
+				padding-right: 2em;
 			}
 		}
 	}

--- a/src/plugins/tabs/tabs.js
+++ b/src/plugins/tabs/tabs.js
@@ -59,8 +59,7 @@ var pluginName = "wb-tabs",
 				elmId = $elm.attr( "id" ),
 				hashFocus = false,
 				open = "open",
-				$panel, i, len, tablist, isOpen, newId,
-				$summaries, summary, positionY;
+				$panel, i, len, tablist, isOpen, newId, positionY;
 
 			// Ensure there is an id on the element
 			if ( !elmId ) {
@@ -110,7 +109,6 @@ var pluginName = "wb-tabs",
 				$elm.addClass( "tabs-acc" );
 				addControls = false;
 				$panels = $elm.children();
-				$summaries = $panels.children( "summary" );
 				len = $panels.length;
 
 				// Ensure there is only one panel open
@@ -129,15 +127,15 @@ var pluginName = "wb-tabs",
 				if ( isSmallView && $elm.hasClass( equalHeightClass ) ) {
 					$elm.toggleClass( equalHeightClass + " " + equalHeightOffClass );
 				}
-				$summaries
-					.addClass( "wb-toggle" )
-					.attr( "data-toggle", "{\"parent\": \"#" + elmId +
-						"\", \"group\": \"details\"}" )
-					.trigger( "wb-init.wb-toggle" );
 
 				for ( i = 0; i !== len; i += 1 ) {
 					$panel = $panels.eq( i );
-					summary = $summaries[ i ];
+					$panel.html(
+						$panel.html()
+							.replace( /(<\/summary>)/i, "$1<div class='tgl-panel'>" ) +
+						"</div>"
+					);
+
 					newId = $panel.attr( "id" );
 					if ( !newId ) {
 						newId = "tabpanel" + uniqueCount;
@@ -148,12 +146,7 @@ var pluginName = "wb-tabs",
 
 					if ( isSmallView ) {
 						if ( !Modernizr.details ) {
-							$panel
-								.toggleClass( "open", !isOpen )
-								.attr({
-									"aria-expanded": !isOpen,
-									"aria-hidden": isOpen
-								});
+							$panel.toggleClass( "open", !isOpen );
 						}
 					} else {
 						$panel.attr({
@@ -166,10 +159,17 @@ var pluginName = "wb-tabs",
 
 					tablist += "<li" + ( isOpen ? " class='active'" : "" ) +
 						"><a id='" + newId + "-lnk' href='#" + newId + "'>" +
-						summary.innerHTML + "</a></li>";
+						$panel.children( "summary" ).html() + "</a></li>";
 				}
+
 				$tablist = $( tablist + "</ul>" );
-				$elm.prepend( $tablist );
+				$elm
+					.prepend( $tablist )
+					.find( "summary" )
+					.addClass( "wb-toggle tgl-tab" )
+					.attr( "data-toggle", "{\"parent\": \"#" + elmId +
+						"\", \"group\": \"details\"}" )
+					.trigger( "wb-init.wb-toggle" );
 			} else if ( $openPanel && $openPanel.length !== 0 ) {
 				$panels.filter( ".in" )
 					.addClass( "out" )

--- a/src/plugins/toggle/demo/toggle.scss
+++ b/src/plugins/toggle/demo/toggle.scss
@@ -2,20 +2,21 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
+main {
+	.box {
+		display: inline-block;
+		width: 30px;
+		height: 30px;
+		margin-right: 15px;
 
-.box {
-	display: inline-block;
-	width: 30px;
-	height: 30px;
-	margin-right: 15px;
-
-	border-radius: 4px;
-	background-color: #d9edf7;
-	transition: background-color 0.5s;
-	&.on {
-		background-color: #428bca;
+		border-radius: 4px;
+		background-color: #d9edf7;
+		transition: background-color 0.5s;
+		&.on {
+			background-color: #428bca;
+		}
 	}
-}
-details, .btn-group {
-	margin: 10px 0;
+	details, .btn-group {
+		margin: 10px 0;
+	}
 }

--- a/src/plugins/toggle/test.js
+++ b/src/plugins/toggle/test.js
@@ -110,15 +110,15 @@ describe( "Toggle test suite", function() {
 					expect( $parent.attr( "role" ) ).to.equal( "tablist" );
 					expect( $parent.data( "init" ) ).to.equal( true );
 
-					$parent.find( ".tab" ).each( function() {
+					$parent.find( ".tgl-tab" ).each( function() {
 						expect( this.getAttribute( "role" ) ).to.equal( "tab" );
 					});
-					$parent.find( ".panel" ).each( function() {
-						expect( this.getAttribute( "role" ) ).to.equal( "panel" );
+					$parent.find( ".tgl-panel" ).each( function() {
+						expect( this.getAttribute( "role" ) ).to.equal( "tabpanel" );
 					});
 					$parent.find( data.group ).each( function() {
 						$panel = $( this );
-						expect( $panel.find( ".panel" ).attr( "aria-labelledby" )  ).to.equal( $panel.find( ".tab" ).attr( "id" ) );
+						expect( $panel.find( ".tgl-panel" ).attr( "aria-labelledby" )  ).to.equal( $panel.find( ".tgl-tab" ).attr( "id" ) );
 					});
 				}
 			});
@@ -367,8 +367,8 @@ describe( "Toggle test suite", function() {
 		before(function() {
 			$accordion = $( ".accordion" );
 			$details = $accordion.find( "details" );
-			$panels = $accordion.find( ".panel" );
-			$tabs = $accordion.find( ".tab" );
+			$panels = $accordion.find( ".tgl-panel" );
+			$tabs = $accordion.find( ".tgl-tab" );
 		});
 
 		it( "should open the first accordion panel", function() {

--- a/src/plugins/toggle/toggle-en.hbs
+++ b/src/plugins/toggle/toggle-en.hbs
@@ -318,8 +318,8 @@
 			<div class="accordion">
 
 				<details>
-					<summary class="wb-toggle tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Example 1</summary>
-					<div class="panel">
+					<summary class="wb-toggle tgl-tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Example 1</summary>
+					<div class="tgl-panel">
 						<p>Example content that provides more details.</p>
 						<table>
 							<caption>Cups of coffee consumed by each delegate</caption>
@@ -350,8 +350,8 @@
 				</details>
 
 				<details>
-					<summary class="wb-toggle tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Example 2</summary>
-					<div class="panel">
+					<summary class="wb-toggle tgl-tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Example 2</summary>
+					<div class="tgl-panel">
 						<p>Example content that provides more details.</p>
 						<table>
 							<caption>Cups of coffee consumed by each delegate</caption>
@@ -382,8 +382,8 @@
 				</details>
 
 				<details>
-					<summary class="wb-toggle tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Example 3</summary>
-					<div class="panel">
+					<summary class="wb-toggle tgl-tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Example 3</summary>
+					<div class="tgl-panel">
 						<p>Example content that provides more details.</p>
 						<table>
 							<caption>Cups of coffee consumed by each delegate</caption>
@@ -421,8 +421,8 @@
 				<li>For each accordion section:
 					<ul>
 						<li>Add the <code>.wb-toggle</code> class and <code>data-toggle</code> attribute to the element the user will click to open/close the section.</li>
-						<li>Add the <code>.tab</code> class to the element that shows the section's heading.</li>
-						<li>Wrap the content in a <code>&lt;div class="panel"&gt;</code> element.</li>
+						<li>Add the <code>.tgl-tab</code> class to the element that shows the section's heading.</li>
+						<li>Wrap the content in a <code>&lt;div class="tgl-panel"&gt;</code> element.</li>
 					</ul>
 				</li>
 			</ul>

--- a/src/plugins/toggle/toggle-fr.hbs
+++ b/src/plugins/toggle/toggle-fr.hbs
@@ -261,8 +261,8 @@
 			<div class="accordion">
 
 				<details>
-					<summary class="wb-toggle tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Example 1</summary>
-					<div class="panel">
+					<summary class="wb-toggle tgl-tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Example 1</summary>
+					<div class="tgl-panel">
 						<p>Le contenu d'exemple qui fournit plus de détails.</p>
 						<table>
 							<caption>Tasses de café bues par chaque député</caption>
@@ -293,8 +293,8 @@
 				</details>
 
 				<details>
-					<summary class="wb-toggle tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Example 2</summary>
-					<div class="panel">
+					<summary class="wb-toggle tgl-tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Example 2</summary>
+					<div class="tgl-panel">
 						<p>Le contenu d'exemple qui fournit plus de détails.</p>
 						<table>
 							<caption>Tasses de café bues par chaque député</caption>
@@ -325,8 +325,8 @@
 				</details>
 
 				<details>
-					<summary class="wb-toggle tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Exemple 3</summary>
-					<div class="panel">
+					<summary class="wb-toggle tgl-tab" data-toggle='{"parent": ".accordion", "group": "details"}'>Exemple 3</summary>
+					<div class="tgl-panel">
 						<p>Le contenu d'exemple qui fournit plus de détails.</p>
 						<table>
 							<caption>Tasses de café bues par chaque député</caption>

--- a/theme/sass/parts/_banner.scss
+++ b/theme/sass/parts/_banner.scss
@@ -12,21 +12,22 @@
 	border-bottom: 1px solid #fff;
 	z-index: 1;
 	min-height: 2.2em;
-	a {
-		color: #fff;
-		text-decoration: none;
-	}
-	ul {
-		float: right;
-		margin: 0;
-		li {
-			border-left: 1px solid #777;
-			list-style-type: none;
-			float: left;
-			padding: 6px 10px;
-			&:first-child {
-				border-left: none;
-			}
+}
+
+#wb-lng ul, #wb-glb-mn .pnl-btn {
+	float: right;
+	margin: 0;
+	li {
+		border-left: 1px solid #777;
+		list-style-type: none;
+		float: left;
+		padding: 6px 10px;
+		&:first-child {
+			border-left: none;
+		}
+		a {
+			color: #fff;
+			text-decoration: none;
 		}
 	}
 }
@@ -57,9 +58,11 @@
 }
 
 [dir=rtl] {
-	#wb-bar {
-		ul {
-			float: left;
+	#wb-lng, #wb-glb-mn {
+		> {
+			ul {
+				float: left;
+			}
 		}
 	}
 	#wb-sttl {

--- a/theme/sass/parts/_siteMenu.scss
+++ b/theme/sass/parts/_siteMenu.scss
@@ -94,6 +94,16 @@
 	.lng-ofr {
 		text-align: right;
 	}
+	summary {
+		&:hover, &:focus {
+			background: transparent;
+			color: #fff;
+		}
+	}
+	a {
+		color: #fff;
+		text-decoration: none;
+	}
 }
 
 [dir=rtl] {


### PR DESCRIPTION
Changes to toggle and and tabs were in part because of the conflict between the Bootstrap "panel" class" and the Toggle "panel" class. When moving the mobile panel to details/summary, the "panel" class conflict became readily apparent.
