### PR TITLE
Mocha: temporary fix for mocha timeout

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -948,6 +948,7 @@ module.exports = (grunt) ->
 		mocha:
 			all:
 				options:
+					run: true
 					reporter: "Spec"
 					urls: grunt.file.expand(
 						filter: ( src ) ->


### PR DESCRIPTION
This is a temp fix for #4493.  It bypasses the PhantomJS timeout warning but does not actually run any of the unit tests.  At least this way the working examples will be getting updated while I look for a fix.
