### PR TITLE
Toggle: add toggle state persistence

### DIFF
--- a/src/plugins/toggle/test.js
+++ b/src/plugins/toggle/test.js
@@ -424,6 +424,131 @@ describe( "Toggle test suite", function() {
 			expect( $detailsOff.hasClass( "off" ) ).to.equal( true );
 		});
 	});
+
+	/*
+	 * Test persistence behaviour
+	 */
+	describe( "Persist toggle state: no saved state", function() {
+		var $detailsLocal, $detailsSession,
+			keyLocal = "wb-toggletest-local",
+			keySession = "wb-toggletest-session";
+
+		before(function() {
+			spy.reset();
+			localStorage.removeItem( keyLocal );
+			sessionStorage.removeItem( keySession );
+
+			$detailsLocal = $( "<details class=\"wb-toggle\" id=\"test-local\" data-toggle='{\"persist\": \"local\"}'><summary></summary></details>" )
+				.appendTo( wb.doc.find( "body" ) )
+				.trigger( "wb-init.wb-toggle" );
+
+			$detailsSession = $( "<details class=\"wb-toggle\" id=\"test-session\" data-toggle='{\"persist\": \"session\"}'><summary></summary></details>" )
+				.appendTo( wb.doc.find( "body" ) )
+				.trigger( "wb-init.wb-toggle" );
+		});
+
+		after(function() {
+			$detailsLocal.remove();
+			$detailsSession.remove();
+		});
+
+		it( "should not trigger toggle.wb-toggle when initialized", function() {
+			expect( spy.calledWith( "toggle.wb-toggle" ) ).to.equal( false );
+			expect( localStorage.getItem( keyLocal ) ).to.equal( null );
+			expect( sessionStorage.getItem( keySession ) ).to.equal( null );
+		});
+
+		it( "should save the toggle 'on' state in localStorage", function() {
+			$detailsLocal.trigger( "click" );
+			expect( localStorage.getItem( keyLocal ) ).to.equal( "on" );
+		});
+
+		it( "should save the toggle 'off' state in localStorage", function() {
+			$detailsLocal.trigger( "click" );
+			expect( localStorage.getItem( keyLocal ) ).to.equal( "off" );
+		});
+
+		it( "should save the toggle 'on' state in sessionStorage", function() {
+			$detailsSession.trigger( "click" );
+			expect( sessionStorage.getItem( keySession ) ).to.equal( "on" );
+		});
+
+		it( "should save the toggle 'off' state in sessionStorage", function() {
+			$detailsSession.trigger( "click" );
+			expect( sessionStorage.getItem( keySession ) ).to.equal( "off" );
+		});
+	});
+
+	describe( "Persist toggle state: saved state", function() {
+		var $details,
+			key = "wb-toggletest-session";
+
+		before(function() {
+			spy.reset();
+			sessionStorage.setItem( key, "on" );
+
+			$details = $( "<details class=\"wb-toggle\" id=\"test-session\" data-toggle='{\"persist\": \"session\"}'><summary></summary></details>" )
+				.appendTo( wb.doc.find( "body" ) )
+				.trigger( "wb-init.wb-toggle" );
+		});
+
+		after(function() {
+			$details.remove();
+		});
+
+		it( "should trigger toggle.wb-toggle when initialized", function() {
+			expect( spy.calledWith( "toggle.wb-toggle" ) ).to.equal( true );
+			expect( sessionStorage.getItem( key ) ).to.equal( "on" );
+		});
+
+		it( "should save the toggle 'off' state in sessionStorage", function() {
+			$details.trigger( "click" );
+			expect( sessionStorage.getItem( key ) ).to.equal( "off" );
+		});
+	});
+
+	describe( "Persist toggle state: group toggle", function() {
+		var $details1, $details2,
+			key1 = "wb-toggle.test-grouptest-1",
+			key2 = "wb-toggle.test-grouptest-2";
+
+		before(function() {
+			spy.reset();
+			sessionStorage.removeItem( key1 );
+			sessionStorage.removeItem( key2 );
+
+			$details1 = $( "<details class=\"wb-toggle test-group\" id=\"test-1\" data-toggle='{\"persist\": \"session\", \"group\": \".test-group\"}'><summary></summary></details>" )
+				.appendTo( wb.doc.find( "body" ) );
+			$details2 = $( "<details class=\"wb-toggle test-group\" id=\"test-2\" data-toggle='{\"persist\": \"session\", \"group\": \".test-group\"}'><summary></summary></details>" )
+				.appendTo( wb.doc.find( "body" ) );
+
+			$details1.trigger( "wb-init.wb-toggle" );
+			$details2.trigger( "wb-init.wb-toggle" );
+		});
+
+		after(function() {
+			$details1.remove();
+			$details2.remove();
+		});
+
+		it( "should save the 'on' state for $details1 and clear the state for $details2", function() {
+			$details1.trigger( "click" );
+			expect( sessionStorage.getItem( key1 ) ).to.equal( "on" );
+			expect( sessionStorage.getItem( key2 ) ).to.equal( null );
+		});
+
+		it( "should save the 'off' state for $details1 and clear the state for $details2", function() {
+			$details1.trigger( "click" );
+			expect( sessionStorage.getItem( key1 ) ).to.equal( "off" );
+			expect( sessionStorage.getItem( key2 ) ).to.equal( null );
+		});
+
+		it( "should clear the state for $details1 and save the 'on' state for $details2", function() {
+			$details2.trigger( "click" );
+			expect( sessionStorage.getItem( key1 ) ).to.equal( null );
+			expect( sessionStorage.getItem( key2 ) ).to.equal( "on" );
+		});
+	});
 });
 
 }( jQuery, wb ));

