### PR TITLE
V4 build cleaning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,9 +10,6 @@ insert_final_newline = true
 indent_style = tabs
 indent_size = 4
 
-[package.json]
-charset = utf-8
-trim_trailing_whitespace = true
-insert_final_newline = true
+[{package.json},{bower.json}]
 indent_style = space
 indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -33,4 +33,4 @@ sprite*.png
 node_modules/
 lib/
 wet-boew-dist/
-site/data/i18n
+site/data/i18n/

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -194,6 +194,8 @@ module.exports = (grunt) ->
 
 		# Metadata.
 		pkg: grunt.file.readJSON("package.json")
+		jqueryVersion: grunt.file.readJSON("lib/jquery/bower.json")
+		jqueryOldIEVersion: grunt.file.readJSON("lib/jquery-oldIE/bower.json")
 		banner: "/*!\n * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)\n * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html\n" +
 				" * v<%= pkg.version %> - " + "<%= grunt.template.today(\"yyyy-mm-dd\") %>\n *\n */"
 		modernizrBanner: "/*! Modernizr (Custom Build) | MIT & BSD */\n"
@@ -324,6 +326,8 @@ module.exports = (grunt) ->
 				options:
 					environment:
 						root: "/v4.0-ci/unmin"
+						jqueryVersion: "<%= jqueryVersion.version %>"
+						jqueryOldIEVersion: "<%= jqueryOldIEVersion.version %>"
 					assets: "dist/unmin"
 					flatten: true,
 					plugins: ["assemble-contrib-i18n"]
@@ -340,6 +344,8 @@ module.exports = (grunt) ->
 				options:
 					environment:
 						root: "/v4.0-ci/unmin"
