### PR TITLE
Build: Add local gh-pages task

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -51,7 +51,7 @@ module.exports = (grunt) ->
 		[
 			"dist"
 			"copy:deploy"
-			"gh-pages"
+			"gh-pages:travis"
 		]
 	)
 
@@ -931,15 +931,24 @@ module.exports = (grunt) ->
 
 		"gh-pages":
 			options:
-				repo: "https://" + process.env.GH_TOKEN + "@github.com/wet-boew/wet-boew-dist.git"
-				branch: process.env.build_branch
 				clone: "wet-boew-dist"
-				message: "Travis build " + process.env.TRAVIS_BUILD_NUMBER
-				silent: true
 				base: "dist"
-			src: [
-				"**/*.*"
-			]
+
+			travis:
+				options:
+					repo: "https://" + process.env.GH_TOKEN + "@github.com/wet-boew/wet-boew-dist.git"
+					branch: process.env.build_branch
+					message: "Travis build " + process.env.TRAVIS_BUILD_NUMBER
+					silent: true
+				src: [
+					"**/*.*"
+				]
+
+			local:
+				src: [
+					"**/*.*"
+				]
+
 
 
 	# These plugins provide necessary tasks.

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt-gh-pages": "~0.8.0",
+    "grunt-gh-pages": "~0.9.0",
     "grunt-htmlcompressor": "~0.1.9",
     "grunt-imagine": "http://github.com/LaurentGoderre/grunt-imagine/tarball/custom",
     "grunt-jscs-checker": "~0.2.6",


### PR DESCRIPTION
Useful for pushing test content to your own `gh-pages` branch. The "dist" and "copy:deploy" should still be run beforehand.
