### PR TITLE
Session timeout docs and change to plugin init

### DIFF
--- a/site/pages/docs/ref/session-timeout/session-timeout-en.hbs
+++ b/site/pages/docs/ref/session-timeout/session-timeout-en.hbs
@@ -2,7 +2,7 @@
 {
 	"title": "Session Timeout",
 	"language": "en",
-	"description": "Helps Web asset owners to provide session timeout and inactivity timeout functionality.",
+	"description": "Create a session inactivity timeout that warns users when their session is about to expire.",
 	"altLangPrefix": "session-timeout"
 }
 ---
@@ -10,51 +10,60 @@
 
 <section>
 	<h2>Purpose</h2>
-	<p>A brief description of the component.</p>
+	<div class="alert alert-info">
+		Create a session inactivity timeout that warns users when their session is about to expire.
+	</div>
+	<p>This plugin helps web page owners by providing session timeout and inactivity timeout functionality. When a user requests a page with this plugin implemented their session will begin. After the specified session period, they will be notified that their session is about to timeout. At this point, they will have the option to remain logged in by clicking "Continue session", or signing out by clicking "End session now".</p>
+	<p>At anytime during the session, if the user remains idle for a specified amount of time, they will be notified that they're session is about to timeout. In either case, if the user does not respond to the timeout notification within a specified amount of time, once they click either "Continue session" or "End session now" they will be automatically redirected to the sign out page.</p>	
 </section>
 
 <section>
 	<h2>Use when</h2>
 	<ul>
-		<li>Use case 1</li>
-		<li>Use case 2</li>
-		<li>Use case 3</li>
-	</ul>
-</section>
-
-<section>
-	<h2>Do not use when</h2>
-	<ul>
-		<li>Use case 1</li>
-		<li>Use case 2</li>
-		<li>Use case 3</li>
+		<li>A session timeout warning is required.  This will alert the user before their session expires and give them a chance to extend the session.</li>
+		<li>User activity on a web page should extend their session.</li>
 	</ul>
 </section>
 
 <section>
 	<h2>Working example</h2>
-	<p><a href="#">Link to a working example</a></p>
+	<p><a href="../../../demos/session-timeout/session-timeout-en.html">English example</a></p>
+	<p><a href="../../../demos/session-timeout/session-timeout-fr.html">French example</a></p>
 </section>
 
 <section>
 	<h2>How to implement</h2>
 	<ol>
-		<li>Step 1</li>
-		<li>Step 2
-			<pre><code>Example code</code></pre>
+		<li>
+			Add a <b>class="wb-sessto"</b> element to the web page (only required once).  You must set the <b>logouturl</b>, which controls where the user is redirected if their session expires:
+			<pre><code>&lt;span class="wb-sessto" data-wet-boew='{"logouturl": "http://app.gc.ca/logout"}'&gt;&lt;/span&gt;</code></pre>		
+		</li>		
+		<li>Configure the plugin using the <b>data-wet-boew</b> attribute of the element:
+			<pre><code>&lt;span class="wb-sessto" data-wet-boew='{
+	"inactivity": 1200000, 
+	"reactionTime": 30000, 
+	"sessionalive": 1200000, 
+	"logouturl": "./", 
+	"refreshCallbackUrl": "./"
+	"refreshOnClick": true,
+	"refreshLimit": 200000}'&gt;&lt;/span&gt;</code></pre>
 		</li>
-		<li>Step 3
-			<pre><code>Example of multi-line code
-Example of multi-line code
-Example of multi-line code</code></pre>
-		</li>
-		<li>Step 4</li>
 	</ol>
 </section>
 
 <section>
 	<h2>Configuration options</h2>
-	<p>Document the public configuration options that can be used by implementers or developers.</p>
+	<p>All configuration options of the plugin are controlled by the <b>data-wet-boew</b> attribute.  Any configuration parameter that accepts a time value, can optionally have the time unit specified (e.g. "100 ms").</p>
+	<p>Supported time units are:</p>
+	<ul>
+		<li><b>ms:</b> millisecond (0.001 seconds)</li>
+		<li><b>cs:</b> centisecond (0.01 seconds)</li>
+		<li><b>ds:</b> decisecond (0.1 seconds)</li>
+		<li><b>s:</b> seconds (1 second)</li>
+		<li><b>das:</b> dekasecond (10 seconds)</li>
+		<li><b>hs:</b> hectosecond (100 seconds)</li>
+		<li><b>ks:</b> kilosecond (1,000 seconds)</li>
+	</ul>	
 	<table class="table">
 		<thead>
 			<tr>
