### PR TITLE
Feedback: fix reset button click

### DIFF
--- a/src/plugins/feedback/feedback.js
+++ b/src/plugins/feedback/feedback.js
@@ -145,6 +145,11 @@ $document.on( "click", selector + " input[type=reset]", function( event ) {
 
 	// Ignore middle/right mouse buttons
 	if ( !which || which === 1 ) {
+
+		// Manually reset the form as this event handler can be triggered
+		// before the browser invokes the native form reset.
+		event.target.form.reset();
+
 		showHide( fbrsn );
 		showHide( fbaxs );
 		showHide( fbcntc1 );

--- a/src/plugins/feedback/feedback.scss
+++ b/src/plugins/feedback/feedback.scss
@@ -20,7 +20,10 @@
 	}
 	#fbinfo {
 		@extend %wb-fdbck-display-none;
-	}	
+	}
+	#fbcntc {
+		margin-bottom: 15px;
+	}
 	#fbcmplt {
 		text-align: center;
 		p {

--- a/src/plugins/feedback/test.js
+++ b/src/plugins/feedback/test.js
@@ -70,7 +70,7 @@ describe( "Feedback test suite", function() {
 	describe( "showHide Web", function() {
 
 		before(function() {
-			$reasonWeb.stop().hide();
+			$reasonWeb.hide();
 		});
 
 		it( "should hide the 'Web' section when reason is not 'web'", function() {
@@ -90,8 +90,8 @@ describe( "Feedback test suite", function() {
 	describe( "showHide Access", function() {
 
 		before(function() {
-			$accessComp.stop().hide();
-			$accessMobile.stop().hide();
+			$accessComp.hide();
+			$accessMobile.hide();
 		});
 
 		it( "should hide the 'Mobile' section when reason is not 'mobile'", function() {
@@ -112,7 +112,7 @@ describe( "Feedback test suite", function() {
 	describe( "showHide Info", function() {
 
 		before(function() {
-			$info.stop().hide();
+			$info.hide();
 		});
 
 		it( "should hide the 'Info' section when contacts are not checked", function() {
@@ -130,6 +130,27 @@ describe( "Feedback test suite", function() {
 			$contact1.prop( "checked", false ).trigger( "change" );
 			$contact2.prop( "checked", true ).trigger( "change" );
 			expectVisible( $info );
+		});
+	});
+
+	/*
+	 * Test reset button behaviour
+	 */
+	describe( "Reset button click", function() {
+
+		before(function() {
+			$reason.val( "web" );
+			$contact1.prop( "checked", true ).trigger( "change" );
+		});
+
+		it( "should hide all sections when reset is clicked", function() {
+			expectVisible( $info );
+			expectVisible( $reasonWeb );
+
+			$( "input[type='reset']" ).trigger( "click" );
+
+			expectHidden( $info );
+			expectHidden( $reasonWeb );
 		});
 	});
 });


### PR DESCRIPTION
1. Manually call `form.reset()` as this reset button event handler can be triggered before the browser invokes the native form reset.  
2. Add vertical space between buttons and form fields.
