### PR TITLE
Fixed grunt-contrib-imagemin install on Windows.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-csslint": "~0.2.0",
     "grunt-contrib-cssmin": "~0.7.0",
-    "grunt-contrib-imagemin": "~0.4.0",
+    "grunt-contrib-imagemin": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",


### PR DESCRIPTION
For some reason, the version v0.4.x of this module doesn't install anymore on Windows. V0.5 is ok.
