### PR TITLE
Build: Restore minification for IE8

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -120,7 +120,8 @@ module.exports = (grunt) ->
 			"concat:css"
 			"concat:css_addBanners"
 			"cssmin:dist"
-			"copy:cssIE8"
+			"cssmin:distIE8"
+			"ie8csscleaning"
 		]
 	)
 
@@ -664,6 +665,19 @@ module.exports = (grunt) ->
 				dest: "dist/css"
 				ext: ".min.css"
 
+			distIE8:
+				options:
+					banner: ""
+					compatibility: "ie8"
+					noAdvanced: true
+				expand: true
+				cwd: "dist/unmin/css"
+				src: [
+					"**/ie8*.css"
+				]
+				dest: "dist/css"
+				ext: ".min.css"
+
 			demos_min:
 				options:
 					banner: "@charset \"utf-8\";\n/*!\n * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)\n * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html\n" +
@@ -688,6 +702,15 @@ module.exports = (grunt) ->
 				]
 				dest: "dist"
 				expand: true
+
+		ie8csscleaning:
+			min:
+				expand: true
+				cwd: "dist/css"
+				src: [
+					"**/ie8*.min.css"
+				]
+				dest: "dist/css"
 
 		modernizr:
 			devFile: "lib/modernizr/modernizr-custom.js"
@@ -818,12 +841,6 @@ module.exports = (grunt) ->
 					dest: "dist/unmin/demos/"
 					expand: true
 				]
-
-			cssIE8:
-				cwd: "dist/unmin/css/"
-				src: "ie8-wet-boew.css"
-				dest: "dist/css"
-				expand: true
 
 			themeAssets:
 				cwd: "theme/"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-csslint": "~0.2.0",
-    "grunt-contrib-cssmin": "~0.7.0",
+    "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-imagemin": "~0.5.0",
     "grunt-contrib-jshint": "~0.7.1",
     "grunt-contrib-uglify": "~0.2.0",

--- a/site/includes/headresources.hbs
+++ b/site/includes/headresources.hbs
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="{{assets}}/css/theme{{environment.suffix}}.css" />
 {{#if page.css}}<link rel="stylesheet" href="{{page.css}}{{environment.suffix}}.css" />{{/if}}
 <!--[if lt IE 9]>
-<link rel="stylesheet" href="{{assets}}/css/ie8-wet-boew.css" />
+<link rel="stylesheet" href="{{assets}}/css/ie8-wet-boew{{environment.suffix}}.css" />
 <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery{{environment.suffix}}.js"></script>
 <script src="{{assets}}/js/ie8-wet-boew{{environment.suffix}}.js"></script>
 <![endif]-->

--- a/tasks/ie8-css-cleaning.js
+++ b/tasks/ie8-css-cleaning.js
@@ -1,0 +1,47 @@
+/* jshint node: true, onevar: false */
+module.exports = function( grunt ) {
+	"use strict";
+	grunt.registerMultiTask("ie8csscleaning", "Manual cleaning of Minified CSS for IE8", function() {
+
+		this.files.forEach(function( f ) {
+
+		/**
+		 * @type {string[]}
+		 */
+		var sources = f.src.filter(function( filepath ) {
+
+			// Warn on and remove invalid source files (if nonull was set).
+			if ( !grunt.file.exists( filepath ) ) {
+				grunt.log.warn( "Source file '" + filepath + "' not found." );
+				return false;
+			} else {
+				return true;
+			}
+		});
+
+		// Write the destination file, or source file if destination isn't specified.
+		if ( typeof f.dest !== "undefined" ) {
+
+			// Concat specified files.
+			var css = sources.map(function( filepath ) {
+				return grunt.file.read( filepath );
+			}).join( grunt.util.linefeed );
+
+			grunt.file.write( f.dest, ie8Replacements( css ) );
+			grunt.log.writeln( "Cleaned file '" + f.dest + "' created." );
+
+		} else {
+
+			sources.forEach(function(filepath) {
+				grunt.file.write(filepath, ie8Replacements( grunt.file.read( filepath ) ) );
+				grunt.log.writeln( "File '" + filepath + "' prefixed." );
+			});
+		}
+
+		});
+
+		function ie8Replacements( css ) {
+			return css.replace( /@/g, grunt.util.linefeed + "@" );
+		}
+	});
+};


### PR DESCRIPTION
- Use compatibility mode for minification, although this still produces
  some incompatible CSS
- Move all "@" keywords to newlines so that when IE8 stops processing the unknown CSS it doesn't drop other CSS on the line
- Bump cssmin to the latest version. Note the "^" selector is the new default for NPM and needs later versions of NPM to understand.
