### PR TITLE
Build: Add check dependency plug-in

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -16,6 +16,7 @@ module.exports = (grunt) ->
 		"dist"
 		"Produces the production files"
 		[
+			"checkDependencies"
 			"test"
 			"build"
 			"assets-dist"
@@ -968,11 +969,15 @@ module.exports = (grunt) ->
 					"**/*.*"
 				]
 
-
+		checkDependencies:
+			all:
+				options:
+					npmInstall: false
 
 	# These plugins provide necessary tasks.
 	@loadNpmTasks "assemble"
 	@loadNpmTasks "grunt-autoprefixer"
+	@loadNpmTasks "grunt-check-dependencies"
 	@loadNpmTasks "grunt-contrib-clean"
 	@loadNpmTasks "grunt-contrib-concat"
 	@loadNpmTasks "grunt-contrib-connect"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "expect.js": "~0.2.0",
     "grunt": "~0.4.1",
     "grunt-autoprefixer": "~0.4.0",
+    "grunt-check-dependencies": "~0.3.0",
     "grunt-contrib-clean": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-connect": "~0.5.0",


### PR DESCRIPTION
Before running tasks, confirm the installed versions are correct. The
install flag is turned off because I found it failed on my machine
