### PR TITLE
Documentation: Moved promotional material to HTML pages and fixed up metadata

### DIFF
--- a/License-en.html
+++ b/License-en.html
@@ -8,13 +8,13 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<title>Web Experience Toolkit (WET)</title>
+<title>Terms and Conditions of Use - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities." />
+<meta name="description" content="Terms and conditions of use of the Web Experience Toolkit." />
 <meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
-<meta name="dcterms.title" content="Web Experience Toolkit (WET)" />
-<meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
+<meta name="dcterms.title" content="Terms and Conditions of Use - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
 <meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
 <meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
@@ -54,7 +54,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.ca/en/index.html">Canada.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.canada.ca/en/services/index.html">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.ca/en/gov/dept/index.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="index-fr.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="Licence-fr.html" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 
@@ -78,6 +78,13 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <li><div><a href="http://wet-boew.github.io/wet-boew/docs/gs-cd/contrib-en.html">Contribute to WET</a></div></li>
 </ul>
 </div></div></div></div>
+
+<div id="gcwu-bc"><h2>Breadcrumb trail</h2><div id="gcwu-bc-in">
+<ol>
+<li><a href="../index-en.html">Home</a></li>
+<li>Terms and Conditions of Use - Web Experience Toolkit (WET)</li>
+</ol>
+</div></div>
 </nav>
 <!-- HeaderEnd -->
 </header></div></div>
@@ -85,118 +92,39 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Web Experience Toolkit (WET)</h1>
+<h1 id="wb-cont">Terms and Conditions of Use - Web Experience Toolkit (WET)</h1>
 
-<section><h2 id="about">What is the Web Experience Toolkit?</h2>
-<ul>
-<li>Collaborative open source project led by the Government of Canada</li>
-<li><a href="docs/ref/accolades-en.html#awards">Award-winning</a> code library for building innovative websites that are:
-	<ul>
-	<li><a href="#accessibility">Accessible</a>, <a href="#usability">usable</a> and <a href="#interoperability">interoperable</a>
-	<li><a href="#mobile-friendly-responsive-design">Mobile friendly</a>
-	<li><a href="#multilingual">Multilingual</a>
-	</ul>
-</li>
-<li><a href="#themeable-and-reusable">Flexible and themeable templates and reusable components</a></li>
-<li>Open source software
-	<ul>
-	<li>Free to use for commercial and non-commercial purposes (MIT license - <a href="http://wet-boew.github.io/wet-boew/License-en.html">Terms and conditions</a>)</li>
-	<li><a href="#collaborative-approach">Developed openly by the community on GitHub</a></li>
-	</ul>
-</li>
-</ul>
-</section>
+<p>Unless otherwise noted, computer program source code of the Web Experience Toolkit (WET) is
+covered under Crown Copyright, Government of Canada, and is distributed under the <a href="#license">MIT License</a>.</p>
 
-<section><h2 id="key">Key resources</h2>
-<ul>
-<li><a href="#benefits">Benefits</a></li>
-<li><a href="demos/index-en.html">Working examples</a></li>
-<li><a href="http://wet-boew.github.io/v4.0-ci/demos/index-en.html">Working examples - v4.0</a></li>
-<li><a href="docs/index-en.html">Documentation</a></li>
-<li><a href="docs/versions/dwnld-en.html">Downloads</a></li>
-<li><a href="https://github.com/wet-boew/wet-boew/">Main project</a></li>
-<li><a href="License-en.html">Terms and conditions</a></li>
-<li><a href="docs/gs-cd/contrib-en.html">Contributor guidelines</a></li>
-<li><a href="docs/versions/version-info-en.html">Versioning</a></li>
-<li><a href="docs/versions/index-en.html">Version history</a></li>
-<li><a href="docs/versions/rdmp-en.html">Roadmap</a></li>
-<li><a href="docs/index-en.html#comms">Communications material</a></li>
-</ul>
-</section>
+<p>The Canada wordmark and related graphics associated with this distribution are protected under
+trademark law and copyright law. No permission is granted to use them outside the parameters
+of the Government of Canada's corporate identity program. For more information, see
+<a href="http://www.tbs-sct.gc.ca/fip-pcim/index-eng.asp">http://www.tbs-sct.gc.ca/fip-pcim/index-eng.asp</a>.</p>
 
-<section><h2 id="benefits">Benefits</h2>
+<p>Copyright title to all 3rd party software distributed with the Web Experience Toolkit (WET) is
+held by the respective copyright holders as noted in those files. Users are asked to read the
+3rd Party Licenses referenced with those assets.</p>
 
-<section><h3 id="accessibility">Accessibility</h3>
-<ul>
-<li>Conforms to <a href="http://www.w3.org/TR/WCAG20/">WCAG 2.0</a> level AA</li>
-<li>Leverages <a href="http://www.w3.org/TR/wai-aria/">WAI-ARIA</a> to further enhance accessibility</li>
-<li>Assistive technology testing (Access Working Group)</li>
-</ul>
-</section>
 
-<section><h3 id="usability">Usability</h3>
-<ul>
-<li>Iterative approach to design</li>
-<li>Design patterns and usability testing (User Experience Working Group)</li>
-</ul>
-</section>
+<section><h2 id="license">MIT License</h2>
 
-<section><h3 id="interoperability">Interoperability</h3>
-<ul>
-<li><a href="http://www.w3.org/TR/html5/">HTML5</a>-first approach (leveraging native HTML5 support and filling support gaps with “polyfills”)</li>
-<li>Supporting a wide variety of browsers (IE, Firefox, Chrome, Safari, Opera)</li>
-<li>Building support for HTML data (<a href="http://www.w3.org/TR/rdfa-lite/">RDFa 1.1 Lite</a>, <a href="http://www.schema.org/">Schema.org</a>)</li>
-</ul>
-</section>
+<p>Copyright (c) 2014 Government of Canada</p>
 
-<section><h3 id="mobile-friendly-responsive-design">Mobile friendly responsive design</h3>
-<ul>
-<li>Adapts to different screen sizes and device capabilities</li>
-<li>Touchscreen support (<a href="http://www.jquerymobile.com">jQuery Mobile</a>)</li>
-<li>Optimized for performance</li>
-<li>Building support for device-based mobile applications</li>
-</ul>
-</section>
+<p>Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:</p>
 
-<section><h3 id="multilingual">Multilingual</h3>
-<ul>
-<li>Currently supports 3 languages (English, French and Spanish)</li>
-<li>Partial support for 29 languages (including right-to-left languages)</li>
-</ul>
-</section>
+<p>The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.</p>
 
-<section><h3 id="themeable-and-reusable">Themeable and reusable</h3>
-<ul>
-<li>Flexible framework that supports custom themes</li>
-<li>Includes support for 5 different themes including a “Base” theme to use as a template</li>
-<li>Reusable templates, plugins and widgets</li>
-<li>Adapted to various CMS and programming frameworks (Drupal, WordPress, SharePoint (in development), DotNetNuke (in development), PHP, SSI and Java/Maven)
-</ul>
-</section>
-
-<section><h3>Reduces costs by openly sharing and collaborating</h3>
-<ul>
-<li>Drives down research and development costs</li>
-<li>Avoids duplication of effort</li>
-<li>Produces better quality results</li>
-</ul>
-</section>
-
-<section><h3 id="collaborative-approach">Collaborative approach</h3>
-<ul>
-<li>Project managed openly on GitHub, including discussion through the issues tracker</li>
-<li>Encouraging a free flow of ideas, dialogue and innovation including sharing of challenges and ideas</li>
-<li>External contributions welcome
-	<ul>
-	<li>Pull requests</li>
-	<li>Design patterns</li>
-	<li>Issues and suggestions</li>
-	<li>Documentation</li>
-	<li>Testing</li>
-	</ul>
-<li>Multi-level review process for contributions to ensure code integrity (combination of automated and manual reviews)</li>
-</ul>
-</section>
+<p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.</p>
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">

--- a/License-fr.html
+++ b/License-fr.html
@@ -8,31 +8,31 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<title>Documentation - Boîte à outils de l’expérience Web (BOEW)</title>
+<title>Conditions régissant l'utilisation - Boîte à outils de l’expérience Web (BOEW)</title>
 
-<link rel="shortcut icon" href="../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="Documentation de la Boîte à outils de l’expérience Web (BOEW)." />
+<link rel="shortcut icon" href="dist/theme-gcwu-fegc/images/favicon.ico" />
+<meta name="description" content="Conditions régissant l'utilisation de la Boîte à outils de l’expérience Web (BOEW)." />
 <meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
-<meta name="dcterms.title" content="Documentation - Boîte à outils de l’expérience Web (BOEW)" />
-<meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
+<meta name="dcterms.title" content="Conditions régissant l'utilisation - Boîte à outils de l’expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
 <meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
 <meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-<script src="../dist/js/jquery.min.js"></script>
+<script src="dist/js/jquery.min.js"></script>
 <!--[if lte IE 8]>
