### PR TITLE
Documentation: Corrected questions and comment query string so valid HTML

### DIFF
--- a/site/includes/contentbuttons.hbs
+++ b/site/includes/contentbuttons.hbs
@@ -1,13 +1,17 @@
+---
+"addDescription": <%= #i18n "tmpl-add-desc" %>
+---
+
 {{#contains page.src "src/"}}
 <p>
 	<a class="btn btn-primary" href="../../docs/ref/{{altLangPrefix}}/{{altLangPrefix}}-{{language}}.html">{{#i18n "tmpl-documentation"}}{{/i18n}}</a>
-	<a class="btn btn-primary" href="https://github.com/wet-boew/wet-boew/issues/new?title={{title}}{{#i18n "colon"}}{{/i18n}} {{#i18n "tmpl-add-desc"}}{{/i18n}}">{{#i18n "tmpl-questions-comments"}}{{/i18n}}</a>
+	<a class="btn btn-primary" href="https://github.com/wet-boew/wet-boew/issues/new?title={{encodeURI title}}:%20">{{#i18n "tmpl-questions-comments"}}{{/i18n}}</a>
 </p>
 {{/contains}}
 {{#contains page.src "/docs/ref/"}}
 	{{#isnt assets "../.."}}
 <p>
-	<a class="btn btn-primary" href="https://github.com/wet-boew/wet-boew/issues/new?title={{title}}{{#i18n "colon"}}{{/i18n}} {{#i18n "tmpl-add-desc"}}{{/i18n}}">{{#i18n "tmpl-questions-comments"}}{{/i18n}}</a>
+	<a class="btn btn-primary" href="https://github.com/wet-boew/wet-boew/issues/new?title={{encodeURI title}}:%20">{{#i18n "tmpl-questions-comments"}}{{/i18n}}</a>
 </p>
 	{{/isnt}}
 {{/contains}}


### PR DESCRIPTION
Problem was that the generated query string had unencoded spaces or non-breaking spaces in it that are not valid HTML. Fixed by uriEncoding the page title and removing the i18n insertions (since couldn't find a way to uriEncode the i18n insertions).
