### PR TITLE
Moved all SCSS placeholders to the root of each file since ignored otherwise

### DIFF
--- a/site/data/i18n/af.json
+++ b/site/data/i18n/af.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/ar.json
+++ b/site/data/i18n/ar.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/bg.json
+++ b/site/data/i18n/bg.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/cs.json
+++ b/site/data/i18n/cs.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/de.json
+++ b/site/data/i18n/de.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/el.json
+++ b/site/data/i18n/el.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/en.json
+++ b/site/data/i18n/en.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/es.json
+++ b/site/data/i18n/es.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/et.json
+++ b/site/data/i18n/et.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/hi.json
+++ b/site/data/i18n/hi.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/hu.json
+++ b/site/data/i18n/hu.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/hy.json
+++ b/site/data/i18n/hy.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/is.json
+++ b/site/data/i18n/is.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/it.json
+++ b/site/data/i18n/it.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/ja.json
+++ b/site/data/i18n/ja.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/ko.json
+++ b/site/data/i18n/ko.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/lt.json
+++ b/site/data/i18n/lt.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/lv.json
+++ b/site/data/i18n/lv.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/nl.json
+++ b/site/data/i18n/nl.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/pl.json
+++ b/site/data/i18n/pl.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/pt.json
+++ b/site/data/i18n/pt.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/ru.json
+++ b/site/data/i18n/ru.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/sk.json
+++ b/site/data/i18n/sk.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/sq.json
+++ b/site/data/i18n/sq.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/th.json
+++ b/site/data/i18n/th.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/tr.json
+++ b/site/data/i18n/tr.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/uk.json
+++ b/site/data/i18n/uk.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/vi.json
+++ b/site/data/i18n/vi.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/site/data/i18n/zh.json
+++ b/site/data/i18n/zh.json
@@ -213,7 +213,7 @@
  "tmpl-health-url": "healthycanadians.gc.ca",
  "tmpl-travel": "Travel",
  "tmpl-travel-url": "travel.gc.ca",
- "tmpl-servicecanada": "Service  Canada",
+ "tmpl-servicecanada": "Service Canada",
  "tmpl-servicecanada-url": "servicecanada.gc.ca",
  "tmpl-jobs": "Jobs",
  "tmpl-jobs-url": "jobbank.gc.ca",

--- a/src/plugins/calendar/calendar-base.scss
+++ b/src/plugins/calendar/calendar-base.scss
@@ -5,6 +5,12 @@
 %cal-position-relative {
 	position: relative;
 }
+
+%cal-goto-btns {
+	display: inline-block;
+	margin: 10px 5px;
+}
+	
 .cal-cnt {
 	width: 18em;
 	text-shadow: none;
@@ -26,10 +32,6 @@
 	}
 	.cal-goto {
 		display: inline-block;
-	}
-	%cal-goto-btns {
-		display: inline-block;
-		margin: 10px 5px;
 	}
 	.cal-goto-mnth {
 		@extend %cal-goto-btns;

--- a/src/plugins/menu/menu.scss
+++ b/src/plugins/menu/menu.scss
@@ -104,6 +104,9 @@
 	}
 }
 
+%menu-mb-pnl-margin-bottom-5px {
+	margin-bottom: 5px;
+}
 #mb-pnl {
 	ul {
 		margin-bottom: 0;
@@ -120,9 +123,6 @@
 		}
 	}
 
-	%menu-mb-pnl-margin-bottom-5px {
-		margin-bottom: 5px;
-	}
 	.srch-pnl {
 		form {
 			white-space: nowrap;
@@ -149,11 +149,10 @@
 	}
 }
 
+%menu-noscript-display-block-important {
+	display: block !important;
+}
 .wb-disable {
-	%menu-noscript-display-block-important {
-		display: block !important;
-	}
-
 	#wb-glb-mn {
 		display: none !important;
 	}

--- a/src/plugins/multimedia/multimedia.scss
+++ b/src/plugins/multimedia/multimedia.scss
@@ -157,17 +157,17 @@
 	transition: all 0.26s ease;
 }
 
