### PR TITLE
[CSS] Implemented the 'default' button style using the same method as the other buttons

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -12,10 +12,6 @@ $clrWhite: #FFF;
 $clrLight: #EEE;
 $clrMedium: #CCC;
 $clrDark: #555;
-$accentBlue: #335075;
-$activeBlue: #243850;
-$wbGray: #e1e4e7;
-$wbGrayLight: #eaebed;
 
 // Views
 $xxSmallViewMax: 479px;
@@ -56,5 +52,9 @@ $link-visited-color: #7834BC;
 
 $table-bg-accent: #f5f5f5;
 $table-bg-hover: #f0f0f0;
+
+$btn-default-color: #335075;
+$btn-default-bg: #eaebed;
+$btn-default-border: darken($btn-default-bg, 5%);
 
 $btn-warning-color: #000;

--- a/src/base/partials/_bootstrap-overrides.scss
+++ b/src/base/partials/_bootstrap-overrides.scss
@@ -38,19 +38,6 @@ main {
 }
 
 /*
- *	Override color for "default" button style
- */
-
-.btn-default {
-	background-color: $wbGrayLight;
-	color: $accentBlue;
-	&:hover, &:focus {
-		background-color: $wbGray;
-		color: $activeBlue;
-	}
-}
-
-/*
  *	Override the design of alerts and labels
  */
 


### PR DESCRIPTION
Currently the 'default' button style is implemented completely differently than other button styles and the values for the `color`, 'background-color`and`border-color` aren't determined using the same algorithm. That means that any changes have to be calculated manually instead of algorithmically.
