### PR TITLE
Country Content: increase Mocha timeout of unit tests

### DIFF
--- a/src/plugins/country-content/test.js
+++ b/src/plugins/country-content/test.js
@@ -22,7 +22,7 @@ describe( "Country Content test suite", function() {
 	before(function( done ) {
 
 		// Increase test timeout to allow http://freegeoip.net time to respond
-		this.timeout( 5000 );
+		this.timeout( 6000 );
 
 		// Lookup the country code for this test run.  Lookup times out before the test
 		// to prevent a failed lookup from throwing a test error.


### PR DESCRIPTION
Mocha timeout needs to be greater than geo IP lookup timeout (a.k.a. making the code match my comments).
