### PR TITLE
Tabs: fix auto-height-none on slider

### DIFF
--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -321,6 +321,9 @@
 							nextPanel.addClass(opts.panelActiveClass);
 							$panels.filter(':not(.'+opts.panelActiveClass+')').hide();
 						});
+						if (!opts.autoHeight) {
+							$tabsPanel.stop().animate({height: nextPanel.outerHeight()}, opts.animationSpeed);
+						}
 					} else {
 						activePanel.fadeOut(opts.animationSpeed, function () {
 							return nextPanel.fadeIn(opts.animationSpeed, function () {
@@ -414,7 +417,11 @@
 					}
 				}
 
-				$tabsPanel.css(panelSize);
+				if (opts.autoHeight) {
+					$tabsPanel.css(panelSize);
+				} else {
+					$tabsPanel.css('height', $panels.filter('.'+opts.panelActiveClass).outerHeight());
+				}
 				if (isSlideHorz) {
 					$viewport.css($.extend({
 						width: viewportSize.width,
@@ -429,7 +436,7 @@
 
 				$hiddenParents.removeClass('display-block');
 			};
-			if (isSlider() || (opts.autoHeight && !elm.hasClass('tabs-style-4') && !elm.hasClass('tabs-style-5'))) {
+			if (opts.autoHeight && !elm.hasClass('tabs-style-4') && !elm.hasClass('tabs-style-5')) {
 				$panels.show();
 				tallest = 0;
 				len = panelsDOM.length;


### PR DESCRIPTION
The slider-horz and slider-vert now work with variable height panels.  As new panels slide into view, the height of the plugin adjusts as needed.

Fixes #2793.
