### PR TITLE
Menu: Converted mobile panel menu to multiple WAI-ARIA menus

### DIFF
--- a/src/plugins/menu/menu-en.hbs
+++ b/src/plugins/menu/menu-en.hbs
@@ -3,30 +3,13 @@
 	"title": "Menu",
 	"language": "en",
 	"category": "Plugin",
-	"description": "Provides an interactive menu bar with optional sub-menus.",
+	"description": "Provides an interactive menu with optional sub-menus.",
 	"tag": "menu",
 	"fr": "menu",
 	"css": "demo/menu"
 }
 ---
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione, minima deleniti autem tenetur odit nostrum sunt eligendi quasi maiores veritatis voluptate tempore dolorem animi libero!</p>
-<nav role="navigation" id="menu-demo-1" data-ajax-replace="demo/menu-include-{{language}}.html" class="menu-demo wb-menu" typeof="SiteNavigationElement">
-	<ul class="list-inline menu">
-		<li><a href="http://www.canada.gc.ca" class="item">Section 1</a></li>
-		<li><a href="http://www.tc.gc.ca" class="item">Section 2</a></li>
-		<li><a href="http://www.tbs-sct.gc.ca" class="item">Section 3</a></li>
-		<li><a href="http://www.ec.gc.ca" class="item">Section 4</a></li>
-	</ul>
-</nav>
-
-<hr />
-
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione, minima deleniti autem tenetur odit nostrum sunt eligendi quasi maiores veritatis voluptate tempore dolorem animi libero!</p>
-<nav role="navigation" id="menu-demo-2" data-ajax-replace="demo/menu-include-{{language}}.html" class="menu-demo wb-menu" typeof="SiteNavigationElement">
-	<ul class="list-inline menu">
-		<li><a href="http://www.canada.gc.ca" class="item">Section 1</a></li>
-		<li><a href="http://www.tc.gc.ca" class="item">Section 2</a></li>
-		<li><a href="http://www.tbs-sct.gc.ca" class="item">Section 3</a></li>
-		<li><a href="http://www.ec.gc.ca" class="item">Section 4</a></li>
-	</ul>
-</nav>
+<ul>
+	<li><strong>Large screens:</strong> The menu is rendered in the header as a menu bar.</li>
+	<li><strong>Small and medium screens:</strong> The menu is rendered as a side panel, triggered by a menu button in the header, and includes the secondary menu and the footer.</p>
+</ul>

--- a/src/plugins/menu/menu-fr.hbs
+++ b/src/plugins/menu/menu-fr.hbs
@@ -9,24 +9,7 @@
 	"css": "demo/menu"
 }
 ---
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione, minima deleniti autem tenetur odit nostrum sunt eligendi quasi maiores veritatis voluptate tempore dolorem animi libero!</p>
-<nav role="navigation" id="menu-demo-1" data-ajax-replace="demo/menu-include-{{language}}.html" class="menu-demo wb-menu" typeof="SiteNavigationElement">
-	<ul class="list-inline menu">
-		<li><a href="http://www.canada.gc.ca" class="item">Section 1</a></li>
-		<li><a href="http://www.tc.gc.ca" class="item">Section 2</a></li>
-		<li><a href="http://www.tbs-sct.gc.ca" class="item">Section 3</a></li>
-		<li><a href="http://www.ec.gc.ca" class="item">Section 4</a></li>
-	</ul>
-</nav>
-
-<hr />
-
-<p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ratione, minima deleniti autem tenetur odit nostrum sunt eligendi quasi maiores veritatis voluptate tempore dolorem animi libero!</p>
-<nav role="navigation" id="menu-demo-2" data-ajax-replace="demo/menu-include-{{language}}.html" class="menu-demo wb-menu" typeof="SiteNavigationElement">
-	<ul class="list-inline menu">
-		<li><a href="http://www.canada.gc.ca" class="item">Section 1</a></li>
-		<li><a href="http://www.tc.gc.ca" class="item">Section 2</a></li>
-		<li><a href="http://www.tbs-sct.gc.ca" class="item">Section 3</a></li>
-		<li><a href="http://www.ec.gc.ca" class="item">Section 4</a></li>
-	</ul>
-</nav>
+<ul>
+	<li><strong>Grands écrans&#160;:</strong> Le menu est affiché dans l'en-tête comme une barre de menu.</li>
+	<li><strong>Petits écrans et écrans de taille moyenne&#160;:</strong> Le menu est affiché comme un panneau latéral, activé par un bouton de menu dans l'en-tête, et comprend le menu secondaire et le pied de page.</p>
+</ul>

--- a/src/plugins/navcurrent/navcurrent.js
+++ b/src/plugins/navcurrent/navcurrent.js
@@ -112,10 +112,8 @@ var $document = wb.doc,
 
 		if ( match ) {
 			link.className += " " + navClass;
-			if ( menu.id === "mb-pnl" ) {
-				link.parentNode.parentNode.parentNode.parentNode.getElementsByTagName( "summary" )[ 0 ].className += " " + navClass;
-			} else if ( menu.className.indexOf( "wb-menu" ) !== -1 && link.className.indexOf( "item" ) === -1 ) {
-				link.parentNode.parentNode.parentNode.getElementsByTagName( "a" )[ 0 ].className += " " + navClass;
+			if ( menu.className.indexOf( "wb-menu" ) !== -1 && link.className.indexOf( "item" ) === -1 ) {
+				$( link ).closest( ".sm" ).parent().children( "a" ).addClass( navClass );
 			}
 		}
 	};

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -126,22 +126,23 @@ $document.on( "timerpoke.wb " + initEvent + " keydown open" + selector +
 
 			// No special tab handling when ignoring outside activity
 			if ( overlay.className.indexOf( ignoreOutsideClass ) === -1 ) {
-				event.preventDefault();
-				$focusable = $( overlay ).find( ":focusable" );
+				$focusable = $( overlay ).find( ":focusable:not([tabindex='-1'])" );
 				length = $focusable.length;
 				index = $focusable.index( event.target ) + ( event.shiftKey ? -1 : 1 );
-				if ( index === -1 ) {
-					index = length - 1;
-				} else if ( index === length ) {
-					index = 0;
+
+				if ( index === -1 || index === length ) {
+					event.preventDefault();
+					$focusable.eq( index === -1 ? length - 1 : 0 )
+						.trigger( setFocusEvent );
 				}
-				$focusable.eq( index ).trigger( setFocusEvent );
 			}
 			break;
 
 		// Escape key
 		case 27:
-			closeOverlay( overlayId, false, true );
+			if ( !event.isDefaultPrevented() ) {
+				closeOverlay( overlayId, false, true );
+			}
 			break;
 		}
 	}


### PR DESCRIPTION
- Switched from a WAI-ARIA tabs to WAI-ARIA menus since it makes more sense through a screen reader
- Split up the the navigation for site menu, secondary menu and site information so they each have their own tab stop and behave like 3 independent menu systems (easier to understand semantically)
- Fixed the default menu opening based upon wb-navcurr

Note: This no longer behaves like an accordion. Multiple menus can be opened at the same time. Is that okay or should any newly opened menu result in the others being closed? @thomasgohard What do you think?
