### PR TITLE
Favicon change to rel="[icon]"

### DIFF
--- a/site/pages/docs/ref/favicon/favicon-en.hbs
+++ b/site/pages/docs/ref/favicon/favicon-en.hbs
@@ -35,10 +35,10 @@
 		<h3>Add a mobile favicon:</h3>
 		<ol>
 			<li>Add a favicon to the web page using a link element: 
-				<pre><code>&lt;link href="favion.ico" rel="shortcut icon"&gt;</code></pre>
+				<pre><code>&lt;link href="favion.ico" rel="icon" type="image/x-icon"&gt;</code></pre>
 			</li>
 			<li>Optionally specify the mobile favion's filename, path, rel attribute and sizes attribute:
-				<pre><code>&lt;link href="favion.ico" rel="shortcut icon" 
+				<pre><code>&lt;link href="favion.ico" rel="icon" type="image/x-icon" 
 	data-filename="my-mobile-favicon.ico" 
 	data-path="/path/to/favicon/"
 	data-rel="apple-touch-icon-precomposed"
@@ -51,7 +51,7 @@
 		<h3>Update an existing favicon's href attribute:</h3>
 		<ol>
 			<li>Using JavaScript, get a reference to the favicon's link element: 
-				<pre><code>var $favicon = $( "link[rel='shortcut icon']" );</code></pre>
+				<pre><code>var $favicon = $( "link[rel='icon']" );</code></pre>
 			</li>
 			<li>Trigger the <code>icon.wb-favicon</code> event on the favicon element:
 				<pre><code>$favicon.trigger( "icon.wb-favicon" );</code></pre>
@@ -95,7 +95,7 @@
 				<td>
 					<dl>
 						<dt>None (default):</dt>
-						<dd>If not specified, defaults to the same path as the <code>&lt;link&gt;</code> shortcut icon</dd>
+						<dd>If not specified, defaults to the same path as the <code>&lt;link&gt;</code> icon</dd>
 						<dt>String (favicon path):</dt>
 						<dd>Custom mobile favicon path.</dd>
 					</dl>

--- a/site/pages/docs/ref/favicon/favicon-fr.hbs
+++ b/site/pages/docs/ref/favicon/favicon-fr.hbs
@@ -37,10 +37,10 @@
 			<h3>Add a mobile favicon:</h3>
 			<ol>
 				<li>Add a favicon to the web page using a link element: 
-					<pre><code>&lt;link href="favion.ico" rel="shortcut icon"&gt;</code></pre>
+					<pre><code>&lt;link href="favion.ico" rel="icon" type="image/x-icon"&gt;</code></pre>
 				</li>
 				<li>Optionally specify the mobile favion's filename, path, rel attribute and sizes attribute:
-					<pre><code>&lt;link href="favion.ico" rel="shortcut icon" 
+					<pre><code>&lt;link href="favion.ico" rel="icon" type="image/x-icon"
 		data-filename="my-mobile-favicon.ico" 
 		data-path="/path/to/favicon/"
 		data-rel="apple-touch-icon-precomposed"
@@ -53,7 +53,7 @@
 			<h3>Update an existing favicon's href attribute:</h3>
 			<ol>
 				<li>Using JavaScript, get a reference to the favicon's link element: 
-					<pre><code>var $favicon = $( "link[rel='shortcut icon']" );</code></pre>
+					<pre><code>var $favicon = $( "link[rel='icon']" );</code></pre>
 				</li>
 				<li>Trigger the <code>icon.wb-favicon</code> event on the favicon element:
 					<pre><code>$favicon.trigger( "icon.wb-favicon" );</code></pre>
@@ -97,7 +97,7 @@
 					<td>
 						<dl>
 							<dt>None (default):</dt>
-							<dd>If not specified, defaults to the same path as the <code>&lt;link&gt;</code> shortcut icon</dd>
+							<dd>If not specified, defaults to the same path as the <code>&lt;link&gt;</code> icon</dd>
 							<dt>String (favicon path):</dt>
 							<dd>Custom mobile favicon path.</dd>
 						</dl>

