### PR TITLE
Tabs: Remove single quote escape for SVG fallback

### DIFF
--- a/src/plugins/tabs/tabs.scss
+++ b/src/plugins/tabs/tabs.scss
@@ -224,7 +224,7 @@ $medGray: #ccc;
 
 							img {
 								/* Firefox 10+, Firefox on Android */
-								filter: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'grayscale\'><feColorMatrix type=\'matrix\' values=\'1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0\'/></filter></svg>#grayscale");
+								filter: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'><filter id='grayscale'><feColorMatrix type='matrix' values='1 0 0 0 0, 0 1 0 0 0, 0 0 1 0 0, 0 0 0 1 0'/></filter></svg>#grayscale");
 								/* Chrome 19+, Safari 6+, Safari 6+ iOS */
 								-webkit-filter: unquote("grayscale(0)");
 							}
@@ -235,7 +235,7 @@ $medGray: #ccc;
 						img {
 							box-shadow: none;
 							/* Firefox 10+, Firefox on Android */
-							filter: url("data:image/svg+xml;utf8,<svg xmlns=\'http://www.w3.org/2000/svg\'><filter id=\'grayscale\'><feColorMatrix type=\'matrix\' values=\'0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0\'/></filter></svg>#grayscale");
+							filter: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg'><filter id='grayscale'><feColorMatrix type='matrix' values='0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0.3333 0.3333 0.3333 0 0 0 0 0 1 0'/></filter></svg>#grayscale");
 							/* IE6-9 */
 							filter: #808080;
 							/* Chrome 19+, Safari 6+, Safari 6+ iOS */


### PR DESCRIPTION
Since we now wrap it in double quotes, the escaping can be removed
