### PR TITLE
Menu: Fixed displaying of mobile panel in IE8

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -208,8 +208,10 @@ var pluginName = "wb-menu",
 			$language = $( "#wb-lng" ),
 			search = document.getElementById( "wb-srch" ),
 			panel = "",
+			panelDOM = document.getElementById( target ),
+			$panel = $( panelDOM ),
 			allProperties = [],
-			$panel, $navCurr, $menuItem, len, i;
+			$navCurr, $menuItem, len, i;
 
 		/*
 		 * Build the mobile panel
@@ -279,16 +281,11 @@ var pluginName = "wb-menu",
 			panel += createMobilePanelMenu( allProperties );
 		}
 
-		// Let's create the DOM Element
-		$panel = $( "<div id='" + target +
-				"' class='wb-overlay modal-content overlay-def wb-panel-r'>" +
-				"<header class='modal-header'><div class='modal-title'>" +
-				i18nText.menu  + "</div></header><div class='modal-body'>" +
-				panel + "</div></div>" );
-
 		// Let's now populate the DOM since we have done all the work in a documentFragment
-		$( "#" + target ).replaceWith( $panel );
-
+		panelDOM.innerHTML = "<header class='modal-header'><div class='modal-title'>" +
+				i18nText.menu  + "</div></header><div class='modal-body'>" +
+				panel + "</div>";
+		panelDOM.className += " wb-overlay modal-content overlay-def wb-panel-r";
 		$panel
 			.trigger( "wb-init.wb-overlay" )
 			.find( "summary" )
@@ -306,7 +303,7 @@ var pluginName = "wb-menu",
 			.find( ":discoverable" )
 				.attr( "tabindex", "-1" );
 
-		$menu.eq( 0 ).attr( "tabindex", "0" );
+		$menu[ 0 ].setAttribute( "tabindex", "0" );
 		$menu
 			.filter( "[href^=#]" )
 				.append( "<span class='expicon'></span>" );


### PR DESCRIPTION
Problem: All browsers except IE8 successfully insert the mobile panel content into the DOM. This means that nothing displays when clicking the mobile button in IE8.

Root cause: The problem seems to be related to how jQuery handles inserting content into the DOM in IE8. I tried multiple different approaches and had to rely on plain JS to successfully do it. Here are the results:
- $panel.replaceWith( ... ): Fine in all browsers except IE8 which inserted nothing in the DOM
- $panel.append( ... ): Fine in all browsers except IE8 which inserted nothing in the DOM
- $panel.html( ... ): Fine in all browsers except IE8 which inserted nothing in the DOM
- $panel[ 0 ].innerHTML= ...: Fine in all browsers (even IE8)

So this solution replaces the replaceWith approach with an innerHTML approach to resolve the IE8 issue (which also helps to boost performance because of the reduction in jQuery usage).

/cc @thomasgohard