--- a/src/plugins/favicon/favicon-en.hbs
+++ b/src/plugins/favicon/favicon-en.hbs
@@ -11,16 +11,16 @@
 }
 ---
 
-<p>This plugin provides the ability to add and update the favicon's on a web page. Its default behaviour is to add a mobile favicon to web pages that have a favicon defined by a <code>&lt;link rel="shortcut icon"&gt;</code> element.</p>
-<p>The mobile favicon's file name, rel, path and sizes can be set with <code>data</code> attributes on the <code>&lt;link rel="shortcut icon"&gt;</code>:</p>
+<p>This plugin provides the ability to add and update the favicon's on a web page. Its default behaviour is to add a mobile favicon to web pages that have a favicon defined by a <code>&lt;link rel="icon" type="image/x-icon"&gt;</code> element.</p>
+<p>The mobile favicon's file name, rel, path and sizes can be set with <code>data</code> attributes on the <code>&lt;link rel="icon" type="image/x-icon"&gt;</code>:</p>
 
 <ul>
 	<li><strong>data-filename:</strong> filename of the mobile favicon (defaults to "favicon-mobile.png"). This will be appended to the favicon's path.</li>
-	<li><strong>data-path:</strong> path to the mobile favicon (defaults to using the same path as the shortcut icon).</li>
+	<li><strong>data-path:</strong> path to the mobile favicon (defaults to using the same path as the icon).</li>
 	<li><strong>data-rel:</strong> rel attribute of the mobile favicon (defaults to "apple-touch-icon").</li>
 	<li><strong>data-sizes:</strong> <code>sizes</code> attribute of the mobile favicon (defaults to "57x57 72x72 114x114 144x144 150x150").</li>
 </ul>
 
 <p>For example, the following overrides the <code>rel</code> and <code>filename</code> attributes of the mobile favicon:</p>
 
-<code class="prettyprint">&lt;link href="favion.ico" rel="shortcut icon" data-filename="my-mobile-favicon.ico" data-rel="apple-touch-icon-precomposed"&gt;</code>
+<code class="prettyprint">&lt;link href="favion.ico" rel="icon" type="image/x-icon" data-filename="my-mobile-favicon.ico" data-rel="apple-touch-icon-precomposed"&gt;</code>

--- a/src/plugins/favicon/favicon-fr.hbs
+++ b/src/plugins/favicon/favicon-fr.hbs
@@ -11,16 +11,16 @@
 }
 ---
 
-<p>Offre la possibilité d'ajouter et de mettre à jour les favoricônes d'une page. Son comportement par défaut consiste à ajouter une favoricône d'appareil mobile à des pages Web définie par l'élément <code>&lt;link rel="shortcut icon"&gt;</code>.</p>
-<p>Le nom de fichier de la favoricône, attribut <code>rel</code>, le chemin et les tailles peuvent être définies avec des attributs <code>data</code> sur l'élément <code>&lt;link rel="shortcut icon"&gt;</code>&#160;:</p>
+<p>Offre la possibilité d'ajouter et de mettre à jour les favoricônes d'une page. Son comportement par défaut consiste à ajouter une favoricône d'appareil mobile à des pages Web définie par l'élément <code>&lt;link rel="icon" type="image/x-icon"&gt;</code>.</p>
+<p>Le nom de fichier de la favoricône, attribut <code>rel</code>, le chemin et les tailles peuvent être définies avec des attributs <code>data</code> sur l'élément <code>&lt;link rel="icon" type="image/x-icon"&gt;</code>&#160;:</p>
 
 <ul>
 	<li><strong>data-filename :</strong> Le nom de fichier de la favoricône de l'appareil mobile (&#171;&#160;favicon-mobile.png&#160;&#187;" par défaut). Ce sera ajoutée au chemin de la favoricône.</li>
