### PR TITLE
Added validation method to Jquery Validator for Canadian postal code

### DIFF
--- a/demos/formvalid/formvalid-en.html
+++ b/demos/formvalid/formvalid-en.html
@@ -110,7 +110,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <label for="fname1"><span class="field-name">First Name</span> <strong>(required)</strong></label><input id="fname1" name="fname1" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" />
 <label for="lname1"><span class="field-name">Last Name</span> <strong>(required)</strong></label><input id="lname1" name="lname1" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" />
 <label for="tel1"><span class="field-name">Telephone Number</span> (999-999-9999) <strong>(required)</strong></label><input id="tel1" name="tel1" type="tel" required="required" data-rule-phoneUS="true" />
-<label for="postcode"><span class="field-name">Postal Code:</span></label> <input type="text" id="postcode" name="postcode" data-rule-postcodeCA="true">
+<label for="postcode"><span class="field-name">Postal Code</span></label> <input type="text" id="postcode" name="postcode" data-rule-postcodeCA="true">
 <label for="email1"><span class="field-name">Email Address</span></label><input id="email1" name="email1" type="email" />
 <label for="url1"><span class="field-name">Website URL (http://www.url.com)</span></label><input id="url1" name="url1" type="url" />
 </fieldset>

--- a/demos/formvalid/formvalid-en.html
+++ b/demos/formvalid/formvalid-en.html
@@ -110,6 +110,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <label for="fname1"><span class="field-name">First Name</span> <strong>(required)</strong></label><input id="fname1" name="fname1" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" />
 <label for="lname1"><span class="field-name">Last Name</span> <strong>(required)</strong></label><input id="lname1" name="lname1" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" />
 <label for="tel1"><span class="field-name">Telephone Number</span> (999-999-9999) <strong>(required)</strong></label><input id="tel1" name="tel1" type="tel" required="required" data-rule-phoneUS="true" />
+<label for="postcode"><span class="field-name">Postal Code:</span></label> <input type="text" id="postcode" name="postcode" data-rule-postcodeCA="true">
 <label for="email1"><span class="field-name">Email Address</span></label><input id="email1" name="email1" type="email" />
 <label for="url1"><span class="field-name">Website URL (http://www.url.com)</span></label><input id="url1" name="url1" type="url" />
 </fieldset>

--- a/demos/formvalid/formvalid-fr.html
+++ b/demos/formvalid/formvalid-fr.html
@@ -110,6 +110,7 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 <label for="fname"><span class="field-name">Prénom</span> <strong>(obligatoire)</strong></label><input id="fname" name="fname" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" />
 <label for="lname"><span class="field-name">Nom de famille</span> <strong>(obligatoire)</strong></label><input id="lname" name="lname" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" />
 <label for="tel"><span class="field-name">Numéro de téléphone</span> (999-999-9999) <strong>(obligatoire)</strong></label><input id="tel" name="tel" type="tel" required="required" data-rule-phoneUS="true" />
+    <label for="postcode"><span class="field-name">Code postal</span></label> <input type="text" id="postcode" name="postcode" data-rule-postcodeCA="true">
 <label for="email1"><span class="field-name">Adresse électronique</span></label><input id="email1" name="email1" type="email" />
 <label for="url1"><span class="field-name">URL du site Web (http://www.url.com)</span></label><input id="url1" name="url1" type="url" />
 </fieldset>

--- a/src/js/dependencies/validateAdditional.js
+++ b/src/js/dependencies/validateAdditional.js
@@ -53,9 +53,15 @@ jQuery.validator.addMethod("ziprange", function(value, element) {
 	return this.optional(element) || /^90[2-5]\d\{2\}-\d{4}$/.test(value);
 }, "Your ZIP-code must be in the range 902xx-xxxx to 905-xx-xxxx");
 
+
+
 jQuery.validator.addMethod("zipcodeUS", function(value, element) {
 	return this.optional(element) || /\d{5}-\d{4}$|^\d{5}$/.test(value);
 }, "The specified US ZIP Code is invalid");
+
+jQuery.validator.addMethod("postcodeCA", function(value, element) {
+	return this.optional(element) ||/^([a-zA-Z]\d[a-zA-z]( )?\d[a-zA-Z]\d)$/.test(value);
+}, "The specified postal code is invalid");
 
 jQuery.validator.addMethod("integer", function(value, element) {
 	return this.optional(element) || /^-?\d+$/.test(value);

--- a/src/js/dependencies/validateAdditional.js
+++ b/src/js/dependencies/validateAdditional.js
@@ -60,7 +60,7 @@ jQuery.validator.addMethod("zipcodeUS", function(value, element) {
 }, "The specified US ZIP Code is invalid");
 
 jQuery.validator.addMethod("postcodeCA", function(value, element) {
-	return this.optional(element) ||/^([a-zA-Z]\d[a-zA-z]( )?\d[a-zA-Z]\d)$/.test(value);
+	return this.optional(element) ||/^([a-zA-Z]\d[a-zA-z](?: )?\d[a-zA-Z]\d)$/.test(value);
 }, "The specified postal code is invalid");
 
 jQuery.validator.addMethod("integer", function(value, element) {

--- a/src/js/i18n/formvalid/messages_fr.js
+++ b/src/js/i18n/formvalid/messages_fr.js
@@ -28,6 +28,7 @@
 		alphanumeric: "Veuillez fournir seulement des lettres, nombres, espaces et soulignages",
 		lettersonly: "Veuillez fournir seulement des lettres.",
 		nowhitespace: "Veuillez ne pas inscrire d'espaces blancs.",
+		postcodeCA: "Veuillez fournir un code postal valide.",
 		ziprange: "Veuillez fournir un code postal entre 902xx-xxxx et 905-xx-xxxx.",
 		integer: "Veuillez fournir un nombre non décimal qui est positif ou négatif.",
 		vinUS: "Veuillez fournir un numéro d'identification du véhicule (VIN).",


### PR DESCRIPTION
I added the validation pattern to the Jquery Validation for Canadian postal code and error messages for both official languages. It only checks the format, not if the postal code actually exist.
