### PR TITLE
Bump license year to 2014

### DIFF
--- a/Licence-fr.txt
+++ b/Licence-fr.txt
@@ -1,39 +1,39 @@
-﻿Boîte à outils de l'expérience Web (BOEW) - Conditions régissant l'utilisation
+Boîte à outils de l'expérience Web (BOEW) - Conditions régissant l'utilisation
 
-Sauf indication contraire, le code source de la boîte à outils de l'expérience Web (BOEW) 
-est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué 
+Sauf indication contraire, le code source de la boîte à outils de l'expérience Web (BOEW)
+est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué
 sous la licence MIT.
 
-Le mot-symbole « Canada » et les éléments graphiques connexes liés à cette distribution sont 
+Le mot-symbole « Canada » et les éléments graphiques connexes liés à cette distribution sont
 protégés en vertu des lois portant sur les marques de commerce et le droit d'auteur.
 
-Aucune autorisation n'est accordée pour leur utilisation à l'extérieur des paramètres du 
-programme de coordination de l'image de marque du gouvernement du Canada. Pour obtenir 
-davantage de renseignements à ce sujet, veuillez consulter 
+Aucune autorisation n'est accordée pour leur utilisation à l'extérieur des paramètres du
+programme de coordination de l'image de marque du gouvernement du Canada. Pour obtenir
+davantage de renseignements à ce sujet, veuillez consulter
 http://www.tbs-sct.gc.ca/fip-pcim/index-fra.asp
 
-La propriété du droit d'auteur de tout logiciel tiers distribué avec la boîte à outils de 
-l'expérience Web (BOEW) est conservée par les détenteurs du droit d'auteur mentionnés 
-dans ces fichiers. Nous demandons aux utilisateurs de lire les licences des tiers indiqués 
+La propriété du droit d'auteur de tout logiciel tiers distribué avec la boîte à outils de
+l'expérience Web (BOEW) est conservée par les détenteurs du droit d'auteur mentionnés
+dans ces fichiers. Nous demandons aux utilisateurs de lire les licences des tiers indiqués
 à titre de référence dans ces logiciels.
 
 
 Licence MIT
 
-(c) Droit d'auteur – Gouvernement du Canada, 2013
+(c) Droit d'auteur – Gouvernement du Canada, 2014
 
-La présente autorise toute personne d'obtenir gratuitement une copie du présent logiciel et des 
-documents connexes (le « logiciel »), de traiter le logiciel sans restriction, y compris, mais sans 
-s'y limiter, les droits d'utiliser, de copier, de modifier, de fusionner, de publier, de distribuer, 
-d'accorder une sous licence et de vendre des copies dudit logiciel, et de permettre aux personnes 
+La présente autorise toute personne d'obtenir gratuitement une copie du présent logiciel et des
+documents connexes (le « logiciel »), de traiter le logiciel sans restriction, y compris, mais sans
+s'y limiter, les droits d'utiliser, de copier, de modifier, de fusionner, de publier, de distribuer,
+d'accorder une sous licence et de vendre des copies dudit logiciel, et de permettre aux personnes
 auxquelles le logiciel est fourni de le faire, selon les conditions suivantes :
 
-L'avis de droit d'auteur ci dessus et le présent avis de permission seront inclus dans toutes les copies 
+L'avis de droit d'auteur ci dessus et le présent avis de permission seront inclus dans toutes les copies
 et les sections importantes du logiciel.
 
-LE LOGICIEL EST FOURNI « TEL QUEL », SANS AUCUNE GARANTIE, EXPRESSE OU IMPLICITE, Y COMPRIS, MAIS SANS 
-S'Y LIMITER, LA GARANTIE DE QUALITÉ MARCHANDE, L'ADAPTATION À UN USAGE PARTICULIER ET L'ABSENCE DE 
-CONTREFAÇON. EN AUCUN CAS LES AUTEURS OU LES DÉTENTEURS DU DROIT D'AUTEUR NE SERONT TENUS RESPONSABLES 
-DE TOUTE DEMANDE, DOMMAGE OU BRIS DE CONTRAT, DÉLIT CIVIL OU TOUT AUTRE MANQUEMENT LIÉ AU LOGICIEL, 
+LE LOGICIEL EST FOURNI « TEL QUEL », SANS AUCUNE GARANTIE, EXPRESSE OU IMPLICITE, Y COMPRIS, MAIS SANS
+S'Y LIMITER, LA GARANTIE DE QUALITÉ MARCHANDE, L'ADAPTATION À UN USAGE PARTICULIER ET L'ABSENCE DE
+CONTREFAÇON. EN AUCUN CAS LES AUTEURS OU LES DÉTENTEURS DU DROIT D'AUTEUR NE SERONT TENUS RESPONSABLES
+DE TOUTE DEMANDE, DOMMAGE OU BRIS DE CONTRAT, DÉLIT CIVIL OU TOUT AUTRE MANQUEMENT LIÉ AU LOGICIEL,
 À SON UTILISATION OU À D'AUTRES ÉCHANGES LIÉS AU LOGICIEL.
 

