### PR TITLE
Date picker polyfill: Fixed closing on previous menu click (fixes #3869)

### DIFF
--- a/src/plugins/calendar/calendar.js
+++ b/src/plugins/calendar/calendar.js
@@ -231,6 +231,8 @@ var $document = wb.doc,
 			} else {
 				$btn.trigger( "setfocus.wb" );
 			}
+
+			return false;
 		}
 	},
 


### PR DESCRIPTION
The button handler was missing the <code>return false</code>.
