### PR TITLE
Details: fix open/close on devices with touch events

### DIFF
--- a/src/polyfills/details/details.js
+++ b/src/polyfills/details/details.js
@@ -43,8 +43,8 @@ var pluginName = "wb-details",
 // Bind the init event of the plugin
 $document.on( "timerpoke.wb " + initEvent, selector, init );
 
-// Bind the init event of the plugin
-$document.on( "click vclick touchstart keydown toggle.wb-details", selector, function( event ) {
+// Bind the the event handlers of the plugin
+$document.on( "click keydown toggle.wb-details", selector, function( event ) {
 	var which = event.which,
 		currentTarget = event.currentTarget,
 		details, isClosed;


### PR DESCRIPTION
The `touchstart` event also results in a `click` event on touch devices, which resulted in a double invoke of the open/close action.

By splitting the touch events to their own handler and stopping event propagation, the double invocation no longer occurs.