--- a/src/plugins/toggle/toggle-en.hbs
+++ b/src/plugins/toggle/toggle-en.hbs
@@ -23,10 +23,12 @@
 			<a href="#details" class="list-group-item">Details Elements</a>
 			<a href="#grouped" class="list-group-item">Grouped Toggle</a>
 			<a href="#accordion" class="list-group-item">Accordion</a>
+			<a href="#persist" class="list-group-item">Persist Toggle State</a>
 		</div>
 	</div>
 
 	<div class="col-md-9">
+	
 		<section>
 			<h2 id="setup" class="mrgn-tp-0">Plugin Setup</h2>
 			<p>Adding the <code>.wb-toggle</code> CSS class to any element will turn it into a toggle element.  The behaviour of this toggle element is then controlled by the <code>data-toggle</code> attribute which takes a JavaScript object of properties:</p>
@@ -52,22 +54,32 @@
 						<td>CSS selector that groups multiple toggle elements together and only allows one of the elements to be open at a time.</td>
 					</tr>
 					<tr>
+						<td><code>persist</code></td>
+						<td>
+							Causes a toggle element to remember its current state and re-apply it when the page reloads.  Supports the following values:
+							<ul>
+								<li><strong>session:</strong> toggle state will persist until the user closes their browser window or tab.</li>
+								<li><strong>local:</strong> toggle state will persist even after the browser window or tab is closed.</li>
+							</ul>
+						</td>
+					</tr>					
+					<tr>
 						<td><code>print</code></td>
 						<td>
-							Causes a toggle element to turn the elements it controls on or off when the page is printed.  Supports the following two values:
+							Causes a toggle element to turn the elements it controls on or off when the page is printed.  Supports the following values:
 							<ul>
-								<li>on: elements will be set to "on" toggle state for printing.</li>
-								<li>off: elements will be set to "off" toggle state for printing.</li>
+								<li><strong>on:</strong> elements will be set to "on" toggle state for printing.</li>
+								<li><strong>off:</strong> elements will be set to "off" toggle state for printing.</li>
 							</ul>  
 						</td>
 					</tr>					
 					<tr>
 						<td><code>type</code></td>
 						<td>
-							Causes a toggle element to only turn the elements it controls on or off.  Supports the following two values:
+							Causes a toggle element to only turn the elements it controls on or off.  Supports the following values:
 							<ul>
-								<li>on: toggle element will only turn elements to the "on" toggle state.</li>
-								<li>off: toggle element will only turn elements to the "off" toggle state.</li>
+								<li><strong>on:</strong> toggle element will only turn elements to the "on" toggle state.</li>
+								<li><strong>off:</strong> toggle element will only turn elements to the "off" toggle state.</li>
 							</ul>  
 						</td>
 					</tr>
@@ -460,5 +472,40 @@
 &lt;/div&gt;</code></pre>
 
 		</section>
+		
+		<section>
+			<h2 id="persist">Persist Toggle State</h2>
+			<p>The following <code>details</code> element will remember its toggle state as long as this browser window (or tab) remains open.</p>
+			<details>
+				<summary class="wb-toggle" data-toggle='{"persist": "session"}'>Example 1</summary>
+				<p>Example content that provides more details.</p>
+				<table>
+					<caption>Cups of coffee consumed by each delegate</caption>
+					<thead>
+						<tr>
+							<th scope="col">Name</th>
+							<th scope="col">Cups</th>
+							<th scope="col">Type of Coffee</th>
+							<th scope="col">Sugar?</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>T. Sexton</td>
+							<td>10</td>
+							<td>Espresso</td>
+							<td>No</td>
+						</tr>
+						<tr>
+							<td>J. Dinnen</td>
+							<td>5</td>
+							<td>Decaf</td>
+							<td>Yes</td>
+						</tr>
+					</tbody>
+				</table>
+			</details>
+
+		</section>		
 	</div>
 </div>

--- a/src/plugins/toggle/toggle-fr.hbs
+++ b/src/plugins/toggle/toggle-fr.hbs
@@ -22,6 +22,7 @@
 			<a href="#details" class="list-group-item">Details</a>
 			<a href="#grouped" class="list-group-item">Basculer groupe</a>
 			<a href="#accordion" class="list-group-item">Accordion</a>
+			<a href="#persist" class="list-group-item">Conserver l'état de bascule</a>
 		</div>
 	</div>
 
@@ -359,5 +360,39 @@
 			</div>
 
 		</section>
+		
+		<section>
+			<h2 id="persist">Conserver l'état de bascule</h2>
+			<p>L'état de bascule de l'élément <code>details</code> ci-desous persistra tant que le fureteur (ou onglet) demeure ouvert.</p>
+			<details>
+				<summary class="wb-toggle" data-toggle='{"persist": "session"}'>Exemple 1</summary>
+				<p>Le contenu d'exemple qui fournit plus de détails.</p>
+				<table>
+					<caption>Tasses de café bues par chaque député</caption>
+					<thead>
+					<tr>
+						<th scope="col">Nom</th>
+						<th scope="col">Tasses</th>
+						<th scope="col">Type de café</th>
+						<th scope="col">Sucre?</th>
+					</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>T. Sexton</td>
+							<td>10</td>
+							<td>Expresso</td>
+							<td>Non</td>
+						</tr>
+						<tr>
+							<td>J. Dinnen</td>
+							<td>5</td>
+							<td>Déca</td>
+							<td>Oui</td>
+						</tr>
+					</tbody>
+				</table>
+			</details>			
+		</section>		
 	</div>
 </div>


### PR DESCRIPTION
The "persist" data option allows a toggle element to remember it's on/off state using localStorage or sessionStorage.

Fixes #857, #2620.
