### PR TITLE
Toggle: restrict details example to a parent element

### DIFF
--- a/src/plugins/toggle/test.js
+++ b/src/plugins/toggle/test.js
@@ -74,7 +74,7 @@ describe( "Toggle test suite", function() {
 		});
 
 		it( "should have aria-controls attribute set if not a tablist", function() {
-			var $elm, ariaControls, data, isTablist, selector;
+			var $elm, $elms, ariaControls, data, isTablist, selector, parent;
 			$( ".wb-toggle" ).each( function() {
 				$elm = $( this );
 				data = $elm.data( "toggle" );
@@ -82,9 +82,11 @@ describe( "Toggle test suite", function() {
 
 				if ( !isTablist ) {
 					selector = data.selector;
+					parent = data.parent;
 					if ( selector ) {
 						ariaControls = "";
-						$( selector ).each( function() {
+						$elms = parent ? $( parent ).find( selector ) : $( selector );
+						$elms.each( function() {
 							ariaControls += this.id + " ";
 						});
 						expect( $elm.attr( "aria-controls" ) ).to.equal( $.trim( ariaControls ) );

--- a/src/plugins/toggle/toggle-en.hbs
+++ b/src/plugins/toggle/toggle-en.hbs
@@ -124,14 +124,15 @@
 
 		</section>
 
-		<section>
+		<section id="details-elements">
 			<h2 id="details">Details Elements</h2>
 			<p>The toggle plugin can be used to open/close multiple <code>&lt;details&gt;</code> elements.  By adding the <code>"print": "on"</code> setting to the first toggle element, the plugin will also open all details elements when the page is printed.</p>
-
+			<p><b>Note: </b> this example uses the <code>parent</code> configuration option to restrict the toggle of details elements to those that are contained in a specified parent element (<code>#details-element</code>).  By doing this, the grouped toggle and accordion examples below aren't affected by the toggle.</p>
+						
 			<div class="btn-group">
-				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": "details", "print": "on"}'>Toggle</button>
-				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "type": "on"}'>On</button>
-				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "type": "off"}'>Off</button>
+				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": "details", "parent": "#details-elements", "print": "on"}'>Toggle</button>
+				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "parent": "#details-elements", "type": "on"}'>On</button>
+				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "parent": "#details-elements", "type": "off"}'>Off</button>
 			</div>
 
 			<div class="row">

--- a/src/plugins/toggle/toggle-fr.hbs
+++ b/src/plugins/toggle/toggle-fr.hbs
@@ -47,13 +47,13 @@
 
 		</section>
 
-		<section>
+		<section id="details-elements">
 			<h2 id="details">Details</h2>
 
 			<div class="btn-group">
-				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": "details", "print": "on"}'>Basculer</button>
-				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "type": "on"}'>Activer</button>
-				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "type": "off"}'>Désactiver</button>
+				<button type="button" class="btn btn-primary wb-toggle" data-toggle='{"selector": "details", "parent": "#details-elements", "print": "on"}'>Basculer</button>
+				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "parent": "#details-elements", "type": "on"}'>Activer</button>
+				<button type="button" class="btn btn-default wb-toggle" data-toggle='{"selector": "details", "parent": "#details-elements", "type": "off"}'>Désactiver</button>
 			</div>
 
 			<div class="row">


### PR DESCRIPTION
This stops the details example from opening/closing all details elements on the page. 

Discussed in #4518.
