### PR TITLE
Overlay: Use hexadecimal character reference

### DIFF
--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -379,9 +379,6 @@ var pluginName = "wb-mltmd",
 			}
 			$this.trigger( captionsVisibleChangeEvent );
 			break;
-		case "setPreviousTime":
-			this.object.previousTime = args;
-			break;
 		case "getBuffering":
 			return this.object.buffering || false;
 		case "setBuffering":

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -66,7 +66,7 @@ var pluginName = "wb-overlay",
 			}
 			closeText = closeText.replace( "'", "&#39;" );
 			overlayClose = "<button class='mfp-close " + closeClass +
-				"' title='" + closeText + "'>×<span class='wb-inv'> " +
+				"' title='" + closeText + "'>&#xd7;<span class='wb-inv'> " +
 				closeText + "</span></button>";
 
 			$elm.append( overlayClose );


### PR DESCRIPTION
Overlay: Replace close character (×) with hexadecimal character reference. Fixes incorrect display of '×' character in mobile menus when using different character encodings.
Multimedia plugin: Remove duplicate code.
