### PR TITLE
WET theme: Switched site search to using Google Web search

### DIFF
--- a/Licence-fr.html
+++ b/Licence-fr.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="index-fra.html"><object data="dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/Licence-fra.html
+++ b/Licence-fra.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="index-fra.html"><object data="dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/License-en.html
+++ b/License-en.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="index-eng.html"><object data="dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/License-eng.html
+++ b/License-eng.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="index-eng.html"><object data="dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/arb-rra/arb-rra-en.html
+++ b/demos/arb-rra/arb-rra-en.html
@@ -119,9 +119,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/arb-rra/arb-rra-fr.html
+++ b/demos/arb-rra/arb-rra-fr.html
@@ -121,9 +121,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/arb-rra/arb-rra-planAccess-en.html
+++ b/demos/arb-rra/arb-rra-planAccess-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/arb-rra/arb-rra-planAccess-fr.html
+++ b/demos/arb-rra/arb-rra-planAccess-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/archived/archived-en.html
+++ b/demos/archived/archived-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/archived/archived-fr.html
+++ b/demos/archived/archived-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/complex-en.html
+++ b/demos/charts/complex-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/complex-fr.html
+++ b/demos/charts/complex-fr.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/index-en.html
+++ b/demos/charts/index-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/index-fr.html
+++ b/demos/charts/index-fr.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/labels-en.html
+++ b/demos/charts/labels-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/labels-fr.html
+++ b/demos/charts/labels-fr.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/numberFormat-en.html
+++ b/demos/charts/numberFormat-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/numberFormat-fr.html
+++ b/demos/charts/numberFormat-fr.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/pie-en.html
+++ b/demos/charts/pie-en.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/pie-fr.html
+++ b/demos/charts/pie-fr.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/simple-en.html
+++ b/demos/charts/simple-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/simple-fr.html
+++ b/demos/charts/simple-fr.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/simpleCustomized-en.html
+++ b/demos/charts/simpleCustomized-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/charts/simpleCustomized-fr.html
+++ b/demos/charts/simpleCustomized-fr.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/datalist/datalist-en.html
+++ b/demos/datalist/datalist-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/datalist/datalist-fr.html
+++ b/demos/datalist/datalist-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/datepicker/datepicker-en.html
+++ b/demos/datepicker/datepicker-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/datepicker/datepicker-fr.html
+++ b/demos/datepicker/datepicker-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/details/details-en.html
+++ b/demos/details/details-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/details/details-fr.html
+++ b/demos/details/details-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/details/expandcollapseall-en.html
+++ b/demos/details/expandcollapseall-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/details/expandcollapseall-fr.html
+++ b/demos/details/expandcollapseall-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/eventscalendar/eventscalendar-en.html
+++ b/demos/eventscalendar/eventscalendar-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/eventscalendar/eventscalendar-fr.html
+++ b/demos/eventscalendar/eventscalendar-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/feedback/feedback-en.html
+++ b/demos/feedback/feedback-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/feedback/feedback-fr.html
+++ b/demos/feedback/feedback-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/footnotes/footnotes-en.html
+++ b/demos/footnotes/footnotes-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/footnotes/footnotes-fr.html
+++ b/demos/footnotes/footnotes-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/formvalid/formvalid-en.html
+++ b/demos/formvalid/formvalid-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/formvalid/formvalid-fr.html
+++ b/demos/formvalid/formvalid-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/geomap/geomap-en.html
+++ b/demos/geomap/geomap-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/geomap/geomap-fr.html
+++ b/demos/geomap/geomap-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-base-en.html
+++ b/demos/grids/grid-base-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-base-full-en.html
+++ b/demos/grids/grid-base-full-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-basic-en.html
+++ b/demos/grids/grid-basic-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-border-en.html
+++ b/demos/grids/grid-border-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-button-en.html
+++ b/demos/grids/grid-button-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-color-en.html
+++ b/demos/grids/grid-color-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-form-en.html
+++ b/demos/grids/grid-form-en.html
@@ -59,9 +59,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-icon-en.html
+++ b/demos/grids/grid-icon-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-image-en.html
+++ b/demos/grids/grid-image-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-message-en.html
+++ b/demos/grids/grid-message-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-module-en.html
+++ b/demos/grids/grid-module-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-opacity-en.html
+++ b/demos/grids/grid-opacity-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-other-en.html
+++ b/demos/grids/grid-other-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-position-en.html
+++ b/demos/grids/grid-position-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-proximity-en.html
+++ b/demos/grids/grid-proximity-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-specialty-en.html
+++ b/demos/grids/grid-specialty-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-structure-en.html
+++ b/demos/grids/grid-structure-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-table-en.html
+++ b/demos/grids/grid-table-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/grids/grid-text-en.html
+++ b/demos/grids/grid-text-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/guide-design/components-en.html
+++ b/demos/guide-design/components-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/guide-design/default-en.html
+++ b/demos/guide-design/default-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/guide-design/format-en.html
+++ b/demos/guide-design/format-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/guide-design/guide-en.html
+++ b/demos/guide-design/guide-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/guide-design/javascript-en.html
+++ b/demos/guide-design/javascript-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/guide-design/layout-en.html
+++ b/demos/guide-design/layout-en.html
@@ -65,9 +65,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/index-en.html
+++ b/demos/index-en.html
@@ -60,9 +60,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html" lang="en"><object data="../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/index-eng.html
+++ b/demos/index-eng.html
@@ -61,9 +61,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html" lang="en"><object data="../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/index-fr.html
+++ b/demos/index-fr.html
@@ -60,9 +60,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html" lang="fr"><object data="../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/index-fra.html
+++ b/demos/index-fra.html
@@ -61,9 +61,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html" lang="fr"><object data="../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/langselect/lang-en.html
+++ b/demos/langselect/lang-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/langselect/lang-fr.html
+++ b/demos/langselect/lang-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/langselect/lang-js-en.html
+++ b/demos/langselect/lang-js-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/langselect/lang-js-fr.html
+++ b/demos/langselect/lang-js-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/lightbox/lightbox-en.html
+++ b/demos/lightbox/lightbox-en.html
@@ -67,9 +67,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/lightbox/lightbox-fr.html
+++ b/demos/lightbox/lightbox-fr.html
@@ -67,9 +67,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/mathlib/mathlib-complex-fr.html
+++ b/demos/mathlib/mathlib-complex-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/mathlib/mathlib-en.html
+++ b/demos/mathlib/mathlib-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/mathlib/mathlib-fr.html
+++ b/demos/mathlib/mathlib-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/menubar/hsitenavbar-en.html
+++ b/demos/menubar/hsitenavbar-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/menubar/hsitenavbar-fr.html
+++ b/demos/menubar/hsitenavbar-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/menubar/megamenu-en.html
+++ b/demos/menubar/megamenu-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/menubar/megamenu-fr.html
+++ b/demos/menubar/megamenu-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/meter/meter-en.html
+++ b/demos/meter/meter-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/meter/meter-fr.html
+++ b/demos/meter/meter-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/multimedia/mediaplayer-transcript_captions-en.html
+++ b/demos/multimedia/mediaplayer-transcript_captions-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/multimedia/mediaplayer-transcript_captions-fr.html
+++ b/demos/multimedia/mediaplayer-transcript_captions-fr.html
@@ -62,9 +62,9 @@ progress {
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/multimedia/multimedia-en.html
+++ b/demos/multimedia/multimedia-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/multimedia/multimedia-fr.html
+++ b/demos/multimedia/multimedia-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/app-en.html
+++ b/demos/opt-cont/app-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/clr-en.html
+++ b/demos/opt-cont/clr-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/dk-sv-en.html
+++ b/demos/opt-cont/dk-sv-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/frm-en.html
+++ b/demos/opt-cont/frm-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/hdg-en.html
+++ b/demos/opt-cont/hdg-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/img-en.html
+++ b/demos/opt-cont/img-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/img-org-desc-en.html
+++ b/demos/opt-cont/img-org-desc-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/index-en.html
+++ b/demos/opt-cont/index-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/kb-cv-en.html
+++ b/demos/opt-cont/kb-cv-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/lin-en.html
+++ b/demos/opt-cont/lin-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/qlg-en.html
+++ b/demos/opt-cont/qlg-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/smm-en.html
+++ b/demos/opt-cont/smm-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/tbl-en.html
+++ b/demos/opt-cont/tbl-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/tbl-simp-en.html
+++ b/demos/opt-cont/tbl-simp-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/opt-cont/wcag-en.html
+++ b/demos/opt-cont/wcag-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/prettify/prettify-en.html
+++ b/demos/prettify/prettify-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/prettify/prettify-fr.html
+++ b/demos/prettify/prettify-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/progress/progress-en.html
+++ b/demos/progress/progress-en.html
@@ -62,9 +62,9 @@ progress {
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/progress/progress-fr.html
+++ b/demos/progress/progress-fr.html
@@ -62,9 +62,9 @@ progress {
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/responsiveimg/responsiveimg-en.html
+++ b/demos/responsiveimg/responsiveimg-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/sessiontimeout/sessiontimeout-en.html
+++ b/demos/sessiontimeout/sessiontimeout-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/sessiontimeout/sessiontimeout-fr.html
+++ b/demos/sessiontimeout/sessiontimeout-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/share/share-en.html
+++ b/demos/share/share-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/share/share-filtered-en.html
+++ b/demos/share/share-filtered-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/share/share-filtered-fr.html
+++ b/demos/share/share-filtered-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/share/share-fr.html
+++ b/demos/share/share-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/slideout/slideout-en.html
+++ b/demos/slideout/slideout-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/slideout/slideout-fr.html
+++ b/demos/slideout/slideout-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/slider/slider-en.html
+++ b/demos/slider/slider-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/slider/slider-fr.html
+++ b/demos/slider/slider-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/ssi/index-en.html
+++ b/demos/ssi/index-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/ssi/index-fr.html
+++ b/demos/ssi/index-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/About-the-Table-Usability-Concept.html
+++ b/demos/tableparser/About-the-Table-Usability-Concept.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/ExtendedDefinition.html
+++ b/demos/tableparser/ExtendedDefinition.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/Table-CaseStudies-2.html
+++ b/demos/tableparser/Table-CaseStudies-2.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/Table-CaseStudies-3.html
+++ b/demos/tableparser/Table-CaseStudies-3.html
@@ -62,9 +62,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/Table-CaseStudies.html
+++ b/demos/tableparser/Table-CaseStudies.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/colgroupheader-techniques.html
+++ b/demos/tableparser/colgroupheader-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/colgroupsummary-techniques.html
+++ b/demos/tableparser/colgroupsummary-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/colheader-description-techniques.html
+++ b/demos/tableparser/colheader-description-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/datacolgroup-techniques.html
+++ b/demos/tableparser/datacolgroup-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/headercolgroupstructure-techniques.html
+++ b/demos/tableparser/headercolgroupstructure-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/headerrowgroupstructure-techniques.html
+++ b/demos/tableparser/headerrowgroupstructure-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/index-en.html
+++ b/demos/tableparser/index-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/keycell-techniques.html
+++ b/demos/tableparser/keycell-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/layoutcell-techniques.html
+++ b/demos/tableparser/layoutcell-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/rowgroupheader-description-techniques.html
+++ b/demos/tableparser/rowgroupheader-description-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/rowgrouping-techniques.html
+++ b/demos/tableparser/rowgrouping-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/rowheader-description-techniques.html
+++ b/demos/tableparser/rowheader-description-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/summariesrowgroup-techniques.html
+++ b/demos/tableparser/summariesrowgroup-techniques.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tableparser/validator-htmltable.html
+++ b/demos/tableparser/validator-htmltable.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tables/tables-en.html
+++ b/demos/tables/tables-en.html
@@ -62,9 +62,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tabs/tabs-en.html
+++ b/demos/tabs/tabs-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/tabs/tabs-fr.html
+++ b/demos/tabs/tabs-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/texthighlight/texthighlight-en.html
+++ b/demos/texthighlight/texthighlight-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/texthighlight/texthighlight-fr.html
+++ b/demos/texthighlight/texthighlight-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/af/cont-af.html
+++ b/demos/theme-wet-boew/af/cont-af.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Gereedskapkis van die Ervaring van die Web&#160;(WET) <small>Gesamentlike projek wat oopbron en word gelei deur die regering van Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Soek</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/af/cont-fixedmobileheader-af.html
+++ b/demos/theme-wet-boew/af/cont-fixedmobileheader-af.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Gereedskapkis van die Ervaring van die Web&#160;(WET) <small>Gesamentlike projek wat oopbron en word gelei deur die regering van Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Soek</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/af/cont-nositemenubc-af.html
+++ b/demos/theme-wet-boew/af/cont-nositemenubc-af.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Gereedskapkis van die Ervaring van die Web&#160;(WET) <small>Gesamentlike projek wat oopbron en word gelei deur die regering van Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Soek</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/af/cont-secnav1-af.html
+++ b/demos/theme-wet-boew/af/cont-secnav1-af.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Gereedskapkis van die Ervaring van die Web&#160;(WET) <small>Gesamentlike projek wat oopbron en word gelei deur die regering van Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Soek</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/af/cont-secnav2-af.html
+++ b/demos/theme-wet-boew/af/cont-secnav2-af.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Gereedskapkis van die Ervaring van die Web&#160;(WET) <small>Gesamentlike projek wat oopbron en word gelei deur die regering van Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Soek</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/af/cont-signin-af.html
+++ b/demos/theme-wet-boew/af/cont-signin-af.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Gereedskapkis van die Ervaring van die Web&#160;(WET) <small>Gesamentlike projek wat oopbron en word gelei deur die regering van Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Soek</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/af/cont-signout-af.html
+++ b/demos/theme-wet-boew/af/cont-signout-af.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Gereedskapkis van die Ervaring van die Web&#160;(WET) <small>Gesamentlike projek wat oopbron en word gelei deur die regering van Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Soek</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/af/cont-subsite-af.html
+++ b/demos/theme-wet-boew/af/cont-subsite-af.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Gereedskapkis van die Ervaring van die Web&#160;(WET) <small>Gesamentlike projek wat oopbron en word gelei deur die regering van Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Soek</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Soek webwerf</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Soek" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/ar/cont-ar.html
+++ b/demos/theme-wet-boew/ar/cont-ar.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>الأدوات من تجربة ويب (WET) <small>ويقود المشروع التعاوني الذي هو المصدر المفتوح وحكومة كندا</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>البحث</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ar/cont-fixedmobileheader-ar.html
+++ b/demos/theme-wet-boew/ar/cont-fixedmobileheader-ar.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>الأدوات من تجربة ويب (WET) <small>ويقود المشروع التعاوني الذي هو المصدر المفتوح وحكومة كندا</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>البحث</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ar/cont-nositemenubc-ar.html
+++ b/demos/theme-wet-boew/ar/cont-nositemenubc-ar.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>الأدوات من تجربة ويب (WET) <small>ويقود المشروع التعاوني الذي هو المصدر المفتوح وحكومة كندا</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>البحث</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ar/cont-secnav1-ar.html
+++ b/demos/theme-wet-boew/ar/cont-secnav1-ar.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>الأدوات من تجربة ويب (WET) <small>ويقود المشروع التعاوني الذي هو المصدر المفتوح وحكومة كندا</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>البحث</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ar/cont-secnav2-ar.html
+++ b/demos/theme-wet-boew/ar/cont-secnav2-ar.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>الأدوات من تجربة ويب (WET) <small>ويقود المشروع التعاوني الذي هو المصدر المفتوح وحكومة كندا</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>البحث</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ar/cont-signin-ar.html
+++ b/demos/theme-wet-boew/ar/cont-signin-ar.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>الأدوات من تجربة ويب (WET) <small>ويقود المشروع التعاوني الذي هو المصدر المفتوح وحكومة كندا</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>البحث</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ar/cont-signout-ar.html
+++ b/demos/theme-wet-boew/ar/cont-signout-ar.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>الأدوات من تجربة ويب (WET) <small>ويقود المشروع التعاوني الذي هو المصدر المفتوح وحكومة كندا</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>البحث</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ar/cont-subsite-ar.html
+++ b/demos/theme-wet-boew/ar/cont-subsite-ar.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>الأدوات من تجربة ويب (WET) <small>ويقود المشروع التعاوني الذي هو المصدر المفتوح وحكومة كندا</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>البحث</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">البحث الموقع الالكتروني</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="البحث" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/bg/cont-bg.html
+++ b/demos/theme-wet-boew/bg/cont-bg.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Кутия за инструменти на Опитът на Web&#160;(WET) <small>Проект за сътрудничество, който е с отворен код и се ръководи от правителството на Канада</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Търсене</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/bg/cont-fixedmobileheader-bg.html
+++ b/demos/theme-wet-boew/bg/cont-fixedmobileheader-bg.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Кутия за инструменти на Опитът на Web&#160;(WET) <small>Проект за сътрудничество, който е с отворен код и се ръководи от правителството на Канада</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Търсене</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/bg/cont-nositemenubc-bg.html
+++ b/demos/theme-wet-boew/bg/cont-nositemenubc-bg.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Кутия за инструменти на Опитът на Web&#160;(WET) <small>Проект за сътрудничество, който е с отворен код и се ръководи от правителството на Канада</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Търсене</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/bg/cont-secnav1-bg.html
+++ b/demos/theme-wet-boew/bg/cont-secnav1-bg.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Кутия за инструменти на Опитът на Web&#160;(WET) <small>Проект за сътрудничество, който е с отворен код и се ръководи от правителството на Канада</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Търсене</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/bg/cont-secnav2-bg.html
+++ b/demos/theme-wet-boew/bg/cont-secnav2-bg.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Кутия за инструменти на Опитът на Web&#160;(WET) <small>Проект за сътрудничество, който е с отворен код и се ръководи от правителството на Канада</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Търсене</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/bg/cont-signin-bg.html
+++ b/demos/theme-wet-boew/bg/cont-signin-bg.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Кутия за инструменти на Опитът на Web&#160;(WET) <small>Проект за сътрудничество, който е с отворен код и се ръководи от правителството на Канада</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Търсене</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/bg/cont-signout-bg.html
+++ b/demos/theme-wet-boew/bg/cont-signout-bg.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Кутия за инструменти на Опитът на Web&#160;(WET) <small>Проект за сътрудничество, който е с отворен код и се ръководи от правителството на Канада</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Търсене</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/bg/cont-subsite-bg.html
+++ b/demos/theme-wet-boew/bg/cont-subsite-bg.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Кутия за инструменти на Опитът на Web&#160;(WET) <small>Проект за сътрудничество, който е с отворен код и се ръководи от правителството на Канада</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Търсене</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Търси в сайта</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Търсене" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/cont-en.html
+++ b/demos/theme-wet-boew/cont-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-fixedmobileheader-en.html
+++ b/demos/theme-wet-boew/cont-fixedmobileheader-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-fixedmobileheader-fr.html
+++ b/demos/theme-wet-boew/cont-fixedmobileheader-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-fr.html
+++ b/demos/theme-wet-boew/cont-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-nositemenubc-en.html
+++ b/demos/theme-wet-boew/cont-nositemenubc-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-nositemenubc-fr.html
+++ b/demos/theme-wet-boew/cont-nositemenubc-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-secnav1-en.html
+++ b/demos/theme-wet-boew/cont-secnav1-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-secnav1-fr.html
+++ b/demos/theme-wet-boew/cont-secnav1-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-secnav2-en.html
+++ b/demos/theme-wet-boew/cont-secnav2-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-secnav2-fr.html
+++ b/demos/theme-wet-boew/cont-secnav2-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-signin-en.html
+++ b/demos/theme-wet-boew/cont-signin-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-signin-fr.html
+++ b/demos/theme-wet-boew/cont-signin-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-signout-en.html
+++ b/demos/theme-wet-boew/cont-signout-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-signout-fr.html
+++ b/demos/theme-wet-boew/cont-signout-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cont-subsite-en.html
+++ b/demos/theme-wet-boew/cont-subsite-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/cont-subsite-fr.html
+++ b/demos/theme-wet-boew/cont-subsite-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/cs/cont-cs.html
+++ b/demos/theme-wet-boew/cs/cont-cs.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Soubor Nástrojů Zkušeností z Webu&#160;(WET) <small>Kolaborativní projekt, který je open source a je veden vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hledat</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cs/cont-fixedmobileheader-cs.html
+++ b/demos/theme-wet-boew/cs/cont-fixedmobileheader-cs.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Soubor Nástrojů Zkušeností z Webu&#160;(WET) <small>Kolaborativní projekt, který je open source a je veden vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hledat</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cs/cont-nositemenubc-cs.html
+++ b/demos/theme-wet-boew/cs/cont-nositemenubc-cs.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Soubor Nástrojů Zkušeností z Webu&#160;(WET) <small>Kolaborativní projekt, který je open source a je veden vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hledat</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cs/cont-secnav1-cs.html
+++ b/demos/theme-wet-boew/cs/cont-secnav1-cs.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Soubor Nástrojů Zkušeností z Webu&#160;(WET) <small>Kolaborativní projekt, který je open source a je veden vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hledat</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cs/cont-secnav2-cs.html
+++ b/demos/theme-wet-boew/cs/cont-secnav2-cs.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Soubor Nástrojů Zkušeností z Webu&#160;(WET) <small>Kolaborativní projekt, který je open source a je veden vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hledat</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cs/cont-signin-cs.html
+++ b/demos/theme-wet-boew/cs/cont-signin-cs.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Soubor Nástrojů Zkušeností z Webu&#160;(WET) <small>Kolaborativní projekt, který je open source a je veden vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hledat</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cs/cont-signout-cs.html
+++ b/demos/theme-wet-boew/cs/cont-signout-cs.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Soubor Nástrojů Zkušeností z Webu&#160;(WET) <small>Kolaborativní projekt, který je open source a je veden vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hledat</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/cs/cont-subsite-cs.html
+++ b/demos/theme-wet-boew/cs/cont-subsite-cs.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Soubor Nástrojů Zkušeností z Webu&#160;(WET) <small>Kolaborativní projekt, který je open source a je veden vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hledat</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hledat ve webových stránkách</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hledat" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/de/cont-de.html
+++ b/demos/theme-wet-boew/de/cont-de.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkzeugkiste von der Erfahrung des Web&#160;(WET) <small>Verbundprojekt, das Open Source ist und wird von der Regierung von Kanada geführt</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Suchen</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/de/cont-fixedmobileheader-de.html
+++ b/demos/theme-wet-boew/de/cont-fixedmobileheader-de.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkzeugkiste von der Erfahrung des Web&#160;(WET) <small>Verbundprojekt, das Open Source ist und wird von der Regierung von Kanada geführt</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Suchen</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/de/cont-nositemenubc-de.html
+++ b/demos/theme-wet-boew/de/cont-nositemenubc-de.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkzeugkiste von der Erfahrung des Web&#160;(WET) <small>Verbundprojekt, das Open Source ist und wird von der Regierung von Kanada geführt</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Suchen</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/de/cont-secnav1-de.html
+++ b/demos/theme-wet-boew/de/cont-secnav1-de.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkzeugkiste von der Erfahrung des Web&#160;(WET) <small>Verbundprojekt, das Open Source ist und wird von der Regierung von Kanada geführt</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Suchen</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/de/cont-secnav2-de.html
+++ b/demos/theme-wet-boew/de/cont-secnav2-de.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkzeugkiste von der Erfahrung des Web&#160;(WET) <small>Verbundprojekt, das Open Source ist und wird von der Regierung von Kanada geführt</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Suchen</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/de/cont-signin-de.html
+++ b/demos/theme-wet-boew/de/cont-signin-de.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkzeugkiste von der Erfahrung des Web&#160;(WET) <small>Verbundprojekt, das Open Source ist und wird von der Regierung von Kanada geführt</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Suchen</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/de/cont-signout-de.html
+++ b/demos/theme-wet-boew/de/cont-signout-de.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkzeugkiste von der Erfahrung des Web&#160;(WET) <small>Verbundprojekt, das Open Source ist und wird von der Regierung von Kanada geführt</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Suchen</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/de/cont-subsite-de.html
+++ b/demos/theme-wet-boew/de/cont-subsite-de.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkzeugkiste von der Erfahrung des Web&#160;(WET) <small>Verbundprojekt, das Open Source ist und wird von der Regierung von Kanada geführt</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Suchen</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website durchsuchen</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Suchen" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/el/cont-el.html
+++ b/demos/theme-wet-boew/el/cont-el.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Εργαλειοθήκη της εμπειρίας του Web&#160;(WET) <small>Συνεργατική έργο που είναι open source και οδηγείται από την κυβέρνηση του Καναδά</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Αναζήτηση σε</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/el/cont-fixedmobileheader-el.html
+++ b/demos/theme-wet-boew/el/cont-fixedmobileheader-el.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Εργαλειοθήκη της εμπειρίας του Web&#160;(WET) <small>Συνεργατική έργο που είναι open source και οδηγείται από την κυβέρνηση του Καναδά</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Αναζήτηση σε</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/el/cont-nositemenubc-el.html
+++ b/demos/theme-wet-boew/el/cont-nositemenubc-el.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Εργαλειοθήκη της εμπειρίας του Web&#160;(WET) <small>Συνεργατική έργο που είναι open source και οδηγείται από την κυβέρνηση του Καναδά</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Αναζήτηση σε</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/el/cont-secnav1-el.html
+++ b/demos/theme-wet-boew/el/cont-secnav1-el.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Εργαλειοθήκη της εμπειρίας του Web&#160;(WET) <small>Συνεργατική έργο που είναι open source και οδηγείται από την κυβέρνηση του Καναδά</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Αναζήτηση σε</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/el/cont-secnav2-el.html
+++ b/demos/theme-wet-boew/el/cont-secnav2-el.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Εργαλειοθήκη της εμπειρίας του Web&#160;(WET) <small>Συνεργατική έργο που είναι open source και οδηγείται από την κυβέρνηση του Καναδά</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Αναζήτηση σε</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/el/cont-signin-el.html
+++ b/demos/theme-wet-boew/el/cont-signin-el.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Εργαλειοθήκη της εμπειρίας του Web&#160;(WET) <small>Συνεργατική έργο που είναι open source και οδηγείται από την κυβέρνηση του Καναδά</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Αναζήτηση σε</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/el/cont-signout-el.html
+++ b/demos/theme-wet-boew/el/cont-signout-el.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Εργαλειοθήκη της εμπειρίας του Web&#160;(WET) <small>Συνεργατική έργο που είναι open source και οδηγείται από την κυβέρνηση του Καναδά</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Αναζήτηση σε</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/el/cont-subsite-el.html
+++ b/demos/theme-wet-boew/el/cont-subsite-el.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Εργαλειοθήκη της εμπειρίας του Web&#160;(WET) <small>Συνεργατική έργο που είναι open source και οδηγείται από την κυβέρνηση του Καναδά</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Αναζήτηση σε</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Δικτυακό τόπο Αναζήτηση</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Αναζήτηση σε" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/es/cont-es.html
+++ b/demos/theme-wet-boew/es/cont-es.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caja de Herramientas de Experiencia Web&#160;(WET) <small>Proyecto colaborativo que es de código abierto y está dirigido por el Gobierno de Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Búsqueda</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/es/cont-fixedmobileheader-es.html
+++ b/demos/theme-wet-boew/es/cont-fixedmobileheader-es.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caja de Herramientas de Experiencia Web&#160;(WET) <small>Proyecto colaborativo que es de código abierto y está dirigido por el Gobierno de Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Búsqueda</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/es/cont-nositemenubc-es.html
+++ b/demos/theme-wet-boew/es/cont-nositemenubc-es.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caja de Herramientas de Experiencia Web&#160;(WET) <small>Proyecto colaborativo que es de código abierto y está dirigido por el Gobierno de Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Búsqueda</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/es/cont-secnav1-es.html
+++ b/demos/theme-wet-boew/es/cont-secnav1-es.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caja de Herramientas de Experiencia Web&#160;(WET) <small>Proyecto colaborativo que es de código abierto y está dirigido por el Gobierno de Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Búsqueda</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/es/cont-secnav2-es.html
+++ b/demos/theme-wet-boew/es/cont-secnav2-es.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caja de Herramientas de Experiencia Web&#160;(WET) <small>Proyecto colaborativo que es de código abierto y está dirigido por el Gobierno de Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Búsqueda</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/es/cont-signin-es.html
+++ b/demos/theme-wet-boew/es/cont-signin-es.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caja de Herramientas de Experiencia Web&#160;(WET) <small>Proyecto colaborativo que es de código abierto y está dirigido por el Gobierno de Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Búsqueda</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/es/cont-signout-es.html
+++ b/demos/theme-wet-boew/es/cont-signout-es.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caja de Herramientas de Experiencia Web&#160;(WET) <small>Proyecto colaborativo que es de código abierto y está dirigido por el Gobierno de Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Búsqueda</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/es/cont-subsite-es.html
+++ b/demos/theme-wet-boew/es/cont-subsite-es.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caja de Herramientas de Experiencia Web&#160;(WET) <small>Proyecto colaborativo que es de código abierto y está dirigido por el Gobierno de Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Búsqueda</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Buscar en este sitio Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Búsqueda" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/et/cont-et.html
+++ b/demos/theme-wet-boew/et/cont-et.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Tööriistad Kogemuse Web&#160;(WET) <small>Koostööprojekt, mis on avatud lähtekoodiga ja juhivad Kanada valitsuse</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Otsi</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/et/cont-fixedmobileheader-et.html
+++ b/demos/theme-wet-boew/et/cont-fixedmobileheader-et.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Tööriistad Kogemuse Web&#160;(WET) <small>Koostööprojekt, mis on avatud lähtekoodiga ja juhivad Kanada valitsuse</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Otsi</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/et/cont-nositemenubc-et.html
+++ b/demos/theme-wet-boew/et/cont-nositemenubc-et.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Tööriistad Kogemuse Web&#160;(WET) <small>Koostööprojekt, mis on avatud lähtekoodiga ja juhivad Kanada valitsuse</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Otsi</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/et/cont-secnav1-et.html
+++ b/demos/theme-wet-boew/et/cont-secnav1-et.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Tööriistad Kogemuse Web&#160;(WET) <small>Koostööprojekt, mis on avatud lähtekoodiga ja juhivad Kanada valitsuse</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Otsi</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/et/cont-secnav2-et.html
+++ b/demos/theme-wet-boew/et/cont-secnav2-et.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Tööriistad Kogemuse Web&#160;(WET) <small>Koostööprojekt, mis on avatud lähtekoodiga ja juhivad Kanada valitsuse</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Otsi</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/et/cont-signin-et.html
+++ b/demos/theme-wet-boew/et/cont-signin-et.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Tööriistad Kogemuse Web&#160;(WET) <small>Koostööprojekt, mis on avatud lähtekoodiga ja juhivad Kanada valitsuse</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Otsi</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/et/cont-signout-et.html
+++ b/demos/theme-wet-boew/et/cont-signout-et.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Tööriistad Kogemuse Web&#160;(WET) <small>Koostööprojekt, mis on avatud lähtekoodiga ja juhivad Kanada valitsuse</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Otsi</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/et/cont-subsite-et.html
+++ b/demos/theme-wet-boew/et/cont-subsite-et.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Tööriistad Kogemuse Web&#160;(WET) <small>Koostööprojekt, mis on avatud lähtekoodiga ja juhivad Kanada valitsuse</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Otsi</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Otsi lehekülge</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Otsi" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/hi/cont-fixedmobileheader-hi.html
+++ b/demos/theme-wet-boew/hi/cont-fixedmobileheader-hi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>वेब के अनुभव के उपकरण बॉक्स&#160;(WET) <small>खुला स्रोत है और उस सहयोगात्मक परियोजना कनाडा की सरकार के नेतृत्व में है</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>खोजें</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hi/cont-hi.html
+++ b/demos/theme-wet-boew/hi/cont-hi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>वेब के अनुभव के उपकरण बॉक्स&#160;(WET) <small>खुला स्रोत है और उस सहयोगात्मक परियोजना कनाडा की सरकार के नेतृत्व में है</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>खोजें</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hi/cont-nositemenubc-hi.html
+++ b/demos/theme-wet-boew/hi/cont-nositemenubc-hi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>वेब के अनुभव के उपकरण बॉक्स&#160;(WET) <small>खुला स्रोत है और उस सहयोगात्मक परियोजना कनाडा की सरकार के नेतृत्व में है</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>खोजें</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hi/cont-secnav1-hi.html
+++ b/demos/theme-wet-boew/hi/cont-secnav1-hi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>वेब के अनुभव के उपकरण बॉक्स&#160;(WET) <small>खुला स्रोत है और उस सहयोगात्मक परियोजना कनाडा की सरकार के नेतृत्व में है</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>खोजें</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hi/cont-secnav2-hi.html
+++ b/demos/theme-wet-boew/hi/cont-secnav2-hi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>वेब के अनुभव के उपकरण बॉक्स&#160;(WET) <small>खुला स्रोत है और उस सहयोगात्मक परियोजना कनाडा की सरकार के नेतृत्व में है</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>खोजें</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hi/cont-signin-hi.html
+++ b/demos/theme-wet-boew/hi/cont-signin-hi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>वेब के अनुभव के उपकरण बॉक्स&#160;(WET) <small>खुला स्रोत है और उस सहयोगात्मक परियोजना कनाडा की सरकार के नेतृत्व में है</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>खोजें</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hi/cont-signout-hi.html
+++ b/demos/theme-wet-boew/hi/cont-signout-hi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>वेब के अनुभव के उपकरण बॉक्स&#160;(WET) <small>खुला स्रोत है और उस सहयोगात्मक परियोजना कनाडा की सरकार के नेतृत्व में है</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>खोजें</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hi/cont-subsite-hi.html
+++ b/demos/theme-wet-boew/hi/cont-subsite-hi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>वेब के अनुभव के उपकरण बॉक्स&#160;(WET) <small>खुला स्रोत है और उस सहयोगात्मक परियोजना कनाडा की सरकार के नेतृत्व में है</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>खोजें</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">खोज वेबसाइट</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="खोजें" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/hu/cont-fixedmobileheader-hu.html
+++ b/demos/theme-wet-boew/hu/cont-fixedmobileheader-hu.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Eszközkészlet a Tapasztalat a Web&#160;(WET) <small>Együttműködésen alapuló projekt, amely nyílt forráskódú, és vezeti a kanadai kormány</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Keresés</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hu/cont-hu.html
+++ b/demos/theme-wet-boew/hu/cont-hu.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Eszközkészlet a Tapasztalat a Web&#160;(WET) <small>Együttműködésen alapuló projekt, amely nyílt forráskódú, és vezeti a kanadai kormány</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Keresés</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hu/cont-nositemenubc-hu.html
+++ b/demos/theme-wet-boew/hu/cont-nositemenubc-hu.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Eszközkészlet a Tapasztalat a Web&#160;(WET) <small>Együttműködésen alapuló projekt, amely nyílt forráskódú, és vezeti a kanadai kormány</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Keresés</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hu/cont-secnav1-hu.html
+++ b/demos/theme-wet-boew/hu/cont-secnav1-hu.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Eszközkészlet a Tapasztalat a Web&#160;(WET) <small>Együttműködésen alapuló projekt, amely nyílt forráskódú, és vezeti a kanadai kormány</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Keresés</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hu/cont-secnav2-hu.html
+++ b/demos/theme-wet-boew/hu/cont-secnav2-hu.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Eszközkészlet a Tapasztalat a Web&#160;(WET) <small>Együttműködésen alapuló projekt, amely nyílt forráskódú, és vezeti a kanadai kormány</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Keresés</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hu/cont-signin-hu.html
+++ b/demos/theme-wet-boew/hu/cont-signin-hu.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Eszközkészlet a Tapasztalat a Web&#160;(WET) <small>Együttműködésen alapuló projekt, amely nyílt forráskódú, és vezeti a kanadai kormány</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Keresés</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hu/cont-signout-hu.html
+++ b/demos/theme-wet-boew/hu/cont-signout-hu.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Eszközkészlet a Tapasztalat a Web&#160;(WET) <small>Együttműködésen alapuló projekt, amely nyílt forráskódú, és vezeti a kanadai kormány</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Keresés</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hu/cont-subsite-hu.html
+++ b/demos/theme-wet-boew/hu/cont-subsite-hu.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Eszközkészlet a Tapasztalat a Web&#160;(WET) <small>Együttműködésen alapuló projekt, amely nyílt forráskódú, és vezeti a kanadai kormány</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Keresés</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Keresés a honlapon</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Keresés" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/hy/cont-fixedmobileheader-hy.html
+++ b/demos/theme-wet-boew/hy/cont-fixedmobileheader-hy.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Գործիքներ եւ փորձի ցանցին&#160;(WET) <small>Համագործակցային ծրագրի որ բաց կոդով է եւ ղեկավարում է կառավարության Կանադայի</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Որոնել</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hy/cont-hy.html
+++ b/demos/theme-wet-boew/hy/cont-hy.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Գործիքներ եւ փորձի ցանցին&#160;(WET) <small>Համագործակցային ծրագրի որ բաց կոդով է եւ ղեկավարում է կառավարության Կանադայի</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Որոնել</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hy/cont-nositemenubc-hy.html
+++ b/demos/theme-wet-boew/hy/cont-nositemenubc-hy.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Գործիքներ եւ փորձի ցանցին&#160;(WET) <small>Համագործակցային ծրագրի որ բաց կոդով է եւ ղեկավարում է կառավարության Կանադայի</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Որոնել</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hy/cont-secnav1-hy.html
+++ b/demos/theme-wet-boew/hy/cont-secnav1-hy.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Գործիքներ եւ փորձի ցանցին&#160;(WET) <small>Համագործակցային ծրագրի որ բաց կոդով է եւ ղեկավարում է կառավարության Կանադայի</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Որոնել</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hy/cont-secnav2-hy.html
+++ b/demos/theme-wet-boew/hy/cont-secnav2-hy.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Գործիքներ եւ փորձի ցանցին&#160;(WET) <small>Համագործակցային ծրագրի որ բաց կոդով է եւ ղեկավարում է կառավարության Կանադայի</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Որոնել</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hy/cont-signin-hy.html
+++ b/demos/theme-wet-boew/hy/cont-signin-hy.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Գործիքներ եւ փորձի ցանցին&#160;(WET) <small>Համագործակցային ծրագրի որ բաց կոդով է եւ ղեկավարում է կառավարության Կանադայի</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Որոնել</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hy/cont-signout-hy.html
+++ b/demos/theme-wet-boew/hy/cont-signout-hy.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Գործիքներ եւ փորձի ցանցին&#160;(WET) <small>Համագործակցային ծրագրի որ բաց կոդով է եւ ղեկավարում է կառավարության Կանադայի</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Որոնել</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/hy/cont-subsite-hy.html
+++ b/demos/theme-wet-boew/hy/cont-subsite-hy.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Գործիքներ եւ փորձի ցանցին&#160;(WET) <small>Համագործակցային ծրագրի որ բաց կոդով է եւ ղեկավարում է կառավարության Կանադայի</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Որոնել</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Որոնել կայք</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Որոնել" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/id/cont-fixedmobileheader-id.html
+++ b/demos/theme-wet-boew/id/cont-fixedmobileheader-id.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Kotak Peralatan dari Pengalaman dari Web&#160;(WET) <small>Proyek kolaborasi yang bersifat open source dan dipimpin oleh Pemerintah Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cari</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cari situs</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cari situs</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/id/cont-id.html
+++ b/demos/theme-wet-boew/id/cont-id.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Kotak Peralatan dari Pengalaman dari Web&#160;(WET) <small>Proyek kolaborasi yang bersifat open source dan dipimpin oleh Pemerintah Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cari</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cari situs</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cari situs</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/id/cont-nositemenubc-id.html
+++ b/demos/theme-wet-boew/id/cont-nositemenubc-id.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Kotak Peralatan dari Pengalaman dari Web&#160;(WET) <small>Proyek kolaborasi yang bersifat open source dan dipimpin oleh Pemerintah Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cari</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cari situs</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cari situs</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/id/cont-secnav1-id.html
+++ b/demos/theme-wet-boew/id/cont-secnav1-id.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Kotak Peralatan dari Pengalaman dari Web&#160;(WET) <small>Proyek kolaborasi yang bersifat open source dan dipimpin oleh Pemerintah Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cari</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cari situs</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cari situs</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/id/cont-secnav2-id.html
+++ b/demos/theme-wet-boew/id/cont-secnav2-id.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Kotak Peralatan dari Pengalaman dari Web&#160;(WET) <small>Proyek kolaborasi yang bersifat open source dan dipimpin oleh Pemerintah Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cari</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cari situs</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cari situs</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/id/cont-signin-id.html
+++ b/demos/theme-wet-boew/id/cont-signin-id.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Kotak Peralatan dari Pengalaman dari Web&#160;(WET) <small>Proyek kolaborasi yang bersifat open source dan dipimpin oleh Pemerintah Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cari</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cari situs</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cari situs</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/id/cont-signout-id.html
+++ b/demos/theme-wet-boew/id/cont-signout-id.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Kotak Peralatan dari Pengalaman dari Web&#160;(WET) <small>Proyek kolaborasi yang bersifat open source dan dipimpin oleh Pemerintah Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cari</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cari situs</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cari situs</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/id/cont-subsite-id.html
+++ b/demos/theme-wet-boew/id/cont-subsite-id.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Kotak Peralatan dari Pengalaman dari Web&#160;(WET) <small>Proyek kolaborasi yang bersifat open source dan dipimpin oleh Pemerintah Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cari</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cari situs</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cari situs</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cari" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/index-en.html
+++ b/demos/theme-wet-boew/index-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/index-fr.html
+++ b/demos/theme-wet-boew/index-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/is/cont-fixedmobileheader-is.html
+++ b/demos/theme-wet-boew/is/cont-fixedmobileheader-is.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Verkfæri af Reynslu á Vefnum&#160;(WET) <small>Samstarfsverkefni sem er opinn uppspretta og er stýrt af ríkisstjórn Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Leita</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/is/cont-is.html
+++ b/demos/theme-wet-boew/is/cont-is.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Verkfæri af Reynslu á Vefnum&#160;(WET) <small>Samstarfsverkefni sem er opinn uppspretta og er stýrt af ríkisstjórn Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Leita</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/is/cont-nositemenubc-is.html
+++ b/demos/theme-wet-boew/is/cont-nositemenubc-is.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Verkfæri af Reynslu á Vefnum&#160;(WET) <small>Samstarfsverkefni sem er opinn uppspretta og er stýrt af ríkisstjórn Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Leita</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/is/cont-secnav1-is.html
+++ b/demos/theme-wet-boew/is/cont-secnav1-is.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Verkfæri af Reynslu á Vefnum&#160;(WET) <small>Samstarfsverkefni sem er opinn uppspretta og er stýrt af ríkisstjórn Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Leita</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/is/cont-secnav2-is.html
+++ b/demos/theme-wet-boew/is/cont-secnav2-is.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Verkfæri af Reynslu á Vefnum&#160;(WET) <small>Samstarfsverkefni sem er opinn uppspretta og er stýrt af ríkisstjórn Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Leita</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/is/cont-signin-is.html
+++ b/demos/theme-wet-boew/is/cont-signin-is.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Verkfæri af Reynslu á Vefnum&#160;(WET) <small>Samstarfsverkefni sem er opinn uppspretta og er stýrt af ríkisstjórn Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Leita</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/is/cont-signout-is.html
+++ b/demos/theme-wet-boew/is/cont-signout-is.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Verkfæri af Reynslu á Vefnum&#160;(WET) <small>Samstarfsverkefni sem er opinn uppspretta og er stýrt af ríkisstjórn Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Leita</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/is/cont-subsite-is.html
+++ b/demos/theme-wet-boew/is/cont-subsite-is.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Verkfæri af Reynslu á Vefnum&#160;(WET) <small>Samstarfsverkefni sem er opinn uppspretta og er stýrt af ríkisstjórn Kanada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Leita</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Leita i vefsiðu</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Leita" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/it/cont-fixedmobileheader-it.html
+++ b/demos/theme-wet-boew/it/cont-fixedmobileheader-it.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Casella Degli Strumenti di Esperienza del Web&#160;(WET) <small>Progetto di collaborazione che è open source ed è guidata dal governo del Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cerca</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/it/cont-it.html
+++ b/demos/theme-wet-boew/it/cont-it.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Casella Degli Strumenti di Esperienza del Web&#160;(WET) <small>Progetto di collaborazione che è open source ed è guidata dal governo del Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cerca</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/it/cont-nositemenubc-it.html
+++ b/demos/theme-wet-boew/it/cont-nositemenubc-it.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Casella Degli Strumenti di Esperienza del Web&#160;(WET) <small>Progetto di collaborazione che è open source ed è guidata dal governo del Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cerca</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/it/cont-secnav1-it.html
+++ b/demos/theme-wet-boew/it/cont-secnav1-it.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Casella Degli Strumenti di Esperienza del Web&#160;(WET) <small>Progetto di collaborazione che è open source ed è guidata dal governo del Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cerca</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/it/cont-secnav2-it.html
+++ b/demos/theme-wet-boew/it/cont-secnav2-it.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Casella Degli Strumenti di Esperienza del Web&#160;(WET) <small>Progetto di collaborazione che è open source ed è guidata dal governo del Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cerca</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/it/cont-signin-it.html
+++ b/demos/theme-wet-boew/it/cont-signin-it.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Casella Degli Strumenti di Esperienza del Web&#160;(WET) <small>Progetto di collaborazione che è open source ed è guidata dal governo del Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cerca</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/it/cont-signout-it.html
+++ b/demos/theme-wet-boew/it/cont-signout-it.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Casella Degli Strumenti di Esperienza del Web&#160;(WET) <small>Progetto di collaborazione che è open source ed è guidata dal governo del Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cerca</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/it/cont-subsite-it.html
+++ b/demos/theme-wet-boew/it/cont-subsite-it.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Casella Degli Strumenti di Esperienza del Web&#160;(WET) <small>Progetto di collaborazione che è open source ed è guidata dal governo del Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Cerca</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Cerca nel sito</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Cerca" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/ja/cont-fixedmobileheader-ja.html
+++ b/demos/theme-wet-boew/ja/cont-fixedmobileheader-ja.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>ウェブの経験のツールボックス（WET） <small>オープンソースであり、共同プロジェクトは、カナダ政府が主導している</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>検索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ja/cont-ja.html
+++ b/demos/theme-wet-boew/ja/cont-ja.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>ウェブの経験のツールボックス（WET） <small>オープンソースであり、共同プロジェクトは、カナダ政府が主導している</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>検索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ja/cont-nositemenubc-ja.html
+++ b/demos/theme-wet-boew/ja/cont-nositemenubc-ja.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>ウェブの経験のツールボックス（WET） <small>オープンソースであり、共同プロジェクトは、カナダ政府が主導している</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>検索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ja/cont-secnav1-ja.html
+++ b/demos/theme-wet-boew/ja/cont-secnav1-ja.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>ウェブの経験のツールボックス（WET） <small>オープンソースであり、共同プロジェクトは、カナダ政府が主導している</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>検索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ja/cont-secnav2-ja.html
+++ b/demos/theme-wet-boew/ja/cont-secnav2-ja.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>ウェブの経験のツールボックス（WET） <small>オープンソースであり、共同プロジェクトは、カナダ政府が主導している</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>検索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ja/cont-signin-ja.html
+++ b/demos/theme-wet-boew/ja/cont-signin-ja.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>ウェブの経験のツールボックス（WET） <small>オープンソースであり、共同プロジェクトは、カナダ政府が主導している</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>検索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ja/cont-signout-ja.html
+++ b/demos/theme-wet-boew/ja/cont-signout-ja.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>ウェブの経験のツールボックス（WET） <small>オープンソースであり、共同プロジェクトは、カナダ政府が主導している</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>検索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ja/cont-subsite-ja.html
+++ b/demos/theme-wet-boew/ja/cont-subsite-ja.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>ウェブの経験のツールボックス（WET） <small>オープンソースであり、共同プロジェクトは、カナダ政府が主導している</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>検索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">サイト内検索</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="検索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/ko/cont-fixedmobileheader-ko.html
+++ b/demos/theme-wet-boew/ko/cont-fixedmobileheader-ko.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>웹 경험의 도구 상자 (WET) <small>오픈 소스 협업 프로젝트는 캐나다 정부에 의해 주도</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>검색</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ko/cont-ko.html
+++ b/demos/theme-wet-boew/ko/cont-ko.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>웹 경험의 도구 상자 (WET) <small>오픈 소스 협업 프로젝트는 캐나다 정부에 의해 주도</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>검색</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ko/cont-nositemenubc-ko.html
+++ b/demos/theme-wet-boew/ko/cont-nositemenubc-ko.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>웹 경험의 도구 상자 (WET) <small>오픈 소스 협업 프로젝트는 캐나다 정부에 의해 주도</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>검색</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ko/cont-secnav1-ko.html
+++ b/demos/theme-wet-boew/ko/cont-secnav1-ko.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>웹 경험의 도구 상자 (WET) <small>오픈 소스 협업 프로젝트는 캐나다 정부에 의해 주도</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>검색</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ko/cont-secnav2-ko.html
+++ b/demos/theme-wet-boew/ko/cont-secnav2-ko.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>웹 경험의 도구 상자 (WET) <small>오픈 소스 협업 프로젝트는 캐나다 정부에 의해 주도</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>검색</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ko/cont-signin-ko.html
+++ b/demos/theme-wet-boew/ko/cont-signin-ko.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>웹 경험의 도구 상자 (WET) <small>오픈 소스 협업 프로젝트는 캐나다 정부에 의해 주도</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>검색</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ko/cont-signout-ko.html
+++ b/demos/theme-wet-boew/ko/cont-signout-ko.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>웹 경험의 도구 상자 (WET) <small>오픈 소스 협업 프로젝트는 캐나다 정부에 의해 주도</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>검색</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ko/cont-subsite-ko.html
+++ b/demos/theme-wet-boew/ko/cont-subsite-ko.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>웹 경험의 도구 상자 (WET) <small>오픈 소스 협업 프로젝트는 캐나다 정부에 의해 주도</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>검색</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">검색 사이트</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="검색" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/lt/cont-fixedmobileheader-lt.html
+++ b/demos/theme-wet-boew/lt/cont-fixedmobileheader-lt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Įrankiai nuo Interneto Patirtį&#160;(WET) <small>endradarbiavimo projektas, kuris yra atviro kodo ir vadovauja Kanados Vyriausybės</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Ieškoti</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lt/cont-lt.html
+++ b/demos/theme-wet-boew/lt/cont-lt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Įrankiai nuo Interneto Patirtį&#160;(WET) <small>endradarbiavimo projektas, kuris yra atviro kodo ir vadovauja Kanados Vyriausybės</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Ieškoti</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lt/cont-nositemenubc-lt.html
+++ b/demos/theme-wet-boew/lt/cont-nositemenubc-lt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Įrankiai nuo Interneto Patirtį&#160;(WET) <small>endradarbiavimo projektas, kuris yra atviro kodo ir vadovauja Kanados Vyriausybės</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Ieškoti</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lt/cont-secnav1-lt.html
+++ b/demos/theme-wet-boew/lt/cont-secnav1-lt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Įrankiai nuo Interneto Patirtį&#160;(WET) <small>endradarbiavimo projektas, kuris yra atviro kodo ir vadovauja Kanados Vyriausybės</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Ieškoti</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lt/cont-secnav2-lt.html
+++ b/demos/theme-wet-boew/lt/cont-secnav2-lt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Įrankiai nuo Interneto Patirtį&#160;(WET) <small>endradarbiavimo projektas, kuris yra atviro kodo ir vadovauja Kanados Vyriausybės</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Ieškoti</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lt/cont-signin-lt.html
+++ b/demos/theme-wet-boew/lt/cont-signin-lt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Įrankiai nuo Interneto Patirtį&#160;(WET) <small>endradarbiavimo projektas, kuris yra atviro kodo ir vadovauja Kanados Vyriausybės</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Ieškoti</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lt/cont-signout-lt.html
+++ b/demos/theme-wet-boew/lt/cont-signout-lt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Įrankiai nuo Interneto Patirtį&#160;(WET) <small>endradarbiavimo projektas, kuris yra atviro kodo ir vadovauja Kanados Vyriausybės</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Ieškoti</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lt/cont-subsite-lt.html
+++ b/demos/theme-wet-boew/lt/cont-subsite-lt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Įrankiai nuo Interneto Patirtį&#160;(WET) <small>endradarbiavimo projektas, kuris yra atviro kodo ir vadovauja Kanados Vyriausybės</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Ieškoti</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Ieškoti svetainėje</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Ieškoti" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/lv/cont-fixedmobileheader-lv.html
+++ b/demos/theme-wet-boew/lv/cont-fixedmobileheader-lv.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Rīklodziņš par Pieredze Web&#160;(WET) <small>Sadarbības projekts, kas ir open source un vada Kanādas valdība</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Meklēt</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lv/cont-lv.html
+++ b/demos/theme-wet-boew/lv/cont-lv.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Rīklodziņš par Pieredze Web&#160;(WET) <small>Sadarbības projekts, kas ir open source un vada Kanādas valdība</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Meklēt</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lv/cont-nositemenubc-lv.html
+++ b/demos/theme-wet-boew/lv/cont-nositemenubc-lv.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Rīklodziņš par Pieredze Web&#160;(WET) <small>Sadarbības projekts, kas ir open source un vada Kanādas valdība</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Meklēt</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lv/cont-secnav1-lv.html
+++ b/demos/theme-wet-boew/lv/cont-secnav1-lv.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Rīklodziņš par Pieredze Web&#160;(WET) <small>Sadarbības projekts, kas ir open source un vada Kanādas valdība</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Meklēt</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lv/cont-secnav2-lv.html
+++ b/demos/theme-wet-boew/lv/cont-secnav2-lv.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Rīklodziņš par Pieredze Web&#160;(WET) <small>Sadarbības projekts, kas ir open source un vada Kanādas valdība</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Meklēt</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lv/cont-signin-lv.html
+++ b/demos/theme-wet-boew/lv/cont-signin-lv.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Rīklodziņš par Pieredze Web&#160;(WET) <small>Sadarbības projekts, kas ir open source un vada Kanādas valdība</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Meklēt</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lv/cont-signout-lv.html
+++ b/demos/theme-wet-boew/lv/cont-signout-lv.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Rīklodziņš par Pieredze Web&#160;(WET) <small>Sadarbības projekts, kas ir open source un vada Kanādas valdība</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Meklēt</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/lv/cont-subsite-lv.html
+++ b/demos/theme-wet-boew/lv/cont-subsite-lv.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Rīklodziņš par Pieredze Web&#160;(WET) <small>Sadarbības projekts, kas ir open source un vada Kanādas valdība</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Meklēt</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Meklēt mājas lapā</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Meklēt" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/nl/cont-fixedmobileheader-nl.html
+++ b/demos/theme-wet-boew/nl/cont-fixedmobileheader-nl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkset van de Ervaring van het Web&#160;(WET) <small>Samenwerkingsproject dat is open source en wordt geleid door de Regering van Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Zoeken</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/nl/cont-nl.html
+++ b/demos/theme-wet-boew/nl/cont-nl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkset van de Ervaring van het Web&#160;(WET) <small>Samenwerkingsproject dat is open source en wordt geleid door de Regering van Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Zoeken</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/nl/cont-nositemenubc-nl.html
+++ b/demos/theme-wet-boew/nl/cont-nositemenubc-nl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkset van de Ervaring van het Web&#160;(WET) <small>Samenwerkingsproject dat is open source en wordt geleid door de Regering van Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Zoeken</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/nl/cont-secnav1-nl.html
+++ b/demos/theme-wet-boew/nl/cont-secnav1-nl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkset van de Ervaring van het Web&#160;(WET) <small>Samenwerkingsproject dat is open source en wordt geleid door de Regering van Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Zoeken</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/nl/cont-secnav2-nl.html
+++ b/demos/theme-wet-boew/nl/cont-secnav2-nl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkset van de Ervaring van het Web&#160;(WET) <small>Samenwerkingsproject dat is open source en wordt geleid door de Regering van Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Zoeken</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/nl/cont-signin-nl.html
+++ b/demos/theme-wet-boew/nl/cont-signin-nl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkset van de Ervaring van het Web&#160;(WET) <small>Samenwerkingsproject dat is open source en wordt geleid door de Regering van Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Zoeken</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/nl/cont-signout-nl.html
+++ b/demos/theme-wet-boew/nl/cont-signout-nl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkset van de Ervaring van het Web&#160;(WET) <small>Samenwerkingsproject dat is open source en wordt geleid door de Regering van Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Zoeken</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/nl/cont-subsite-nl.html
+++ b/demos/theme-wet-boew/nl/cont-subsite-nl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Werkset van de Ervaring van het Web&#160;(WET) <small>Samenwerkingsproject dat is open source en wordt geleid door de Regering van Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Zoeken</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website zoeken</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Zoeken" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/pl/cont-fixedmobileheader-pl.html
+++ b/demos/theme-wet-boew/pl/cont-fixedmobileheader-pl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Skrzynka Narzedziowa z Doświadczeń Sieci&#160;(WET) <small>Wspólny projekt, który jest open source i jest prowadzona przez rząd Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Szukaj</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pl/cont-nositemenubc-pl.html
+++ b/demos/theme-wet-boew/pl/cont-nositemenubc-pl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Skrzynka Narzedziowa z Doświadczeń Sieci&#160;(WET) <small>Wspólny projekt, który jest open source i jest prowadzona przez rząd Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Szukaj</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pl/cont-pl.html
+++ b/demos/theme-wet-boew/pl/cont-pl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Skrzynka Narzedziowa z Doświadczeń Sieci&#160;(WET) <small>Wspólny projekt, który jest open source i jest prowadzona przez rząd Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Szukaj</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pl/cont-secnav1-pl.html
+++ b/demos/theme-wet-boew/pl/cont-secnav1-pl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Skrzynka Narzedziowa z Doświadczeń Sieci&#160;(WET) <small>Wspólny projekt, który jest open source i jest prowadzona przez rząd Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Szukaj</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pl/cont-secnav2-pl.html
+++ b/demos/theme-wet-boew/pl/cont-secnav2-pl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Skrzynka Narzedziowa z Doświadczeń Sieci&#160;(WET) <small>Wspólny projekt, który jest open source i jest prowadzona przez rząd Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Szukaj</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pl/cont-signin-pl.html
+++ b/demos/theme-wet-boew/pl/cont-signin-pl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Skrzynka Narzedziowa z Doświadczeń Sieci&#160;(WET) <small>Wspólny projekt, który jest open source i jest prowadzona przez rząd Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Szukaj</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pl/cont-signout-pl.html
+++ b/demos/theme-wet-boew/pl/cont-signout-pl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Skrzynka Narzedziowa z Doświadczeń Sieci&#160;(WET) <small>Wspólny projekt, który jest open source i jest prowadzona przez rząd Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Szukaj</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pl/cont-subsite-pl.html
+++ b/demos/theme-wet-boew/pl/cont-subsite-pl.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Skrzynka Narzedziowa z Doświadczeń Sieci&#160;(WET) <small>Wspólny projekt, który jest open source i jest prowadzona przez rząd Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Szukaj</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Szukaj na stronie</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Szukaj" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/pt-BR/cont-fixedmobileheader-pt-BR.html
+++ b/demos/theme-wet-boew/pt-BR/cont-fixedmobileheader-pt-BR.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt-BR/cont-nositemenubc-pt-BR.html
+++ b/demos/theme-wet-boew/pt-BR/cont-nositemenubc-pt-BR.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt-BR/cont-pt-BR.html
+++ b/demos/theme-wet-boew/pt-BR/cont-pt-BR.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt-BR/cont-secnav1-pt-BR.html
+++ b/demos/theme-wet-boew/pt-BR/cont-secnav1-pt-BR.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt-BR/cont-secnav2-pt-BR.html
+++ b/demos/theme-wet-boew/pt-BR/cont-secnav2-pt-BR.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt-BR/cont-signin-pt-BR.html
+++ b/demos/theme-wet-boew/pt-BR/cont-signin-pt-BR.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt-BR/cont-signout-pt-BR.html
+++ b/demos/theme-wet-boew/pt-BR/cont-signout-pt-BR.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt-BR/cont-subsite-pt-BR.html
+++ b/demos/theme-wet-boew/pt-BR/cont-subsite-pt-BR.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Pesquisar esta página</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/pt/cont-fixedmobileheader-pt.html
+++ b/demos/theme-wet-boew/pt/cont-fixedmobileheader-pt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Site de busca</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Site de busca</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt/cont-nositemenubc-pt.html
+++ b/demos/theme-wet-boew/pt/cont-nositemenubc-pt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Site de busca</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Site de busca</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt/cont-pt.html
+++ b/demos/theme-wet-boew/pt/cont-pt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Site de busca</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Site de busca</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt/cont-secnav1-pt.html
+++ b/demos/theme-wet-boew/pt/cont-secnav1-pt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Site de busca</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Site de busca</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt/cont-secnav2-pt.html
+++ b/demos/theme-wet-boew/pt/cont-secnav2-pt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Site de busca</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Site de busca</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt/cont-signin-pt.html
+++ b/demos/theme-wet-boew/pt/cont-signin-pt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Site de busca</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Site de busca</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt/cont-signout-pt.html
+++ b/demos/theme-wet-boew/pt/cont-signout-pt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Site de busca</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Site de busca</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/pt/cont-subsite-pt.html
+++ b/demos/theme-wet-boew/pt/cont-subsite-pt.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Caixa de Ferramenta da Experiência Web&#160;(WET) <small>Projeto colaborativo que é open source e é liderada pelo Governo do Canadá</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Pesquisar</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Site de busca</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Site de busca</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Pesquisar" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/ru/cont-fixedmobileheader-ru.html
+++ b/demos/theme-wet-boew/ru/cont-fixedmobileheader-ru.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Инструментарий Опыта Web&#160;(WET) <small>Совместный проект, который имеет открытый исходный код и возглавляет правительство Канады</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Искать</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ru/cont-nositemenubc-ru.html
+++ b/demos/theme-wet-boew/ru/cont-nositemenubc-ru.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Инструментарий Опыта Web&#160;(WET) <small>Совместный проект, который имеет открытый исходный код и возглавляет правительство Канады</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Искать</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ru/cont-ru.html
+++ b/demos/theme-wet-boew/ru/cont-ru.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Инструментарий Опыта Web&#160;(WET) <small>Совместный проект, который имеет открытый исходный код и возглавляет правительство Канады</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Искать</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ru/cont-secnav1-ru.html
+++ b/demos/theme-wet-boew/ru/cont-secnav1-ru.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Инструментарий Опыта Web&#160;(WET) <small>Совместный проект, который имеет открытый исходный код и возглавляет правительство Канады</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Искать</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ru/cont-secnav2-ru.html
+++ b/demos/theme-wet-boew/ru/cont-secnav2-ru.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Инструментарий Опыта Web&#160;(WET) <small>Совместный проект, который имеет открытый исходный код и возглавляет правительство Канады</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Искать</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ru/cont-signin-ru.html
+++ b/demos/theme-wet-boew/ru/cont-signin-ru.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Инструментарий Опыта Web&#160;(WET) <small>Совместный проект, который имеет открытый исходный код и возглавляет правительство Канады</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Искать</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ru/cont-signout-ru.html
+++ b/demos/theme-wet-boew/ru/cont-signout-ru.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Инструментарий Опыта Web&#160;(WET) <small>Совместный проект, который имеет открытый исходный код и возглавляет правительство Канады</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Искать</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/ru/cont-subsite-ru.html
+++ b/demos/theme-wet-boew/ru/cont-subsite-ru.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Инструментарий Опыта Web&#160;(WET) <small>Совместный проект, который имеет открытый исходный код и возглавляет правительство Канады</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Искать</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Поиск по сайту</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Искать" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/sk/cont-fixedmobileheader-sk.html
+++ b/demos/theme-wet-boew/sk/cont-fixedmobileheader-sk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Súbor Nástrojov Skúseností z Webu&#160;(WET) <small>Kolaboratívne projekt, ktorý je open source a je vedený vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hľadať</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sk/cont-nositemenubc-sk.html
+++ b/demos/theme-wet-boew/sk/cont-nositemenubc-sk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Súbor Nástrojov Skúseností z Webu&#160;(WET) <small>Kolaboratívne projekt, ktorý je open source a je vedený vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hľadať</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sk/cont-secnav1-sk.html
+++ b/demos/theme-wet-boew/sk/cont-secnav1-sk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Súbor Nástrojov Skúseností z Webu&#160;(WET) <small>Kolaboratívne projekt, ktorý je open source a je vedený vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hľadať</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sk/cont-secnav2-sk.html
+++ b/demos/theme-wet-boew/sk/cont-secnav2-sk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Súbor Nástrojov Skúseností z Webu&#160;(WET) <small>Kolaboratívne projekt, ktorý je open source a je vedený vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hľadať</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sk/cont-signin-sk.html
+++ b/demos/theme-wet-boew/sk/cont-signin-sk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Súbor Nástrojov Skúseností z Webu&#160;(WET) <small>Kolaboratívne projekt, ktorý je open source a je vedený vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hľadať</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sk/cont-signout-sk.html
+++ b/demos/theme-wet-boew/sk/cont-signout-sk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Súbor Nástrojov Skúseností z Webu&#160;(WET) <small>Kolaboratívne projekt, ktorý je open source a je vedený vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hľadať</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sk/cont-sk.html
+++ b/demos/theme-wet-boew/sk/cont-sk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Súbor Nástrojov Skúseností z Webu&#160;(WET) <small>Kolaboratívne projekt, ktorý je open source a je vedený vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hľadať</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sk/cont-subsite-sk.html
+++ b/demos/theme-wet-boew/sk/cont-subsite-sk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Súbor Nástrojov Skúseností z Webu&#160;(WET) <small>Kolaboratívne projekt, ktorý je open source a je vedený vládou Kanady</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Hľadať</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Hľadať vo webových stránkach</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Hľadať" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/sq/cont-fixedmobileheader-sq.html
+++ b/demos/theme-wet-boew/sq/cont-fixedmobileheader-sq.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Toolbox i Përvojës së Web&#160;(WET) <small>Projekt bashkëpunues që është burim i hapur dhe është udhëhequr nga Qeveria e Kanadasë</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Kërko</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website kërko</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website kërko</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sq/cont-nositemenubc-sq.html
+++ b/demos/theme-wet-boew/sq/cont-nositemenubc-sq.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Toolbox i Përvojës së Web&#160;(WET) <small>Projekt bashkëpunues që është burim i hapur dhe është udhëhequr nga Qeveria e Kanadasë</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Kërko</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website kërko</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website kërko</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sq/cont-secnav1-sq.html
+++ b/demos/theme-wet-boew/sq/cont-secnav1-sq.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Toolbox i Përvojës së Web&#160;(WET) <small>Projekt bashkëpunues që është burim i hapur dhe është udhëhequr nga Qeveria e Kanadasë</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Kërko</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website kërko</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website kërko</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sq/cont-secnav2-sq.html
+++ b/demos/theme-wet-boew/sq/cont-secnav2-sq.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Toolbox i Përvojës së Web&#160;(WET) <small>Projekt bashkëpunues që është burim i hapur dhe është udhëhequr nga Qeveria e Kanadasë</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Kërko</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website kërko</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website kërko</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sq/cont-signin-sq.html
+++ b/demos/theme-wet-boew/sq/cont-signin-sq.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Toolbox i Përvojës së Web&#160;(WET) <small>Projekt bashkëpunues që është burim i hapur dhe është udhëhequr nga Qeveria e Kanadasë</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Kërko</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website kërko</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website kërko</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sq/cont-signout-sq.html
+++ b/demos/theme-wet-boew/sq/cont-signout-sq.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Toolbox i Përvojës së Web&#160;(WET) <small>Projekt bashkëpunues që është burim i hapur dhe është udhëhequr nga Qeveria e Kanadasë</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Kërko</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website kërko</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website kërko</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sq/cont-sq.html
+++ b/demos/theme-wet-boew/sq/cont-sq.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Toolbox i Përvojës së Web&#160;(WET) <small>Projekt bashkëpunues që është burim i hapur dhe është udhëhequr nga Qeveria e Kanadasë</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Kërko</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website kërko</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website kërko</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/sq/cont-subsite-sq.html
+++ b/demos/theme-wet-boew/sq/cont-subsite-sq.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Toolbox i Përvojës së Web&#160;(WET) <small>Projekt bashkëpunues që është burim i hapur dhe është udhëhequr nga Qeveria e Kanadasë</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Kërko</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Website kërko</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Website kërko</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Kërko" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/th/cont-fixedmobileheader-th.html
+++ b/demos/theme-wet-boew/th/cont-fixedmobileheader-th.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>กล่องเครื่องมือจากประสบการณ์การทำงานของเว็บ (WET) <small>โครงการความร่วมมือที่เป็นโอเพนซอร์สและเป็นที่นำโดยรัฐบาลแคนาดา</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>ค้นหา</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/th/cont-nositemenubc-th.html
+++ b/demos/theme-wet-boew/th/cont-nositemenubc-th.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>กล่องเครื่องมือจากประสบการณ์การทำงานของเว็บ (WET) <small>โครงการความร่วมมือที่เป็นโอเพนซอร์สและเป็นที่นำโดยรัฐบาลแคนาดา</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>ค้นหา</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/th/cont-secnav1-th.html
+++ b/demos/theme-wet-boew/th/cont-secnav1-th.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>กล่องเครื่องมือจากประสบการณ์การทำงานของเว็บ (WET) <small>โครงการความร่วมมือที่เป็นโอเพนซอร์สและเป็นที่นำโดยรัฐบาลแคนาดา</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>ค้นหา</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/th/cont-secnav2-th.html
+++ b/demos/theme-wet-boew/th/cont-secnav2-th.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>กล่องเครื่องมือจากประสบการณ์การทำงานของเว็บ (WET) <small>โครงการความร่วมมือที่เป็นโอเพนซอร์สและเป็นที่นำโดยรัฐบาลแคนาดา</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>ค้นหา</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/th/cont-signin-th.html
+++ b/demos/theme-wet-boew/th/cont-signin-th.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>กล่องเครื่องมือจากประสบการณ์การทำงานของเว็บ (WET) <small>โครงการความร่วมมือที่เป็นโอเพนซอร์สและเป็นที่นำโดยรัฐบาลแคนาดา</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>ค้นหา</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/th/cont-signout-th.html
+++ b/demos/theme-wet-boew/th/cont-signout-th.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>กล่องเครื่องมือจากประสบการณ์การทำงานของเว็บ (WET) <small>โครงการความร่วมมือที่เป็นโอเพนซอร์สและเป็นที่นำโดยรัฐบาลแคนาดา</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>ค้นหา</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/th/cont-subsite-th.html
+++ b/demos/theme-wet-boew/th/cont-subsite-th.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>กล่องเครื่องมือจากประสบการณ์การทำงานของเว็บ (WET) <small>โครงการความร่วมมือที่เป็นโอเพนซอร์สและเป็นที่นำโดยรัฐบาลแคนาดา</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>ค้นหา</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/th/cont-th.html
+++ b/demos/theme-wet-boew/th/cont-th.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>กล่องเครื่องมือจากประสบการณ์การทำงานของเว็บ (WET) <small>โครงการความร่วมมือที่เป็นโอเพนซอร์สและเป็นที่นำโดยรัฐบาลแคนาดา</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>ค้นหา</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">เว็บไซต์ค้นหา</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="ค้นหา" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/tr/cont-fixedmobileheader-tr.html
+++ b/demos/theme-wet-boew/tr/cont-fixedmobileheader-tr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Deneyimi Araç Kutusu&#160;(WET) <small>Açık kaynak ve ortak proje Kanada Hükümeti tarafından yönetiliyor</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Arama</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/tr/cont-nositemenubc-tr.html
+++ b/demos/theme-wet-boew/tr/cont-nositemenubc-tr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Deneyimi Araç Kutusu&#160;(WET) <small>Açık kaynak ve ortak proje Kanada Hükümeti tarafından yönetiliyor</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Arama</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/tr/cont-secnav1-tr.html
+++ b/demos/theme-wet-boew/tr/cont-secnav1-tr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Deneyimi Araç Kutusu&#160;(WET) <small>Açık kaynak ve ortak proje Kanada Hükümeti tarafından yönetiliyor</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Arama</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/tr/cont-secnav2-tr.html
+++ b/demos/theme-wet-boew/tr/cont-secnav2-tr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Deneyimi Araç Kutusu&#160;(WET) <small>Açık kaynak ve ortak proje Kanada Hükümeti tarafından yönetiliyor</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Arama</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/tr/cont-signin-tr.html
+++ b/demos/theme-wet-boew/tr/cont-signin-tr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Deneyimi Araç Kutusu&#160;(WET) <small>Açık kaynak ve ortak proje Kanada Hükümeti tarafından yönetiliyor</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Arama</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/tr/cont-signout-tr.html
+++ b/demos/theme-wet-boew/tr/cont-signout-tr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Deneyimi Araç Kutusu&#160;(WET) <small>Açık kaynak ve ortak proje Kanada Hükümeti tarafından yönetiliyor</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Arama</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/tr/cont-subsite-tr.html
+++ b/demos/theme-wet-boew/tr/cont-subsite-tr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Deneyimi Araç Kutusu&#160;(WET) <small>Açık kaynak ve ortak proje Kanada Hükümeti tarafından yönetiliyor</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Arama</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/tr/cont-tr.html
+++ b/demos/theme-wet-boew/tr/cont-tr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Deneyimi Araç Kutusu&#160;(WET) <small>Açık kaynak ve ortak proje Kanada Hükümeti tarafından yönetiliyor</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Arama</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Arama web sitesi</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Arama" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/uk/cont-fixedmobileheader-uk.html
+++ b/demos/theme-wet-boew/uk/cont-fixedmobileheader-uk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Інструментарій Досвід Web&#160;(WET) <small>Проект спільного відкритого джерела за ініциативою Уряду Канади</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Шукати</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/uk/cont-nositemenubc-uk.html
+++ b/demos/theme-wet-boew/uk/cont-nositemenubc-uk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Інструментарій Досвід Web&#160;(WET) <small>Проект спільного відкритого джерела за ініциативою Уряду Канади</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Шукати</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/uk/cont-secnav1-uk.html
+++ b/demos/theme-wet-boew/uk/cont-secnav1-uk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Інструментарій Досвід Web&#160;(WET) <small>Проект спільного відкритого джерела за ініциативою Уряду Канади</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Шукати</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/uk/cont-secnav2-uk.html
+++ b/demos/theme-wet-boew/uk/cont-secnav2-uk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Інструментарій Досвід Web&#160;(WET) <small>Проект спільного відкритого джерела за ініциативою Уряду Канади</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Шукати</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/uk/cont-signin-uk.html
+++ b/demos/theme-wet-boew/uk/cont-signin-uk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Інструментарій Досвід Web&#160;(WET) <small>Проект спільного відкритого джерела за ініциативою Уряду Канади</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Шукати</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/uk/cont-signout-uk.html
+++ b/demos/theme-wet-boew/uk/cont-signout-uk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Інструментарій Досвід Web&#160;(WET) <small>Проект спільного відкритого джерела за ініциативою Уряду Канади</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Шукати</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/uk/cont-subsite-uk.html
+++ b/demos/theme-wet-boew/uk/cont-subsite-uk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Інструментарій Досвід Web&#160;(WET) <small>Проект спільного відкритого джерела за ініциативою Уряду Канади</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Шукати</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/uk/cont-uk.html
+++ b/demos/theme-wet-boew/uk/cont-uk.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Інструментарій Досвід Web&#160;(WET) <small>Проект спільного відкритого джерела за ініциативою Уряду Канади</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Шукати</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Пошук на сайті</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Шукати" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/vi/cont-fixedmobileheader-vi.html
+++ b/demos/theme-wet-boew/vi/cont-fixedmobileheader-vi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Hộp công cụ của những kinh nghiệm của các trang web&#160;(WET) <small>Dự án hợp tác đó là mã nguồn mở và được dẫn dắt bởi chính phủ Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Tìm kiếm</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/vi/cont-nositemenubc-vi.html
+++ b/demos/theme-wet-boew/vi/cont-nositemenubc-vi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Hộp công cụ của những kinh nghiệm của các trang web&#160;(WET) <small>Dự án hợp tác đó là mã nguồn mở và được dẫn dắt bởi chính phủ Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Tìm kiếm</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/vi/cont-secnav1-vi.html
+++ b/demos/theme-wet-boew/vi/cont-secnav1-vi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Hộp công cụ của những kinh nghiệm của các trang web&#160;(WET) <small>Dự án hợp tác đó là mã nguồn mở và được dẫn dắt bởi chính phủ Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Tìm kiếm</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/vi/cont-secnav2-vi.html
+++ b/demos/theme-wet-boew/vi/cont-secnav2-vi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Hộp công cụ của những kinh nghiệm của các trang web&#160;(WET) <small>Dự án hợp tác đó là mã nguồn mở và được dẫn dắt bởi chính phủ Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Tìm kiếm</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/vi/cont-signin-vi.html
+++ b/demos/theme-wet-boew/vi/cont-signin-vi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Hộp công cụ của những kinh nghiệm của các trang web&#160;(WET) <small>Dự án hợp tác đó là mã nguồn mở và được dẫn dắt bởi chính phủ Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Tìm kiếm</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/vi/cont-signout-vi.html
+++ b/demos/theme-wet-boew/vi/cont-signout-vi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Hộp công cụ của những kinh nghiệm của các trang web&#160;(WET) <small>Dự án hợp tác đó là mã nguồn mở và được dẫn dắt bởi chính phủ Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Tìm kiếm</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/vi/cont-subsite-vi.html
+++ b/demos/theme-wet-boew/vi/cont-subsite-vi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Hộp công cụ của những kinh nghiệm của các trang web&#160;(WET) <small>Dự án hợp tác đó là mã nguồn mở và được dẫn dắt bởi chính phủ Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Tìm kiếm</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/vi/cont-vi.html
+++ b/demos/theme-wet-boew/vi/cont-vi.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Hộp công cụ của những kinh nghiệm của các trang web&#160;(WET) <small>Dự án hợp tác đó là mã nguồn mở và được dẫn dắt bởi chính phủ Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Tìm kiếm</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Tìm kiếm trang web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Tìm kiếm" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh-Hans/cont-fixedmobileheader-zh-Hans.html
+++ b/demos/theme-wet-boew/zh-Hans/cont-fixedmobileheader-zh-Hans.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web体验（WET） <small>协作项目，该项目是开源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜索网站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜索网站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh-Hans/cont-nositemenubc-zh-Hans.html
+++ b/demos/theme-wet-boew/zh-Hans/cont-nositemenubc-zh-Hans.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web体验（WET） <small>协作项目，该项目是开源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜索网站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜索网站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh-Hans/cont-secnav1-zh-Hans.html
+++ b/demos/theme-wet-boew/zh-Hans/cont-secnav1-zh-Hans.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web体验（WET） <small>协作项目，该项目是开源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜索网站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜索网站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh-Hans/cont-secnav2-zh-Hans.html
+++ b/demos/theme-wet-boew/zh-Hans/cont-secnav2-zh-Hans.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web体验（WET） <small>协作项目，该项目是开源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜索网站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜索网站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh-Hans/cont-signin-zh-Hans.html
+++ b/demos/theme-wet-boew/zh-Hans/cont-signin-zh-Hans.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web体验（WET） <small>协作项目，该项目是开源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜索网站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜索网站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh-Hans/cont-signout-zh-Hans.html
+++ b/demos/theme-wet-boew/zh-Hans/cont-signout-zh-Hans.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web体验（WET） <small>协作项目，该项目是开源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜索网站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜索网站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh-Hans/cont-subsite-zh-Hans.html
+++ b/demos/theme-wet-boew/zh-Hans/cont-subsite-zh-Hans.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web体验（WET） <small>协作项目，该项目是开源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜索网站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜索网站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/zh-Hans/cont-zh-Hans.html
+++ b/demos/theme-wet-boew/zh-Hans/cont-zh-Hans.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web体验（WET） <small>协作项目，该项目是开源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜索</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜索网站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜索网站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜索" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh/cont-fixedmobileheader-zh.html
+++ b/demos/theme-wet-boew/zh/cont-fixedmobileheader-zh.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web體驗（WET） <small>協作項目，該項目是開源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜尋</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh/cont-nositemenubc-zh.html
+++ b/demos/theme-wet-boew/zh/cont-nositemenubc-zh.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web體驗（WET） <small>協作項目，該項目是開源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜尋</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh/cont-secnav1-zh.html
+++ b/demos/theme-wet-boew/zh/cont-secnav1-zh.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web體驗（WET） <small>協作項目，該項目是開源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜尋</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh/cont-secnav2-zh.html
+++ b/demos/theme-wet-boew/zh/cont-secnav2-zh.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web體驗（WET） <small>協作項目，該項目是開源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜尋</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh/cont-signin-zh.html
+++ b/demos/theme-wet-boew/zh/cont-signin-zh.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web體驗（WET） <small>協作項目，該項目是開源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜尋</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh/cont-signout-zh.html
+++ b/demos/theme-wet-boew/zh/cont-signout-zh.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web體驗（WET） <small>協作項目，該項目是開源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜尋</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/theme-wet-boew/zh/cont-subsite-zh.html
+++ b/demos/theme-wet-boew/zh/cont-subsite-zh.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web體驗（WET） <small>協作項目，該項目是開源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜尋</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div>

--- a/demos/theme-wet-boew/zh/cont-zh.html
+++ b/demos/theme-wet-boew/zh/cont-zh.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>工具箱的Web體驗（WET） <small>協作項目，該項目是開源的，是由加拿大政府</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>搜尋</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">搜尋網站</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="搜尋" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/wamethod/wamethod-AAA-en.html
+++ b/demos/wamethod/wamethod-AAA-en.html
@@ -63,9 +63,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/wamethod/wamethod-AAA-fr.html
+++ b/demos/wamethod/wamethod-AAA-fr.html
@@ -63,9 +63,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/wamethod/wamethod-en.html
+++ b/demos/wamethod/wamethod-en.html
@@ -63,9 +63,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/wamethod/wamethod-fr.html
+++ b/demos/wamethod/wamethod-fr.html
@@ -63,9 +63,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/webfeeds/webfeeds-en.html
+++ b/demos/webfeeds/webfeeds-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/webfeeds/webfeeds-fr.html
+++ b/demos/webfeeds/webfeeds-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/webstorage/localstorage-en.html
+++ b/demos/webstorage/localstorage-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/webstorage/localstorage-fr.html
+++ b/demos/webstorage/localstorage-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/webstorage/sessionstorage-en.html
+++ b/demos/webstorage/sessionstorage-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/webstorage/sessionstorage-fr.html
+++ b/demos/webstorage/sessionstorage-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/zebra/columnhighlight.html
+++ b/demos/zebra/columnhighlight.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/zebra/hover-effect-with-row-group.html
+++ b/demos/zebra/hover-effect-with-row-group.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/zebra/hover-effect.html
+++ b/demos/zebra/hover-effect.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/zebra/invoice.html
+++ b/demos/zebra/invoice.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/zebra/rowlevelwithsummary.html
+++ b/demos/zebra/rowlevelwithsummary.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/zebra/simple.html
+++ b/demos/zebra/simple.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/zebra/simplegrouping.html
+++ b/demos/zebra/simplegrouping.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/zebra/zebra-en.html
+++ b/demos/zebra/zebra-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/demos/zebra/zebra-fr.html
+++ b/demos/zebra/zebra-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/docstmpl-en.html
+++ b/docs/docstmpl-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html" lang="en"><object data="../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/docstmpl-fr.html
+++ b/docs/docstmpl-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html" lang="fr"><object data="../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/add-en.html
+++ b/docs/gs-cd/add-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/add-fr.html
+++ b/docs/gs-cd/add-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/build-en.html
+++ b/docs/gs-cd/build-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/build-fr.html
+++ b/docs/gs-cd/build-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/contrib-en.html
+++ b/docs/gs-cd/contrib-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/contrib-fr.html
+++ b/docs/gs-cd/contrib-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/dev-en.html
+++ b/docs/gs-cd/dev-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/dev-fr.html
+++ b/docs/gs-cd/dev-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/github-en.html
+++ b/docs/gs-cd/github-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/github-fr.html
+++ b/docs/gs-cd/github-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/impl-en.html
+++ b/docs/gs-cd/impl-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/impl-fr.html
+++ b/docs/gs-cd/impl-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/index-en.html
+++ b/docs/gs-cd/index-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/index-fr.html
+++ b/docs/gs-cd/index-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/opt-en.html
+++ b/docs/gs-cd/opt-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/gs-cd/opt-fr.html
+++ b/docs/gs-cd/opt-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html" lang="en"><object data="../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/index-fr.html
+++ b/docs/index-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html" lang="fr"><object data="../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/accolades-en.html
+++ b/docs/ref/accolades-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/accolades-fr.html
+++ b/docs/ref/accolades-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/arb-rra/arb-rra-en.html
+++ b/docs/ref/arb-rra/arb-rra-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-en.html" lang="en"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/arb-rra/arb-rra-fr.html
+++ b/docs/ref/arb-rra/arb-rra-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-fr.html" lang="fr"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/archived/archived-en.html
+++ b/docs/ref/archived/archived-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-en.html" lang="en"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/archived/archived-fr.html
+++ b/docs/ref/archived/archived-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-fr.html" lang="fr"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/core-en.html
+++ b/docs/ref/core-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/core-fr.html
+++ b/docs/ref/core-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/datalist/datalist-en.html
+++ b/docs/ref/datalist/datalist-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-en.html" lang="en"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/datalist/datalist-fr.html
+++ b/docs/ref/datalist/datalist-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-fr.html" lang="fr"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/datepicker/datepicker-en.html
+++ b/docs/ref/datepicker/datepicker-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-en.html" lang="en"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/datepicker/datepicker-fr.html
+++ b/docs/ref/datepicker/datepicker-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-fr.html" lang="fr"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/details/details-en.html
+++ b/docs/ref/details/details-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-en.html" lang="en"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/details/details-fr.html
+++ b/docs/ref/details/details-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-fr.html" lang="fr"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/docstmpl-en.html
+++ b/docs/ref/docstmpl-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-en.html" lang="en"><object data="../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/docstmpl-fr.html
+++ b/docs/ref/docstmpl-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../index-fr.html" lang="fr"><object data="../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/mathlib/mathlib-en.html
+++ b/docs/ref/mathlib/mathlib-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-en.html" lang="en"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/mathlib/mathlib-fr.html
+++ b/docs/ref/mathlib/mathlib-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-fr.html" lang="fr"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/other-en.html
+++ b/docs/ref/other-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/other-fr.html
+++ b/docs/ref/other-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/plugins-en.html
+++ b/docs/ref/plugins-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/plugins-fr.html
+++ b/docs/ref/plugins-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/polyfills-en.html
+++ b/docs/ref/polyfills-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/polyfills-fr.html
+++ b/docs/ref/polyfills-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/themesstyle-en.html
+++ b/docs/ref/themesstyle-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/themesstyle-fr.html
+++ b/docs/ref/themesstyle-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/variants-en.html
+++ b/docs/ref/variants-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/ref/variants-fr.html
+++ b/docs/ref/variants-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/versions/dwnld-en.html
+++ b/docs/versions/dwnld-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/versions/dwnld-fr.html
+++ b/docs/versions/dwnld-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/versions/index-en.html
+++ b/docs/versions/index-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/versions/index-fr.html
+++ b/docs/versions/index-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/versions/rdmp-en.html
+++ b/docs/versions/rdmp-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/versions/rdmp-fr.html
+++ b/docs/versions/rdmp-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/versions/v3.0/changes2.3-3.0-en.html
+++ b/docs/versions/v3.0/changes2.3-3.0-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-en.html" lang="en"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/versions/v3.0/changes2.3-3.0-fr.html
+++ b/docs/versions/v3.0/changes2.3-3.0-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../../index-fr.html" lang="fr"><object data="../../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/versions/version-info-en.html
+++ b/docs/versions/version-info-en.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-en.html" lang="en"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/docs/versions/version-info-fr.html
+++ b/docs/versions/version-info-fr.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="../../index-fr.html" lang="fr"><object data="../../dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="../../dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/index-en.html
+++ b/index-en.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="index-en.html"><object data="dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/index-eng.html
+++ b/index-eng.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="index-en.html"><object data="dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Web Experience Toolkit&#160;(WET) <small>Collaborative open source project led by the Government of Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Search</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Search website</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Search website</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Search" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/index-fr.html
+++ b/index-fr.html
@@ -57,9 +57,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="index-fr.html"><object data="dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>

--- a/index-fra.html
+++ b/index-fra.html
@@ -58,9 +58,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wet-title"><p id="wet-title-in"><a href="index-fr.html"><object data="dist/theme-wet-boew/images/logo.svg" role="img" tabindex="-1" type="image/svg+xml"><img src="dist/theme-wet-boew/images/logo.png" alt="" /></object> <span>Boîte à outils de l'expérience Web&#160;(BOEW) <small>Projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</small></span></a></p></div>
 
 <section role="search"><div id="wet-srchbx"><h2>Recherche</h2>
-<form action="#" method="post"><div id="wet-srchbx-in">
-<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="wet-srch" type="search" value="" size="27" maxlength="150" />
-<input id="wet-srch-submit" name="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
+<form action="https://google.ca/search" method="get"><div id="wet-srchbx-in">
+<label for="wet-srch">Recherchez le site Web</label><input id="wet-srch" name="q" type="search" value="" size="27" maxlength="150" /><input type="hidden" name="q" value="site:wet-boew.github.io OR github.com/wet-boew/" />
+<input id="wet-srch-submit" type="submit" value="Recherche" data-icon="search" class="button button-accent" />
 </div></form>
 </div></section>
 </div></div>


### PR DESCRIPTION
@nschonni This change would allow the v3.1 site search to work with Google Web search (if we go that way for search and if the action is changed to https://google.ca/search). Should this change be propagated to the other themes? It is a markup change but not a mandatory one (besides people are expected to configure the form method and field name anyway so it effectively would be non-breaking).
