### PR TITLE
[Carousel] Fixed the bottom margin height for Carousel Style 2

### DIFF
--- a/src/plugins/tabs/tabs.scss
+++ b/src/plugins/tabs/tabs.scss
@@ -132,7 +132,8 @@ $medGray: #ccc;
 	 */
 	&.carousel-s2 {
 		$thumbHeight: 50px;
-		margin-bottom: $thumbHeight + 10px;
+		// 44px = 2 x 10px for anchor padding + 2 x 4px for list item padding + 16px for carousel bottom margin
+		margin-bottom: $thumbHeight + 44px;
 		[role="tablist"] {
 			@extend %carouselTabs;
 			width: 100%;


### PR DESCRIPTION
Bottom margin only accounted for the height of the thumbnail plus a 10 pixels margin.

Increased it to account for the padding on the anchor and list item elements, as well as increased the 10 pixels margin to 16 pixels (1 em).