--- a/Licence-fra.txt
+++ b/Licence-fra.txt
@@ -1,39 +1,39 @@
-﻿Boîte à outils de l'expérience Web (BOEW) - Conditions régissant l'utilisation
+Boîte à outils de l'expérience Web (BOEW) - Conditions régissant l'utilisation
 
-Sauf indication contraire, le code source de la boîte à outils de l'expérience Web (BOEW) 
-est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué 
+Sauf indication contraire, le code source de la boîte à outils de l'expérience Web (BOEW)
+est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué
 sous la licence MIT.
 
-Le mot-symbole « Canada » et les éléments graphiques connexes liés à cette distribution sont 
+Le mot-symbole « Canada » et les éléments graphiques connexes liés à cette distribution sont
 protégés en vertu des lois portant sur les marques de commerce et le droit d'auteur.
 
-Aucune autorisation n'est accordée pour leur utilisation à l'extérieur des paramètres du 
-programme de coordination de l'image de marque du gouvernement du Canada. Pour obtenir 
-davantage de renseignements à ce sujet, veuillez consulter 
+Aucune autorisation n'est accordée pour leur utilisation à l'extérieur des paramètres du
+programme de coordination de l'image de marque du gouvernement du Canada. Pour obtenir
+davantage de renseignements à ce sujet, veuillez consulter
 http://www.tbs-sct.gc.ca/fip-pcim/index-fra.asp
 
-La propriété du droit d'auteur de tout logiciel tiers distribué avec la boîte à outils de 
-l'expérience Web (BOEW) est conservée par les détenteurs du droit d'auteur mentionnés 
-dans ces fichiers. Nous demandons aux utilisateurs de lire les licences des tiers indiqués 
+La propriété du droit d'auteur de tout logiciel tiers distribué avec la boîte à outils de
+l'expérience Web (BOEW) est conservée par les détenteurs du droit d'auteur mentionnés
+dans ces fichiers. Nous demandons aux utilisateurs de lire les licences des tiers indiqués
 à titre de référence dans ces logiciels.
 
 
 Licence MIT
 
-(c) Droit d'auteur – Gouvernement du Canada, 2013
+(c) Droit d'auteur – Gouvernement du Canada, 2014
 
-La présente autorise toute personne d'obtenir gratuitement une copie du présent logiciel et des 
-documents connexes (le « logiciel »), de traiter le logiciel sans restriction, y compris, mais sans 
-s'y limiter, les droits d'utiliser, de copier, de modifier, de fusionner, de publier, de distribuer, 
-d'accorder une sous licence et de vendre des copies dudit logiciel, et de permettre aux personnes 
+La présente autorise toute personne d'obtenir gratuitement une copie du présent logiciel et des
+documents connexes (le « logiciel »), de traiter le logiciel sans restriction, y compris, mais sans
+s'y limiter, les droits d'utiliser, de copier, de modifier, de fusionner, de publier, de distribuer,
+d'accorder une sous licence et de vendre des copies dudit logiciel, et de permettre aux personnes
 auxquelles le logiciel est fourni de le faire, selon les conditions suivantes :
 
-L'avis de droit d'auteur ci dessus et le présent avis de permission seront inclus dans toutes les copies 
+L'avis de droit d'auteur ci dessus et le présent avis de permission seront inclus dans toutes les copies
 et les sections importantes du logiciel.
 
