### PR TITLE
Tabs: fix saving of user's last visited tab

### DIFF
--- a/src/js/workers/tabbedinterface.js
+++ b/src/js/workers/tabbedinterface.js
@@ -655,7 +655,7 @@
 		_set_active_panel : function(id, tabListIdx) {
 			if (typeof window.sessionStorage !== 'undefined') {
 				try {
-					window.sessionStorage.setItem('activePanel-' + tabListIdx, id);
+					window.sessionStorage.setItem('activePanel-' + _pe.urlpage.path + tabListIdx, id);
 				} catch (error) {
 				}
 			}
@@ -663,7 +663,7 @@
 
 		_get_active_panel : function(tabListIdx) {
 			if (typeof window.sessionStorage !== 'undefined') {
-				return window.sessionStorage.getItem('activePanel-' + tabListIdx);
+				return window.sessionStorage.getItem('activePanel-' + _pe.urlpage.path + tabListIdx);
 			}
 			return null;
 		},


### PR DESCRIPTION
The sessionStorage key now includes the page's path to limit tab saving/restoring to page's the user has visited.

Fixes #4384.
