### PR TITLE
i18n: Add missing commas for missing Spanish translations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,6 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.csv]
+trim_trailing_whitespace = false

--- a/src/js/i18n/i18n.csv
+++ b/src/js/i18n/i18n.csv
@@ -193,17 +193,17 @@ Filler content (GC Web Usability theme),%tmpl-headlines,Headlines,Nouvelles,
 ,%tmpl-sample-text,Sample text.,Texte modèle.,
 ,%tmpl-read-more,Read more,En&#160;plus,
 ,%tmpl-priority,Priority,Priorité,
-,%tmpl-videos,Videos,Vidéo
-,%tmpl-sample-player,Sample video player,Exemple d'un lecteur multimédia
-,%tmpl-video-title,Video title,Titre de la vidéo
-,%tmpl-desc-video,Short description of the current video.,Description courte de la vidéo actuelle.
-,%tmpl-multi-help,Multimedia help,Aide multimédia
-,%tmpl-transcripts,Transcripts and Alternative Formats,Formats de transcription et de remplacement
-,%tmpl-meet-minister,Meet the Minister,Rencontrer le Ministre
-,%tmpl-honourable,The Honourable,L'honorable
-,%tmpl-minister-name,minister name,nom du ministre
-,%tmpl-about-minister,About the minister,Le ministre
-,%tmpl-portfolio,His portfolio,Son portefeuille
+,%tmpl-videos,Videos,Vidéo,
+,%tmpl-sample-player,Sample video player,Exemple d'un lecteur multimédia,
+,%tmpl-video-title,Video title,Titre de la vidéo,
+,%tmpl-desc-video,Short description of the current video.,Description courte de la vidéo actuelle.,
+,%tmpl-multi-help,Multimedia help,Aide multimédia,
+,%tmpl-transcripts,Transcripts and Alternative Formats,Formats de transcription et de remplacement,
+,%tmpl-meet-minister,Meet the Minister,Rencontrer le Ministre,
+,%tmpl-honourable,The Honourable,L'honorable,
+,%tmpl-minister-name,minister name,nom du ministre,
+,%tmpl-about-minister,About the minister,Le ministre,
+,%tmpl-portfolio,His portfolio,Son portefeuille,
 ,%tmpl-multi-help,Multimedia help,Aide multimédia,
 ,%tmpl-transcripts,Transcripts and Alternative Formats,Formats de transcription et de remplacement,
 ,%tmpl-meet-minister,Meet the Minister,Rencontrer le Ministre,


### PR DESCRIPTION
- EditorConfig setting added to prevent whitespace trimming on Save for CSVs

---

I actually came accross this because GitHub said there was a parsing error on line 196 :smile: 