@@ -66,35 +75,104 @@ Example of multi-line code</code></pre>
 		</thead>
 		<tbody>
 			<tr>
-				<td>Option 1</td>
-				<td>Brief description of the option</td>
-				<td>How to configure the option</td>
+				<td><code>inactivity</code></td>
+				<td>Sets the inactivity timeout. Once this expires, the plugin's modal dialog will appear and prompt the user to continue or end their session.</td>
+				<td>Provide a numeric value, optionally with a time unit appended.</td>
 				<td>
 					<dl>
-						<dt>Value 1 (default):</dt>
-						<dd>Brief description</dd>
-						<dt>Value 2:</dt>
-						<dd>Brief description</dd>
-						<dt>Value 3:</dt>
-						<dd>Brief description</dd>
+						<dt>None (default):</dt>
+						<dd>Default inactivity period is 20 minutes.</dd>
+						<dt>Numeric value:</dt>
+						<dd>Treated as a millisecond value.</dd>
+						<dt>String numeric value with time unit appended (e.g. "100 s"):</dt>
+						<dd>Treated as a time value in the provided unit.</dd>
 					</dl>
 				</td>
 			</tr>
 			<tr>
-				<td>Option 2</td>
-				<td>Brief description of the option</td>
-				<td>How to configure the option</td>
+				<td><code>reactionTime</code></td>
+				<td>Sets the period of time the user has to perform an action once the modal dialog is displayed</td>
+				<td>Provide a numeric value, optionally with a time unit appended.</td>
 				<td>
 					<dl>
-						<dt>Value 1 (default):</dt>
-						<dd>Brief description</dd>
-						<dt>Value 2:</dt>
-						<dd>Brief description</dd>
-						<dt>Value 3:</dt>
-						<dd>Brief description</dd>
+						<dt>None (default):</dt>
+						<dd>Default reation time is 3 minutes.</dd>
+						<dt>Numeric value:</dt>
+						<dd>Treated as a millisecond value.</dd>
+						<dt>String numeric value with time unit appended (e.g. "100 s"):</dt>
+						<dd>Treated as a time value in the provided unit.</dd>
 					</dl>
 				</td>
 			</tr>
+			<tr>
+				<td><code>sessionalive</code></td>
+				<td>Sets the period of time before an ajax request is made to the server to determine if the session is still alive.  A refreshCallbackUrl must be specified for this to work.</td>
+				<td>Provide a numeric value, optionally with a time unit appended.</td>
+				<td>
+					<dl>
+						<dt>None (default):</dt>
+						<dd>Default session alive time is 20 minutes.</dd>
+						<dt>Numeric value:</dt>
+						<dd>Treated as a millisecond value.</dd>
+						<dt>String numeric value with time unit appended (e.g. "100 s"):</dt>
+						<dd>Treated as a time value in the provided unit.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>logouturl</code></td>
+				<td>URL that users are sent to when their session has expired.</td>
+				<td>Provide a URL.</td>
+				<td>
+					<dl>
+						<dt>None (default):</dt>
+						<dd>Default logout URL is "./"</dd>
+						<dt>String URL:</dt>
+						<dd>The URL to redirect to once the session has expired.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>refreshCallbackUrl</code></td>
+				<td>URL used to perform an ajax request. Must be a viewless page that returns "true" to indicate session is still valid.</td>
+				<td>Provide a URL whose response to a POST request is "true" if the session is still valid.  Any other characters in the response will mark the session as expired.</td>
+				<td>
+					<dl>
+						<dt>None (default):</dt>
+						<dd>No ajax request will be performed.</dd>
+						<dt>String URL:</dt>
+						<dd>An ajax request (POST) will be made to the URL.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>refreshOnClick</code></td>
+				<td>Determines if clicking on the document should reset the inactivity timeout and perform an ajax request (if a refreshCallbackUrl has been specified).</td>
+				<td>Provide a boolean true/false value.</td>
+				<td>
+					<dl>
+						<dt>None (default):</dt>
+						<dd>true (refresh on click is turned on)</dd>
+						<dt>Boolean:</dt>
+						<dd>true/false.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>refreshLimit</code></td>
+				<td>Sets the amount of time that must pass before an ajax request can be made.</td>
+				<td>Provide a numeric value, optionally with a time unit appended.</td>
+				<td>
+					<dl>
+						<dt>None (default):</dt>
+						<dd>Default refresh limit is 2 minutes.</dd>
+						<dt>Numeric value:</dt>
+						<dd>Treated as a millisecond value.</dd>
+						<dt>String numeric value with time unit appended (e.g. "100 s"):</dt>
+						<dd>Treated as a time value in the provided unit.</dd>
+					</dl>
+				</td>
+			</tr>															
 		</tbody>
 	</table>
 </section>