-<script src="../dist/js/polyfills/html5shiv-min.js"></script>
-<link rel="stylesheet" href="../dist/grids/css/util-ie-min.css" />
-<link rel="stylesheet" href="../dist/js/css/pe-ap-ie-min.css" />
-<link rel="stylesheet" href="../dist/theme-gcwu-fegc/css/theme-ie-min.css" />
+<script src="dist/js/polyfills/html5shiv-min.js"></script>
+<link rel="stylesheet" href="dist/grids/css/util-ie-min.css" />
+<link rel="stylesheet" href="dist/js/css/pe-ap-ie-min.css" />
+<link rel="stylesheet" href="dist/theme-gcwu-fegc/css/theme-ie-min.css" />
 <![endif]-->
 <!--[if gt IE 8]><!-->
-<link rel="stylesheet" href="../dist/grids/css/util-min.css" />
-<link rel="stylesheet" href="../dist/js/css/pe-ap-min.css" />
-<link rel="stylesheet" href="../dist/theme-gcwu-fegc/css/theme-min.css" />
+<link rel="stylesheet" href="dist/grids/css/util-min.css" />
+<link rel="stylesheet" href="dist/js/css/pe-ap-min.css" />
+<link rel="stylesheet" href="dist/theme-gcwu-fegc/css/theme-min.css" />
 <!--<![endif]-->
-<noscript><link rel="stylesheet" href="../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
+<noscript><link rel="stylesheet" href="dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
 
 <!-- CustomScriptsCSSStart -->
 <!-- CustomScriptsCSSEnd -->
@@ -49,18 +49,18 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-head"><div id="wb-head-in"><header>
 <!-- HeaderStart -->
 <nav role="navigation"><div id="gcwu-gcnb"><h2>Barre de navigation du gouvernement du Canada</h2><div id="gcwu-gcnb-in"><div id="gcwu-gcnb-fip">
-<div id="gcwu-sig"><div id="gcwu-sig-in"><div id="gcwu-sig-fra" title="Gouvernement du Canada"><img src="../dist/theme-gcwu-fegc/images/sig-fr.gif" width="214" height="20" alt="Gouvernement du Canada" /></div></div></div>
+<div id="gcwu-sig"><div id="gcwu-sig-in"><div id="gcwu-sig-fra" title="Gouvernement du Canada"><img src="dist/theme-gcwu-fegc/images/sig-fr.gif" width="214" height="20" alt="Gouvernement du Canada" /></div></div></div>
 <ul>
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.canada.ca/fr/services/index.html">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.ca/fr/gouv/min/index.html">Ministères</a></li>
-<li id="gcwu-gcnb-lang"><a href="index-en.html" lang="en">English</a></li>
+<li id="gcwu-gcnb-lang"><a href="License-en.html" lang="en">English</a></li>
 </ul>
 </div></div></div></nav>
 
 <div id="gcwu-bnr" role="banner"><div id="gcwu-bnr-in">
-<div id="gcwu-wmms"><div id="gcwu-wmms-in"><div id="gcwu-wmms-fip" title="Symbole du gouvernement du Canada"><img src="../dist/theme-gcwu-fegc/images/wmms.gif" width="126" height="30"  alt="Symbole du gouvernement du Canada" /></div></div></div>
-<div id="gcwu-title"><p id="gcwu-title-in"><a href="../index-fr.html">Boîte à outils de l’expérience Web (BOEW)</a></p></div>
+<div id="gcwu-wmms"><div id="gcwu-wmms-in"><div id="gcwu-wmms-fip" title="Symbole du gouvernement du Canada"><img src="dist/theme-gcwu-fegc/images/wmms.gif" width="126" height="30"  alt="Symbole du gouvernement du Canada" /></div></div></div>
+<div id="gcwu-title"><p id="gcwu-title-in"><a href="index-fr.html">Boîte à outils de l’expérience Web (BOEW)</a></p></div>
 
 <section role="search"><div id="gcwu-srchbx"><h2>Recherche</h2>
 <form action="#" method="post"><div id="gcwu-srchbx-in">
@@ -72,7 +72,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 
 <nav role="navigation">
 <div id="gcwu-psnb"><h2>Menu<span> du site</span></h2><div id="gcwu-psnb-in"><div class="wet-boew-menubar mb-mega"><div>
-<ul class="mb-menu" data-ajax-replace="../demos/includes/projectmenu-fr.txt">
+<ul class="mb-menu" data-ajax-replace="demos/includes/projectmenu-fr.txt">
 <li><div><a href="http://wet-boew.github.io/wet-boew/index-fr.html">Projet de la BOEW</a></div></li>
 <li><div><a href="http://wet-boew.github.io/wet-boew/docs/gs-cd/impl-fr.html">Mise en œuvre de la BOEW</a></div></li>
 <li><div><a href="http://wet-boew.github.io/wet-boew/docs/gs-cd/contrib-fr.html">Contribuer à la BOEW</a></div></li>
@@ -82,8 +82,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="gcwu-bc"><h2>Fil d'Ariane</h2><div id="gcwu-bc-in">
 <ol>
 <li><a href="../index-fr.html">Accueil</a></li>
-<li>Documentation</li>
-</ol></div></div>
+<li>Conditions régissant l'utilisation - Boîte à outils de l’expérience Web (BOEW)</li>
+</ol>
+</div></div>
 </nav>
 <!-- HeaderEnd -->
 </header></div></div>
@@ -91,48 +92,44 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Documentation</h1>
+<h1 id="wb-cont">Conditions régissant l'utilisation - Boîte à outils de l’expérience Web (BOEW)</h1>
 
-<p lang="en"><strong>Needs translation</strong> WET operates on the principle of progressive enhancement, and implements well established techniques increasing the accessibility and usability of web content. If you are new to WET, please begin with our Getting Started section, which contains all the information anyone new requires to access, implement or contribute to the toolkit. Otherwise, see the Reference section.</p>
-<p id="change">Voici quelques lignes directrices si vous désirez créer ou modifier de la documentation existante&#160;:</p>
-<ul>
-	<li>Verser tous les guides, les descriptions ou les directives pour la BOEW dans le répertoire de GitHub.</li>
-	<li>Suivre le <a href="ref/docstmpl-fr.html">modèle de documentation</a>.</li>
-	<li>Fournir au moins un exemple pour chaque attribut, thème ou élément de la BOEW. D’autres exemples doivent être donnés pour chaque paramètre ou option. </li>
-</ul>
+<p>Sauf indication contraire, le code source de la boîte à outils de l'expérience Web (BOEW)
+est protégé par le droit d'auteur de la Couronne du gouvernement du Canada et distribué
+sous la <a href="#licence">licence MIT</a>.</p>
 
-<section>
-	<h2>Comment démarrer</h2>
-	<ul>
-		<li><a href="gs-cd/index-fr.html">Comment démarrer</a>
-			<ul>
-				<li><a href="gs-cd/github-fr.html">Guide d'utilisation de GitHub pour la BOEW</a></li>
-				<li><a href="gs-cd/impl-fr.html">Mise en œuvre de la BOEW</a></li>
-				<li><a href="gs-cd/dev-fr.html">Développer pour la BOEW</a></li>
-			</ul>
-		</li>
-	</ul>
-</section>
+<p>Le mot-symbole «&#160;Canada&#160;» et les éléments graphiques connexes liés à cette distribution sont
+protégés en vertu des lois portant sur les marques de commerce et le droit d'auteur.</p>
 
-<section>
-	<h2>Référence</h2>
-	<ul>
-		<li><a href="ref/core-fr.html">Cadre fondamental</a></li>
-		<li><a href="ref/themesstyle-fr.html">Thèmes et style</a></li>
-		<li><a href="ref/plugins-fr.html">Plugiciels</a></li>
-		<li><a href="ref/polyfills-fr.html">Correctifs</a></li>
-		<li><a href="ref/variants-fr.html">Variants</a></li>
-		<li><a href="ref/other-fr.html">Autre composants</a></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/wiki/Projets-externes-utilis%C3%A9s-par-la-BOEW">Projets externes utilisés par la BOEW</a></li>
-	</ul>
-</section>
+<p>Aucune autorisation n'est accordée pour leur utilisation à l'extérieur des paramètres du
+programme de coordination de l'image de marque du gouvernement du Canada. Pour obtenir
+davantage de renseignements à ce sujet, veuillez consulter
+<a href="http://www.tbs-sct.gc.ca/fip-pcim/index-fra.asp">http://www.tbs-sct.gc.ca/fip-pcim/index-fra.asp</a></p>
 
