### PR TITLE
[TABS] Amended default carousel class to expand the caption bar the full width

### DIFF
--- a/src/plugins/tabs/tabs-smallViewUnder.scss
+++ b/src/plugins/tabs/tabs-smallViewUnder.scss
@@ -33,9 +33,33 @@
 			li[role="presentation"] {
 				@extend %tabs-smallview-display-none;
 			}
+			li.prv, li.nxt {
+				a {
+					.glyphicon {
+						bottom: -2em;
+						top: auto;
+					}
+				}
+			}
+			li.nxt {
+				a {
+					.glyphicon {
+						right: auto;
+						left: 0;
+					}
+				}
+			}
+			li.plypause {
+				right: auto;
+				text-align: center;
+				width: 100%;
+				font-size: 1.5em;
+				margin-top: 0.3em;
+			}
 		}
 		figcaption {
-			margin: 1em 3.5em;
+			position: relative;
+			margin: auto;
 		}
 	}
 	&.tabs-acc {

--- a/src/plugins/tabs/tabs.scss
+++ b/src/plugins/tabs/tabs.scss
@@ -39,7 +39,7 @@ $medGray: #ccc;
 %carouselFigureCaptions {
 	position: absolute;
 	color: #fff;
-	padding: 1em;
+	padding: 0.5em 1em;
 	z-index: 101;
 }
 
@@ -266,10 +266,14 @@ $medGray: #ccc;
 		}
 		figcaption {
 			@extend %carouselFigureCaptions;
-			bottom: 1em;
-			left: 3em;
+			bottom: 0;
+			left: 0;
+			right: 0;
 			a {
 				@extend %carouselFigureCaptionsLinks;
+			}
+			p {
+				margin-bottom: 0;
 			}
 		}
 	}


### PR DESCRIPTION
PR request after discussion for amending the default display of carousel 2 style:

https://github.com/wet-boew/GCWeb/issues/524

P.S: Sorry about pushing from the main branch on my fork, it was a fresh fork and my -b checkout did not take.
