### PR TITLE
Core: quote object property keys in minified files

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -549,6 +549,8 @@ module.exports = (grunt) ->
 
 			core:
 				options:
+					beautify:
+						quote_keys: true
 					preserveComments: (uglify,comment) ->
 						return comment.value.match(/^!/i)
 				cwd: "dist/unmin/js/"
@@ -948,7 +950,6 @@ module.exports = (grunt) ->
 		mocha:
 			all:
 				options:
-					run: true
 					reporter: "Spec"
 					urls: grunt.file.expand(
 						filter: ( src ) ->


### PR DESCRIPTION
The unquoted property keys in normalizeDiacritics were causing PhantomeJS and IE8 to fail with a JavaScript error. Fixes #4493.

This PR also removes the temp workaround that allowed the mocha tests to run successfully with the JavaScript error.