-	<li><strong>data-path :</strong> Le chemin au favoricône de l'appareil mobile (utilise le même chemin que l'élément <code>&lt;link rel="shortcut icon"&gt;</code> par défaut).</li>
+	<li><strong>data-path :</strong> Le chemin au favoricône de l'appareil mobile (utilise le même chemin que l'élément <code>&lt;link rel="icon" type="image/x-icon"&gt;</code> par défaut).</li>
 	<li><strong>data-rel :</strong> L'attribut <code>rel</code> de la favoricône de l'appareil mobile (&#171;&#160;apple-touch-icon&#160;&#187; par défaut).</li>
 	<li><strong>data-sizes :</strong> L'attribut <code>sizes</code> de la favoricône de l'appareil mobile (&#171;&#160;57x57 72x72 114x114 144x144 150x150&#160;&#187; par défaut).</li>
 </ul>
 
 <p>Par exemple, code suivant substitue les attributs <code>rel</code> et <code>filename</code> de la favoricône de l'appareil mobile&#160;:</p>
 
-<code class="prettyprint">&lt;link href="favion.ico" rel="shortcut icon" data-filename="my-mobile-favicon.ico" data-rel="apple-touch-icon-precomposed"&gt;</code>
+<code class="prettyprint">&lt;link href="favion.ico" rel="icon" type="image/x-icon" data-filename="my-mobile-favicon.ico" data-rel="apple-touch-icon-precomposed"&gt;</code>

--- a/src/plugins/favicon/favicon.js
+++ b/src/plugins/favicon/favicon.js
@@ -4,9 +4,9 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @patheard
  *
- * This plugin provides the ability to add and update the favicon's on a web page. Its default behaviour is to add a mobile favicon to web pages that have a favicon defined by a `<link rel="shortcut icon">` element.
+ * This plugin provides the ability to add and update the favicon's on a web page. Its default behaviour is to add a mobile favicon to web pages that have a favicon defined by a `<link rel='icon'>` element.
  *
- * The mobile favicon's file name, rel, path and sizes can be set with data attributes on the `<link rel="shortcut icon">`:
+ * The mobile favicon's file name, rel, path and sizes can be set with data attributes on the `<link rel='icon'>`:
  *
  * -**data-filename:** filename of the mobile favicon (defaults to "favicon-mobile.png"). This will be appended to the favicon's path.
  * -**data-path:** path to the mobile favicon (defaults to using the same path as the shortcut icon).
@@ -15,7 +15,7 @@
  *
  * For example, the following overides the rel and file name attributes of the mobile favicon:
  *
- *     <link href="favion.ico" rel="shortcut icon" data-rel="apple-touch-icon-precomposed" data-filename="my-mobile-favicon.ico">
+ *     <link href="favion.ico" rel='icon' data-rel="apple-touch-icon-precomposed" data-filename="my-mobile-favicon.ico">
  */
 (function( $, window, wb ) {
 "use strict";
@@ -27,7 +27,7 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var pluginName = "wb-favicon",
-	selector = "link[rel='shortcut icon']",
+	selector = "link[rel='icon']",
 	initEvent = "wb-init." + pluginName,
 	mobileEvent = "mobile." + pluginName,
 	iconEvent = "icon." + pluginName,

--- a/src/plugins/favicon/test.js
+++ b/src/plugins/favicon/test.js
@@ -26,7 +26,7 @@ describe( "Favicon test suite", function() {
 		// Spy on jQuery's trigger methods
 		spy = sandbox.spy( $.prototype, "trigger" );
 
-		$favicon = $( "<link href='test/path/favicon.ico' rel='shortcut icon'>" )
+		$favicon = $( "<link href='test/path/favicon.ico' rel='icon' type='image/x-icon'>" )
 			.appendTo( wb.doc.find( "head" ) )
 			.trigger( "wb-init.wb-favicon" );
 	});


### PR DESCRIPTION
This change addresses the W3C no longer allowing `link[rel="shortcut icon"]` for favicons.  Plugin now looks for `link[rel="icon"]` elements to determine if a mobile favicon should be added.
