### PR TITLE
[CSS] Overrode the default width of 100% for form controls

### DIFF
--- a/src/base/partials/_bootstrap-overrides.scss
+++ b/src/base/partials/_bootstrap-overrides.scss
@@ -352,3 +352,15 @@ input[type="reset"], input[type="button"], input[type="submit"] {
 blockquote {
 	font-size: $font-size-base;
 }
+
+/*
+ *	Form control width
+ *
+ *	Default should be representative of the expected length of input.
+ *	Full width should be only for cases when the expected length of input is
+ *	greater than the available width.
+ */
+.form-control {
+	width: auto;
+	max-width: 100%;
+}


### PR DESCRIPTION
The width of form controls should be representative of the expected length of input.

A width of 100% should only be used when the expected length of input for a field is greater than the available width. This override does this automatically by setting `max-width: 100%;`.

Fixes issue #4940.
