### PR TITLE
Unit tests: start tests with plugin wb-init event

### DIFF
--- a/src/plugins/data-inview/test.js
+++ b/src/plugins/data-inview/test.js
@@ -30,9 +30,9 @@ describe( "data-inview test suite", function() {
 		// Spy on jQuery's trigger method to see how it's called during the plugin's initialization
 		spy = sandbox.spy( $.prototype, "trigger" );
 
-		$( ".wb-inview" ).on( "scroll.wb-inview", function() {
-			done();
-		});
+		// Init the plugin and give it 1ms before starting the tests
+		$( ".wb-inview" ).trigger( "wb-init.wb-inview" );
+		setTimeout( done, 1 );
 	});
 
 	/*

--- a/src/plugins/favicon/test.js
+++ b/src/plugins/favicon/test.js
@@ -16,19 +16,18 @@
  */
 describe( "Favicon test suite", function() {
 
-	var spy,
+	var $faviconMobile, spy,
+		$favicon = $( "link[rel='shortcut icon']" ),
 		sandbox = sinon.sandbox.create();
 
 	/*
 	 * Before beginning the test suite, this function is executed once.
 	 */
-	before(function( done ) {
+	before(function() {
 		// Spy on jQuery's trigger methods
 		spy = sandbox.spy( $.prototype, "trigger" );
 
-		wb.doc.on( "mobile.wb-favicon", "link[rel='shortcut icon']", function() {
-			done();
-		});
+		$favicon.trigger( "wb-init.wb-favicon" );
 	});
 
 	/*
@@ -70,9 +69,8 @@ describe( "Favicon test suite", function() {
 	 */
 	describe( "create default mobile favicon", function() {
 
-		var $favicon, $faviconMobile, href, path;
+		var href, path;
 		before(function() {
-			$favicon = $( "link[rel='shortcut icon']" );
 			$faviconMobile = $( ".wb-favicon" );
 			href = $favicon.attr( "href" );
 			path = href.substring( 0, href.lastIndexOf( "/" ) + 1 );
@@ -100,22 +98,20 @@ describe( "Favicon test suite", function() {
 	 */
 	describe( "create custom mobile favicon", function() {
 
-		var $favicon, $faviconMobile;
 		before(function( done ) {
-			$( ".wb-favicon" ).remove();
+			$faviconMobile.remove();
 
-			wb.doc.on( "mobile.wb-favicon", "link[rel='shortcut icon']", function() {
-				$faviconMobile = $( ".wb-favicon" );
-				done();
-			});
-
-			$favicon = $( "link[rel='shortcut icon']" );
 			$favicon.data({
 				rel: "apple-touch-icon-precompossed",
 				sizes: "57x57",
 				path: "foo/",
 				filename: "bar"
 			}).trigger( "wb-init.wb-favicon" );
+
+			setTimeout( function() {
+				$faviconMobile = $( ".wb-favicon" );
+				done();
+			}, 1);
 
 		});
 
@@ -141,10 +137,8 @@ describe( "Favicon test suite", function() {
 	 */
 	describe( "update favicon", function() {
 
-		var $favicon;
 		before(function() {
-			$( ".wb-favicon" ).remove();
-			$favicon = $( "link[rel='shortcut icon']" );
+			$faviconMobile.remove();
 			$favicon.trigger( "icon.wb-favicon", {
 				path: "foobar/",
 				filename: "baz"


### PR DESCRIPTION
Where possible, removed the unit tests dependency on waiting for an event to trigger before starting.

Requested in #4169.
