### PR TITLE
Build: 404 middleware

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -814,6 +814,10 @@ module.exports = (grunt) ->
 								/json|text|javascript|dart|image\/svg\+xml|application\/x-font-ttf|application\/vnd\.ms-opentype|application\/vnd\.ms-fontobject/.test(res.getHeader('Content-Type'))
 						))
 
+						middlewares.push (req, res, next) ->
+							req.url = req.url.replace( "/v4.0-ci/", "/" )
+							next()
+
 						middlewares.push(connect.static(options.base));
 
 						# Serve the custom error page

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -813,7 +813,21 @@ module.exports = (grunt) ->
 							filter: (req, res) ->
 								/json|text|javascript|dart|image\/svg\+xml|application\/x-font-ttf|application\/vnd\.ms-opentype|application\/vnd\.ms-fontobject/.test(res.getHeader('Content-Type'))
 						))
+
 						middlewares.push(connect.static(options.base));
+
+						# Serve the custom error page
+						middlewares.push (req, res) ->
+							filename = options.base + req.url
+
+							if not grunt.file.exists( filename )
+								filename = options.base + "/404.html"
+
+								# Set the status code manually
+								res.statusCode = 404
+
+							res.end( grunt.file.read( filename ) )
+
 						middlewares
 
 			test:

--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -8,12 +8,23 @@
 		<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 		<title>{{title}} - {{#i18n "site.title"}}{{/i18n}}</title>
-		<link href="{{assets}}/assets/favicon.ico" rel="shortcut icon" />
+		<link href="{{environment.root}}/assets/favicon.ico" rel="shortcut icon" />
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
 		<!-- Meta data -->
 		<meta name="description" content="{{#i18n "site.description"}}{{/i18n}}" />
 		<!-- Meta data-->
-		{{>headresources}}
+		<!--[if gte IE 9 | !IE ]><!-->
+		<link rel="stylesheet" href="{{environment.root}}/css/wet-boew{{environment.suffix}}.css" />
+		<!--<![endif]-->
+		<link rel="stylesheet" href="{{environment.root}}/css/theme{{environment.suffix}}.css" />
+		{{#if page.css}}<link rel="stylesheet" href="{{page.css}}{{environment.suffix}}.css" />{{/if}}
+		<!--[if lt IE 9]>
+		<link rel="stylesheet" href="{{environment.root}}/css/ie8-wet-boew.css" />
+		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery{{environment.suffix}}.js"></script>
+		<script src="{{environment.root}}/js/ie8-wet-boew{{environment.suffix}}.js"></script>
+		<![endif]-->
+
+		<noscript><link rel="stylesheet" href="{{environment.root}}/css/noscript{{environment.suffix}}.css" /></noscript>
 
 	</head>
 	<body vocab="http://schema.org/" typeof="WebPage">


### PR DESCRIPTION
- Add middleware to serve 404 page
- Add middleware to serve Assemble's `environment.root` value locally
- Use absolute asset values in server message templates due to the fact they can be served at any folder depth