+%pnl {
+	vertical-align: middle;
+	display: table-cell;
+}
+
 .wb-mm-ctrls {
 	display: table;
 	background: #000;
 	color: #fff;
 	position: relative;
 	width: 100%;
-
-	%pnl {
-		vertical-align: middle;
-		display: table-cell;
-	}
 
 	.frstpnl {
 		@extend %pnl;

--- a/src/plugins/overlay/overlay-ie8.scss
+++ b/src/plugins/overlay/overlay-ie8.scss
@@ -6,15 +6,14 @@
 /*
  *	Overlay base
  */
-.ie8 {
-	%overlay-ie8-border-left-999 {
-		border-left: 1px solid #999;
-	}
-	
-	%overlay-ie8-border-right-999 {
-		border-left: 1px solid #999;
-	}
+%overlay-ie8-border-left-999 {
+	border-left: 1px solid #999;
+}
 
+%overlay-ie8-border-right-999 {
+	border-left: 1px solid #999;
+}
+.ie8 {
 	.wb-panel-l {
 		@extend %overlay-ie8-border-right-999;
 	}

--- a/src/plugins/tabs/tabs-mediumViewOver.scss
+++ b/src/plugins/tabs/tabs-mediumViewOver.scss
@@ -7,6 +7,27 @@
 	background: transparentize($drabBlue, 0.1);
 }
 
+%tabs-mediumview-prv-nxt-common {
+	top: 0;
+	bottom: 0;
+	height: 100%;
+	width: 3em;
+}
+%tabs-mediumview-prv-nxt-a-common {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+	left: 0;
+}
+%tabs-mediumview-prv-nxt-glyphicon-common {
+	position: absolute;
+	top: 0;
+	bottom: 0;
+}
+%tabs-mediumview-right-0 {
+	right: 0;
+}
+
 .wb-tabs {
 	&.carousel-s1, &.carousel-s2 {
 		figcaption {
@@ -25,26 +46,6 @@
 			li {
 				&.control {
 					position: absolute;
-				}
-				%tabs-mediumview-prv-nxt-common {
-					top: 0;
-					bottom: 0;
-					height: 100%;
-					width: 3em;
-				}
-				%tabs-mediumview-prv-nxt-a-common {
-					position: absolute;
-					top: 0;
-					bottom: 0;
-					left: 0;
-				}
-				%tabs-mediumview-prv-nxt-glyphicon-common {
-					position: absolute;
-					top: 0;
-					bottom: 0;
-				}
-				%tabs-mediumview-right-0 {
-					right: 0;
 				}
 				&.prv {
 					left: 0;

--- a/src/plugins/tabs/tabs-smallViewUnder.scss
+++ b/src/plugins/tabs/tabs-smallViewUnder.scss
@@ -10,6 +10,14 @@
 	display: none;
 }
 
+%tabs-smallview-font-size-15-em {
+	font-size: 1.5em;
+}
+
+%tabs-details-padding-6-12 {
+	padding: 6px 12px;
+}
+
 .wb-tabs {
 	&.carousel-s1, &.carousel-s2 {
 		figcaption {
@@ -60,9 +68,6 @@
 						padding-left: 1em;
 					}
 				}
-				%tabs-smallview-font-size-15-em {
-					font-size: 1.5em;
-				}
 				&.tab-count {
 					line-height: normal;
 					> {
@@ -101,9 +106,6 @@
 				@extend %tabs-smallview-display-none;
 			}
 		}
-	}
-	%tabs-details-padding-6-12 {
-		padding: 6px 12px;
 	}
 	> {
 		details {

--- a/src/plugins/tabs/tabs.scss
+++ b/src/plugins/tabs/tabs.scss
@@ -48,6 +48,43 @@ $medGray: #ccc;
 	color: #fff;
 }
 
+%carousel-s2-prv-nxt-common {
+	background: none;
+	margin: 0;
+	padding: 0;
+}
+
+%carousel-s2-prv-nxt-a-common {
+	width: 100%;
+	color: $drabBlue;
+	border: none;
+}
+
+%carousel-s2-prv-nxt-glyphicon-common {
+	margin: auto 0;
+	height: 1.75em;
+	width: 1.75em;
+	font-size: 1.75em;
+	line-height: 1.75em;
+	text-align: center;
+	background: #fff;
+	border-radius: 999px;
+	box-shadow: 0 0 4px $drabBlue;
+}
+
+%tabs-background-transparent {
+	background: transparent;
+}
+
+%tabs-box-shadow-none {
+	box-shadow: none;
+}
+
+%tabs-carousel-border-top-none-padding-top-1 {
+	border-top: none;
+	padding-top: 10px;
+}
+
 .wb-tabs {
 	/**
 	 * Default, minimal, shared style
@@ -97,10 +134,6 @@ $medGray: #ccc;
 		}
 	}
 
-	%tabs-carousel-border-top-none-padding-top-1 {
-		border-top: none;
-		padding-top: 10px;
-	}
 	/**
 	 * Style 1 - Basic carousel style
 	 */
@@ -184,33 +217,6 @@ $medGray: #ccc;
 				}
 				&.control {
 					display: inline-block;
-				}
-				%carousel-s2-prv-nxt-common {
-					background: none;
-					margin: 0;
-					padding: 0;
-				}
-				%carousel-s2-prv-nxt-a-common {
-					width: 100%;
-					color: $drabBlue;
-					border: none;
-				}
-				%carousel-s2-prv-nxt-glyphicon-common {
-					margin: auto 0;
-					height: 1.75em;
-					width: 1.75em;
-					font-size: 1.75em;
-					line-height: 1.75em;
-					text-align: center;
-					background: #fff;
-					border-radius: 999px;
-					box-shadow: 0 0 4px $drabBlue;
-				}
-				%tabs-background-transparent {
-					background: transparent;
-				}
-				%tabs-box-shadow-none {
-					box-shadow: none;
 				}
 				&.prv {
 					@extend %carousel-s2-prv-nxt-common;

--- a/theme/sass/parts/_secMenu.scss
+++ b/theme/sass/parts/_secMenu.scss
@@ -1,6 +1,10 @@
 /*
  * Secondary menu
  */
+%secmenu-wet-theme-menuitem-curr-hover-focus {
+	background: darken($clrWhite, 50%);
+	color: lighten($clrDark, 75%);
+}
 #wb-sec {
 	margin-top: 20px;
 	padding-bottom: 2em;
@@ -25,10 +29,6 @@
 				border-radius: 0;
 				margin-top: -1px;
 				text-decoration: none;
-				%secmenu-wet-theme-menuitem-curr-hover-focus {
-					background: darken($clrWhite, 50%);
-					color: lighten($clrDark, 75%);
-				}
 				&.wb-navcurr {
 					@extend %secmenu-wet-theme-menuitem-curr-hover-focus;
 				}


### PR DESCRIPTION
Seems bumping the node-sass version (#4827) introduced a bug (intentional or otherwise) that causes placeholders that are not at the root of the file to fail silently. So this ended up breaking a few plugins, which started working again once I moved the placeholders to the file root (so no nesting).

Also it looks like an i18n update is piggy-backing on my pull request.

/cc @nschonni @LaurentGoderre
