### PR TITLE
Toggle: onbeforeprint behaviour

### DIFF
--- a/src/plugins/toggle/test.js
+++ b/src/plugins/toggle/test.js
@@ -211,10 +211,10 @@ describe( "Toggle test suite", function() {
 
 		before(function() {
 			// Create the toggle elements and start testing once it has been initialized
-			$togglerOn = $( "<button type='button' class='wb-toggle test' data-toggle='{\"type\": \"open\", \"stateOn\": \"open\"}'/>" ).appendTo( wb.doc.find( "body" ) );
+			$togglerOn = $( "<button type='button' class='wb-toggle test' data-toggle='{\"type\": \"on\", \"stateOn\": \"open\"}'/>" ).appendTo( wb.doc.find( "body" ) );
 			$togglerOn.trigger( "wb-init.wb-toggle" );
 
-			$togglerOff = $( "<button type='button' class='wb-toggle test' data-toggle='{\"type\": \"close\", \"stateOff\": \"close\"}'/>" ).appendTo( wb.doc.find( "body" ) );
+			$togglerOff = $( "<button type='button' class='wb-toggle test' data-toggle='{\"type\": \"off\", \"stateOff\": \"close\"}'/>" ).appendTo( wb.doc.find( "body" ) );
 			$togglerOff.trigger( "wb-init.wb-toggle" );
 		});
 
@@ -385,6 +385,43 @@ describe( "Toggle test suite", function() {
 			testAccordionClosed( 0 );
 			testAccordionClosed( 1 );
 			testAccordionClosed( 2 );
+		});
+	});
+
+	/*
+	 * Test onbeforeprint behaviour
+	 */
+	describe( "Printing toggle elements", function() {
+		var $detailsOn, $detailsOff;
+
+		before(function() {
+			spy.reset();
+
+			$detailsOn = $( "<details class=\"wb-toggle\" data-toggle='{\"print\": \"on\"}'><summary></summary></details>" )
+				.appendTo( wb.doc.find( "body" ) )
+				.trigger( "wb-init.wb-toggle" );
+			$detailsOff = $( "<details class=\"wb-toggle\" data-toggle='{\"print\": \"off\"}'><summary></summary></details>" )
+				.appendTo( wb.doc.find( "body" ) )
+				.trigger( "wb-init.wb-toggle" );
+
+			wb.win.trigger( "beforeprint" );
+		});
+
+		after(function() {
+			$detailsOn.remove();
+			$detailsOff.remove();
+		});
+
+		it( "should trigger toggle.wb-toggle", function() {
+			expect( spy.calledWith( "toggle.wb-toggle" ) ).to.equal( true );
+		});
+
+		it( "should toggle on the $detailsOn element", function() {
+			expect( $detailsOn.hasClass( "on" ) ).to.equal( true );
+		});
+
+		it( "should toggle off the $detailsOff element", function() {
+			expect( $detailsOff.hasClass( "off" ) ).to.equal( true );
 		});
 	});
 });

--- a/src/plugins/toggle/toggle-en.hbs
+++ b/src/plugins/toggle/toggle-en.hbs
@@ -28,7 +28,7 @@
 
 	<div class="col-md-9">
 		<section>
-			<h2 id="setup">Plugin Setup</h2>
+			<h2 id="setup" class="mrgn-tp-0">Plugin Setup</h2>
 			<p>Adding the <code>.wb-toggle</code> CSS class to any element will turn it into a toggle element.  The behaviour of this toggle element is then controlled by the <code>data-toggle</code> attribute which takes a JavaScript object of properties:</p>
 
 			<table class="table">
@@ -52,6 +52,16 @@
 						<td>CSS selector that groups multiple toggle elements together and only allows one of the elements to be open at a time.</td>
 					</tr>
 					<tr>
+						<td><code>print</code></td>
+						<td>
+							Causes a toggle element to turn the elements it controls on or off when the page is printed.  Supports the following two values:
+							<ul>
+								<li>on: elements will be set to "on" toggle state for printing.</li>
+								<li>off: elements will be set to "off" toggle state for printing.</li>
+							</ul>  
+						</td>
+					</tr>					
+					<tr>
 						<td><code>type</code></td>
 						<td>
 							Causes a toggle element to only turn the elements it controls on or off.  Supports the following two values:
@@ -72,9 +82,9 @@
 				</tbody>
 			</table>
 
-			<p>For example, the following toggle element that would only toggle on elements with the <code>.foo</code> CSS class that were contained in a parent with the <code>.bar</code> CSS class:</p>
+			<p>For example, the following element will always toggle on elements with the <code>.foo</code> CSS class that are contained in a parent with the <code>.bar</code> CSS class.  In addition, the elements it controls will be toggled on when the page is printed.</p>
 
-			<pre class="lang-css"><code>&lt;button type="button" class="wb-toggle" data-toggle='{"type": "on", "selector": ".foo", "parent": ".bar"}'&gt;Turn on&lt;/button&gt;</code></pre>
+			<pre class="lang-css"><code>&lt;button type="button" class="wb-toggle" data-toggle='{"type": "on", "selector": ".foo", "parent": ".bar", "print": "on"}'&gt;Turn on&lt;/button&gt;</code></pre>
 		</section>
 
 		<section class="wb-prettify all-pre linenums">
@@ -104,10 +114,10 @@
 
 		<section>
 			<h2 id="details">Details Elements</h2>
-			<p>The toggle plugin can be used to open/close multiple <code>&lt;details&gt;</code> elements:</p>
+			<p>The toggle plugin can be used to open/close multiple <code>&lt;details&gt;</code> elements.  By adding the <code>"print": "on"</code> setting to the first toggle element, the plugin will also open all details elements when the page is printed.</p>
 
 			<div class="btn-group">
