### PR TITLE
WET theme: Added ability to include/exclude various page sections using front matter

### DIFF
--- a/site/includes/breadcrumbs.hbs
+++ b/site/includes/breadcrumbs.hbs
@@ -4,11 +4,11 @@
 			<li>
 				<a href="{{assets}}/index-{{language}}.html">{{#i18n "tmpl-home"}}{{/i18n}}</a>
 			</li>
-{{#unless_eq assets compare=".."}}
+{{#isnt assets ".."}}
 			<li>
 				<a href="{{assets}}/demos/index-{{language}}.html">{{#i18n "tmpl-work-examples"}}{{/i18n}}</a>
 			</li>
-{{/unless_eq}}
+{{/isnt}}
 			<li>{{title}}</li>
 		</ol>
 	</div>

--- a/site/includes/fullmenu.hbs
+++ b/site/includes/fullmenu.hbs
@@ -1,4 +1,3 @@
-<!-- secondary navigation if enabled -->
 <div class="pnl-strt container visible-md visible-lg nvbar">
 	<h2>{{#i18n "tmpl-site-menu"}}{{/i18n}}</h2>
 	<div class="row">

--- a/site/includes/languagetoggle.hbs
+++ b/site/includes/languagetoggle.hbs
@@ -1,19 +1,19 @@
 <ul class="text-right">
-{{#if_eq language compare="en"}}
+{{#is language "en"}}
 	{{#if page.fr}}
 	<li>
 		<a lang="fr" href="{{page.fr}}-fr.html">Français</a>
 	</li>
 	{{/if}}
-{{/if_eq}}
+{{/is}}
 	<li class="curr">
 		{{#i18n "lang-native"}}{{/i18n}}{{#i18n "space"}}{{/i18n}}<span>{{#i18n "current"}}{{/i18n}}</span>
 	</li>
-{{#unless_eq language compare="en"}}
+{{#isnt language "en"}}
 	{{#if page.en}}
 	<li>
 		<a lang="en" href="{{page.en}}-en.html">English</a>
 	</li>
 	{{/if}}
-{{/unless_eq}}
+{{/isnt}}
 </ul>

--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -20,31 +20,34 @@
 			<li class="wb-slc">
 				<a class="wb-sl" href="#wb-cont">{{#i18n "tmpl-skip-cont"}}{{/i18n}}</a>
 			</li>
+{{#isnt footer "false"}}
 			<li class="wb-slc visible-md visible-lg">
 				<a class="wb-sl" href="#wb-info">{{#i18n "tmpl-skip-info"}}{{/i18n}}</a>
 			</li>
-			<!-- Secondary Menu
+{{/isnt}}
+{{#is secondarymenu "true"}}
 			<li class="wb-slc visible-md visible-lg">
 				<a class="wb-sl" href="#wb-sec">{{#i18n "tmpl-skip-sec"}}{{/i18n}}</a>
 			</li>
-			[optional] -->
+{{/is}}
 		</ul>
 		<header role="banner">
 			<div id="wb-bnr">
 				<div id="wb-bar">
 					<div class="container">
 						<div class="row">
-
+{{#isnt languagetoggle "false"}}
 							<section id="wb-lng" class="visible-md visible-lg">
 								<h2>{{#i18n "tmpl-lang-select"}}{{/i18n}}</h2>
 								{{>languagetoggle}}
 							</section>
-
+{{/isnt}}
+{{#isnt mobimenu "false"}}
 							<section class="wb-mb-links col-xs-12 visible-sm visible-xs" id="wb-glb-mn">
 								<h2>{{#i18n "menu"}}{{/i18n}}</h2>
 								{{>mobimenu}}
 							</section>
-
+{{/isnt}}
 						</div>
 					</div>
 				</div>
@@ -55,54 +58,57 @@
 						<div id="wb-sttl" class="col-md-8">
 							{{>brand}}
 						</div>
-
+{{#isnt sitesearch "false"}}
 						<section id="wb-srch" class="col-md-4 visible-md visible-lg">
 							<h2>{{#i18n "tmpl-search"}}{{/i18n}}</h2>
 							{{>sitesearch}}
 						</section>
-
+{{/isnt}}
 					</div>
 				</div>
 			</div>
-
-			<nav role="navigation" id="wb-sm" data-ajax-fetch="{{assets}}/ajax/sitemenu-{{language}}.html" data-import="wb-sec wb-srch" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement">
+{{#isnt sitemenu "false"}}
+			<nav role="navigation" id="wb-sm" data-ajax-fetch="{{assets}}/ajax/sitemenu-{{language}}.html" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement">
 				{{>sitemenu}}
 			</nav>
-{{#unless_eq assets compare="."}}
-
+{{else}}
+			<span data-trgt="mb-pnl" class="wb-menu hide"></span>
+{{/isnt}}
+{{#isnt breadcrumb "false"}}
+	{{#isnt assets "."}}
 			<nav role="navigation" id="wb-bc" property="breadcrumb">
 				<h2>{{#i18n "you-are-here"}}{{/i18n}}</h2>
 				{{>breadcrumbs}}
 			</nav>
-{{/unless_eq}}
+	{{/isnt}}
+{{/isnt}}
 		</header>
 
-		<main role="main" property="mainContentOfPage" class="container">
+{{#is secondarymenu "true"}}
+		<div class="container">
+			<div class="row">
+{{/is}}
+		<main role="main" property="mainContentOfPage" class="{{#is secondarymenu "true"}}col-md-9 col-md-push-3{{else}}container{{/is}}">
 			<h1 id="wb-cont" property="name">{{title}}</h1>
 			{{>body}}
 		</main>
-
-		<!-- Secondary Menu
-		<div class="container">
-			<div class="row">
-				<main role="main" property="mainContentOfPage" class="col-md-9 col-md-push-3">
-					<h1 id="wb-cont" property="name">{{title}}</h1>
-				</main>
-
+{{#is secondarymenu "true"}}
 				<nav role="navigation" id="wb-sec" typeof="SiteNavigationElement" class="col-md-3 col-md-pull-9 visible-md visible-lg">
 					<h2>{{#i18n "tmpl-sec-menu"}}{{/i18n}}</h2>
 					{{>secondarymenu}}
 				</nav>
 			</div>
 		</div>
-		[optional] -->
+{{/is}}
 
+{{#isnt footer "false"}}
 		<footer role="contentinfo" id="wb-info" class="container visible-md visible-lg">
 			<nav role="navigation" class="row">
 				<h2>{{#i18n "tmpl-site-info"}}{{/i18n}}</h2>
 				{{>footer}}
 			</nav>
 		</footer>
+{{/isnt}}
 		{{>footerresources}}
 		{{#if environment.test}}{{>test}}{{/if}}
 	</body>

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -56,7 +56,7 @@ var pluginName = "wb-menu",
 				};
 			}
 
-			// Lets test to see if we have any
+			// Lets test to see if we have any menus to fetch
 			if ( $elm.data( "ajax-fetch" ) ) {
 				$document.trigger({
 					type: "ajax-fetch.wb",
@@ -66,8 +66,13 @@ var pluginName = "wb-menu",
 			} else {
 
 				// Trigger the navcurrent plugin
-				$elm.trigger( navCurrentEvent, breadcrumb );
+				$elm
+					.trigger( navCurrentEvent, breadcrumb )
+					.find( ".menu" )
+						.attr( "role", "menubar" );
 				$( "#wb-sec" ).trigger( navCurrentEvent, breadcrumb );
+				
+				onAjaxLoaded( $elm, $elm );
 			}
 		}
 	},
@@ -136,8 +141,8 @@ var pluginName = "wb-menu",
 	 * @param {jQuery DOM element} $ajaxed The AJAX'd in menu content to import
 	 */
 	onAjaxLoaded = function( $elm, $ajaxed ) {
-		var $menubar = $ajaxed.find( "[role='menubar']" ),
-			$menu = $menubar.find( ".item" ),
+		var $menubar = $ajaxed.find( ".menu" ),
+			$menu = $menubar.find( "> li > a" ),
 
 			// Optimized the code block to look to see if we need to import anything instead
 			// of just doing a query with which could result in no result
@@ -306,7 +311,7 @@ var pluginName = "wb-menu",
 		// Recalibrate context
 		$elm.data({
 			self: $elm,
-			menu: $elm.find( "[role=menubar] .item" ),
+			menu: $elm.find( ".menu > li > a" ),
 			items: $elm.find( ".sm" )
 		});
 
@@ -549,7 +554,7 @@ $document.on( "click vclick", selector + " .item[aria-haspopup]", onPanelClick )
  */
 $document.on( "mouseover focusin", selector + " .item", onHoverFocus );
 
-$document.on( "keydown", selector + " .item", function( event ) {
+$document.on( "keydown", selector + " .menu > li > a", function( event ) {
 	var elm = event.target,
 		which = event.which,
 		ref = expand( elm ),


### PR DESCRIPTION
Adds the ability to include/exclude the following through front matter in the .hbs files (affects mobile panel as well):

Include:
- Secondary menu ("secondarymenu": "true")

Exclude:
- Language toggle ("languagetoggle": "false")
- Mobile panel ("mobimenu": "false")
- Search ("sitesearch": "false")
- Site menu ("sitemenu": "false")
- Breadcrumb ("breadcrumb": "false")
- Site information/footer ("footer": "false")

Note: Parameter names match the existing include file names (in case anyone is wondering about the naming convention).
