### PR TITLE
Docs: remove DataTables from external plugins used in 3.0

### DIFF
--- a/docs/ref/external-en.html
+++ b/docs/ref/external-en.html
@@ -125,7 +125,6 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 		<li><a href="https://github.com/jquery/jquery-mobile">jQuery Mobile</a></li>
 		<li><a href="https://github.com/kbwood/bookmark">jQuery Bookmark</a></li>
 		<li><a href="https://github.com/jackmoore/colorbox">Colorbox</a></li>
-		<li><a href="https://github.com/DataTables/DataTables">DataTables</a></li>
 		<li><a href="https://github.com/JangoSteve/jQuery-EasyTabs">jQuery EasyTabs</a></li>
 		<li><a href="https://github.com/filamentgroup/jQuery-Equal-Heights">jQuery Equal Heights</a></li>
 		<li><a href="http://excanvas.sourceforge.net/">ExplorerCanvas</a></li>

--- a/docs/ref/external-fr.html
+++ b/docs/ref/external-fr.html
@@ -125,7 +125,6 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 		<li><a href="https://github.com/jquery/jquery-mobile">jQuery Mobile</a></li>
 		<li><a href="https://github.com/kbwood/bookmark">jQuery Bookmark</a></li>
 		<li><a href="https://github.com/jackmoore/colorbox">Colorbox</a></li>
-		<li><a href="https://github.com/DataTables/DataTables">DataTables</a></li>
 		<li><a href="https://github.com/JangoSteve/jQuery-EasyTabs">jQuery EasyTabs</a></li>
 		<li><a href="https://github.com/filamentgroup/jQuery-Equal-Heights">jQuery Equal Heights</a></li>
 		<li><a href="http://excanvas.sourceforge.net/">ExplorerCanvas</a></li>


### PR DESCRIPTION
@nschonni's comments on #4373 made me realize DataTables is 3.1 only.

I'll add OpenLayers and Proj4js once this goes to master.
