### PR TITLE
data-ajax: remove working example dependency from unit tests

### DIFF
--- a/src/plugins/data-ajax/test.js
+++ b/src/plugins/data-ajax/test.js
@@ -15,18 +15,26 @@
  */
 describe( "data-ajax test suite", function() {
 	var spy,
-		sandbox = sinon.sandbox.create();
+		sandbox = sinon.sandbox.create(),
+		createElm = function( type, done ) {
+			var $elm = $( "<div data-ajax-" + type + "='ajax/data-ajax-extra-en.html'>" );
+			$elm
+				.appendTo( wb.doc.find( "body" ) )
+				.trigger( "wb-init.wb-ajax" )
+				.on( "ajax-fetched.wb", function() {
+					if ( typeof done === "function" ) {
+						done();
+					}
+				});
+			return $elm;
+		};
 
 	/*
 	 * Before beginning the test suite, this function is executed once.
 	 */
-	before(function( done ) {
+	before(function() {
 		// Spy on jQuery's trigger method to see how it's called during the plugin's initialization
 		spy = sandbox.spy( $.prototype, "trigger" );
-		
-		$( "[data-ajax-replace]" ).on( "ajax-replace-loaded.wb", function() {
-			done();
-		});
 	});
 
 	/*
@@ -41,6 +49,15 @@ describe( "data-ajax test suite", function() {
 	 * Test the initialization events of the plugin
 	 */
 	describe( "init events", function() {
+		var $elm;
+
+		before(function() {
+			$elm = createElm( "replace" );
+		});
+
+		after(function() {
+			$elm.remove();
+		});
 
 		it( "should trigger an ajax-fetch.wb event", function() {
 			var arg,
@@ -52,113 +69,135 @@ describe( "data-ajax test suite", function() {
 			}
 			expect( isEvent ).to.equal( true );
 		});
-		
-		it( "should triger ajax-type-loaded.wb events", function() {
-			var i,
-				ajaxTypes = [
-					"before",
-					"replace",
-					"after",
-					"append",
-					"prepend"
-				],
-				len = ajaxTypes.length;
-			for ( i = 0; i !== len; i += 1 ) {
-				expect( spy.calledWith( "ajax-" + ajaxTypes[ i ] + "-loaded.wb" ) ).to.equal( true );
-			}
-		});
 	});
-	
+
 	/*
 	 * Test data-ajax-before
 	 */
 	describe( "data-ajax-before", function() {
+		var $elm, $before;
+
+		before(function( done ) {
+			$elm = createElm( "before", done );
+		});
+
+		after(function() {
+			$elm.remove();
+			$before.remove();
+		});
+
+		it( "should add the .wb-ajaxbefore-inited class", function() {
+			expect( $elm.hasClass( "wb-ajaxbefore-inited" ) ).to.equal( true );
+		});
+
 		it( "should load an element before itself", function() {
-			var $before, $elm;
-			
-			$( ".wb-ajaxbefore-inited" ).each(function() {
-				$elm = $( this );
-				$before = $elm.prev( ".ajaxed-in" );
-				
-				expect( $elm.length ).to.be.greaterThan( 0 );
-				expect( $before.length ).to.be.greaterThan( 0 );
-				expect( $before.children().length ).to.be.greaterThan( 0 );
-			});
+			$before = $elm.prev( ".ajaxed-in" );
+			expect( $before.length ).to.be.greaterThan( 0 );
+			expect( $before.children().length ).to.be.greaterThan( 0 );
 		});
 	});
-	
+
 	/*
 	 * Test data-ajax-after
 	 */
 	describe( "data-ajax-after", function() {
+		var $elm, $after;
+
+		before(function( done ) {
+			$elm = createElm( "after", done );
+		});
+
+		after(function() {
+			$elm.remove();
+			$after.remove();
+		});
+
+		it( "should add the .wb-ajaxafter-inited class", function() {
+			expect( $elm.hasClass( "wb-ajaxafter-inited" ) ).to.equal( true );
+		});
+
 		it( "should load an element after itself", function() {
-			var $after, $elm;
-			
-			$( ".wb-ajaxafter-inited" ).each(function() {
-				$elm = $( this );
-				$after = $elm.next( ".ajaxed-in" );
-				
-				expect( $elm.length ).to.be.greaterThan( 0 );
-				expect( $after.length ).to.be.greaterThan( 0 );
-				expect( $after.children().length ).to.be.greaterThan( 0 );
-			});
+			$after = $elm.next( ".ajaxed-in" );
+			expect( $after.length ).to.be.greaterThan( 0 );
+			expect( $after.children().length ).to.be.greaterThan( 0 );
 		});
 	});
-	
+
 	/*
 	 * Test data-ajax-replace
 	 */
 	describe( "data-ajax-replace", function() {
+		var $elm;
+
+		before(function( done ) {
+			$elm = createElm( "replace", done );
+		});
+
+		after(function() {
+			$elm.remove();
+		});
+
+		it( "should add the .wb-ajaxreplace-inited class", function() {
+			expect( $elm.hasClass( "wb-ajaxreplace-inited" ) ).to.equal( true );
+		});
+
 		it( "should replace its content", function() {
-			var $replace, $elm;
-			
-			$( ".wb-ajaxreplace-inited" ).each(function() {
-				$elm = $( this );
-				$replace = $elm.find( ".ajaxed-in" );
-				
-				expect( $elm.length ).to.be.greaterThan( 0 );
-				expect( $elm.children().first()[0] ).to.equal( $replace[0] );
-				expect( $replace.length ).to.be.greaterThan( 0 );
-				expect( $replace.children().length ).to.be.greaterThan( 0 );
-			});
+			var $replace = $elm.find( ".ajaxed-in" );
+			expect( $elm.children().first()[0] ).to.equal( $replace[0] );
+			expect( $replace.length ).to.be.greaterThan( 0 );
+			expect( $replace.children().length ).to.be.greaterThan( 0 );
 		});
 	});
-	
+
 	/*
 	 * Test data-ajax-prepend
 	 */
 	describe( "data-ajax-prepend", function() {
+		var $elm;
+
+		before(function( done ) {
+			$elm = createElm( "prepend", done );
+		});
+
+		after(function() {
+			$elm.remove();
+		});
+
+		it( "should add the .wb-ajaxprepend-inited class", function() {
+			expect( $elm.hasClass( "wb-ajaxprepend-inited" ) ).to.equal( true );
+		});
+
 		it( "should prepend to its content", function() {
-			var $prepend, $elm;
-			
-			$( ".wb-ajaxprepend-inited" ).each(function() {
-				$elm = $( this );
-				$prepend = $elm.find( ".ajaxed-in" );
-				
-				expect( $elm.length ).to.be.greaterThan( 0 );
-				expect( $elm.children().first()[0] ).to.equal( $prepend[0] );
-				expect( $prepend.length ).to.be.greaterThan( 0 );
-				expect( $prepend.children().length ).to.be.greaterThan( 0 );
-			});
+			var $prepend = $elm.find( ".ajaxed-in" );
+			expect( $elm.children().first()[0] ).to.equal( $prepend[0] );
+			expect( $prepend.length ).to.be.greaterThan( 0 );
+			expect( $prepend.children().length ).to.be.greaterThan( 0 );
 		});
 	});
-			
+
 	/*
 	 * Test data-ajax-append
 	 */
 	describe( "data-ajax-append", function() {
+		var $elm;
+
+		before(function( done ) {
+			$elm = createElm( "append", done );
+		});
+
+		after(function() {
+			$elm.remove();
+		});
+
+		it( "should add the .wb-ajaxprepend-inited class", function() {
+			expect( $elm.hasClass( "wb-ajaxappend-inited" ) ).to.equal( true );
+		});
+
 		it( "should append to its content", function() {
-			var $append, $elm;
-			
-			$( ".wb-ajaxappend-inited" ).each(function() {
-				$elm = $( this );
-				$append = $elm.find( ".ajaxed-in" );
-				
-				expect( $elm.length ).to.be.greaterThan( 0 );
-				expect( $elm.children().last()[0] ).to.equal( $append[0] );
-				expect( $append.length ).to.be.greaterThan( 0 );
-				expect( $append.children().length ).to.be.greaterThan( 0 );
-			});
+			var $append = $elm.find( ".ajaxed-in" );
+			expect( $elm.children().last()[0] ).to.equal( $append[0] );
+			expect( $append.length ).to.be.greaterThan( 0 );
+			expect( $append.children().length ).to.be.greaterThan( 0 );
 		});
 	});
 });


### PR DESCRIPTION
Required to support single test harness (#4439).