@@ -112,20 +190,37 @@ Example of multi-line code</code></pre>
 		</thead>
 		<tbody>
 			<tr>
-				<td>Event 1</td>
-				<td>When the event is triggered and how to trigger it manually (where supported)</td>
-				<td>Brief description of what it does.</td>
+				<td><code>wb-init.wb-sessto</code></td>
+				<td>Triggered manually.</td>
+				<td>Initializes the plugin and starts the session and inactivity timeouts. <b>Note: </b> the session timeout plugin will be initialized automatically unless the <b>.wb-sessto</b> element is added after the page has already loaded.</td>
 			</tr>
 			<tr>
-				<td>Event 2</td>
-				<td>When the event is triggered and how to trigger it manually (where supported)</td>
-				<td>Brief description of what it does.</td>
+				<td><code>inactivity.wb-sessto</code></td>
+				<td>Triggered manually and by the plugin.</td>
+				<td>Causes the modal dialog to appear and prompt the user to continue or end their session.  This event is triggered automatically when the inactivity timeout expires.</td>
+			</tr>			
+			<tr>
+				<td><code>keepalive.wb-sessto</code></td>
+				<td>Triggered manually and by the plugin.</td>
+				<td>Causes an ajax request to be made (if a refreshCallbackUrl has been specified).  This will alert the user that their session has expired if the refreshCallbackUrl response is not "true".</td>
 			</tr>
+			<tr>
+				<td><code>reset.wb-sessto</code></td>
+				<td>Triggered manually and by the plugin.</td>
+				<td>Restarts the inactivity and keepalive timeouts.</td>
+			</tr>			
 		</tbody>
 	</table>
+	<p><b>Note:</b> when manually triggering the inactivity, keepalive and reset events, you must pass the data-wet-boew attribute as a second argument:</p>
+	<pre><code>// Get a reference to the session timeout element and its data-wet-boew attribute	
+var $element = $( ".wb-sessto" ),
+    settings = $element.data( "wet-boew" );
+	
+// Trigger the event on the element
+$element.trigger( "reset.wb-sessto", settings );</code></pre>
 </section>
 
 <section>
 	<h2>Source code</h2>
-	<p><a href="#">Link to the folder on GitHub containing the files for the component</a></p>
+	<p><a href="https://github.com/wet-boew/wet-boew/tree/v4.0/src/plugins/session-timeout">Session timeout source code on GitHub</a></p>
 </section>

--- a/site/pages/docs/ref/session-timeout/session-timeout-fr.hbs
+++ b/site/pages/docs/ref/session-timeout/session-timeout-fr.hbs
@@ -2,133 +2,232 @@
 {
 	"title": "Expiration de la session",
 	"language": "fr",
-	"description": "Ferme la session de l'utilisateur après un certain délai.",
+	"description": "Créer un délai d'inactivité qui avertit les utilisateurs lorsque leur session est sur le point d'expirer.",
 	"altLangPrefix": "session-timeout"
 }
 ---	
 <span class="wb-prettify all-pre hide"></span>
 
+<section>
+	<h2>But</h2>
+	<div class="alert alert-info">
+		Créer un délai d'inactivité qui avertit les utilisateurs lorsque leur session est sur le point d'expirer.
+	</div>	
+	<p>Ce plugiciel aidera les propriétaires d'actifs Web à configurer leurs actifs avec une fonction « Expiration de la session ». Celle-ci sera activée en deux circonstances : après une période de temps spécifique ou lors d'inactivité.</p>
+	<p>Par exemple, si l'utilisateur demeure trop longtemps sur la même page, la fonction sera activée. De même, si l’utilisateur demeure inactif, la fonction sera activée. Le fureteur affichera alors une boîte de dialogue proposant deux options à l'utilisateur ; s’il souhaite rester connecté il devra sélectionner « Continuer la session » et ce, dans un laps de temps précis et s’il souhaite mettre fin à sa session, il n’aura qu’à choisir « Mettre fin à la session ». Advenant que l'utilisateur tarde trop à faire son choix, ce sera le paramètre de déconnexion qui s’affichera.</p>	
+</section>
+
+	
 <div lang="en">
