### PR TITLE
Menu: Fixed navcurrent triggering to automatically support the secondary menu, site information and the mobile panel

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -64,14 +64,6 @@ var pluginName = "wb-menu",
 					fetch: $elm.data( "ajax-fetch" )
 				});
 			} else {
-
-				// Trigger the navcurrent plugin
-				$elm
-					.trigger( navCurrentEvent, breadcrumb )
-					.find( ".menu" )
-						.attr( "role", "menubar" );
-				$( "#wb-sec" ).trigger( navCurrentEvent, breadcrumb );
-				
 				onAjaxLoaded( $elm, $elm );
 			}
 		}
@@ -198,6 +190,14 @@ var pluginName = "wb-menu",
 				"sec-pnl",
 				$secnav.find( "h2" ).html()
 			]);
+
+			if ( !$secnav.hasClass( "wb-navcurr" ) ) {
+
+				// Trigger the navcurrent plugin
+				setTimeout(function() {
+					$secnav.trigger( navCurrentEvent, breadcrumb );
+				}, 1 );
+			}
 		}
 
 		// Add the site menu
@@ -269,6 +269,14 @@ var pluginName = "wb-menu",
 			panel += navOpen + " class='info-pnl'>" +
 				"<h3>" + info.getElementsByTagName( "h2" )[ 0 ].innerHTML + "</h3>" +
 				sectionUlOpen + sectionHtml + sectionUlClose + navClose;
+
+			if ( info.className.indexOf( "wb-navcurr" ) === -1 ) {
+
+				// Trigger the navcurrent plugin
+				setTimeout(function() {
+					$( info ).trigger( navCurrentEvent, breadcrumb );
+				}, 1 );
+			}
 		}
 
 		// Let's create the DOM Element
@@ -317,7 +325,10 @@ var pluginName = "wb-menu",
 		});
 
 		// Trigger the navcurrent plugin
-		$elm.trigger( navCurrentEvent, breadcrumb );
+		setTimeout(function() {
+			$elm.trigger( navCurrentEvent, breadcrumb );
+			$panel.trigger( navCurrentEvent, breadcrumb );
+		}, 1 );
 	},
 
 	/**

--- a/src/plugins/navcurrent/navcurrent.js
+++ b/src/plugins/navcurrent/navcurrent.js
@@ -112,7 +112,9 @@ var $document = wb.doc,
 
 		if ( match ) {
 			link.className += " " + navClass;
-			if ( menu.className.indexOf( "wb-menu" ) !== -1 && link.className.indexOf( "item" ) === -1 ) {
+			if ( menu.id === "mb-pnl" ) {
+				link.parentNode.parentNode.parentNode.parentNode.getElementsByTagName( "summary" )[ 0 ].className += " " + navClass;
+			} else if ( menu.className.indexOf( "wb-menu" ) !== -1 && link.className.indexOf( "item" ) === -1 ) {
 				link.parentNode.parentNode.parentNode.getElementsByTagName( "a" )[ 0 ].className += " " + navClass;
 			}
 		}


### PR DESCRIPTION
@masterbee Note that this means you could remove the wb-navcurr class from the footer downstream but there is no harm with leaving it there either (doesn't double fire).
