### PR TITLE
Feedback: unit tests and stop()

### DIFF
--- a/src/plugins/feedback/feedback.js
+++ b/src/plugins/feedback/feedback.js
@@ -78,9 +78,11 @@ var pluginName = "wb-fdbck",
 	 * @param {DOM element} elm The element triggering the show/hide
 	 */
 	showHide = function( elm ) {
-		var targetId = elm.id,
-			$show,
-			$hide;
+		var $hide, $show,
+			classHide = "hide",
+			classShow = "show",
+			funcToggle = "toggle",
+			targetId = elm.id;
 
 		switch ( targetId ) {
 		case "fbrsn":
@@ -111,14 +113,16 @@ var pluginName = "wb-fdbck",
 
 		// Element to show
 		if ( $show ) {
-			// TODO: Use CSS transitions instead
-			$show.attr( "aria-hidden", "false" ).show( "slow" );
+			$show
+				.attr( "aria-hidden", "false" )
+				.wb( funcToggle, classShow, classHide );
 		}
 
 		// Element to hide
 		if ( $hide ) {
-			// TODO: Use CSS transitions instead
-			$hide.attr( "aria-hidden", "true" ).hide( "slow" );
+			$hide
+				.attr( "aria-hidden", "true" )
+				.wb( funcToggle, classHide, classShow );
 		}
 	};
 

--- a/src/plugins/feedback/test.js
+++ b/src/plugins/feedback/test.js
@@ -1,0 +1,137 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * @title Feedback Unit Tests
+ * @overview Test the feedback plugin behaviour
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @patheard
+ */
+/* global jQuery, describe, it, expect, before */
+/* jshint unused:vars */
+(function( $, wb ) {
+
+/*
+ * Create a suite of related test cases using `describe`. Test suites can also be
+ * nested in other test suites if you want to use the same setup `before()` and
+ * teardown `after()` for more than one test suite (as is the case below.)
+ */
+describe( "Feedback test suite", function() {
+
+	var $form = $( ".wb-fdbck" ),
+		$reason = $form.find( "#fbrsn" ),
+		$reasonWeb = $form.find( "#fbweb" ),
+		$access = $form.find( "#fbaxs" ),
+		$accessComp = $form.find( "#fbcomp" ),
+		$accessMobile = $form.find( "#fbmob" ),
+		$info = $form.find( "#fbinfo" ),
+		$contact1 = $form.find( "#fbcntc1" ),
+		$contact2 = $form.find( "#fbcntc2" ),
+
+		// Tests sections for visibility.  Not using the ":visible" jQuery selector
+		// because it is giving inconsistent results in PhantomJS.
+		expectVisible = function( $elm ) {
+			expect( $elm.hasClass( "hide" ) ).to.equal( false );
+			expect( $elm.hasClass( "show" ) ).to.equal( true );
+			expect( $elm.attr( "aria-hidden" ) ).to.equal( "false" );
+		},
+		expectHidden = function( $elm ) {
+			expect( $elm.hasClass( "hide" ) ).to.equal( true );
+			expect( $elm.hasClass( "show" ) ).to.equal( false );
+			expect( $elm.attr( "aria-hidden" ) ).to.equal( "true" );
+		};
+
+	/*
+	 * Before beginning the test suite, this function is executed once.
+	 */
+	before(function() {
+		$form.trigger( "wb-init.wb-fdbck" );
+	});
+
+	/*
+	 * Test the initialization events of the plugin
+	 */
+	describe( "plugin init", function() {
+		it( "should have added the plugin init class to the form", function() {
+			expect( $form.hasClass( "wb-fdbck-inited" ) ).to.equal( true );
+		});
+
+		it( "should have set aria-controls attributes", function() {
+			expect( $reason.attr( "aria-controls" ) ).to.equal( "fbweb" );
+			expect( $access.attr( "aria-controls" ) ).to.equal( "fbmob fbcomp" );
+		});
+
+		it( "should have set the referrer", function() {
+			expect( $( "#fbpg" ).val() ).to.equal( document.referrer );
+		});
+	});
+
+	/*
+	 * Test showHide Web behaviour
+	 */
+	describe( "showHide Web", function() {
+
+		before(function() {
+			$reasonWeb.stop().hide();
+		});
+
+		it( "should hide the 'Web' section when reason is not 'web'", function() {
+			$reason.val( "" ).trigger( "change" );
+			expectHidden( $reasonWeb );
+		});
+
+		it( "should show the 'Web' section when reason is 'web'", function() {
+			$reason.val( "web" ).trigger( "change" );
+			expectVisible( $reasonWeb );
+		});
+	});
+
+	/*
+	 * Test showHide Access behaviour
+	 */
+	describe( "showHide Access", function() {
+
+		before(function() {
+			$accessComp.stop().hide();
+			$accessMobile.stop().hide();
+		});
+
+		it( "should hide the 'Mobile' section when reason is not 'mobile'", function() {
+			$access.val( "desktop" ).trigger( "change" );
+			expectVisible( $accessComp );
+			expectHidden( $accessMobile );
+		});
+
+		it( "should show the 'Mobile' section when reason is 'mobile'", function() {
+			$access.val( "mobile" ).trigger( "change" );
+			expectVisible( $accessMobile );
+		});
+	});
+
+	/*
+	 * Test showHide Info behaviour
+	 */
+	describe( "showHide Info", function() {
+
+		before(function() {
+			$info.stop().hide();
+		});
+
+		it( "should hide the 'Info' section when contacts are not checked", function() {
+			$contact1.prop( "checked", false );
+			$contact2.prop( "checked", false ).trigger( "change" );
+			expectHidden( $info );
+		});
+
+		it( "should show the 'Info' section when contact1 is checked", function() {
+			$contact1.prop( "checked", true ).trigger( "change" );
+			expectVisible( $info );
+		});
+
+		it( "should show the 'Info' section when contact2 is checked", function() {
+			$contact1.prop( "checked", false ).trigger( "change" );
+			$contact2.prop( "checked", true ).trigger( "change" );
+			expectVisible( $info );
+		});
+	});
+});
+
+}( jQuery, wb ));


### PR DESCRIPTION
1. Adds unit tests for the feedback plugin.
2. Adds `stop()` to the animation to prevent a built-up queue of animations.  If you agree with this change I'll also apply it to v3.x.
