### PR TITLE
Documentation: Zebra plugin - i18n - fix $ and %

### DIFF
--- a/src/plugins/zebra/zebra-en.hbs
+++ b/src/plugins/zebra/zebra-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "zebra",
 	"parentdir": "zebra",
 	"altLangPrefix": "zebra",
-	"dateModified": "2014-03-06"
+	"dateModified": "2014-03-23"
 }
 ---
 
@@ -48,7 +48,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -56,7 +56,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -64,7 +64,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -72,7 +72,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -80,7 +80,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -88,7 +88,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -96,7 +96,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -104,7 +104,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -112,7 +112,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -120,7 +120,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 	</tbody>
@@ -184,7 +184,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -192,7 +192,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -200,7 +200,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -208,7 +208,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -216,7 +216,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -224,7 +224,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -232,7 +232,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -240,7 +240,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -248,7 +248,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 		<tr>
@@ -256,7 +256,7 @@
 			<th>Item</th>
 			<td>Description</td>
 			<td>2 times</td>
-			<td>25.99 $</td>
+			<td>$25.99</td>
 			<td>51.98</td>
 		</tr>
 	</tbody>
@@ -310,7 +310,7 @@
 			&lt;th&gt;Item&lt;/th&gt;
 			&lt;td&gt;Description&lt;/td&gt;
 			&lt;td&gt;2 times&lt;/td&gt;
-			&lt;td&gt;25.99 $&lt;/td&gt;
+			&lt;td&gt;$25.99&lt;/td&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
@@ -318,7 +318,7 @@
 			&lt;th&gt;Item&lt;/th&gt;
 			&lt;td&gt;Description&lt;/td&gt;
 			&lt;td&gt;2 times&lt;/td&gt;
-			&lt;td&gt;25.99 $&lt;/td&gt;
+			&lt;td&gt;$25.99&lt;/td&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
@@ -326,7 +326,7 @@
 			&lt;th&gt;Item&lt;/th&gt;
 			&lt;td&gt;Description&lt;/td&gt;
 			&lt;td&gt;2 times&lt;/td&gt;
-			&lt;td&gt;25.99 $&lt;/td&gt;
+			&lt;td&gt;$25.99&lt;/td&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
@@ -334,7 +334,7 @@
 			&lt;th&gt;Item&lt;/th&gt;
 			&lt;td&gt;Description&lt;/td&gt;
 			&lt;td&gt;2 times&lt;/td&gt;
-			&lt;td&gt;25.99 $&lt;/td&gt;
+			&lt;td&gt;$25.99&lt;/td&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
@@ -342,7 +342,7 @@
 			&lt;th&gt;Item&lt;/th&gt;
 			&lt;td&gt;Description&lt;/td&gt;
 			&lt;td&gt;2 times&lt;/td&gt;
-			&lt;td&gt;25.99 $&lt;/td&gt;
+			&lt;td&gt;$25.99&lt;/td&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
@@ -350,7 +350,7 @@
 			&lt;th&gt;Item&lt;/th&gt;
 			&lt;td&gt;Description&lt;/td&gt;
 			&lt;td&gt;2 times&lt;/td&gt;
-			&lt;td&gt;25.99 $&lt;/td&gt;
+			&lt;td&gt;$25.99&lt;/td&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
@@ -358,7 +358,7 @@
 			&lt;th&gt;Item&lt;/th&gt;
 			&lt;td&gt;Description&lt;/td&gt;
 			&lt;td&gt;2 times&lt;/td&gt;
-			&lt;td&gt;25.99 $&lt;/td&gt;
+			&lt;td&gt;$25.99&lt;/td&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
@@ -366,7 +366,7 @@
 			&lt;th&gt;Item&lt;/th&gt;
 			&lt;td&gt;Description&lt;/td&gt;
 			&lt;td&gt;2 times&lt;/td&gt;
-			&lt;td&gt;25.99 $&lt;/td&gt;
+			&lt;td&gt;$25.99&lt;/td&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
@@ -374,7 +374,7 @@
 			&lt;th&gt;Item&lt;/th&gt;
 			&lt;td&gt;Description&lt;/td&gt;
 			&lt;td&gt;2 times&lt;/td&gt;
-			&lt;td&gt;25.99 $&lt;/td&gt;
+			&lt;td&gt;$25.99&lt;/td&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
@@ -382,7 +382,7 @@
 			&lt;th&gt;Item&lt;/th&gt;
 			&lt;td&gt;Description&lt;/td&gt;
 			&lt;td&gt;2 times&lt;/td&gt;
-			&lt;td&gt;25.99 $&lt;/td&gt;
+			&lt;td&gt;$25.99&lt;/td&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 	&lt;/tbody&gt;

--- a/src/plugins/zebra/zebra-fr.hbs
+++ b/src/plugins/zebra/zebra-fr.hbs
@@ -477,7 +477,7 @@
 					<td>8</td>
 				</tr>
 				<tr>
-					<td>&#160;</td>
+					<td></td>
 					<td></td>
 					<td></td>
 					<td></td>
@@ -603,7 +603,7 @@
 			&lt;td&gt;8&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
-			&lt;td&gt;&amp;#160;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
 			&lt;td&gt;&lt;/td&gt;
 			&lt;td&gt;&lt;/td&gt;
 			&lt;td&gt;&lt;/td&gt;

--- a/src/plugins/zebra/zebra-fr.hbs
+++ b/src/plugins/zebra/zebra-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "zebra",
 	"parentdir": "zebra",
 	"altLangPrefix": "zebra",
-	"dateModified": "2014-03-06"
+	"dateModified": "2014-03-23"
 }
 ---
 
@@ -129,7 +129,7 @@
 			<td>519.80</td>
 		</tr>
 		<tr>
-			<th colspan="5">Taxes (10%)</th>
+			<th colspan="5">Taxes (10 %)</th>
 			<td>51.98</td>
 		</tr>
 	</tbody>
@@ -266,7 +266,7 @@
 			<td>519.80</td>
 		</tr>
 		<tr>
-			<th colspan="5">Taxes (10%)</th>
+			<th colspan="5">Taxes (10 %)</th>
 			<td>51.98</td>
 		</tr>
 	</tbody>
@@ -392,7 +392,7 @@
 			&lt;td&gt;519.80&lt;/td&gt;
 		&lt;/tr&gt;
 		&lt;tr&gt;
-			&lt;th colspan=&quot;5&quot;&gt;Taxes (10%)&lt;/th&gt;
+			&lt;th colspan=&quot;5&quot;&gt;Taxes (10 %)&lt;/th&gt;
 			&lt;td&gt;51.98&lt;/td&gt;
 		&lt;/tr&gt;
 	&lt;/tbody&gt;


### PR DESCRIPTION
Documentation: Zebra plugin
- Fix dollar signs in English version.
- Add space before % - French version.
- Remove non-breaking space.
