### PR TITLE
[CSS] Removed underline for button links

### DIFF
--- a/src/base/partials/_bootstrap-overrides.scss
+++ b/src/base/partials/_bootstrap-overrides.scss
@@ -577,6 +577,9 @@ address {
  */
 a {
 	text-decoration: underline;		// re-enable underlining
+	&.btn {
+		text-decoration: none;		// except for buttons
+	}
 }
 
 /*


### PR DESCRIPTION
Fix for issue https://github.com/wet-boew/wet-boew/issues/4083.
