### PR TITLE
Forms CSS: fix .form-addon button alignment in Chrome

### DIFF
--- a/src/grids/sass/includes/_form.scss
+++ b/src/grids/sass/includes/_form.scss
@@ -211,9 +211,9 @@
 
 		.form-addon {
 			@include inline-block;
-			min-height: 18px;
 			line-height: 18px;
 			min-width: 16px;
+			margin-top: 0;
 			@if $legacy-support-for-ie7 {
 				*min-width: auto;
 			}


### PR DESCRIPTION
Fixes the alignment of the [.form-addon button](http://wet-boew.github.io/wet-boew/demos/grids/grid-form-en.html#buttons) in Chrome and removes an extra min-height rule.

![form-addon](https://f.cloud.github.com/assets/2110107/1994777/35e06344-84f6-11e3-9344-39336b51baa3.png)
