### PR TITLE
Docs: add GCWU theme documentation

### DIFF
--- a/demos/theme-gcwu-fegc/index-en.html
+++ b/demos/theme-gcwu-fegc/index-en.html
@@ -100,7 +100,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <h1 id="wb-cont">GC Web Usability theme</h1>
 
 <ul class="button-group">
-<li><a href="https://github.com/wet-boew/wet-boew/wiki/GC-Web-Usability-theme" class="button">Documentation</a></li>
+<li><a href="../../docs/ref/theme-gcwu-fegc/index-en.html" class="button">Documentation</a></li>
 <li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
 </ul>
 

--- a/demos/theme-gcwu-fegc/index-fr.html
+++ b/demos/theme-gcwu-fegc/index-fr.html
@@ -100,7 +100,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <h1 id="wb-cont">Thème de la facilité d'emploi Web GC</h1>
 
 <ul class="button-group">
-<li><a href="https://github.com/wet-boew/wet-boew/wiki/Th%C3%A8me-de-la-facilit%C3%A9-d%27emploi-Web-GC" class="button">Documentation</a></li>
+<li><a href="../../docs/ref/theme-gcwu-fegc/index-fr.html" class="button">Documentation</a></li>
 <li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
 </ul>
 

--- a/docs/ref/theme-gcwu-fegc/index-en.html
+++ b/docs/ref/theme-gcwu-fegc/index-en.html
@@ -1,0 +1,336 @@
+<!DOCTYPE html>
+<!--[if IE 7]><html lang="en" class="no-js ie7"><![endif]-->
+<!--[if IE 8]><html lang="en" class="no-js ie8"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html lang="en" class="no-js">
+<!--<![endif]-->
+<head>
+<meta charset="utf-8" />
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+<title>GC Web Usability Theme - Themes and style - Documentation - Web Experience Toolkit (WET)</title>
+
+<link rel="shortcut icon" href="../../../dist/theme-gcwu-fegc/images/favicon.ico" />
+<meta name="description" content="GC Web Usability Theme - Themes and style - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="GC Web Usability Theme - Themes and style - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
+<meta name="dcterms.language" title="ISO639-2" content="eng" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<script src="../../../dist/js/jquery.min.js"></script>
+<!--[if lte IE 8]>
+<script src="../../../dist/js/polyfills/html5shiv-min.js"></script>
+<link rel="stylesheet" href="../../../dist/grids/css/util-ie-min.css" />
+<link rel="stylesheet" href="../../../dist/js/css/pe-ap-ie-min.css" />
+<link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-ie-min.css" />
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<link rel="stylesheet" href="../../../dist/grids/css/util-min.css" />
+<link rel="stylesheet" href="../../../dist/js/css/pe-ap-min.css" />
+<link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-min.css" />
+<!--<![endif]-->
+<noscript><link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
+
+<!-- CustomScriptsCSSStart -->
+<!-- CustomScriptsCSSEnd -->
+</head>
+
+<body><div id="wb-body">
+<div id="wb-skip">
+<ul id="wb-tphp">
+<li id="wb-skip1"><a href="#wb-cont">Skip to main content</a></li>
+<li id="wb-skip2"><a href="#wb-nav">Skip to footer</a></li>
+</ul>
+</div>
+
+<div id="wb-head"><div id="wb-head-in"><header>
+<!-- HeaderStart -->
+<nav role="navigation"><div id="gcwu-gcnb"><h2>Government of Canada navigation bar</h2><div id="gcwu-gcnb-in"><div id="gcwu-gcnb-fip">
+<div id="gcwu-sig"><div id="gcwu-sig-in"><div id="gcwu-sig-eng" title="Government of Canada"><img src="../../../dist/theme-gcwu-fegc/images/sig-en.gif" width="214" height="20" alt="Government of Canada" /></div></div></div>
+<ul>
+<li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.ca/en/index.html">Canada.ca</a></li>
+<li id="gcwu-gcnb2"><a rel="external" href="http://www.canada.ca/en/services/index.html">Services</a></li>
+<li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.ca/en/gov/dept/index.html">Departments</a></li>
+<li id="gcwu-gcnb-lang"><a href="index-fr.html" lang="fr">Français</a></li>
+</ul>
+</div></div></div></nav>
+
+<div id="gcwu-bnr" role="banner"><div id="gcwu-bnr-in">
+<div id="gcwu-wmms"><div id="gcwu-wmms-in"><div id="gcwu-wmms-fip" title="Symbol of the Government of Canada"><img src="../../../dist/theme-gcwu-fegc/images/wmms.gif" width="126" height="30" alt="Symbol of the Government of Canada" /></div></div></div>
+<div id="gcwu-title"><p id="gcwu-title-in"><a href="../../../index-en.html">Web Experience Toolkit&#160;(WET)</a></p></div>
+
+<section role="search"><div id="gcwu-srchbx"><h2>Search</h2>
+<form action="#" method="post"><div id="gcwu-srchbx-in">
+<label for="gcwu-srch">Search website</label><input id="gcwu-srch" name="gcwu-srch" type="search" value="" size="27" maxlength="150" />
+<input id="gcwu-srch-submit" name="gcwu-srch-submit" type="submit" value="Search" data-icon="search" />
+</div></form>
+</div></section>
+</div></div>
+
+<nav role="navigation">
+<div id="gcwu-psnb"><h2><span>Site </span>menu</h2><div id="gcwu-psnb-in"><div class="wet-boew-menubar mb-mega"><div>
+<ul class="mb-menu" data-ajax-replace="../../../demos/includes/menu-en.txt">
+<li><div><a href="http://wet-boew.github.io/wet-boew/index-en.html">WET project</a></div></li>
+<li><div><a href="section2/index-en.html">Section 2</a></div></li>
+<li><div><a href="#">Section 3</a></div></li>
+<li><div><a href="#">Section 4</a></div></li>
+<li><div><a href="#">Section 5</a></div></li>
+<li><div><a href="#">Section 6</a></div></li>
+<li><div><a href="#">Section 7</a></div></li>
+</ul>
+</div></div></div></div>
+
+<div id="gcwu-bc"><h2>Breadcrumb trail</h2><div id="gcwu-bc-in">
+<ol>
+<li><a href="../../../index-en.html">Home</a></li>
+<li><a href="../../index-en.html">Documentation</a></li>
+<li><a href="../themesstyle-en.html">Themes and style</a></li>
+<li>GC Web Usability Theme</li>
+</ol>
+</div></div>
+</nav>
+<!-- HeaderEnd -->
+</header></div></div>
+
+<div id="wb-core"><div id="wb-core-in" class="equalize">
+<div id="wb-main" role="main"><div id="wb-main-in">
+<!-- MainContentStart -->
+<h1 id="wb-cont">GC Web Usability Theme</h1>
+
+<ul class="button-group">
+<li><a href="../../../demos/theme-gcwu-fegc/index-en.html" class="button">Working examples</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions or comments?</a></li>
+</ul>
+
+<span class="wet-boew-prettify all-pre"></span>
+
+<section>
+	<h2>Overview</h2>
+	<p><b>Project lead:</b> Paul Jackson (<a href="https://www.github.com/pjackson28">@pjackson28</a>)</p>
+
+	<section>
+		<h3>Description</h3>
+		<p>The GC Web Usability theme was developed to comply with the Standard on Web Usability.</p>
+	</section>
+
+	<section>
+		<h3>Benefits</h3>
+		<ul>
+			<li>Top tasks have been tested with users: contact us, search, return to home page, learn about us, stay connected through social media, navigate the site, read the terms and conditions, and toggling to the users official language of choice.</li>
+			<li>Conforms to the Standard on Web Accessibility and Standard on Web Usability </li>
+			<li>Conforms to WCAG 2.0 AA </li>
+			<li>Responsive design that includes both mobile and desktop views</li>
+			<li>Uses HTML5 semantic elements and WAI-ARIA to enhance accessibility</li>
+			<li>Groups most of the navigation after the content area </li>
+			<li>Validates to HTML5 and is XML conformant</li>
+		</ul>
+	</section>
+
+	<section>
+		<h3>Recommended usage</h3>
+
+		<section>
+			<h4>Use When</h4>
+			<p>This theme must be used on Government of Canada websites (including web applications).</p>
+		</section>
+
+		<section>
+			<h4>Do Not Use When</h4>
+			<p>This theme can only be used on Government of Canada websites.</p>
+		</section>
+
+		<section>
+			<h4>Appearance</h4>
+			<p>The theme prescribes the look of the template for content pages, splash pages and server error pages. Content layout, including that of the home page, is not prescribed, except for the Priorities section that is right-aligned somewhere below the breadcrumbs.</p>
+		</section>
+
+		<section>
+			<h4>Content</h4>
+			<p>Content should focus on users' top tasks. Users tend to navigate through the content area first and then to the menus. They are looking for keywords that will help them meet their information need. Write in active voice and use verbs. Users will often scan the information looking for things that stand out - like links. Each link must be descriptive and representative of the content to which it leads. This is especially pronounced when users are accessing the site via a mobile device.</p>
+		</section>
+	</section>
+</section>
+
+<section>
+	<h2>Implementation</h2>
+
+	<section>
+		<h3>General instructions</h3>
+		<ol>
+			<li>Use the <b>\theme-gcwu-fegc\*.html</b> files to create your Web pages.</li>
+			<li><b>Optional:</b> Create and install one or more new CSS files (will be used for custom CSS)</li>
+			<li><b>Optional:</b> Create link(s) to the new CSS file(s) in between the following comments:</li>
+		</ol>
+		<pre>&lt; !-- CustomScriptsCSSStart --&gt;
+&lt; !-- CustomScriptsCSSEnd --&gt;</pre>
+
+		<ol>
+			<li>Correct all <b>*.css</b>, <b>*.js</b>, and <b>*.gif</b> file paths referenced in the installed <b>*.html</b> files</li>
+			<li>Replace the page title (in between <b>&lt;title&gt;</b> and <b>&lt;/title&gt;,</b>), the site title, and the content title (in between <b>&lt;h1 id="wb-cont"&gt;</b> and <b>&lt;/h1&gt;</b>)</li>
+			<li>Correct the metadata values</li>
+			<li>Correct the <b>Terms and conditions/Avis</b> link(s)</li>
+		</ol>
+	</section>
+
+	<section>
+		<h3>Content page-specific instructions (cont*.html)</h3>
+		<ol>
+			<li>Correct the menu bar links</li>
+			<li>Correct the mega menu links or <a href="../../../demos/menubar/hsitenavbar-en.html">remove the mega menus</a></li>
+			<li>Correct the <b>English/français</b> link</li>
+			<li><b>Optional:</b> Implement either <a href="../../../demos/theme-gcwu-fegc/cont-secnav1-en.html">secondary navigation version 1</a> (maximum of 3 levels) or <a href="../../../demos/theme-gcwu-fegc/cont-secnav2-en.html">secondary navigation version 2</a> (maximum of 4 levels)</li>
+			<li>Correct the search field</li>
+			<li>Correct the breadcrumb</li>
+			<li>Correct the <b>Transparency/Transparence</b> link</li>
+			<li>Correct the site footer links</li>
+			<li>Correct the <b>Date modified/Date de modification</b> or change to <b>Version</b> (where permitted by the <i>Standard on Web Usability</i>)</li>
+		</ol>
+	</section>
+
+	<section>
+		<h3>Welcome page-specific instructions (sp-pe*.html)</h3>
+		<ol>
+			<li>Correct the English and French language links</li>
+			<li><b>Optional:</b> <a href="../../../demos/theme-gcwu-fegc/sp-pe-mult-en-fr.html">Include language selection links for other languages</a></li>
+		</ol>
+	</section>
+
+	<section>
+		<h3>Server message page-specific instructions (serv*.html)</h3>
+		<ol>
+			<li>Replace the English and/or French messages.</li>
+			<li><b>Optional:</b> <a href="../../../demos/theme-gcwu-fegc/serv-mult-en-fr.html">Include messages for other languages</a></li>
+		</ol>
+	</section>
+</section>
+
+<section>
+	<h2>Examples</h2>
+	<ul>
+		<li><a href="../../../demos/theme-gcwu-fegc/index-en.html">English working examples</a></li>
+		<li><a href="../../../demos/theme-gcwu-fegc/index-fr.html">French working examples</a></li>
+	</ul>
+</section>
+
+<section>
+	<h2>Development</h2>
+	<p>The code for the GC Web Usability theme is located in several places within the <b>source</b> folder of WET:</p>
+	<ul>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/js/theme.js">theme-gcwu-fegc/js/theme.js</a> - contains the JavaScript code for the GC Web Usability theme</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme.scss">theme-gcwu-fegc/sass/theme.scss</a> - contains the CSS for the GC Web Usability theme content pages</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme-ie.scss">theme-gcwu-fegc/sass/theme-ie.scss</a> - contains the IE7/8-specific CSS for the GC Web Usability theme content pages</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme-serv.scss">theme-gcwu-fegc/sass/theme-serv.scss</a> - contains the CSS for the GC Web Usability theme server message pages</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme-serv-ie.scss">theme-gcwu-fegc/sass/theme-serv-ie.scss</a> - contains the IE7/8-specific CSS for the GC Web Usability theme server message pages</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme-sp-pe.scss">theme-gcwu-fegc/sass/theme-sp-pe.scss</a> - contains the CSS for the GC Web Usability theme splash pages</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme-sp-pe-ie.scss">theme-gcwu-fegc/sass/theme-sp-pe-ie.scss</a> - contains the IE7/8-specific CSS for the GC Web Usability theme splash pages</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/includes/">theme-gcwu-fegc/sass/includes/</a> - contains the include files for building the CSS files for the GC Web Usability theme</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/jquerymobile/jquery.mobile.theme.css">theme-gcwu-fegc/jquerymobile/jquery.mobile.theme.css</a> - contains the jQuery Mobile specific CSS for the GC Web Usability theme</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/images/">theme-gcwu-fegc/images/</a> - contains the images for the GC Web Usability theme</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/jquerymobile/images/">theme-gcwu-fegc/jquerymobile/images/</a> - contains the jQuery Mobile specific images for the GC Web Usability theme</li>
+	</ul>
+</section>
+
+<section>
+	<h2>Known Issues</h2>
+	<ul>
+		<li>CSS styling will not be entirely consistent across all browsers since many of them will interpret CSS syntax differently. </li>
+		<li>Usability testing is required on the <a href="../../../demos/grids/grid-base-en.html">styles in the CSS grid system</a>.</li>
+	</ul>
+</section>
+
+<section>
+	<h2>Version History</h2>
+	<ul>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/js/theme.js">theme.js</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme.scss">theme.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme-ie.scss">theme-ie.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme-serv.scss">theme-serv.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme-serv-ie.scss">theme-serv-ie.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme-sp-pe.scss">theme-sp-pe.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme-sp-pe-ie.scss">theme-sp-pe-ie.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/jquerymobile/jquery.mobile.theme.css">jquery.mobile.theme.css</a> </li>
+	</ul>
+</section>
+
+<section>
+	<h2>Related Documentation</h2>
+	<ul>
+		<li><a href="../menubar/menubar-en.html">Menu bar</a></li>
+		<li><a href="https://github.com/wet-boew/wet-boew/wiki/Mega-menu">Mega menu</a></li>
+		<li><a href="https://github.com/wet-boew/wet-boew/wiki/Vertical-menu">Vertical menu</a></li>
+		<li><a href="../archived/archived-en.html">Archiving content</a></li>
+	</ul>
+</section>
+
+<dl id="gcwu-date-mod" role="contentinfo">
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
+</dl>
+<div class="clear"></div>
+<!-- MainContentEnd -->
+</div></div>
+</div></div>
+
+<div id="wb-foot"><div id="wb-foot-in"><footer><h2 id="wb-nav">Footer</h2>
+<!-- FooterStart -->
+<nav role="navigation"><div id="gcwu-sft"><h3>Site footer</h3><div id="gcwu-sft-in">
+<div id="gcwu-tctr">
+<ul>
+<li class="gcwu-tc"><a href="#" rel="license">Terms and conditions</a></li>
+<li class="gcwu-tr"><a href="#">Transparency</a></li>
+</ul>
+</div>
+<div class="clear"></div>
+<section><div class="span-2"><h4 class="gcwu-col-head"><a href="#">About us</a></h4>
+<ul>
+<li><a href="#">Our Mandate</a></li>
+<li><a href="#">Our Minister</a></li>
+</ul>
+</div></section>
+<section><div class="span-2"><h4 class="gcwu-col-head"><a href="#">News</a></h4>
+<ul>
+<li><a href="#">News releases</a></li>
+<li><a href="#">Media advisories</a></li>
+<li><a href="#">Multimedia</a></li>
+</ul>
+</div></section>
+<section><div class="span-2"><h4 class="gcwu-col-head"><a href="#">Contact us</a></h4>
+<address>
+<ul>
+<li><a href="#">Phone numbers</a></li>
+<li><a href="#">Office locations</a></li>
+</ul>
+</address>
+</div></section>
+<section><div class="span-2"><h4 class="gcwu-col-head"><a href="#">Stay connected</a></h4>
+<ul>
+<li><a rel="external" href="#">YouTube</a></li>
+<li><a rel="external" href="#">Twitter</a></li>
+<li><a href="#">Feeds</a></li>
+</ul>
+</div></section>
+</div></div></nav>
+
+<nav role="navigation"><div id="gcwu-gcft"><h3>Government of Canada footer</h3><div id="gcwu-gcft-in"><div id="gcwu-gcft-fip">
+<ul>
+<li><a rel="external" href="http://healthycanadians.gc.ca/index-eng.php"><span>Health</span><br />healthycanadians.gc.ca</a></li>
+<li><a rel="external" href="http://www.voyage.gc.ca/index-eng.asp"><span>Travel</span><br />travel.gc.ca</a></li>
+<li><a rel="external" href="http://www.servicecanada.gc.ca/eng/home.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
+<li><a rel="external" href="http://www.jobbank.gc.ca/intro-eng.aspx"><span>Jobs</span><br />jobbank.gc.ca</a></li>
+<li><a rel="external" href="http://actionplan.gc.ca/en"><span>Economy</span><br />actionplan.gc.ca</a></li>
+<li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/en/index.html">Canada.ca</a></div></li>
+</ul>
+</div></div></div></nav>
+<!-- FooterEnd -->
+</footer>
+</div></div></div>
+
+<!-- ScriptsStart -->
+<script src="../../../dist/theme-gcwu-fegc/js/theme-min.js"></script>
+<script src="../../../dist/js/settings.js"></script>
+<script src="../../../dist/js/pe-ap-min.js"></script>
+<!-- ScriptsEnd -->
+</body>
+</html>

