### PR TITLE
[CSS] Updated the position CSS to work like the grid CSS

### DIFF
--- a/src/base/partials/_proximity.scss
+++ b/src/base/partials/_proximity.scss
@@ -26,6 +26,22 @@
 	bottom: 0;
 }
 
+@mixin pstn-lft-rst {
+	left: auto;
+}
+
+@mixin pstn-rght-rst {
+	right: auto;
+}
+
+@mixin pstn-tp-rst {
+	top: auto;
+}
+
+@mixin pstn-bttm-rst {
+	bottom: auto;
+}
+
 .opct-100 {
 	opacity: 1;
 }
@@ -98,69 +114,81 @@
 	@include pstn-bttm;
 }
 
-@media screen and (max-width: $smallViewMax) {
+@media screen and (min-width: $smallViewMin) {
 	.pstn-lft-sm {
 		@include pstn;
 		@include pstn-lft;
+		@include pstn-rght-rst;
 	}
 
 	.pstn-rght-sm {
 		@include pstn;
 		@include pstn-rght;
+		@include pstn-lft-rst;
 	}
 
 	.pstn-tp-sm {
 		@include pstn;
 		@include pstn-tp;
+		@include pstn-bttm-rst;
 	}
 
 	.pstn-bttm-sm {
 		@include pstn;
 		@include pstn-bttm;
+		@include pstn-tp-rst;
 	}
 }
 
-@media screen and (min-width: $mediumViewMin) and (max-width: $mediumViewMax) {
+@media screen and (min-width: $mediumViewMin) {
 	.pstn-lft-md {
 		@include pstn;
 		@include pstn-lft;
+		@include pstn-rght-rst;
 	}
 
 	.pstn-rght-md {
 		@include pstn;
 		@include pstn-rght;
+		@include pstn-lft-rst;
 	}
 
 	.pstn-tp-md {
 		@include pstn;
 		@include pstn-tp;
+		@include pstn-bttm-rst;
 	}
 
 	.pstn-bttm-md {
 		@include pstn;
 		@include pstn-bttm;
+		@include pstn-tp-rst;
 	}
 }
 
-@media screen and (min-width: $largeViewMin) and (max-width: $largeViewMax) {
+@media screen and (min-width: $largeViewMin) {
 	.pstn-lft-lg {
 		@include pstn;
 		@include pstn-lft;
+		@include pstn-rght-rst;
 	}
 
 	.pstn-rght-lg {
 		@include pstn;
 		@include pstn-rght;
+		@include pstn-lft-rst;
 	}
 
 	.pstn-tp-lg {
 		@include pstn;
 		@include pstn-tp;
+		@include pstn-bttm-rst;
 	}
 
 	.pstn-bttm-lg {
 		@include pstn;
 		@include pstn-bttm;
+		@include pstn-tp-rst;
 	}
 }
 
@@ -168,21 +196,25 @@
 	.pstn-lft-xl {
 		@include pstn;
 		@include pstn-lft;
+		@include pstn-rght-rst;
 	}
 
 	.pstn-rght-xl {
 		@include pstn;
 		@include pstn-rght;
+		@include pstn-lft-rst;
 	}
 
 	.pstn-tp-xl {
 		@include pstn;
 		@include pstn-tp;
+		@include pstn-bttm-rst;
 	}
 
 	.pstn-bttm-xl {
 		@include pstn;
 		@include pstn-bttm;
+		@include pstn-tp-rst;
 	}
 }
 


### PR DESCRIPTION
In the previous iteration of the position CSS, each class applied exclusively to a specified screen size range (e.g., `sm`).

In this iteration, each class applies starting from the lowest range for the specified screen size. This mirrors the behaviour of the grid CSS `sm`, `md`, `lg`, etc. specific classes.

cc/@cfarquharson