+						jqueryVersion: "<%= jqueryVersion.version %>"
+						jqueryOldIEVersion: "<%= jqueryOldIEVersion.version %>"
 					assets: "dist/unmin"
 				files: [
 						expand: true
@@ -372,6 +378,8 @@ module.exports = (grunt) ->
 					environment:
 						suffix: ".min"
 						root: "/v4.0-ci"
+						jqueryVersion: "<%= jqueryVersion.version %>"
+						jqueryOldIEVersion: "<%= jqueryOldIEVersion.version %>"
 					assets: "dist"
 					flatten: true,
 					plugins: ['assemble-contrib-i18n']
@@ -389,6 +397,8 @@ module.exports = (grunt) ->
 					environment:
 						suffix: ".min"
 						root: "/v4.0-ci"
+						jqueryVersion: "<%= jqueryVersion.version %>"
+						jqueryOldIEVersion: "<%= jqueryOldIEVersion.version %>"
 					assets: "dist"
 				files: [
 						expand: true

--- a/bower.json
+++ b/bower.json
@@ -1,45 +1,45 @@
 {
-	"name": "wet-boew",
-	"version": "4.0.0-development",
-	"homepage": "https://github.com/wet-boew/wet-boew",
-	"authors": [
-		"WET-BOEW Team"
-	],
-	"description": "Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)",
-	"keywords": [
-		"i18n",
-		"a11y",
-		"wet-boew",
-		"bootstrap"
-	],
-	"license": "MIT",
-	"private": true,
-	"ignore": [
-		".git*",
-		".travis.yml",
-		".editorconfig",
-		"node_modules",
-		"bower_components",
-		"test",
-		"tests"
-	],
-	"dependencies": {
-		"bootstrap-sass-official": "3.1.1",
-		"DataTables": "1.9.4",
-		"excanvas": "*",
-		"flot": "0.8.1",
-		"google-code-prettify": "1.0.0",
-		"html5shiv": "3.7.0",
-		"jquery-pjax": "1.7.3",
-		"jquery.validation": "1.11.1",
-		"magnific-popup": "0.9.8",
-		"openlayers": "http://openlayers.org/download/OpenLayers-2.13.1.tar.gz",
-		"proj4": "2.1.0",
-		"respond": "1.4.0",
-		"selectivizr": "1.0.2",
-		"SideBySideImproved": "https://github.com/pkoltermann/SideBySideImproved.git"
-	},
-	"resolutions": {
-		"jquery": ">= 1.9.0"
-	}
+  "name": "wet-boew",
+  "version": "4.0.0-development",
+  "homepage": "https://github.com/wet-boew/wet-boew",
+  "authors": [
+    "WET-BOEW Team"
+  ],
+  "description": "Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)",
+  "keywords": [
+    "i18n",
+    "a11y",
+    "wet-boew",
+    "bootstrap"
+  ],
+  "license": "MIT",
+  "private": true,
+  "ignore": [
+    ".git*",
+    ".travis.yml",
+    ".editorconfig",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "bootstrap-sass-official": "3.1.1",
+    "DataTables": "1.9.4",
+    "excanvas": "*",
+    "flot": "0.8.1",
+    "google-code-prettify": "1.0.0",
+    "html5shiv": "3.7.0",
+    "jquery-pjax": "1.7.3",
+    "jquery.validation": "1.11.1",
+    "magnific-popup": "0.9.8",
+    "openlayers": "http://openlayers.org/download/OpenLayers-2.13.1.tar.gz",
+    "proj4": "2.1.0",
+    "respond": "1.4.0",
+    "selectivizr": "1.0.2",
+    "SideBySideImproved": "https://github.com/pkoltermann/SideBySideImproved.git"
+  },
+  "resolutions": {
+    "jquery": ">= 1.9.0"
+  }
 }

--- a/bower.json
+++ b/bower.json
@@ -30,6 +30,8 @@
     "flot": "0.8.1",
     "google-code-prettify": "1.0.0",
     "html5shiv": "3.7.0",
+    "jquery": "2.1.0",
+    "jquery-oldIE": "jquery#1.11.0",
     "jquery-pjax": "1.7.3",
     "jquery.validation": "1.11.1",
     "magnific-popup": "0.9.8",
@@ -40,6 +42,6 @@
     "SideBySideImproved": "https://github.com/pkoltermann/SideBySideImproved.git"
   },
   "resolutions": {
-    "jquery": ">= 1.9.0"
+    "jquery": "~2.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.html",
   "scripts": {
     "test": "grunt test",
-    "postinstall": "bower update --config.interactive=false && grunt init"
+    "postinstall": "bower update && grunt init"
   },
   "repository": {
     "type": "git",

--- a/site/includes/footerresources.hbs
+++ b/site/includes/footerresources.hbs
@@ -1,5 +1,5 @@
 <!--[if gte IE 9 | !IE ]><!-->
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery{{environment.suffix}}.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/{{environment.jqueryVersion}}/jquery{{environment.suffix}}.js"></script>
 <script src="{{assets}}/js/wet-boew{{environment.suffix}}.js"></script>
 <!--<![endif]-->
 <!--[if lt IE 9]>

--- a/site/includes/headresources.hbs
+++ b/site/includes/headresources.hbs
@@ -7,7 +7,7 @@
 <!--[if lt IE 9]>
 <link href="{{assets}}/assets/favicon.ico" rel="shortcut icon" />
 <link rel="stylesheet" href="{{assets}}/css/ie8-wet-boew{{environment.suffix}}.css" />
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery{{environment.suffix}}.js"></script>
+<script src="http://ajax.googleapis.com/ajax/libs/jquery/{{environment.jqueryOldIEVersion}}/jquery{{environment.suffix}}.js"></script>
 <script src="{{assets}}/js/ie8-wet-boew{{environment.suffix}}.js"></script>
 <![endif]-->
 

--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -21,7 +21,7 @@
 		<!--[if lt IE 9]>
 		<link href="{{environment.root}}/assets/favicon.ico" rel="shortcut icon" />
 		<link rel="stylesheet" href="{{environment.root}}/css/ie8-wet-boew.css" />
-		<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery{{environment.suffix}}.js"></script>
+		<script src="http://ajax.googleapis.com/ajax/libs/jquery/{{environment.jqueryOldIEVersion}}/jquery{{environment.suffix}}.js"></script>
 		<script src="{{environment.root}}/js/ie8-wet-boew{{environment.suffix}}.js"></script>
 		<![endif]-->
 

--- a/site/layouts/splashpage.hbs
+++ b/site/layouts/splashpage.hbs
@@ -35,6 +35,5 @@
 			</div>
 		</main>
 		{{>footerresources}}
-		{{#if environment.test}}{{>test}}{{/if}}
 	</body>
 </html>


### PR DESCRIPTION
Didn't really fix the i18n diff stuff because it looks like the index needs to be ignored if you already have the files :frowning: 
- Convert the bower stuff to spaces (Fixes gh-5032)
- Re-add jQuery to Bower and read versions into templates (Fixes gh-4816)
- Remove leftover test partial reference