-<section>
-	<h2 id="comms">Matériel de communications</h2>
-	<ul>
-		<li><a href="ref/promo-fr.html">Matériel promotionnel</a></li>
-		<li><a href="ref/accolades-fr.html">Articles, blogues, vidéos et implémentations de la BOEW</a></li>
-	</ul>
+<p>La propriété du droit d'auteur de tout logiciel tiers distribué avec la boîte à outils de
+l'expérience Web (BOEW) est conservée par les détenteurs du droit d'auteur mentionnés
+dans ces fichiers. Nous demandons aux utilisateurs de lire les licences des tiers indiqués
+à titre de référence dans ces logiciels.</p>
+
+
+<section><h2 id="licence">Licence MIT</h2>
+
+<p>(c) Droit d'auteur – Gouvernement du Canada, 2014</p>
+
+<p>La présente autorise toute personne d'obtenir gratuitement une copie du présent logiciel et des
+documents connexes (le « logiciel »), de traiter le logiciel sans restriction, y compris, mais sans
+s'y limiter, les droits d'utiliser, de copier, de modifier, de fusionner, de publier, de distribuer,
+d'accorder une sous licence et de vendre des copies dudit logiciel, et de permettre aux personnes
+auxquelles le logiciel est fourni de le faire, selon les conditions suivantes&#160;:</p>
+
+<p>L'avis de droit d'auteur ci dessus et le présent avis de permission seront inclus dans toutes les copies
+et les sections importantes du logiciel.</p>
+
+<p>LE LOGICIEL EST FOURNI «&#160;TEL QUEL&#160;», SANS AUCUNE GARANTIE, EXPRESSE OU IMPLICITE, Y COMPRIS, MAIS SANS
+S'Y LIMITER, LA GARANTIE DE QUALITÉ MARCHANDE, L'ADAPTATION À UN USAGE PARTICULIER ET L'ABSENCE DE
+CONTREFAÇON. EN AUCUN CAS LES AUTEURS OU LES DÉTENTEURS DU DROIT D'AUTEUR NE SERONT TENUS RESPONSABLES
+DE TOUTE DEMANDE, DOMMAGE OU BRIS DE CONTRAT, DÉLIT CIVIL OU TOUT AUTRE MANQUEMENT LIÉ AU LOGICIEL,
+À SON UTILISATION OU À D'AUTRES ÉCHANGES LIÉS AU LOGICIEL.</p>
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
@@ -192,21 +189,9 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div></div></div>
 
 <!-- ScriptsStart -->
-<script src="../dist/theme-gcwu-fegc/js/theme-min.js"></script>
-<script src="../dist/js/settings.js"></script>
-<script src="../dist/js/pe-ap-min.js"></script>
+<script src="dist/theme-gcwu-fegc/js/theme-min.js"></script>
+<script src="dist/js/settings.js"></script>
+<script src="dist/js/pe-ap-min.js"></script>
 <!-- ScriptsEnd -->