-<p><strong>Needs translation</strong></p>
+	<p><strong>Needs translation</strong></p>	
+	<section>
+		<h2>Use when</h2>
+		<ul>
+			<li>A session timeout warning is required.  This will alert the user before their session expires and give them a chance to extend the session.</li>
+			<li>User activity on a web page should extend their session.</li>
+		</ul>
+	</section>
+</div>
+	
 <section>
-	<h2>Purpose</h2>
-	<p>A brief description of the component.</p>
-</section>
-
-<section>
-	<h2>Use when</h2>
-	<ul>
-		<li>Use case 1</li>
-		<li>Use case 2</li>
-		<li>Use case 3</li>
-	</ul>
-</section>
-
-<section>
-	<h2>Do not use when</h2>
-	<ul>
-		<li>Use case 1</li>
-		<li>Use case 2</li>
-		<li>Use case 3</li>
-	</ul>
-</section>
-
-<section>
-	<h2>Working example</h2>
-	<p><a href="#">Link to a working example</a></p>
-</section>
-
-<section>
-	<h2>How to implement</h2>
-	<ol>
-		<li>Step 1</li>
-		<li>Step 2
-			<pre><code>Example code</code></pre>
-		</li>
-		<li>Step 3
-			<pre><code>Example of multi-line code
-Example of multi-line code
-Example of multi-line code</code></pre>
-		</li>
-		<li>Step 4</li>
-	</ol>
-</section>
-
-<section>
-	<h2>Configuration options</h2>
-	<p>Document the public configuration options that can be used by implementers or developers.</p>
-	<table class="table">
-		<thead>
-			<tr>
-				<th>Option</th>
-				<th>Description</th>
-				<th>How to configure</th>
-				<th>Values</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td>Option 1</td>
-				<td>Brief description of the option</td>
-				<td>How to configure the option</td>
-				<td>
-					<dl>
-						<dt>Value 1 (default):</dt>
-						<dd>Brief description</dd>
-						<dt>Value 2:</dt>
-						<dd>Brief description</dd>
-						<dt>Value 3:</dt>
-						<dd>Brief description</dd>
-					</dl>
-				</td>
-			</tr>
-			<tr>
-				<td>Option 2</td>
-				<td>Brief description of the option</td>
-				<td>How to configure the option</td>
-				<td>
-					<dl>
-						<dt>Value 1 (default):</dt>
-						<dd>Brief description</dd>
-						<dt>Value 2:</dt>
-						<dd>Brief description</dd>
-						<dt>Value 3:</dt>
-						<dd>Brief description</dd>
-					</dl>
-				</td>
-			</tr>
-		</tbody>
-	</table>
-</section>
-
-<section>
-	<h2>Events</h2>
-	<p>Document the public events that can be used by implementers or developers.</p>
-	<table class="table">
-		<thead>
-			<tr>
-				<th>Event</th>
-				<th>Trigger</th>
-				<th>What it does</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td>Event 1</td>
-				<td>When the event is triggered and how to trigger it manually (where supported)</td>
-				<td>Brief description of what it does.</td>
-			</tr>
-			<tr>
-				<td>Event 2</td>
-				<td>When the event is triggered and how to trigger it manually (where supported)</td>
-				<td>Brief description of what it does.</td>
-			</tr>
-		</tbody>
-	</table>
-</section>
-
-<section>
-	<h2>Source code</h2>
-	<p><a href="#">Link to the folder on GitHub containing the files for the component</a></p>
-</section>
+	<h2>Exemple pratique</h2>
+	<p><a href="../../../demos/session-timeout/session-timeout-en.html">Exemple en anglais</a></p>
+	<p><a href="../../../demos/session-timeout/session-timeout-fr.html">Exemple en français</a></p>
+</section>	
+	
+<div lang="en">
+	<p><strong>Needs translation</strong></p>	
+	<section>
+		<h2>How to implement</h2>
+		<ol>
+			<li>
+				Add a <b>class="wb-sessto"</b> element to the web page (only required once).  You must set the <b>logouturl</b>, which controls where the user is redirected if their session expires:
+				<pre><code>&lt;span class="wb-sessto" data-wet-boew='{"logouturl": "http://app.gc.ca/logout"}'&gt;&lt;/span&gt;</code></pre>		
+			</li>		
+			<li>Configure the plugin using the <b>data-wet-boew</b> attribute of the element:
+				<pre><code>&lt;span class="wb-sessto" data-wet-boew='{
+		"inactivity": 1200000, 
+		"reactionTime": 30000, 
+		"sessionalive": 1200000, 
+		"logouturl": "./", 
+		"refreshCallbackUrl": "./"
+		"refreshOnClick": true,
+		"refreshLimit": 200000}'&gt;&lt;/span&gt;</code></pre>
+			</li>
+		</ol>
+	</section>
+	
+	<section>
+		<h2>Configuration options</h2>
+		<p>All configuration options of the plugin are controlled by the <b>data-wet-boew</b> attribute.  Any configuration parameter that accepts a time value, can optionally have the time unit specified (e.g. "100 ms").</p>
+		<p>Supported time units are:</p>
+		<ul>
+			<li><b>ms:</b> millisecond (0.001 seconds)</li>
+			<li><b>cs:</b> centisecond (0.01 seconds)</li>
+			<li><b>ds:</b> decisecond (0.1 seconds)</li>
+			<li><b>s:</b> seconds (1 second)</li>
+			<li><b>das:</b> dekasecond (10 seconds)</li>
+			<li><b>hs:</b> hectosecond (100 seconds)</li>
+			<li><b>ks:</b> kilosecond (1,000 seconds)</li>
+		</ul>	
+		<table class="table">
+			<thead>
+				<tr>
+					<th>Option</th>
+					<th>Description</th>
+					<th>How to configure</th>
+					<th>Values</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code>inactivity</code></td>
+					<td>Sets the inactivity timeout. Once this expires, the plugin's modal dialog will appear and prompt the user to continue or end their session.</td>
+					<td>Provide a numeric value, optionally with a time unit appended.</td>
+					<td>
+						<dl>
+							<dt>None (default):</dt>
+							<dd>Default inactivity period is 20 minutes.</dd>
+							<dt>Numeric value:</dt>
+							<dd>Treated as a millisecond value.</dd>
+							<dt>String numeric value with time unit appended (e.g. "100 s"):</dt>
+							<dd>Treated as a time value in the provided unit.</dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<td><code>reactionTime</code></td>
+					<td>Sets the period of time the user has to perform an action once the modal dialog is displayed</td>
+					<td>Provide a numeric value, optionally with a time unit appended.</td>
+					<td>
+						<dl>
+							<dt>None (default):</dt>
+							<dd>Default reation time is 3 minutes.</dd>
+							<dt>Numeric value:</dt>
+							<dd>Treated as a millisecond value.</dd>
+							<dt>String numeric value with time unit appended (e.g. "100 s"):</dt>
+							<dd>Treated as a time value in the provided unit.</dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<td><code>sessionalive</code></td>
+					<td>Sets the period of time before an ajax request is made to the server to determine if the session is still alive.  A refreshCallbackUrl must be specified for this to work.</td>
+					<td>Provide a numeric value, optionally with a time unit appended.</td>
+					<td>
+						<dl>
+							<dt>None (default):</dt>
+							<dd>Default session alive time is 20 minutes.</dd>
+							<dt>Numeric value:</dt>
+							<dd>Treated as a millisecond value.</dd>
+							<dt>String numeric value with time unit appended (e.g. "100 s"):</dt>
+							<dd>Treated as a time value in the provided unit.</dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<td><code>logouturl</code></td>
+					<td>URL that users are sent to when their session has expired.</td>
+					<td>Provide a URL.</td>
+					<td>
+						<dl>
+							<dt>None (default):</dt>
+							<dd>Default logout URL is "./"</dd>
+							<dt>String URL:</dt>
+							<dd>The URL to redirect to once the session has expired.</dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<td><code>refreshCallbackUrl</code></td>
+					<td>URL used to perform an ajax request. Must be a viewless page that returns "true" to indicate session is still valid.</td>
+					<td>Provide a URL whose response to a POST request is "true" if the session is still valid.  Any other characters in the response will mark the session as expired.</td>
+					<td>
+						<dl>
+							<dt>None (default):</dt>
+							<dd>No ajax request will be performed.</dd>
+							<dt>String URL:</dt>
+							<dd>An ajax request (POST) will be made to the URL.</dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<td><code>refreshOnClick</code></td>
+					<td>Determines if clicking on the document should reset the inactivity timeout and perform an ajax request (if a refreshCallbackUrl has been specified).</td>
+					<td>Provide a boolean true/false value.</td>
+					<td>
+						<dl>
+							<dt>None (default):</dt>
+							<dd>true (refresh on click is turned on)</dd>
+							<dt>Boolean:</dt>
+							<dd>true/false.</dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<td><code>refreshLimit</code></td>
+					<td>Sets the amount of time that must pass before an ajax request can be made.</td>
+					<td>Provide a numeric value, optionally with a time unit appended.</td>
+					<td>
+						<dl>
+							<dt>None (default):</dt>
+							<dd>Default refresh limit is 2 minutes.</dd>
+							<dt>Numeric value:</dt>
+							<dd>Treated as a millisecond value.</dd>
+							<dt>String numeric value with time unit appended (e.g. "100 s"):</dt>
+							<dd>Treated as a time value in the provided unit.</dd>
+						</dl>
+					</td>
+				</tr>															
+			</tbody>
+		</table>
+	</section>
+	
+	<section>
+		<h2>Events</h2>
+		<p>Document the public events that can be used by implementers or developers.</p>
+		<table class="table">
+			<thead>
+				<tr>
+					<th>Event</th>
+					<th>Trigger</th>
+					<th>What it does</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code>wb-init.wb-sessto</code></td>
+					<td>Triggered manually.</td>
+					<td>Initializes the plugin and starts the session and inactivity timeouts. <b>Note: </b> the session timeout plugin will be initialized automatically unless the <b>.wb-sessto</b> element is added after the page has already loaded.</td>
+				</tr>
+				<tr>
+					<td><code>inactivity.wb-sessto</code></td>
+					<td>Triggered manually and by the plugin.</td>
+					<td>Causes the modal dialog to appear and prompt the user to continue or end their session.  This event is triggered automatically when the inactivity timeout expires.</td>
+				</tr>			
+				<tr>
+					<td><code>keepalive.wb-sessto</code></td>
+					<td>Triggered manually and by the plugin.</td>
+					<td>Causes an ajax request to be made (if a refreshCallbackUrl has been specified).  This will alert the user that their session has expired if the refreshCallbackUrl response is not "true".</td>
+				</tr>
+				<tr>
+					<td><code>reset.wb-sessto</code></td>
+					<td>Triggered manually and by the plugin.</td>
+					<td>Restarts the inactivity and keepalive timeouts.</td>
+				</tr>			
+			</tbody>
+		</table>
+		<p><b>Note:</b> when manually triggering the inactivity, keepalive and reset events, you must pass the data-wet-boew attribute as a second argument:</p>
+		<pre><code>// Get a reference to the session timeout element and its data-wet-boew attribute	
+	var $element = $( ".wb-sessto" ),
+	    settings = $element.data( "wet-boew" );
+		
+	// Trigger the event on the element
+	$element.trigger( "reset.wb-sessto", settings );</code></pre>
+	</section>
+	
+	<section>
+		<h2>Source code</h2>
+		<p><a href="https://github.com/wet-boew/wet-boew/tree/v4.0/src/plugins/session-timeout">Session timeout source code on GitHub</a></p>
+	</section>
 </div>

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -59,8 +59,10 @@ var $modal, $modalLink, countdownInterval, i18n, i18nText,
 
 			$elm = $( elm );
 
-			// Merge default settings with overrides from the selected plugin element. There may be more than one, so don't override defaults globally!
+			// Merge default settings with overrides from the plugin element
+			// and save back to the element for future reference
 			settings = $.extend( {}, defaults, $elm.data( "wet-boew" ) );
+			$elm.data( "wet-boew", settings );
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {


### PR DESCRIPTION
1. Docs: some french translations needed (re: #4516)
2. Plugin now saves the element's updated settings back to the `data-wet-boew` attribute.  This allows other code to interact with the plugin.
