### PR TITLE
[CSS] Added a fix so that bullets are displayed in Chrome and Safari when clmn classes are used

### DIFF
--- a/src/base/partials/_proximity.scss
+++ b/src/base/partials/_proximity.scss
@@ -136,6 +136,17 @@
 	}
 }
 
+/*
+ *	Fix for missing bullets in Chrome and Safari
+ */
+[class*=clmn-] {
+	padding-left: 1.3em;
+	list-style: outside;
+}
+[class*=clmn-] > li {
+	margin-left: 1.3em;
+}
+
 .pstn-lft-xs {
 	@include pstn;
 	@include pstn-lft;


### PR DESCRIPTION
Fix for https://github.com/wet-boew/wet-boew/issues/4444.