-
-<script>
-/* <![CDATA[ */
-(function ($) {
-	$('#wb-main-in #rde + ul a').each(function () {
-		var $this = $(this),
-			url = window.location.href;
-		$this.attr('href', $this.attr('href') + '?' + url.substring(0, url.lastIndexOf('/') + 1) + $this.attr('data-url'));
-	});
-}(jQuery));
-/* ]]> */
-</script>
 </body>
 </html>

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@
 * [Versioning](http://wet-boew.github.io/wet-boew/docs/versions/version-info-en.html)
 * [Version history](http://wet-boew.github.io/wet-boew/docs/versions/index-en.html)
 * [Roadmap](http://wet-boew.github.io/wet-boew/docs/versions/rdmp-en.html)
+* [Communications materials](http://wet-boew.github.io/wet-boew/docs/index-en.html#comms)
 
 ## Benefits
 
@@ -113,6 +114,7 @@
 * [Contrôle des versions](http://wet-boew.github.io/wet-boew/docs/versions/version-info-fr.html)
 * [Historique des versions](http://wet-boew.github.io/wet-boew/docs/versions/index-fr.html)
 * [Feuille de route](http://wet-boew.github.io/wet-boew/docs/versions/rdmp-fr.html)
+* [Matériel de communications](http://wet-boew.github.io/wet-boew/docs/index-fr.html#comms)
 
 ## Avantages
 

--- a/demos/arb-rra/arb-rra-fr.html
+++ b/demos/arb-rra/arb-rra-fr.html
@@ -1229,7 +1229,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/arb-rra/arb-rra-planAccess-fr.html
+++ b/demos/arb-rra/arb-rra-planAccess-fr.html
@@ -233,7 +233,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/archived/archived-fr.html
+++ b/demos/archived/archived-fr.html
@@ -247,7 +247,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/charts/complex-fr.html
+++ b/demos/charts/complex-fr.html
@@ -575,7 +575,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/charts/simple-fr.html
+++ b/demos/charts/simple-fr.html
@@ -348,7 +348,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/charts/simpleCustomized-fr.html
+++ b/demos/charts/simpleCustomized-fr.html
@@ -503,7 +503,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/datalist/datalist-fr.html
+++ b/demos/datalist/datalist-fr.html
@@ -228,7 +228,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/datepicker/datepicker-fr.html
+++ b/demos/datepicker/datepicker-fr.html
@@ -184,7 +184,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/details/details-fr.html
+++ b/demos/details/details-fr.html
@@ -252,7 +252,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/eventscalendar/eventscalendar-fr.html
+++ b/demos/eventscalendar/eventscalendar-fr.html
@@ -276,7 +276,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/feedback/feedback-fr.html
+++ b/demos/feedback/feedback-fr.html
@@ -282,7 +282,7 @@ par courriel, à&#160;: <a href="mailto:info@priv.gc.ca">info@priv.gc.ca</a> ou 
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/footnotes/footnotes-fr.html
+++ b/demos/footnotes/footnotes-fr.html
@@ -205,7 +205,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/formvalid/formvalid-fr.html
+++ b/demos/formvalid/formvalid-fr.html
@@ -212,7 +212,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/index-en.html
+++ b/demos/index-en.html
@@ -12,8 +12,8 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 
 <link rel="shortcut icon" href="../dist/theme-gcwu-fegc/images/favicon.ico" />
 <meta name="description" content="Web Experience Toolkit (WET) working examples." />
-<meta name="dcterms.creator" content="Government of Canada, Treasury Board of Canada Secretariat, Chief Information Officer Branch, IT Project Review and Oversight, Web Standards Office" />
-<meta name="dcterms.title" content="Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Working examples - Web Experience Toolkit (WET)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
 <meta name="dcterms.modified" title="W3CDTF" content="2013-05-16" />
 <meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />

--- a/demos/index-eng.html
+++ b/demos/index-eng.html
@@ -13,8 +13,8 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <link rel="shortcut icon" href="../dist/theme-gcwu-fegc/images/favicon.ico" />
 <link rel="canonical" href="index-en.html" />
 <meta name="description" content="Web Experience Toolkit (WET) working examples." />
-<meta name="dcterms.creator" content="Government of Canada, Treasury Board of Canada Secretariat, Chief Information Officer Branch, IT Project Review and Oversight, Web Standards Office" />
-<meta name="dcterms.title" content="Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Working examples - Web Experience Toolkit (WET)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
 <meta name="dcterms.modified" title="W3CDTF" content="2013-05-16" />
 <meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />

--- a/demos/index-fr.html
+++ b/demos/index-fr.html
@@ -12,11 +12,11 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 
 <link rel="shortcut icon" href="../dist/theme-gcwu-fegc/images/favicon.ico" />
 <meta name="description" content="Exemple pratiques de la Boîte à outils de l’expérience Web (BOEW)." />
-<meta name="dcterms.creator" content="Gouvernement du Canada, Secrétariat du Conseil du Trésor du Canada, Direction du dirigeant principal de l'information, Division de l'examen et de la supervision de projets de TI, Bureau des normes Web" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
 <meta name="dcterms.title" content="Exemples pratiques - Boîte à outils de l’expérience Web (BOEW)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
 <meta name="dcterms.modified" title="W3CDTF" content="2013-05-16" />
-<meta name="dcterms.subject" title="scheme" content="Internet;Normes;Conception" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -421,7 +421,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/index-fra.html
+++ b/demos/index-fra.html
@@ -13,11 +13,11 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <link rel="shortcut icon" href="../dist/theme-gcwu-fegc/images/favicon.ico" />
 <link rel="canonical" href="index-fr.html" />
 <meta name="description" content="Exemple pratiques de la Boîte à outils de l’expérience Web (BOEW)." />
-<meta name="dcterms.creator" content="Gouvernement du Canada, Secrétariat du Conseil du Trésor du Canada, Direction du dirigeant principal de l'information, Division de l'examen et de la supervision de projets de TI, Bureau des normes Web" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
 <meta name="dcterms.title" content="Exemples pratiques - Boîte à outils de l’expérience Web (BOEW)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
 <meta name="dcterms.modified" title="W3CDTF" content="2013-05-16" />
-<meta name="dcterms.subject" title="scheme" content="Internet;Normes;Conception" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -422,7 +422,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/langselect/lang-fr.html
+++ b/demos/langselect/lang-fr.html
@@ -240,7 +240,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/lightbox/lightbox-fr.html
+++ b/demos/lightbox/lightbox-fr.html
@@ -391,7 +391,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/mathlib/mathlib-complex-fr.html
+++ b/demos/mathlib/mathlib-complex-fr.html
@@ -1241,7 +1241,7 @@ ces quatre grandeurs d'intérêt aux niveaux national et provincial.</p>
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/mathlib/mathlib-fr.html
+++ b/demos/mathlib/mathlib-fr.html
@@ -1479,7 +1479,7 @@ Compte tenu de l'équation quadratique
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/menubar/hsitenavbar-fr.html
+++ b/demos/menubar/hsitenavbar-fr.html
@@ -239,7 +239,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/menubar/megamenu-fr.html
+++ b/demos/menubar/megamenu-fr.html
@@ -240,7 +240,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/multimedia/mediaplayer-transcript_captions-fr.html
+++ b/demos/multimedia/mediaplayer-transcript_captions-fr.html
@@ -411,7 +411,7 @@ progress {
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/multimedia/multimedia-fr.html
+++ b/demos/multimedia/multimedia-fr.html
@@ -464,7 +464,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/prettify/prettify-fr.html
+++ b/demos/prettify/prettify-fr.html
@@ -255,7 +255,7 @@ div#gcwu-headlines ul li,div#gcwu-headlines ul{
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/progress/progress-fr.html
+++ b/demos/progress/progress-fr.html
@@ -192,7 +192,7 @@ progress {
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/sessiontimeout/sessiontimeout-fr.html
+++ b/demos/sessiontimeout/sessiontimeout-fr.html
@@ -183,7 +183,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/share/share-filtered-fr.html
+++ b/demos/share/share-filtered-fr.html
@@ -255,7 +255,7 @@ var wet_boew_share = {<br />
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/share/share-fr.html
+++ b/demos/share/share-fr.html
@@ -243,7 +243,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/slideout/slideout-fr.html
+++ b/demos/slideout/slideout-fr.html
@@ -348,7 +348,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/slider/slider-fr.html
+++ b/demos/slider/slider-fr.html
@@ -223,7 +223,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/ssi/index-fr.html
+++ b/demos/ssi/index-fr.html
@@ -201,7 +201,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/tabs/tabs-fr.html
+++ b/demos/tabs/tabs-fr.html
@@ -537,7 +537,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/texthighlight/texthighlight-fr.html
+++ b/demos/texthighlight/texthighlight-fr.html
@@ -268,7 +268,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/theme-gcwu-fegc/cont-fr.html
+++ b/demos/theme-gcwu-fegc/cont-fr.html
@@ -237,7 +237,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/theme-gcwu-fegc/cont-secnav1-fr.html
+++ b/demos/theme-gcwu-fegc/cont-secnav1-fr.html
@@ -286,7 +286,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/theme-gcwu-fegc/cont-secnav2-fr.html
+++ b/demos/theme-gcwu-fegc/cont-secnav2-fr.html
@@ -289,7 +289,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/theme-gcwu-fegc/home-accueil-fr.html
+++ b/demos/theme-gcwu-fegc/home-accueil-fr.html
@@ -242,7 +242,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/theme-gcwu-fegc/index-fr.html
+++ b/demos/theme-gcwu-fegc/index-fr.html
@@ -209,7 +209,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>

--- a/demos/wamethod/wamethod-AAA-fr.html
+++ b/demos/wamethod/wamethod-AAA-fr.html
@@ -1038,7 +1038,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/wamethod/wamethod-fr.html
+++ b/demos/wamethod/wamethod-fr.html
@@ -805,7 +805,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/webfeeds/webfeeds-fr.html
+++ b/demos/webfeeds/webfeeds-fr.html
@@ -224,7 +224,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/webstorage/localstorage-fr.html
+++ b/demos/webstorage/localstorage-fr.html
@@ -161,7 +161,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/demos/zebra/zebra-fr.html
+++ b/demos/zebra/zebra-fr.html
@@ -583,7 +583,7 @@ Donec iaculis diam eget sem bibendum consequat.
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/gs-cd/add-en.html
+++ b/docs/gs-cd/add-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Adding new functionality - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Adding new functionality - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Adding new functionality - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -377,7 +377,7 @@ _pe.document.one('wb-init-loaded', function () {
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/gs-cd/add-fr.html
+++ b/docs/gs-cd/add-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Ajoutant de nouvelles fonctionnalités - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Ajoutant de nouvelles fonctionnalités - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Ajoutant de nouvelles fonctionnalités - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -380,7 +380,7 @@ _pe.document.one('wb-init-loaded', function () {
 </div>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -431,7 +431,7 @@ _pe.document.one('wb-init-loaded', function () {
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/gs-cd/build-en.html
+++ b/docs/gs-cd/build-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Building WET - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Building WET - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Building WET - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -212,7 +212,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/gs-cd/build-fr.html
+++ b/docs/gs-cd/build-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Construire la BOEW - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Construire la BOEW - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Construire la BOEW - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -215,7 +215,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -266,7 +266,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/gs-cd/contrib-fr.html
+++ b/docs/gs-cd/contrib-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Lignes directrices pour les contributeurs - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Lignes directrices pour les contributeurs - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Lignes directrices pour les contributeurs - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -185,7 +185,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -236,7 +236,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/gs-cd/dev-en.html
+++ b/docs/gs-cd/dev-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -151,7 +151,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/gs-cd/dev-fr.html
+++ b/docs/gs-cd/dev-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Guide d'utilisation de GitHub pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Guide d'utilisation de GitHub pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Guide d'utilisation de GitHub pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -154,7 +154,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -205,7 +205,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/gs-cd/github-en.html
+++ b/docs/gs-cd/github-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Using GitHub for WET - Getting started - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Using GitHub for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Using GitHub for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -266,7 +266,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/gs-cd/github-fr.html
+++ b/docs/gs-cd/github-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Guide d'utilisation de GitHub pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Guide d'utilisation de GitHub pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Guide d'utilisation de GitHub pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -269,7 +269,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -320,7 +320,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/gs-cd/impl-en.html
+++ b/docs/gs-cd/impl-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Implementing WET - Getting started - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Implementing WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Implementing WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -316,7 +316,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/gs-cd/impl-fr.html
+++ b/docs/gs-cd/impl-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Mise en œuvre de la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Mise en œuvre de la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Mise en œuvre de la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -319,7 +319,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -370,7 +370,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/gs-cd/index-en.html
+++ b/docs/gs-cd/index-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Getting started - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -174,7 +174,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/gs-cd/index-fr.html
+++ b/docs/gs-cd/index-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -177,7 +177,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div>
 	
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -228,7 +228,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/gs-cd/opt-en.html
+++ b/docs/gs-cd/opt-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Optimize your JavaScript, CSS and HTML code - Contributor guidelines - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Optimize your JavaScript, CSS and HTML code - Contributor guidelines - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Optimize your JavaScript, CSS and HTML code - Contributor guidelines - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -232,7 +232,7 @@ console.log( ( new Date() ).getTime() - test );</code></pre>
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/gs-cd/opt-fr.html
+++ b/docs/gs-cd/opt-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Optimiser votre code JavaScript, CSS et HTML - Lignes directrices pour les contributeurs - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Optimiser votre code JavaScript, CSS et HTML - Lignes directrices pour les contributeurs - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Optimiser votre code JavaScript, CSS et HTML - Lignes directrices pour les contributeurs - Développer pour la BOEW - Comment démarrer - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -235,7 +235,7 @@ console.log( ( new Date() ).getTime() - test );</code></pre>
 </div>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -286,7 +286,7 @@ console.log( ( new Date() ).getTime() - test );</code></pre>
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/index-en.html
+++ b/docs/index-en.html
@@ -11,11 +11,11 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="Web Experience Toolkit (WET) working examples." />
-<meta name="dcterms.creator" content="Government of Canada, Treasury Board of Canada Secretariat, Chief Information Officer Branch, IT Project Review and Oversight, Web Standards Office" />
-<meta name="dcterms.title" content="Web Experience Toolkit (WET)" />
+<meta name="description" content="Documentation for the Web Experience Toolkit." />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Documentation - Web Experience Toolkit (WET)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
-<meta name="dcterms.modified" title="W3CDTF" content="2013-05-16" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
 <meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -128,8 +128,16 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 	</ul>
 </section>
 
+<section>
+	<h2 id="comms">Communications material</h2>
+	<ul>
+		<li><a href="ref/promo-en.html">Promotional material</a></li>
+		<li><a href="ref/accolades-en.html">Articles, blogs, videos and implementations of WET</a></li>
+	</ul>
+</section>
+
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/ref/accolades-en.html
+++ b/docs/ref/accolades-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Accolades - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Accolades - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Accolades - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -378,7 +378,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/ref/accolades-fr.html
+++ b/docs/ref/accolades-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Distinctions - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Distinctions - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Distinctions - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -377,7 +377,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 	
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -428,7 +428,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/arb-rra/arb-rra-fr.html
+++ b/docs/ref/arb-rra/arb-rra-fr.html
@@ -214,7 +214,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/archived/archived-fr.html
+++ b/docs/ref/archived/archived-fr.html
@@ -295,7 +295,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/charts/charts-fr.html
+++ b/docs/ref/charts/charts-fr.html
@@ -379,7 +379,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/core-en.html
+++ b/docs/ref/core-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Core framework - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Core framework - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Core framework - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -200,7 +200,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/ref/core-fr.html
+++ b/docs/ref/core-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Cadre fondamental - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Cadre fondamental - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Cadre fondamental - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -203,7 +203,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div>
 	
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -254,7 +254,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/datalist/datalist-fr.html
+++ b/docs/ref/datalist/datalist-fr.html
@@ -262,7 +262,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/datepicker/datepicker-fr.html
+++ b/docs/ref/datepicker/datepicker-fr.html
@@ -251,7 +251,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/details/details-fr.html
+++ b/docs/ref/details/details-fr.html
@@ -253,7 +253,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/docstmpl-en.html
+++ b/docs/ref/docstmpl-en.html
@@ -11,11 +11,11 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Documentation example template - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="Web Experience Toolkit (WET) working examples." />
-<meta name="dcterms.creator" content="Government of Canada, Treasury Board of Canada Secretariat, Chief Information Officer Branch, IT Project Review and Oversight, Web Standards Office" />
-<meta name="dcterms.title" content="Web Experience Toolkit (WET)" />
+<meta name="description" content="Example template for Web Experience Toolkit (WET) documentation." />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Documentation example template - Documentation - Web Experience Toolkit (WET)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
-<meta name="dcterms.modified" title="W3CDTF" content="2013-05-16" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
 <meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -199,7 +199,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/ref/docstmpl-fr.html
+++ b/docs/ref/docstmpl-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Modèle de documentation - Documentation - Boîte à outils de l’expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="Exemple pratiques de la Boîte à outils de l’expérience Web (BOEW)." />
-<meta name="dcterms.creator" content="Gouvernement du Canada, Secrétariat du Conseil du Trésor du Canada, Direction du dirigeant principal de l'information, Division de l'examen et de la supervision de projets de TI, Bureau des normes Web" />
-<meta name="dcterms.title" content="Exemples pratiques - Boîte à outils de l’expérience Web (BOEW)" />
-<meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
-<meta name="dcterms.modified" title="W3CDTF" content="2013-05-16" />
-<meta name="dcterms.subject" title="scheme" content="Internet;Normes;Conception" />
+<meta name="description" content="Modèle de documentation pour la Boîte à outils de l’expérience Web (BOEW)." />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Modèle de documentation - Documentation - Boîte à outils de l’expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -198,7 +198,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -243,7 +243,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/mathlib/mathlib-fr.html
+++ b/docs/ref/mathlib/mathlib-fr.html
@@ -202,7 +202,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/other-en.html
+++ b/docs/ref/other-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Other components - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Other components - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Other components - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -107,7 +107,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </ul>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/ref/other-fr.html
+++ b/docs/ref/other-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Autres composants - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Autres composants - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Autres composants - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -106,7 +106,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </ul>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -157,7 +157,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/plugins-en.html
+++ b/docs/ref/plugins-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Plugins - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Plugins - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Plugins - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -122,7 +122,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </ul>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/ref/plugins-fr.html
+++ b/docs/ref/plugins-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Plugiciels - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Plugiciels - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Plugiciels - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -121,7 +121,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </ul>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -172,7 +172,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/polyfills-en.html
+++ b/docs/ref/polyfills-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Polyfills - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Polyfills - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Polyfills - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -112,7 +112,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </ul>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/ref/polyfills-fr.html
+++ b/docs/ref/polyfills-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Correctifs - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Correctifs - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Correctifs - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -111,7 +111,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </ul>
 	
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -162,7 +162,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/promo-en.html
+++ b/docs/ref/promo-en.html
@@ -8,12 +8,12 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<title>Contributor guidelines - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)</title>
+<title>Promotional material - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="Contributor guidelines - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="description" content="Material for promoting the Web Experience Toolkit (WET)" />
 <meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
-<meta name="dcterms.title" content="Contributor guidelines - Developing for WET - Getting started - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.title" content="Promotional material - Documentation - Web Experience Toolkit (WET)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
 <meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
 <meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
@@ -54,7 +54,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.ca/en/index.html">Canada.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.canada.ca/en/services/index.html">Services</a></li>
 <li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.ca/en/gov/dept/index.html">Departments</a></li>
-<li id="gcwu-gcnb-lang"><a href="contrib-fr.html" lang="fr">Français</a></li>
+<li id="gcwu-gcnb-lang"><a href="promo-fr.html" lang="fr">Français</a></li>
 </ul>
 </div></div></div></nav>
 
@@ -87,9 +87,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ol>
 <li><a href="../../index-en.html">Home</a></li>
 <li><a href="../index-en.html">Documentation</a></li>
-<li><a href="index-en.html">Getting started</a></li>
-<li><a href="dev-en.html">Developing for WET</a></li>
-<li>Contributor guidelines</li>
+<li>Promotional material</li>
 </ol>
 </div></div>
 </nav>
@@ -99,93 +97,50 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Contributor guidelines</h1>
+<h1 id="wb-cont">Promotional material</h1>
+
+<p>Use the material on this page when promoting the Web Experience Toolkit. Unless otherwise noted, all the material on this page is available under the same <a href="../../License-en.html">terms and conditions</a> as the Web Experience Toolkit.</p>
+
+<p>If you develop additional promotional material, please share it on this page for others to use.</p>
 
 <section>
-	<h2 id="prob">Filing a bug or an issue</h2>
+	<h2>Swag</h2>
+
+	<section>
+		<h3>Make or buy a tshirt!</h3>
+		<ul>
+			<li><a href="http://www.cafepress.com/cp/customize/product2.aspx?number=845431608">Sample Men's tshirt on CafePress</a></li>
+			<li><a href="http://www.cafepress.com/cp/customize/product2.aspx?number=845440330">Sample Women's tshirt on CafePress</a></li>
+		</ul>
+	</section>
+</section>
+
+<section>
+	<h2>Logo</h2>
+	<figure>
+		<img src="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET_Logo.png" width="200" alt="Logo for the Web Experience Toolkit" />
+		<figcaption>Logo for the Web Experience Toolkit</figcaption>
+	</figure>
+	<p>Available in:</p>
 	<ul>
-		<li>What version of WET is the affected experienced in (v3.0.0, v3.0.1, etc)? If it is not the latest stable version, does to the latest version resolve the issue?</li>
-		<li>What browser was the bug found in? (IE8, FireFox 18, Chrome 24, or a combination of browsers)</li>
-		<li>A link to a page that can be used to reproduce the issue (demo or public URL). If a public page cannot be provided, a picture should be attached showing the issue (use GitHub's <a href="https://github.com/blog/1347-issue-attachments">issue attachment feature</a>)</li>
-		<li>Post in the issue space for the WET variant in which the bug was found. If it applies to the project itself, <a href="https://github.com/wet-boew/wet-boew/issues?state=open">post an issue in the WET-BOEW repository</a>.</li>
-		<li>Review the issues to see if someone's already filed it by filtering the categories listed on the left or using the search box.</li>
-		<li>Post your issue.</li>
+		<li><a href="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET_Logo.png">PNG format</a></li>
+		<li><a href="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET%20Logo%20-%20Full%20Bleed.svg">SVG format - Full Bleed</a></li>
+		<li><a href="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET%20Logo%20-%20Safe%20Area.svg">SVG format - Safe Area</a></li>
 	</ul>
 </section>
 
 <section>
-	<h2 id="pr">Creating a pull request</h2>
-	<p>Pull requests are welcome. Please make sure your changes are to the latest code and limit the commit range to just the files you intended to change (to avoid conflicts).</p>
+	<h2>Poster</h2>
+	<figure>
+		<img src="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET_Poster_Preview_English.png" width="300" alt="English poster for the Web Experience Toolkit" />&#160;
+		<img src="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET_Poster_Preview_French.png" width="300" alt="French poster for the Web Experience Toolkit" />
+		<figcaption>English and French posters for the Web Experience Toolkit</figcaption>
+	</figure>
+	<p>Available in:</p>
 	<ul>
-		<li>To cut down on commit pollution in the main code base consider <a rel="external" href="http://git-scm.com/book/en/Git-Branching-Rebasing">rebasing</a> your commits before you create a pull request to the main branch.</li>
+		<li><a href="https://github.com/wet-boew/wet-boew-attachments/raw/master/Promo/WET_Poster_English.pdf">English PDF format</a></li>
+		<li><a href="https://github.com/wet-boew/wet-boew-attachments/raw/master/Promo/WET_Poster_French.pdf">French PDF format</a></li>
 	</ul>
-
-	<section>
-		<h3>New components</h3>
-		<p>Should be added in a feature-* branch (e.g., feature-lightbox) that is created off of the master branch.</p>
-		<ul>
-			<li>Create the a fresh branch off master by using:
-				<ul>
-					<li><code>git fetch upstream</code></li>
-					<li><code>git checkout upstream/master</code></li>
-					<li><code>git checkout -b my-cool-new-feature</code></li>
-				</ul>
-			</li>
-			<li>Licensing for all new components and supporting code must be compatible with the MIT license used by WET.</li>
-			<li>New plugins should use the same structure and formatas existing plugins.</li>
-			<li>Include the WET terms and conditions comment block in all text-based source files that fall under Crown Copyright.</li>
-		</ul>
-	</section>
-
-	<section>
-		<h3>Bug fixes and patches that apply to all versions</h3>
-		<p>Should be submitted to the v3.0 branch.</p>
-		<ul>
-			<li>Create a fresh branch off of v3.0 by using:
-				<ul>
-					<li><code>git fetch upstream</code></li>
-					<li><code>git checkout upstream/v3.0</code></li>
-					<li><code>git checkout -b my-patch-description</code></li>
-				</ul>
-			</li>
-		</ul>
-	</section>
-
-	<section>
-		<h3 id="test">Testing your PR before submitting</h3>
-		<ul>
-			<li>
-				<a rel="external" href="http://validator.w3.org/nu/">Validate your HTML markup</a>. Markup should be well-formed HTML5.
-				<ul>
-					<li>To test for well-formed markup, validate with an XHTML5 preset and a checkmark next to "Be lax about HTTP Content-Type".</li>
-				</ul>
-			</li>
-			<li>
-				<a rel="external" href="http://jigsaw.w3.org/css-validator/#validate_by_uri+with_options">Validate your CSS</a> with the following changes to the default settings:
-				 <ul>
-					<li><strong>Profile:</strong> CSS level 3</li>
-					<li><strong>Vendor extensions:</strong> Warnings</li>
-				</ul>
-			</li>
-			<li><a rel="external" href="http://www.jshint.com">Validate your JavaScript code</a></li>
-			<li><a href="opt-en.html">Optimize your JavaScript, CSS and HTML code</a></li>
-			<li>Formatting recommendations:
-				<ul>
-					<li>Indent with tabs using the <a rel="external" href="http://en.wikipedia.org/wiki/Indent_style#K.26R_style">K&amp;R indenting style</a></li>
-					<li>Use single quotes for strings in JavaScript (so unescaped double quotes can be used for attributes in HTML output)</li>
-				</ul>
-			</li>
-			<li>
-				Test Web pages against the following browser test baseline:
-				<ul>
-					<li>The current and previous major version of each browser that accounts for at least 5 per cent of visits to the website;</li>
-					<li>Any major version of a browser that, on its own, accounts for at least 5 per cent of visits to the website; and</li>
-					<li>The current and previous versions of the default browsers of each mobile operating systems that accounts for at least 5 per cent of the global or Canadian mobile operating system market share.</li>
-				</ul>
-			</li>
-			<li>PR testing is done by <a rel="external" href="https://travis-ci.org/wet-boew/wet-boew">Travis-CI</a>, but the same set of tests can be run using "ant test" locally before you submit</li>
-		</ul>
-	</section>
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">

--- a/docs/ref/promo-fr.html
+++ b/docs/ref/promo-fr.html
@@ -8,15 +8,15 @@
 <meta charset="utf-8" />
 <!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
 wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<title>Sélecteur de langue (JavaScript + PHP) - Exemples pratiques - Boîte à outils de l'expérience Web (BOEW)</title>
+<title>Matériel promotionnel - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Matériel de promotion de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Project de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Matériel promotionnel - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -34,7 +34,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <!--<![endif]-->
 <noscript><link rel="stylesheet" href="../../dist/theme-gcwu-fegc/css/theme-ns-min.css" /></noscript>
 
-<!-- CustomScriptsCSSStart -->
+<!-- CustomScriptsCSSStart --> 
 <!-- CustomScriptsCSSEnd -->
 </head>
 
@@ -51,10 +51,10 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <nav role="navigation"><div id="gcwu-gcnb"><h2>Barre de navigation du gouvernement du Canada</h2><div id="gcwu-gcnb-in"><div id="gcwu-gcnb-fip">
 <div id="gcwu-sig"><div id="gcwu-sig-in"><div id="gcwu-sig-fra" title="Gouvernement du Canada"><img src="../../dist/theme-gcwu-fegc/images/sig-fr.gif" width="214" height="20" alt="Gouvernement du Canada" /></div></div></div>
 <ul>
-<li id="gcwu-gcnb1"><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></li>
+<li id="gcwu-gcnb1"><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></li>
 <li id="gcwu-gcnb2"><a rel="external" href="http://www.canada.ca/fr/services/index.html">Services</a></li>
-<li id="gcwu-gcnb3"><a rel="external" href="http://www.Canada.ca/depts/major/depind-fra.html">Ministères</a></li>
-<li id="gcwu-gcnb-lang"><a class="wet-boew-langselect" href="langselect/lang.php" lang="en">English</a></li>
+<li id="gcwu-gcnb3"><a rel="external" href="http://www.canada.ca/fr/gouv/min/index.html">Ministères</a></li>
+<li id="gcwu-gcnb-lang"><a href="promo-en.html" lang="en">English</a></li>
 </ul>
 </div></div></div></nav>
 
@@ -64,7 +64,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 
 <section role="search"><div id="gcwu-srchbx"><h2>Recherche</h2>
 <form action="#" method="post"><div id="gcwu-srchbx-in">
-<label for="gcwu-srch">Recherchez le site Web</label><input id="gcwu-srch" name="gcwu-srch" type="text" value="" size="27" maxlength="150" />
+<label for="gcwu-srch">Recherchez le site Web</label><input id="gcwu-srch" name="gcwu-srch" type="search" value="" size="27" maxlength="150" />
 <input id="gcwu-srch-submit" name="gcwu-srch-submit" type="submit" value="Recherche" data-icon="search" />
 </div></form>
 </div></section>
@@ -72,7 +72,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 
 <nav role="navigation">
 <div id="gcwu-psnb"><h2>Menu<span> du site</span></h2><div id="gcwu-psnb-in"><div class="wet-boew-menubar mb-mega"><div>
-<ul class="mb-menu" data-ajax-replace="../includes/menu-fr.txt">
+<ul class="mb-menu" data-ajax-replace="../../demos/includes/menu-fr.txt">
 <li><div><a href="http://wet-boew.github.io/wet-boew/index-fr.html">Projet de la BOEW</a></div></li>
 <li><div><a href="section2/index-fr.html">Section 2</a></div></li>
 <li><div><a href="#">Section 3</a></div></li>
@@ -86,8 +86,8 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="gcwu-bc"><h2>Fil d'Ariane</h2><div id="gcwu-bc-in">
 <ol>
 <li><a href="../../index-fr.html">Accueil</a></li>
-<li><a href="../index-fr.html">Exemples pratiques</a></li>
-<li>Sélecteur de langue (JavaScript + PHP)</li>
+<li><a href="../index-fr.html">Documentation</a></li>
+<li>Matériel promotionnel</li>
 </ol></div></div>
 </nav>
 <!-- HeaderEnd -->
@@ -96,100 +96,54 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <div id="wb-core"><div id="wb-core-in" class="equalize">
 <div id="wb-main" role="main"><div id="wb-main-in">
 <!-- MainContentStart -->
-<h1 id="wb-cont">Sélecteur de langue (JavaScript + PHP)</h1>
+<h1 id="wb-cont">Matériel promotionnel</h1>
 
-<ul class="button-group">
-<li><a href="https://github.com/wet-boew/wet-boew/wiki/S%C3%A9lecteur-de-langue" class="button">Documentation</a></li>
-<li><a href="https://github.com/wet-boew/wet-boew/issues/new" class="button">Questions ou commentaires?</a></li>
-</ul>
+<p>ervez-vous du matériel disponible sur cette page lorsque vous faite la promotion de la Boîte à outils de l'expérience Web. Sauf indication contraire, tout le matériel sur cette page est disponible sous les mêmes conditions <a href="../../Licence-fr.html">conditions</a> que celles de la Boîte à outils de l'expérience Web.</p>
 
-<section><h2>En-tête 2 (<code>h2</code>) - apparence par défaut</h2>
-	<section><h3>En-tête 3 (<code>h3</code>) - apparence par défaut</h3>
-		<section><h4>En-tête 4 (<code>h4</code>) - apparence par défaut</h4>
-			<section><h5>En-tête 5 (<code>h5</code>) - apparence par défaut</h5>
-				<section><h6>En-tête 6 (<code>h6</code>) - apparence par défaut</h6>
-					<p>Paragraphe - apparence par défaut</p>
-				</section>
-			</section>
-		</section>
-	</section>
-</section>	
-								
-<p><a href="#">Lien - apparence par défaut</a></p>
-<p><a href="mailto:"><code>mailto:</code> lien - apparence par défaut</a></p>
-<p><a href="http://www." rel="external">Tiers <code>http://www.</code> lien - apparence par défaut</a></p>
-<p><a href=".doc">Lien aux téléchargements des fichiers fondés sur le type de fichier <code>.doc</code>, <code>.psd</code>, <code>.zip</code>, <code>.pdf</code>, <code>.xls</code>, <code>.xlt</code>, <code>.rtf</code> et <code>.txt</code> - apparence par défaut</a></p>
-<p>Abréviation - apparence par défaut: <abbr title="Secrétariat du Conseil de Trésor">SCT</abbr>.</p>
+<p>Si vous développez du matériel promotionnel additionnel, veuillez le partager sur cette page pour que d'autres puissent s'en servir.</p>
 
-<ul>
-<li>liste à puces (<code>ul</code>) premier niveau - apparence par défaut
-	<ul>
-	<li>liste à puces (<code>ul</code>) deuxième niveau - apparence par défaut
+<section>
+	<h2>Marchandise</h2>
+
+	<section>
+		<h3>Faire ou acheter un t-shirt! </h3>
 		<ul>
-		<li>liste à puces (<code>ul</code>) troisième niveau - apparence par défaut</li>
+			<li><a href="http://www.cafepress.com/cp/customize/product2.aspx?number=845431608">Exemple d'un t-shirt d'homme sur CafePress (anglais seulement)</a></li>
+			<li><a href="http://www.cafepress.com/cp/customize/product2.aspx?number=845440330">Exemple d'un t-shirt de femme sur CafePress (anglais seulement)</a></li>
 		</ul>
-	</li>
+	</section>
+</section>
+
+<section>
+	<h2>Logo</h2>
+	<figure>
+		<img src="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET_Logo.png" width="200" alt="Logo for the Web Experience Toolkit" />
+		<figcaption>Logo for the Web Experience Toolkit</figcaption>
+	</figure>
+	<p>Disponible en :</p>
+	<ul>
+		<li><a href="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET_Logo.png">Format PNG</a></li>
+		<li><a href="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET%20Logo%20-%20Full%20Bleed.svg">Format SVG - <span lang="en">«&#160;Full Bleed&#160;»</span></a></li>
+		<li><a href="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET%20Logo%20-%20Safe%20Area.svg">Format SVG - <span lang="en">«&#160;Safe Area&#160;»</span></a></li>
 	</ul>
-</li>
-</ul>
+</section>
 
-<ol>
-<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
-<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
-	<ol>
-	<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
-	<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
-		<ol>
-		<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
-		<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
-		</ol>
-	</li>
-	</ol>
-</li>
-</ol>
-
-<table>
-<caption>Légende de table - apparence par défaut</caption>
-<thead>
-<tr>
-<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
-<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Données de table (<code>td</code>) - apparence par défaut</td>
-<td>Données de table (<code>td</code>) - apparence par défaut</td>
-</tr>
-</tbody>
-</table>
-
-<form action="#" method="post">
-<div><label for="data1">Formulaire - Entrée - apparence par défaut&#160;:</label> <input name="data1" type="text" id="data1" /></div>
-<div><label for="data2">Formulaire - Zone texte - apparence par défaut&#160;:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea></div>
-<div><label for="data4">Formulaire - Sélection - apparence par défaut&#160;:</label> 
-<select id="data4" name="data4">
-<option value="Option 1">Option 1</option>
-<option value="Option 2">Option 2</option>
-<option value="Option 3">Option 3</option>
-<option value="Option 4">Option 4</option>
-</select></div>
-<fieldset><legend>Formulaire - <code lang="en">legend</code>, <code lang="en">fieldset</code> et case à cocher - apparence par défaut</legend>
-<div><input name="checkbox" type="checkbox" id="data5" value="checkbox" />&#160;<label for="data5">Option 1</label>&#160;&#160;
-<input name="checkbox" type="checkbox" id="data6" value="checkbox" />&#160;<label for="data6">Option 2</label>&#160;&#160;
-<input name="checkbox" type="checkbox" id="data7" value="checkbox" />&#160;<label for="data7">Option 3</label>&#160;&#160;
-<input name="checkbox" type="checkbox" id="data8" value="checkbox" />&#160;<label for="data8">Option 4</label></div>
-</fieldset>
-<div><input name="submit" type="submit" id="submit" value="Soumettre - apparence par défaut" />
-<input name="reset" type="reset" id="reset" value="Réinitialiser - apparence par défaut" /></div>
-</form>
-
-<blockquote>
-<p>&quot;Blockquote - apparence par défaut&quot;.</p>
-</blockquote>
-
+<section>
+	<h2>Poster</h2>
+	<figure>
+		<img src="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET_Poster_Preview_English.png" width="300" alt="Poster en anglais pour la Boîte à outils de l'expérience Web" />&#160;
+		<img src="https://raw.github.com/wet-boew/wet-boew-attachments/master/Promo/WET_Poster_Preview_French.png" width="300" alt="Poster en français pour la Boîte à outils de l'expérience Web" />
+		<figcaption>Posters en anglais et en français pour la Boîte à outils de l'expérience Web</figcaption>
+	</figure>
+	<p>Disponible en :</p>
+	<ul>
+		<li><a href="https://github.com/wet-boew/wet-boew-attachments/raw/master/Promo/WET_Poster_English.pdf">anglais, en format PDF</a></li>
+		<li><a href="https://github.com/wet-boew/wet-boew-attachments/raw/master/Promo/WET_Poster_French.pdf">français, en format PDF</a></li>
+	</ul>
+</section>
+	
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-04-11</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -243,7 +197,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
-<li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.Canada.ca/accueil.html">Canada.ca</a></div></li>
+<li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>
 </ul>
 </div></div></div></nav>
 <!-- FooterEnd -->
@@ -255,6 +209,5 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <script src="../../dist/js/settings.js"></script>
 <script src="../../dist/js/pe-ap-min.js"></script>
 <!-- ScriptsEnd -->
-
 </body>
 </html>

--- a/docs/ref/sessiontimeout/sessiontimeout-fr.html
+++ b/docs/ref/sessiontimeout/sessiontimeout-fr.html
@@ -242,7 +242,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/themesstyle-en.html
+++ b/docs/ref/themesstyle-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Themes and style - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Themes and style - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Themes and style - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -116,7 +116,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/ref/themesstyle-fr.html
+++ b/docs/ref/themesstyle-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Thèmes et style - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Thèmes et style - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Thèmes et style - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -115,7 +115,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -166,7 +166,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/variants-en.html
+++ b/docs/ref/variants-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Variants - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Variants - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Variants - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -108,7 +108,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </ul>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/ref/variants-fr.html
+++ b/docs/ref/variants-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Variants - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Variants - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Variants - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -107,7 +107,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </ul>
 	
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -158,7 +158,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/ref/webstorage/localstorage-fr.html
+++ b/docs/ref/webstorage/localstorage-fr.html
@@ -214,7 +214,7 @@ localStorage.setItem('variable', value);</code></pre>
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/versions/dwnld-en.html
+++ b/docs/versions/dwnld-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Downloads - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Downloads - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Downloads - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -347,7 +347,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/versions/dwnld-fr.html
+++ b/docs/versions/dwnld-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Téléchargements - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Téléchargements - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Téléchargements - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -346,7 +346,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 	
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -397,7 +397,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/versions/index-en.html
+++ b/docs/versions/index-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Version history - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Version history - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Version history - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -279,7 +279,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/versions/index-fr.html
+++ b/docs/versions/index-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Historique des versions - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Historique des versions - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Historique des versions - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -278,7 +278,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 	
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -329,7 +329,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/versions/rdmp-en.html
+++ b/docs/versions/rdmp-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Roadmap - Version history - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Roadmap - Version history - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Roadmap - Version history - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -316,7 +316,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/versions/rdmp-fr.html
+++ b/docs/versions/rdmp-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Feuille de route - Historique des versions - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Feuille de route - Historique des versions - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Feuille de route - Historique des versions - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -315,7 +315,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 	
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -366,7 +366,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/versions/v3.0/changes2.3-3.0-en.html
+++ b/docs/versions/v3.0/changes2.3-3.0-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Changes to class and id names from v2.3 to v3.0 - Version history - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Changes to class and id names from v2.3 to v3.0 - Version history - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Changes to class and id names from v2.3 to v3.0 - Version history - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -574,7 +574,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-06-20</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/versions/v3.0/changes2.3-3.0-fr.html
+++ b/docs/versions/v3.0/changes2.3-3.0-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Changements aux noms de class et id de la version 2.3 à la version 3.0 - Historique - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Changements aux noms de class et id de la version 2.3 à la version 3.0 - Historique - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Changements aux noms de class et id de la version 2.3 à la version 3.0 - Historique - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -573,7 +573,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-06-20</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -624,7 +624,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/docs/versions/version-info-en.html
+++ b/docs/versions/version-info-en.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Versioning - Version history - Documentation - Web Experience Toolkit (WET)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="English description / Description en anglais" />
-<meta name="dcterms.creator" content="English name of the content author / Nom en anglais de l'auteur du contenu" />
-<meta name="dcterms.title" content="English title / Titre en anglais" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="English subject terms / Termes de sujet en anglais" />
+<meta name="description" content="Versioning - Version history - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.title" content="Versioning - Version history - Documentation - Web Experience Toolkit (WET)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -165,7 +165,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/docs/versions/version-info-fr.html
+++ b/docs/versions/version-info-fr.html
@@ -11,12 +11,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <title>Contrôle des versions - Historique des versions - Documentation - Boîte à outils de l'expérience Web (BOEW)</title>
 
 <link rel="shortcut icon" href="../../dist/theme-gcwu-fegc/images/favicon.ico" />
-<meta name="description" content="French description / Description en français" />
-<meta name="dcterms.creator" content="French name of the content author / Nom en français de l'auteur du contenu" />
-<meta name="dcterms.title" content="French title / Titre en français" />
-<meta name="dcterms.issued" title="W3CDTF" content="Date published (YYYY-MM-DD) / Date de publication (AAAA-MM-JJ)" />
-<meta name="dcterms.modified" title="W3CDTF" content="Date modified (YYYY-MM-DD) / Date de modification (AAAA-MM-JJ)" />
-<meta name="dcterms.subject" title="scheme" content="French subject terms / Termes de sujet en français" />
+<meta name="description" content="Contrôle des versions - Historique des versions - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.title" content="Contrôle des versions - Historique des versions - Documentation - Boîte à outils de l'expérience Web (BOEW)" />
+<meta name="dcterms.issued" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -167,7 +167,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </div>
 	
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-09-01</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -218,7 +218,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/index-eng.html
+++ b/index-eng.html
@@ -13,10 +13,10 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <link rel="shortcut icon" href="dist/theme-gcwu-fegc/images/favicon.ico" />
 <link rel="canonical" href="index-en.html" />
 <meta name="description" content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities." />
-<meta name="dcterms.creator" content="Government of Canada, Treasury Board of Canada Secretariat, Chief Information Officer Branch, IT Project Review and Oversight, Web Standards Office" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
 <meta name="dcterms.title" content="Web Experience Toolkit (WET)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
-<meta name="dcterms.modified" title="W3CDTF" content="2013-12-16" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
 <meta name="dcterms.subject" title="gccore" content="Internet;Standards;Design" />
 <meta name="dcterms.language" title="ISO639-2" content="eng" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -116,11 +116,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <li><a href="docs/index-en.html">Documentation</a></li>
 <li><a href="docs/versions/dwnld-en.html">Downloads</a></li>
 <li><a href="https://github.com/wet-boew/wet-boew/">Main project</a></li>
-<li><a href="http://wet-boew.github.io/wet-boew/License-en.html">Terms and conditions</a></li>
+<li><a href="License-en.html">Terms and conditions</a></li>
 <li><a href="docs/gs-cd/contrib-en.html">Contributor guidelines</a></li>
 <li><a href="docs/versions/version-info-en.html">Versioning</a></li>
 <li><a href="docs/versions/index-en.html">Version history</a></li>
 <li><a href="docs/versions/rdmp-en.html">Roadmap</a></li>
+<li><a href="docs/index-en.html#comms">Communications material</a></li>
 </ul>
 </section>
 
@@ -200,7 +201,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date modified:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date modified:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->

--- a/index-fr.html
+++ b/index-fr.html
@@ -12,10 +12,10 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 
 <link rel="shortcut icon" href="dist/theme-gcwu-fegc/images/favicon.ico" />
 <meta name="description" content="La Boîte à outils de l’expérience Web (BOEW) rassemble différents composants réutilisables et prêts-à-utiliser pour la conception et la mise à jour de sites Web innovateurs qui sont à la fois accessibles, conviviaux et interopérables. Tous ces composants réutilisables sont des logiciels libres mis à la disposition des ministères et des collectivités Web externes." />
-<meta name="dcterms.creator" content="Gouvernement du Canada, Secrétariat du Conseil du Trésor du Canada, Direction du dirigeant principal de l'information, Division de l'examen et de la supervision de projets de TI, Bureau des normes Web" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
 <meta name="dcterms.title" content="Boîte à outils de l’expérience Web (BOEW)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
-<meta name="dcterms.modified" title="W3CDTF" content="2013-12-16" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
 <meta name="dcterms.subject" title="scheme" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -115,11 +115,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <li><a href="docs/index-fr.html">Documentation</a></li>
 <li><a href="docs/versions/dwnld-fr.html">Téléchargements</a></li>
 <li><a href="https://github.com/wet-boew/wet-boew/">Projet principal</a></li>
-<li><a href="http://wet-boew.github.io/wet-boew/Licence-fr.html">Conditions régissant l'utilisation</a></li>
+<li><a href="Licence-fr.html">Conditions régissant l'utilisation</a></li>
 <li><a href="docs/gs-cd/contrib-fr.html">Lignes directrices pour les contributeurs</a></li>
 <li><a href="docs/versions/version-info-fr.html">Contrôle des versions</a></li>
 <li><a href="docs/versions/index-fr.html">Historique des versions</a></li>
 <li><a href="docs/versions/rdmp-fr.html">Feuille de route</a></li>
+<li><a href="docs/index-fr.html#comms">Matériel de communications</a></li>
 </ul>
 </section>
 
@@ -200,7 +201,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -245,7 +246,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/index-fra.html
+++ b/index-fra.html
@@ -13,11 +13,11 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <link rel="shortcut icon" href="dist/theme-gcwu-fegc/images/favicon.ico" />
 <link rel="canonical" href="index-fr.html" />
 <meta name="description" content="La Boîte à outils de l’expérience Web (BOEW) rassemble différents composants réutilisables et prêts-à-utiliser pour la conception et la mise à jour de sites Web innovateurs qui sont à la fois accessibles, conviviaux et interopérables. Tous ces composants réutilisables sont des logiciels libres mis à la disposition des ministères et des collectivités Web externes." />
-<meta name="dcterms.creator" content="Gouvernement du Canada, Secrétariat du Conseil du Trésor du Canada, Direction du dirigeant principal de l'information, Division de l'examen et de la supervision de projets de TI, Bureau des normes Web" />
+<meta name="dcterms.creator" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
 <meta name="dcterms.title" content="Boîte à outils de l’expérience Web (BOEW)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />
-<meta name="dcterms.modified" title="W3CDTF" content="2013-12-16" />
-<meta name="dcterms.subject" title="scheme" content="Internet;Normes;Conception" />
+<meta name="dcterms.modified" title="W3CDTF" content="2014-01-21" />
+<meta name="dcterms.subject" title="gccore" content="Internet;Normes;Conception" />
 <meta name="dcterms.language" title="ISO639-2" content="fra" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 
@@ -116,11 +116,12 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <li><a href="docs/index-fr.html">Documentation</a></li>
 <li><a href="docs/versions/dwnld-fr.html">Téléchargements</a></li>
 <li><a href="https://github.com/wet-boew/wet-boew/">Projet principal</a></li>
-<li><a href="http://wet-boew.github.io/wet-boew/Licence-fr.html">Conditions régissant l'utilisation</a></li>
+<li><a href="Licence-fr.html">Conditions régissant l'utilisation</a></li>
 <li><a href="docs/gs-cd/contrib-fr.html">Lignes directrices pour les contributeurs</a></li>
 <li><a href="docs/versions/version-info-fr.html">Contrôle des versions</a></li>
 <li><a href="docs/versions/index-fr.html">Historique des versions</a></li>
 <li><a href="docs/versions/rdmp-fr.html">Feuille de route</a></li>
+<li><a href="docs/index-fr.html#comms">Matériel de communications</a></li>
 </ul>
 </section>
 
@@ -201,7 +202,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 </section>
 
 <dl id="gcwu-date-mod" role="contentinfo">
-<dt>Date de modification&#160;:</dt><dd><span><time>2013-12-16</time></span></dd>
+<dt>Date de modification&#160;:</dt><dd><span><time>2014-01-21</time></span></dd>
 </dl>
 <div class="clear"></div>
 <!-- MainContentEnd -->
@@ -246,7 +247,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <ul>
 <li><a rel="external" href="http://canadiensensante.gc.ca/index-fra.php"><span>Santé</span><br />canadiensensante.gc.ca</a></li>
 <li><a rel="external" href="http://www.voyage.gc.ca/index-fra.asp"><span>Voyage</span><br />voyage.gc.ca</a></li>
-<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca
+<li><a rel="external" href="http://www.servicecanada.gc.ca/fra/accueil.shtml"><span>Service Canada</span><br />servicecanada.gc.ca</a></li>
 <li><a rel="external" href="http://www.guichetemplois.gc.ca/Intro-fra.aspx"><span>Emplois</span><br />guichetemplois.gc.ca</a></li>
 <li><a rel="external" href="http://plandaction.gc.ca/fr"><span>Économie</span><br />plandaction.gc.ca</a></li>
 <li id="gcwu-gcft-ca"><div><a rel="external" href="http://www.canada.ca/fr/index.html">Canada.ca</a></div></li>

--- a/index.html
+++ b/index.html
@@ -13,8 +13,8 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <link rel="shortcut icon" href="dist/theme-gcwu-fegc/images/favicon.ico" />
 <meta name="description" content="Web Experience Toolkit (WET) includes reusable components for building and maintaining innovative Web sites that are accessible, usable, and interoperable. These reusable components are open source software and free for use by departments and external Web communities." />
 <meta name="description" lang="fr" content="La Boîte à outils de l’expérience Web (BOEW) rassemble différents composants réutilisables et prêts-à-utiliser pour la conception et la mise à jour de sites Web innovateurs qui sont à la fois accessibles, conviviaux et interopérables. Tous ces composants réutilisables sont des logiciels libres mis à la disposition des ministères et des collectivités Web externes." />
-<meta name="dcterms.creator" content="Government of Canada, Treasury Board of Canada Secretariat, Chief Information Officer Branch, IT Project Review and Oversight, Web Standards Office" />
-<meta name="dcterms.creator" lang="fr" content="Gouvernement du Canada, Secrétariat du Conseil du Trésor du Canada, Direction du dirigeant principal de l'information, Division de l'examen et de la supervision de projets de TI, Bureau des normes Web" />
+<meta name="dcterms.creator" content="Web Experience Toolkit (WET) project" />
+<meta name="dcterms.creator" lang="fr" content="Projet de la Boîte à outils de l'expérience Web (BOEW)" />
 <meta name="dcterms.title" content="Web Experience Toolkit (WET)" />
 <meta name="dcterms.title" lang="fr" content="Boîte à outils de l'expérience Web (BOEW)" />
 <meta name="dcterms.issued" title="W3CDTF" content="2012-05-11" />


### PR DESCRIPTION
Also added License HTML files at the same time because it was causing a lot of synchronization headaches (and promotional material was referencing them).