--- a/docs/ref/theme-gcwu-fegc/index-fr.html
+++ b/docs/ref/theme-gcwu-fegc/index-fr.html
@@ -1,0 +1,335 @@
+<!DOCTYPE html>
+<!--[if IE 7]><html lang="fr" class="no-js ie7"><![endif]-->
+<!--[if IE 8]><html lang="fr" class="no-js ie8"><![endif]-->
+<!--[if gt IE 8]><!-->
+<html lang="fr" class="no-js">
+<!--<![endif]-->
+<head>
+<meta charset="utf-8" />
+<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
+<title>Thème de la facilité d'emploi Web GC - Thèmes et style - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
+
+<link rel="shortcut icon" href="../../../dist/theme-gcwu-fegc/images/favicon.ico" />
+<meta name="description" content="Thème de la facilité d'emploi Web GC - Thèmes et style - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Thème de la facilité d'emploi Web GC - Thèmes et style - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
+<meta name="dcterms.language" title="ISO639-2" content="fra" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+
+<script src="../../../dist/js/jquery.min.js"></script>
+<!--[if lte IE 8]>
+<script src="../../../dist/js/polyfills/html5shiv-min.js"></script>
+<link rel="stylesheet" href="../../../dist/grids/css/util-ie-min.css" />
+<link rel="stylesheet" href="../../../dist/js/css/pe-ap-ie-min.css" />
+<link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-ie-min.css" />
+<![endif]-->
+<!--[if gt IE 8]><!-->
+<link rel="stylesheet" href="../../../dist/grids/css/util-min.css" />
+<link rel="stylesheet" href="../../../dist/js/css/pe-ap-min.css" />
+<link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-min.css" />
+<!--<![endif]-->
+<noscript><link rel="stylesheet" href="../../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
+
+<!-- CustomScriptsCSSStart -->
+<!-- CustomScriptsCSSEnd -->
+</head>
+
+<body><div id="wb-body">
+<div id="wb-skip">
+<ul id="wb-tphp">
+<li id="wb-skip1"><a href="#wb-cont">Passer au contenu principal</a></li>
+<li id="wb-skip2"><a href="#wb-nav">Passer au pied de page</a></li>
+</ul>
+</div>
+
+<div id="wb-head"><div id="wb-head-in"><header>
+<!-- HeaderStart -->
+<nav role="navigation"><div id="gcwu-gcnb"><h2>Barre de navigation du gouvernement du Canada</h2><div id="gcwu-gcnb-in"><div id="gcwu-gcnb-fip">
+<div id="gcwu-sig"><div id="gcwu-sig-in"><div id="gcwu-sig-fra" title="Gouvernement du Canada"><img src="../../../dist/theme-gcwu-fegc/images/sig-fr.gif" width="214" height="20" alt="Gouvernement du Canada" /></div></div></div>
+<ul>
+<li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></li>
+<li id="gcwu-gcnb2"><a rel="external" href="http://www.canada.ca/fr/services/index.html">Services</a></li>
+<li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.ca/fr/gouv/min/index.html">Ministères</a></li>
+<li id="gcwu-gcnb-lang"><a href="index-en.html" lang="en">English</a></li>
+</ul>
+</div></div></div></nav>
+
+<div id="gcwu-bnr" role="banner"><div id="gcwu-bnr-in">
+<div id="gcwu-wmms"><div id="gcwu-wmms-in"><div id="gcwu-wmms-fip" title="Symbole du gouvernement du Canada"><img src="../../../dist/theme-gcwu-fegc/images/wmms.gif" width="126" height="30"  alt="Symbole du gouvernement du Canada" /></div></div></div>
+<div id="gcwu-title"><p id="gcwu-title-in"><a href="../../../index-fr.html">Boîte à outils de l'expérience Web&#160;(BOEW)</a></p></div>
+
+<section role="search"><div id="gcwu-srchbx"><h2>Recherche</h2>
+<form action="#" method="post"><div id="gcwu-srchbx-in">
+<label for="gcwu-srch">Recherchez le site Web</label><input id="gcwu-srch" name="gcwu-srch" type="search" value="" size="27" maxlength="150" />
+<input id="gcwu-srch-submit" name="gcwu-srch-submit" type="submit" value="Recherche" data-icon="search" />
+</div></form>
+</div></section>
+</div></div>
+
+<nav role="navigation">
+<div id="gcwu-psnb"><h2>Menu<span> du site</span></h2><div id="gcwu-psnb-in"><div class="wet-boew-menubar mb-mega"><div>
+<ul class="mb-menu" data-ajax-replace="../../../demos/includes/menu-fr.txt">
+<li><div><a href="http://wet-boew.github.io/wet-boew/index-fr.html">Projet de la BOEW</a></div></li>
+<li><div><a href="section2/index-fr.html">Section 2</a></div></li>
+<li><div><a href="#">Section 3</a></div></li>
+<li><div><a href="#">Section 4</a></div></li>
+<li><div><a href="#">Section 5</a></div></li>
+<li><div><a href="#">Section 6</a></div></li>
+<li><div><a href="#">Section 7</a></div></li>
+</ul>
+</div></div></div></div>
+
+<div id="gcwu-bc"><h2>Fil d'Ariane</h2><div id="gcwu-bc-in">
+<ol>
+<li><a href="../../../index-fr.html">Accueil</a></li>
+<li><a href="../../index-fr.html">Documentation</a></li>
+<li><a href="../themesstyle-fr.html">Thèmes et style</a></li>
+<li>Thème de la facilité d'emploi Web GC</li>
+</ol></div></div>
+</nav>
+<!-- HeaderEnd -->
+</header></div></div>
+
+<div id="wb-core"><div id="wb-core-in" class="equalize">
+<div id="wb-main" role="main"><div id="wb-main-in">
+<!-- MainContentStart -->
+<h1 id="wb-cont">Thème de la facilité d'emploi Web GC</h1>
+
+<ul class="button-group">
+<li><a href="../../../demos/theme-gcwu-fegc/index-fr.html" class="button">Examples pratiques</a></li>
+<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
+</ul>
+
+<span class="wet-boew-prettify all-pre"></span>
+
+<section>
+	<h2>Aperçu</h2>
+	<p><b>Chef du projet :</b> Paul Jackson (<a href="https://github.com/pjackson28">@pjackson28</a>)</p>
+
+	<section>
+		<h3>Description</h3>
+		<p>Le thème base à été créé pour conformer aux principes de la Norme sur la facilité des sites Web.</p>
+	</section>
+
+	<section>
+		<h3>Avantages</h3>
+		<ul>
+			<li>Les premières tâches ont été essayées avec les utilisateurs : contactez-nous, la recherche, retourner à la page d'accueil, à propos de nous, rester connexes par les médias sociaux, naviguer le site, lire les avis, et basculer la langue officielle de choix.</li>
+			<li>Conformes à la Norme sur l'accessibilité des sites Web et la Norme sur la facilité d'emploi des sites Web </li>
+			<li>Conformes à WCAG 2.0 AA </li>
+			<li>Conception réactive avec le soutien pour les appareils mobiles et les ordinateurs de table</li>
+			<li>Recours aux balises sémantiques HTML5 et à la spécification WAI-ARIA pour accroître l’accessibilité</li>
+			<li>Regroupe le gros de la navigation sous le domaine du contenu </li>
+			<li>Conformité aux critères HTML5 et XML</li>
+		</ul>
+	</section>
+
+	<section>
+		<h3>Utilisation recommandée</h3>
+
+		<section>
+			<h4>Quand utiliser</h4>
+			<p>Ce thème doit être utilisé pour les sites Web du gouvernement du Canada (dotés d'applications Web). </p>
+		</section>
+
+		<section>
+			<h4>Quand ne pas utiliser</h4>
+			<p>Ce thème peut seulement être utilisé pour les sites Web du gouvernement du Canada (dotés d'applications Web). </p>
+		</section>
+
+		<section>
+			<h4>Apparence</h4>
+			<p>The theme prescribes the look of the template for content pages, splash pages and server error pages. Content layout, including that of the home page, is not prescribed, except for the Priorities section that is right-aligned somewhere below the breadcrumbs.</p>
+			<p>Le thème prescrit l'apparence du modèle pour les pages de contenu, les pages d'entrée et les pages de messages du serveur. La mise en page du contenu, y compris cela de la page d'accueil, n'est pas prescrit, sauf la section pour les Priorités qui est aligné à droite au dessous du fil d'Ariane.</p>
+		</section>
+
+		<section>
+			<h4>Contenu</h4>
+			<p>Le contenu devrait se fixer sur les premières tâches des utilisateurs. Les utilisateurs ont tendance à naviguer par le zone de contenu premier et les menus deuxième. Ils cherchent des mots-clés qui les aideront à rencontrer leur besoin d'informations. Écrire dans la voix active et les verbes d'usage. Les utilisateurs scruteront souvent les informations distinctes - comme les liens. Chaque lien doit être descriptif et représentatif du contenu à lequel il mène. Ceci est surtout prononcé quand les utilisateurs accèdent au site via un appareil mobile.</p>
+		</section>
+	</section>
+</section>
+
+<section>
+	<h2>Implémentation</h2>
+
+	<section>
+		<h3>Instructions générales</h3>
+		<ol>
+			<li>Utiliser <b>\theme-gcwu-fegc\*.html</b> pour créer vos pages Web.</li>
+			<li><b>Facultatif :</b> Créer et installer un our plusieurs fichers CSS (pour le CSS personnalisé)</li>
+			<li><b>Facultatif :</b> Créer les liens aux nouveaux fichiers CSS entre les commentaires suivants :</li>
+		</ol>
+		<pre>&lt; !-- CustomScriptsCSSStart --&gt;
+&lt; !-- CustomScriptsCSSEnd --&gt;</pre>
+
+		<ol>
+			<li>Corriger les URLs des <b>*.css</b>, <b>*.js</b> et <b>*.gif</b> dans les fichiers <b>*.html</b></li>
+			<li>Remplacer le titre de la page (entre <b>&lt;title&gt;</b> et <b>&lt;/title&gt;,</b>), le titre du site et le titre du contenu (entre <b>&lt;h1 id="wb-cont"&gt;</b> et <b>&lt;/h1&gt;</b>) </li>
+			<li>Remplacer les valeurs des métadonnées</li>
+		</ol>
+	</section>
+
+	<section>
+		<h3>Instructions spécifiques aux pages de contenu (cont*.html)</h3>
+		<ol>
+			<li>Corriger les liens de la barre de menu</li>
+			<li>Corriger les liens des mégamenus ou <a href="../../../demos/menubar/hsitenavbar-fr.html">éliminer les mégamenus</a></li>
+			<li>Corriger les liens de sélection de la langue</li>
+			<li><b>Facultatif :</b> Mettre en oeuvre <a href="../../../demos/theme-gcwu-fegc/cont-secnav1-fr.html">navigation secondaire version 1</a> (trois niveaux maximum) ou <a href="../../../demos/theme-gcwu-fegc/cont-secnav2-fr.html">navigation secondaire version 2</a> (quatre niveaux maximum)</li>
+			<li>Corriger la zone de recherche</li>
+			<li>Corriger le fil d'Ariane</li>
+			<li>Corriger les liens <b>Transparency/Transparence</b></li>
+			<li>Corriger les liens dans le pied de page du site</li>
+			<li>Corriger le valeur pour <b>Date modified/Date de modification</b> ou remplacer avec <b>Version</b> (où permis par la <i>Norme sur la facilité d'emploi des sites Web</i>)</li>
+		</ol>
+	</section>
+
+	<section>
+		<h3>Instructions spécifiques aux pages d'entrée (sp-pe*.html)</h3>
+		<ol>
+			<li>Corriger les liens <b>English/Français</b></li>
+			<li><b>Facultatif :</b> <a href="../../../demos/theme-gcwu-fegc/sp-pe-mult-fr-en.html">Ajouter les autres liens de sélection de la langue</a></li>
+		</ol>
+	</section>
+
+	<section>
+		<h3>Instructions spécifiques aux pages de messages du serveur (serv*.html)</h3>
+		<ol>
+			<li>Remplacer les messages en anglais et français</li>
+			<li><b>Facultatif :</b> <a href="../../../demos/theme-gcwu-fegc/serv-mult-fr-en.html">Ajouter des messages pour les autres langues</a></li>
+		</ol>
+	</section>
+</section>
+
+<section>
+	<h2>Exemples</h2>
+	<ul>
+		<li><a href="../../../demos/theme-gcwu-fegc/index-fr.html">Exemples pratiques en français</a></li>
+		<li><a href="../../../demos/theme-gcwu-fegc/index-en.html">Exemples pratiques en anglais</a></li>
+	</ul>
+</section>
+
+<section>
+	<h2>Développement</h2>
+	<p>Le code pour le thème base se trouve dans plusieurs places dans le dossier source de la BOEW :</p>
+	<ul>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/js/theme.js">theme-gcwu-fegc/js/theme.js</a> - contient le JavaScript du thème pour la facilité d'emploi Web du GC</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme.scss">theme-gcwu-fegc/sass/theme.scss</a> - contient le CSS pour les pages de contenu du thème pour la facilité d'emploi Web du GC</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme-ie.scss">theme-gcwu-fegc/sass/theme-ie.scss</a> - contient le CSS spécifique à IE7/8 pour les pages des contenu du thème pour la facilité d'emploi Web du GC</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme-serv.scss">theme-gcwu-fegc/sass/theme-serv.scss</a> - contient le CSS pour les pages de messages du serveur du thème pour la facilité d'emploi Web du GC</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme-serv-ie.scss">theme-gcwu-fegc/sass/theme-serv-ie.scss</a> - contient le CSS spécifique à IE7/8 pour les pages de messages du serveur du thème pour la facilité d'emploi Web du GC</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme-sp-pe.scss">theme-gcwu-fegc/sass/theme-sp-pe.scss</a> - contient le CSS pour les pages d'entrée du thème pour la facilité d'emploi Web du GC</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/theme-sp-pe-ie.scss">theme-gcwu-fegc/sass/theme-sp-pe-ie.scss</a> - contient le CSS spécifique à IE7/8 pour les pages d'entrée du thème pour la facilité d'emploi Web du GC</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/sass/includes/">theme-gcwu-fegc/sass/includes/</a> - contient les fichiers à inclure pour créer les fichies CSS du thème pour la facilité d'emploi Web du GC</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/jquerymobile/jquery.mobile.theme.css">theme-gcwu-fegc/jquerymobile/jquery.mobile.theme.css</a> - contient le CSS spécifique à jQuery Mobile du thème pour la facilité d'emploi Web du GC</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/images/">theme-gcwu-fegc/images/</a> - contient les images du thème pour la facilité d'emploi Web du GC</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/blob/v3.0/src/theme-gcwu-fegc/jquerymobile/images/">theme-gcwu-fegc/jquerymobile/images/</a> - contient les images spécifique à jQuery Mobile pour le thème pour la facilité d'emploi Web du GC</li>
+	</ul>
+</section>
+
+<section>
+	<h2>Problèmes connus</h2>
+	<ul>
+		<li>Les styles des CSS ne seront pas entièrement uniformes d’un fureteur à l’autre puisque plusieurs interpréteront différemment la syntaxe des CSS. </li>
+		<li>L'essai de facilité d'emploi est nécessaire pour les <a href="../../../demos/grids/grid-base-en.html">styles dans la système styles in the CSS grid system</a>.</li>
+	</ul>
+</section>
+
+<section>
+	<h2>Historique des versions</h2>
+	<ul>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/js/theme.js">theme.js</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme.scss">theme.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme-ie.scss">theme-ie.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme-serv.scss">theme-serv.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme-serv-ie.scss">theme-serv-ie.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme-sp-pe.scss">theme-sp-pe.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/sass/theme-sp-pe-ie.scss">theme-sp-pe-ie.scss</a> </li>
+		<li><a href="https://github.com/wet-boew/wet-boew/commits/v3.0/src/theme-gcwu-fegc/jquerymobile/jquery.mobile.theme.css">jquery.mobile.theme.css</a> </li>
+	</ul>
+</section>
+
+<section>
+	<h2>Documentation connexes</h2>
+	<ul>
+		<li><a href="../menubar/menubar-fr.html">Barre de menu</a></li>
+		<li><a href="https://github.com/wet-boew/wet-boew/wiki/Mega-menu">Mega menu</a></li>
+		<li><a href="https://github.com/wet-boew/wet-boew/wiki/Vertical-menu">Vertical menu</a></li>
+		<li><a href="../archived/archived-fr.html">Archiving content</a></li>
+	</ul>
+</section>
+
+<dl id="gcwu-date-mod" role="contentinfo">
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
+</dl>
+<div class="clear"></div>
+<!-- MainContentEnd -->
+</div></div>
+</div></div>
+
+<div id="wb-foot"><div id="wb-foot-in"><footer><h2 id="wb-nav">Pied de page</h2>
+<!-- FooterStart -->
+<nav role="navigation"><div id="gcwu-sft"><h3>Pied de page du site</h3><div id="gcwu-sft-in">
+<div id="gcwu-tctr">
+<ul>
+<li class="gcwu-tc"><a href="#" rel="license">Avis</a></li>
+<li class="gcwu-tr"><a href="#">Transparence</a></li>
+</ul>
+</div>
+<div class="clear"></div>
+<section><div class="span-2"><h4 class="gcwu-col-head"><a href="#">À propos de nous</a></h4>
+<ul>
+<li><a href="#">Notre mandat</a></li>
+<li><a href="#">Le ministre</a></li>
+</ul>
+</div></section>
+<section><div class="span-2"><h4 class="gcwu-col-head"><a href="#">Nouvelles</a></h4>
+<ul>
+<li><a href="#">Communiqués</a></li>
+<li><a href="#">Avix aux médias</a></li>
+<li><a href="#">Multimédia</a></li>
+</ul>
+</div></section>
+<section><div class="span-2"><h4 class="gcwu-col-head"><a href="#">Contactez-nous</a></h4>
+<address>
+<ul>
+<li><a href="#">Numéros de téléphone</a></li>
+<li><a href="#">Nos bureaux</a></li>
+</ul>
+</address>
+</div></section>
+<section><div class="span-2"><h4 class="gcwu-col-head"><a href="#">Restez branchés</a></h4>
+<ul>
+<li><a rel="external" href="#">YouTube</a></li>
+<li><a rel="external" href="#">Twitter</a></li>
+<li><a href="#">Fils de nouvelles</a></li>
+</ul>
+</div></section>
+</div></div></nav>
+
+<nav role="navigation"><div id="gcwu-gcft"><h3>Pied de page du gouvernement du Canada</h3><div id="gcwu-gcft-in"><div id="gcwu-gcft-fip">
+<ul>
+<li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
+<li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
+<li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
+<li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
+<li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>
+</ul>
+</div></div></div></nav>
+<!-- FooterEnd -->
+</footer>
+</div></div></div>
+
+<!-- ScriptsStart -->
+<script src="../../../dist/theme-gcwu-fegc/js/theme-min.js"></script>
+<script src="../../../dist/js/settings.js"></script>
+<script src="../../../dist/js/pe-ap-min.js"></script>
+<!-- ScriptsEnd -->
+</body>
+</html>

--- a/docs/ref/themesstyle-en.html
+++ b/docs/ref/themesstyle-en.html
@@ -34,7 +34,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <!--<![endif]-->
 <noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
 
-<!-- CustomScriptsCSSStart --> 
+<!-- CustomScriptsCSSStart -->
 <!-- CustomScriptsCSSEnd -->
 </head>
 
@@ -102,7 +102,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <section>
 	<h2>Themes</h2>
 	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew/wiki/GC-Web-Usability-Theme">GC Web usability theme</a> - The GC Web usability theme was developed to comply with the <a href="http://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=24227">Standard on Web Usability</a> and is recommended for use with all Government of Canada websites.</li>
+		<li><a href="theme-gcwu-fegc/index-en.html">GC Web usability theme</a> - The GC Web usability theme was developed to comply with the <a href="http://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=24227">Standard on Web Usability</a> and is recommended for use with all Government of Canada websites.</li>
 		<li><a href="https://github.com/wet-boew/wet-boew/wiki/GC-Web-Usability-Intranet-Theme">GC Web usability intranet theme</a> - The GC Web usability intranet theme adapts the GC Web usability theme for intranet sites.</li>
 		<li><a href="https://github.com/wet-boew/wet-boew/wiki/CLF-2.0-Theme">CLF 2.0 theme</a> - This theme complies with CLF 2.0 while working with the Web Experience Toolkit.</li>
 	</ul>

--- a/docs/ref/themesstyle-fr.html
+++ b/docs/ref/themesstyle-fr.html
@@ -34,7 +34,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <!--<![endif]-->
 <noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
 
-<!-- CustomScriptsCSSStart --> 
+<!-- CustomScriptsCSSStart -->
 <!-- CustomScriptsCSSEnd -->
 </head>
 
@@ -101,7 +101,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <section>
 	<h2>Thèmes</h2>
 	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew/wiki/Th%C3%A8me-de-la-facilit%C3%A9-d%27emploi-Web-GC">Thème de la facilité d’emploi Web GC</a> - Un thème qui met en place la mise en page et la mise en forme exigés par la Norme sur la facilité des sites Web. Il est recommandé de se servir de ce thème sur les sites Web du gouvernement du Canada.</li>
+		<li><a href="theme-gcwu-fegc/index-fr.html">Thème de la facilité d’emploi Web GC</a> - Un thème qui met en place la mise en page et la mise en forme exigés par la Norme sur la facilité des sites Web. Il est recommandé de se servir de ce thème sur les sites Web du gouvernement du Canada.</li>
 		<li><a href="https://github.com/wet-boew/wet-boew/wiki/Th%C3%A8me-de-la-facilit%C3%A9-d%E2%80%99emploi-Web-GC-pour-les-sites-intranet">Thème de la facilité d’emploi Web GC pour les sites intranet</a> - Une version du thème de la facilité d'emploi des sites Web du GC pour les sites intranet.</li>
 		<li><a href="https://github.com/wet-boew/wet-boew/wiki/Th%C3%A8me-de-la-NSI-2.0">Thème de la NSI 2.0</a> - Un thème qui met en place la mise en page et la mise en forme exigées par la NSI 2.0.</li>
 	</ul>


### PR DESCRIPTION
Question about these docs @pjackson28:
1. Would you like me to change the the 3.1 content links in the [Content page-specific instructions (cont*.html)](https://github.com/wet-boew/wet-boew/wiki/GC-Web-Usability-Theme#content-page-specific-instructions-conthtml) section to application template links?  Currently they're removed in this PR since the cont*.html templates don't exist in 3.0.
