### PR TITLE
Feeds: remove finalize and CSS from French working examples

### DIFF
--- a/src/plugins/feeds/feeds-fr.hbs
+++ b/src/plugins/feeds/feeds-fr.hbs
@@ -9,18 +9,6 @@
 	"css": "demo/feeds"
 }
 ---
-<style>
-.feeds-cont {
-	border: 1px solid #ccc;
-	background-color: #e0e2e4;
-	padding: 10px 10px 0 10px;
-}
-.feeds-cont li {
-	padding: 0 0 10px 0;
-	list-style-type: none;
-}
-</style>
-
 <p>Cette composante est un gadget logiciel permettant de regrouper et d’afficher des données d'un ou plusieurs fils de syndication. Les formats soutenus sont Atom, RSS et Media RSS.</p>
 
 <section>

--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -29,7 +29,6 @@ var pluginName = "wb-feeds",
 		var elm = event.target,
 			entries = [],
 			results = [],
-			deferred = [],
 			processEntries = function( data ) {
 				var k, len;
 
@@ -44,11 +43,6 @@ var pluginName = "wb-feeds",
 
 				last -= 1;
 				return last;
-			},
-			finalize = function() {
-
-				// TODO: Use CSS instead
-				$content.find( "li" ).show();
 			},
 			$content, limit, feeds, last, i;
 
@@ -67,15 +61,13 @@ var pluginName = "wb-feeds",
 			i = last;
 
 			while ( i >= 0 ) {
-				deferred[ i ] = $.ajax({
+				$.ajax({
 					url: jsonRequest( feeds[ i ].href, limit ),
 					dataType: "json",
 					timeout: 1000
 				}).done( processEntries );
 				results.push( i -= 1 );
 			}
-			$.when.apply( null, deferred ).always( finalize );
-
 			$.extend( {}, results );
 		}
 	},


### PR DESCRIPTION
1. Finalize function (and deferred objects) are no longer needed because `<li>` items are not hidden.
2. Removed CSS from French working examples since it is included in feeds.scss.
