### PR TITLE
Demos: Remove prettify load from demo table

### DIFF
--- a/site/pages/demos/index-en.hbs
+++ b/site/pages/demos/index-en.hbs
@@ -5,7 +5,7 @@
 	"fr": "index"
 }
 ---
-<table id="components" class="wb-prettify wb-tables table table-striped table-hover" data-wet-boew='{"aoColumnDefs": [ { "bVisible": false, "aTargets": [ 3 ] } ], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1 }'>
+<table id="components" class="wb-tables table table-striped table-hover" data-wet-boew='{"aoColumnDefs": [ { "bVisible": false, "aTargets": [ 3 ] } ], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1 }'>
 	<thead>
 		<tr>
 			<th>Name</th>

--- a/site/pages/demos/index-fr.hbs
+++ b/site/pages/demos/index-fr.hbs
@@ -5,7 +5,7 @@
 	"en": "index"
 }
 ---
-<table id="components" class="wb-prettify wb-tables table table-striped table-hover" data-wet-boew='{"aoColumnDefs": [ { "bVisible": false, "aTargets": [ 3 ] } ], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1 }'>
+<table id="components" class="wb-tables table table-striped table-hover" data-wet-boew='{"aoColumnDefs": [ { "bVisible": false, "aTargets": [ 3 ] } ], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1 }'>
 	<thead>
 		<tr>
 			<th>Nom</th>


### PR DESCRIPTION
Not used after the switch to the demo generation since the frontmatter doesn’t allow html tags