-				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": "details"}'>Toggle</button>
+				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": "details", "print": "on"}'>Toggle</button>
 				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "type": "on"}'>On</button>
 				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "type": "off"}'>Off</button>
 			</div>

--- a/src/plugins/toggle/toggle-fr.hbs
+++ b/src/plugins/toggle/toggle-fr.hbs
@@ -27,7 +27,7 @@
 
 	<div class="col-md-9">
 		<section>
-			<h2 id="simple">Exemple simple</h2>
+			<h2 id="simple" class="mrgn-tp-0">Exemple simple</h2>
 
 			<div class="btn-group">
 				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": ".box"}'>Basculer</button>
@@ -50,7 +50,7 @@
 			<h2 id="details">Details</h2>
 
 			<div class="btn-group">
-				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": "details"}'>Basculer</button>
+				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": "details", "print": "on"}'>Basculer</button>
 				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "type": "on"}'>Activer</button>
 				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "type": "off"}'>Désactiver</button>
 			</div>

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -55,6 +55,11 @@ var pluginName = "wb-toggle",
 
 			// Initialize the aria attributes of the toggle element
 			initAria( link, data );
+
+			// Initialize the toggle behaviour when the page is printed
+			if ( data.print ) {
+				initPrint( $link, data );
+			}
 		}
 	},
 
@@ -78,7 +83,7 @@ var pluginName = "wb-toggle",
 				parent.setAttribute( "role", "tablist" );
 				elms = parent.querySelectorAll( data.group );
 				tabs = parent.querySelectorAll( data.group + " " + selectorTab );
-				
+
 				// Initialize the detail/summaries
 				$( tabs ).trigger( "wb-init.wb-details" );
 
@@ -87,8 +92,8 @@ var pluginName = "wb-toggle",
 					elm = elms[ i ];
 					tab = tabs[ i ];
 					panel = elm.querySelector( selectorPanel );
-					
-					// Check if the element is toggled on based on the 
+
+					// Check if the element is toggled on based on the
 					// open attribute or "on" CSS class
 					isOpen = elm.nodeName.toLowerCase() === "details" ?
 						!!elm.getAttribute( "open" ) :
@@ -96,7 +101,7 @@ var pluginName = "wb-toggle",
 					if ( isOpen ) {
 						hasOpen = true;
 					}
-					
+
 					if ( !tab.getAttribute( "id" ) ) {
 						tab.setAttribute( "id", prefix + i );
 					}
@@ -105,13 +110,13 @@ var pluginName = "wb-toggle",
 					tab.setAttribute( "tabindex", isOpen ? "0" : "-1" );
 					tab.setAttribute( "aria-posinset", i + 1 );
 					tab.setAttribute( "aria-setsize", len );
-					
+
 					panel.setAttribute( "role", "tabpanel" );
 					panel.setAttribute( "aria-labelledby", tab.getAttribute( "id" ) );
 					panel.setAttribute( "aria-expanded", isOpen );
 					panel.setAttribute( "aria-hidden", !isOpen );
 				}
-				
+
 				// No open panels so put the first summary in the tab order
 				if ( !hasOpen ) {
 					tabs[ 0 ].setAttribute( "tabindex", "0" );
@@ -129,6 +134,32 @@ var pluginName = "wb-toggle",
 				ariaControls += elm.id + " ";
 			}
 			link.setAttribute( "aria-controls", ariaControls.slice( 0, -1 ) );
+		}
+	},
+
+	/**
+	 * Initialize open on print behaviour of the toggle element
+	 * @param {jQuery Object} $link The toggle element to initialize
+	 * @param {Object} data Simple key/value data object passed when the event was triggered
+	 */
+	initPrint = function( $link, data ) {
+		var mediaQuery,
+			printEvent = "beforeprint";
+
+		$window.on( printEvent, function() {
+			$link.trigger( toggleEvent, $.extend( {}, data, { type: data.print } ) );
+		});
+
+		// Fallback for browsers that don't support print events
+		if ( window.matchMedia ) {
+			mediaQuery = window.matchMedia( "print" );
+			if ( mediaQuery.addListener ) {
+				mediaQuery.addListener( function( query ) {
+					if ( query.matches ) {
+						$window.trigger( printEvent );
+					}
+				});
+			}
 		}
 	},
 
@@ -284,7 +315,7 @@ var pluginName = "wb-toggle",
 
 			// Type: get opposite state of the type. Toggle reverses this
 			// to the requested state.
-			return type === data.stateOn ? data.stateOff : data.stateOn;
+			return type === "on" ? data.stateOff : data.stateOn;
 		}
 	},
 
@@ -354,11 +385,11 @@ $document.on( toggledEvent, "details", toggleDetails );
 $document.on( "keydown", selectorTab, function( event ) {
 	var which = event.which,
 		data, $elm, $parent, $group, $newPanel, index;
-	
+
 	if ( !event.ctrlKey && which > 34 && which < 41 ) {
 		event.preventDefault();
-		$elm = $( event.currentTarget ),
-		data = $elm.data( "toggle" ),
+		$elm = $( event.currentTarget );
+		data = $elm.data( "toggle" );
 		$parent = $document.find( data.parent );
 		$group = $parent.find( data.group );
 		index = $group.index( $elm.parent() );


### PR DESCRIPTION
1. Allows a toggle element to turn the elements it controls on/off before the page is printed.
2. Fixes a bug with the `type` option if the `stateOn` option is used.
3. Adds unit tests for onbeforeprint behaviour.