-LE LOGICIEL EST FOURNI « TEL QUEL », SANS AUCUNE GARANTIE, EXPRESSE OU IMPLICITE, Y COMPRIS, MAIS SANS 
-S'Y LIMITER, LA GARANTIE DE QUALITÉ MARCHANDE, L'ADAPTATION À UN USAGE PARTICULIER ET L'ABSENCE DE 
-CONTREFAÇON. EN AUCUN CAS LES AUTEURS OU LES DÉTENTEURS DU DROIT D'AUTEUR NE SERONT TENUS RESPONSABLES 
-DE TOUTE DEMANDE, DOMMAGE OU BRIS DE CONTRAT, DÉLIT CIVIL OU TOUT AUTRE MANQUEMENT LIÉ AU LOGICIEL, 
+LE LOGICIEL EST FOURNI « TEL QUEL », SANS AUCUNE GARANTIE, EXPRESSE OU IMPLICITE, Y COMPRIS, MAIS SANS
+S'Y LIMITER, LA GARANTIE DE QUALITÉ MARCHANDE, L'ADAPTATION À UN USAGE PARTICULIER ET L'ABSENCE DE
+CONTREFAÇON. EN AUCUN CAS LES AUTEURS OU LES DÉTENTEURS DU DROIT D'AUTEUR NE SERONT TENUS RESPONSABLES
+DE TOUTE DEMANDE, DOMMAGE OU BRIS DE CONTRAT, DÉLIT CIVIL OU TOUT AUTRE MANQUEMENT LIÉ AU LOGICIEL,
 À SON UTILISATION OU À D'AUTRES ÉCHANGES LIÉS AU LOGICIEL.
 

--- a/License-en.txt
+++ b/License-en.txt
@@ -1,33 +1,33 @@
 Web Experience Toolkit (WET) - Terms and Conditions of Use
 
-Unless otherwise noted, computer program source code of the Web Experience Toolkit (WET) is 
+Unless otherwise noted, computer program source code of the Web Experience Toolkit (WET) is
 covered under Crown Copyright, Government of Canada, and is distributed under the MIT License.
 
-The Canada wordmark and related graphics associated with this distribution are protected under 
-trademark law and copyright law. No permission is granted to use them outside the parameters 
-of the Government of Canada's corporate identity program. For more information, see 
+The Canada wordmark and related graphics associated with this distribution are protected under
+trademark law and copyright law. No permission is granted to use them outside the parameters
+of the Government of Canada's corporate identity program. For more information, see
 http://www.tbs-sct.gc.ca/fip-pcim/index-eng.asp
 
-Copyright title to all 3rd party software distributed with the Web Experience Toolkit (WET) is 
-held by the respective copyright holders as noted in those files. Users are asked to read the 
+Copyright title to all 3rd party software distributed with the Web Experience Toolkit (WET) is
+held by the respective copyright holders as noted in those files. Users are asked to read the
 3rd Party Licenses referenced with those assets.
 
 
 MIT License
 
-Copyright (c) 2013 Government of Canada
+Copyright (c) 2014 Government of Canada
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial 
+The above copyright notice and this permission notice shall be included in all copies or substantial
 portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
-NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/License-eng.txt
+++ b/License-eng.txt
@@ -1,33 +1,33 @@
 Web Experience Toolkit (WET) - Terms and Conditions of Use
 
-Unless otherwise noted, computer program source code of the Web Experience Toolkit (WET) is 
+Unless otherwise noted, computer program source code of the Web Experience Toolkit (WET) is
 covered under Crown Copyright, Government of Canada, and is distributed under the MIT License.
 
-The Canada wordmark and related graphics associated with this distribution are protected under 
-trademark law and copyright law. No permission is granted to use them outside the parameters 
-of the Government of Canada's corporate identity program. For more information, see 
+The Canada wordmark and related graphics associated with this distribution are protected under
+trademark law and copyright law. No permission is granted to use them outside the parameters
+of the Government of Canada's corporate identity program. For more information, see
 http://www.tbs-sct.gc.ca/fip-pcim/index-eng.asp
 
-Copyright title to all 3rd party software distributed with the Web Experience Toolkit (WET) is 
-held by the respective copyright holders as noted in those files. Users are asked to read the 
+Copyright title to all 3rd party software distributed with the Web Experience Toolkit (WET) is
+held by the respective copyright holders as noted in those files. Users are asked to read the
 3rd Party Licenses referenced with those assets.
 
 
 MIT License
 
-Copyright (c) 2013 Government of Canada
+Copyright (c) 2014 Government of Canada
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
-associated documentation files (the "Software"), to deal in the Software without restriction, 
-including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
-and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all copies or substantial 
+The above copyright notice and this permission notice shall be included in all copies or substantial
 portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
-NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
Whitespace was trimmed by editorconfig settings
