### PR TITLE
Bootstrap: Switch to Sass variant

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -117,7 +117,6 @@ module.exports = (grunt) ->
 			"sass:all"
 			"autoprefixer"
 			"csslint:unmin"
-			"concat:css"
 			"concat:css_addBanners"
 			"cssmin:dist"
 			"cssmin:distIE8"
@@ -291,20 +290,6 @@ module.exports = (grunt) ->
 				]
 				dest: "dist/unmin/js/i18n"
 				expand: true
-
-			css:
-				options:
-					banner: "@charset \"utf-8\";\n<%= banner %><%= glyphiconsBanner %>"
-				files:
-					"dist/unmin/css/ie8-wet-boew.css": [
-						"lib/bootstrap/dist/css/bootstrap.css"
-						"dist/unmin/css/wet-boew.css"
-						"dist/unmin/css/ie8-wet-boew.css"
-					]
-					"dist/unmin/css/wet-boew.css": [
-						"lib/bootstrap/dist/css/bootstrap.css"
-						"dist/unmin/css/wet-boew.css"
-					]
 
 			css_addBanners:
 				options:
@@ -547,19 +532,26 @@ module.exports = (grunt) ->
 				# Can be turned off after https://github.com/dimsemenov/Magnific-Popup/pull/303 lands
 				"empty-rules": false
 				"fallback-colors": false
-				"float": false
+				"floats": false
 				"font-sizes": false
 				"gradients": false
 				"headings": false
 				"ids": false
 				"important": false
+				# Need due to use of "\9" hacks for oldIE
+				"known-properties": false
 				"outline-none": false
 				"overqualified-elements": false
 				"qualified-headings": false
 				"regex-selectors": false
+				# Some Bootstrap mixins end up listing all the longhand properties
+				"shorthand": false
+				"text-indent": false
 				"unique-headings": false
 				"universal-selector": false
 				"unqualified-attributes": false
+				# Zeros are output by some of the Bootstrap mixins, but shouldn't be used in our code
+				"zero-units": false
 
 			unmin:
 				options:
@@ -791,7 +783,7 @@ module.exports = (grunt) ->
 
 		copy:
 			bootstrap:
-				cwd: "lib/bootstrap/dist/fonts"
+				cwd: "lib/bootstrap-sass-official/vendor/assets/fonts/bootstrap"
 				src: "*.*"
 				dest: "dist/unmin/fonts"
 				expand: true

--- a/bower.json
+++ b/bower.json
@@ -24,19 +24,19 @@
 		"tests"
 	],
 	"dependencies": {
-		"jquery.validation": "1.11.1",
-		"bootstrap": "3.1.1",
-		"flot": "0.8.1",
+		"bootstrap-sass-official": "3.1.1",
 		"DataTables": "1.9.4",
-		"magnific-popup": "0.9.8",
-		"jquery-pjax": "1.7.3",
+		"excanvas": "*",
+		"flot": "0.8.1",
+		"google-code-prettify": "1.0.0",
 		"html5shiv": "3.7.0",
+		"jquery-pjax": "1.7.3",
+		"jquery.validation": "1.11.1",
+		"magnific-popup": "0.9.8",
+		"openlayers": "http://openlayers.org/download/OpenLayers-2.13.1.tar.gz",
+		"proj4": "2.1.0",
 		"respond": "1.4.0",
 		"selectivizr": "1.0.2",
-		"excanvas": "*",
-		"google-code-prettify": "1.0.0",
-		"proj4": "2.1.0",
-		"openlayers": "http://openlayers.org/download/OpenLayers-2.13.1.tar.gz",
 		"SideBySideImproved": "https://github.com/pkoltermann/SideBySideImproved.git"
 	},
 	"resolutions": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "grunt-jscs-checker": "^0.4.0",
     "grunt-mocha": "~0.4.1",
     "grunt-modernizr": "~0.4.0",
-    "grunt-sass": "~0.9.0",
+    "grunt-sass": "^0.11.0",
     "grunt-saucelabs": "~4.1.2",
     "mocha": "~1.13.0",
     "sinon": "~1.7.3"

--- a/src/base/ie8-wet-boew.scss
+++ b/src/base/ie8-wet-boew.scss
@@ -2,6 +2,8 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
+@import "wet-boew";
+
 @import "partials/bootstrap-overrides-ie8";
 
 /*
@@ -13,7 +15,7 @@
  Polyfills
  */
 @import "../polyfills/details/details-ie8";
- 
+
 /* Print view */
 @media print {
 	@import "../plugins/footnotes/footnotes-ie8-printView";

--- a/src/base/wet-boew.scss
+++ b/src/base/wet-boew.scss
@@ -10,6 +10,17 @@
  */
 @import "../_variables";
 
+// Hack for Bootstrap 3.1.1, since it doesn't convert the "fadein" LESS method.
+// Pending fix release in https://github.com/twbs/bootstrap-sass/commit/df7be4f0412497e22f1d271d94d6e9835f61113e
+@function fadein($colour, $pct) {
+	@return opacify($colour, $pct / 100.0 );
+}
+
+// Override Bootstrap's expected font path
+$icon-font-path: "../fonts/";
+
+@import "../../lib/bootstrap-sass-official/vendor/assets/stylesheets/bootstrap";
+
 /*
  Global placeholders
  */


### PR DESCRIPTION
- Use the bootstrap-sass-official till the Bower package can be renamed
- Monkey patch the LESS "fadein" function till the next release where it is fixed
- Mute CSSLint warnings that are introduced by the Bootstrap mixins
- Bump grunt-sass for latest version of node-sass that can compile Bootstrap-Sass
