### PR TITLE
Tabs: update tab interface medium/large screen appearance

### DIFF
--- a/src/plugins/tabs/tabs-mediumViewOver.scss
+++ b/src/plugins/tabs/tabs-mediumViewOver.scss
@@ -16,10 +16,7 @@
 	> {
 		details {
 			display: none;
-			border: 1px solid #adadad;
-			border-bottom-left-radius: 4px;
-			border-bottom-right-radius: 4px;
-			box-shadow: inset 0 -3px 5px rgba(0, 0, 0, 0.125);
+			border: 1px solid #ccc;
 			margin-top: -1px;
 			&[open] {
 				display: block;

--- a/src/plugins/tabs/tabs.scss
+++ b/src/plugins/tabs/tabs.scss
@@ -61,7 +61,7 @@ $medGray: #ccc;
 		li {
 			display: inline-block;
 			cursor: pointer;
-			margin: 0 5px 0 0;
+			margin: 0 10px 0 0;
 			color: #000;
 			background: $lightGray;
 			background: transparentize($lightGray, 0.1);
@@ -73,13 +73,15 @@ $medGray: #ccc;
 				color: #000;
 				display: inline-block;
 				// changed padding and margin from em to px to fix web-kit layout issue
-				padding: 7px 15px;
+				padding: 10px;
 			}
 			&:focus, &:hover {
 				@extend %tabsGreyBackground;
 			}
 			&.active {
-				@extend %tabsGreyBackground;
+				padding-bottom: 1px;
+				border-bottom: 0;
+				background: #fff;
 				cursor: default;
 				a {
 					cursor: default;


### PR DESCRIPTION
1. Make .active tab more obvious by removing its bottom border and setting its background colour to white.
2. Increase padding/margin of tabs.
3. Remove tab panel bottom shadow and corner rounding.
4. Match tab panel border colour with tab border colour.

Fixes #4456
