### PR TITLE
Fix a Youtube player JS error that getDuration is not a function

### DIFF
--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -694,7 +694,7 @@ $document.on( renderUIEvent, selector, function( event, type ) {
 	$this.data( "properties", data );
 
 	// Trigger the duration change for cases where the event was called before the event binding
-	if ( !isNaN( this.player( "getDuration" ) ) ) {
+	if ( !isNaN( this.player( "getDuration" ) ) && type !== "youtube" ) {
 		data.player.trigger( "durationchange" );
 	}
 


### PR DESCRIPTION
Fixes #4164
