### PR TITLE
Data picture class

### DIFF
--- a/site/pages/docs/ref/data-picture/data-picture-en.hbs
+++ b/site/pages/docs/ref/data-picture/data-picture-en.hbs
@@ -105,6 +105,19 @@
 				</td>
 			</tr>
 			<tr>
+				<td><code>data-class</code></td>
+				<td>Provides a class attribute value to the image element created by the plugin.</td>
+				<td>Set to the string value to use as the image's CSS attribute.</td>
+				<td>
+					<dl>
+						<dt>None (default):</dt>
+						<dd>The image element created by the plugin will not have a class attribute.</dd>
+						<dt>String:</dt>
+						<dd>The string will be used as the image element's class attribute.</dd>
+					</dl>
+				</td>
+			</tr>			
+			<tr>
 				<td><code>data-src</code></td>
 				<td>Image source that will be used if this element's media query (specified by data-media) matches.</td>
 				<td>Set to the image resource path that should be displayed.</td>

--- a/site/pages/docs/ref/data-picture/data-picture-fr.hbs
+++ b/site/pages/docs/ref/data-picture/data-picture-fr.hbs
@@ -108,6 +108,19 @@
 					</td>
 				</tr>
 				<tr>
+					<td><code>data-class</code></td>
+					<td>Provides a class attribute value to the image element created by the plugin.</td>
+					<td>Set to the string value to use as the image's CSS attribute.</td>
+					<td>
+						<dl>
+							<dt>None (default):</dt>
+							<dd>The image element created by the plugin will not have a class attribute.</dd>
+							<dt>String:</dt>
+							<dd>The string will be used as the image element's class attribute.</dd>
+						</dl>
+					</td>
+				</tr>				
+				<tr>
 					<td><code>data-src</code></td>
 					<td>Image source that will be used if this element's media query (specified by data-media) matches.</td>
 					<td>Set to the image resource path that should be displayed.</td>

--- a/src/plugins/data-picture/data-picture-en.hbs
+++ b/src/plugins/data-picture/data-picture-en.hbs
@@ -23,7 +23,7 @@
 		<p>This example uses <a href="http://www.w3.org/TR/css3-mediaqueries/#width">min-width</a> to determine which image should be displayed. Resize the browser window to see the different images load.</p>
 
 		<figure>
-			<span data-pic="data-pic" data-alt="Parliament Hill">
+			<span data-pic="data-pic" data-alt="Parliament Hill" data-class="img-responsive">
 				<!-- Default image: <div [data-src]> with no data-media attribute is displayed when:
 					1. None of the other <div [data-src]> media queries match.
 					2. The browser doesn't support media queries -->
@@ -46,7 +46,7 @@
 		<details class="wb-prettify all-pre linenums">
 			<summary>View code</summary>
 			<pre><code>&lt;figure&gt;
-	&lt;span data-pic="data-pic" data-alt="Parliament Hill"&gt;
+	&lt;span data-pic="data-pic" data-alt="Parliament Hill" data-class="img-responsive"&gt;
 		&lt;!-- Default image: &lt;div [data-src]&gt; with no data-media attribute is displayed when:
 				1. None of the other &lt;div [data-src]&gt; media queries match.
 				2. The browser doesn't support media queries --&gt;
@@ -72,7 +72,7 @@
 		<p>This example uses <a href="http://www.w3.org/blog/CSS/2012/06/14/unprefix-webkit-device-pixel-ratio/" title="Read about high resolution media queries">two media queries</a> to serve high resolution images to devices that will benefit from them (i.e. Retina displays).</p>
 
 		<figure>
-			<span data-pic="data-pic" data-alt="False Kiva in the Canyonlands">
+			<span data-pic="data-pic" data-alt="False Kiva in the Canyonlands" data-class="img-responsive">
 				<!-- Images for different device resolutions -->
 				<span data-src="img/cave-low-res.jpg"></span>
 				<span data-src="img/cave-high-res.jpg" data-media="(-webkit-min-device-pixel-ratio: 2),(min-resolution: 192dpi)"></span>
@@ -88,7 +88,7 @@
 		<details>
 			<summary>View code</summary>
 			<pre><code>&lt;figure&gt;
-	&lt;span data-pic="data-pic" data-alt="False Kiva in the Canyonlands"&gt;
+	&lt;span data-pic="data-pic" data-alt="False Kiva in the Canyonlands" data-class="img-responsive"&gt;
 		&lt;!-- Images for different device resolutions --&gt;
 		&lt;span data-src="img/cave-low-res.jpg"&gt;&lt;/span&gt;
 		&lt;span data-src="img/cave-high-res.jpg" data-media="(-webkit-min-device-pixel-ratio: 2),(min-resolution: 192dpi)"&gt;&lt;/span&gt;

--- a/src/plugins/data-picture/data-picture-fr.hbs
+++ b/src/plugins/data-picture/data-picture-fr.hbs
@@ -23,7 +23,7 @@
 		<p>Cet exemple utilise <a href="http://www.w3.org/TR/css3-mediaqueries/#width">min-width</a> afin de déterminer l'image à afficher. Redimensionner la fenêtre de navigateur pour voir les différentes images qui chargent.</p>
 
 		<figure>
-			<span data-pic="data-pic" data-alt="Colline du Parlement">
+			<span data-pic="data-pic" data-alt="Colline du Parlement" data-class="img-responsive">
 				<!-- Image par défault : l'élément <div [data-src]> sans attribut data-media est affiché quand :
 					1. Aucun des autres requêtes médias <div [data-src]> correspond.
 					2. Le navigateur ne supporte pas les requêtes médias CSS -->
@@ -46,7 +46,7 @@
 		<details class="wb-prettify all-pre linenums">
 			<summary>Visualiser le code</summary>
 			<pre><code>&lt;figure&gt;
-	&lt;span data-pic="data-pic" data-alt="Colline du Parlement"&gt;
+	&lt;span data-pic="data-pic" data-alt="Colline du Parlement" data-class="img-responsive"&gt;
 		&lt;!-- Image par défault : l'élément &lt;div [data-src]&gt; sans attribut data-media est affiché quand&#160;:
 				1. Aucun des autres requêtes médias &lt;div [data-src]&gt; correspond.
 				2. Le navigateur ne supporte pas les requêtes médias CSS --&gt;
@@ -72,7 +72,7 @@
 		<p>Cet exemple utilise <a href="http://www.w3.org/blog/CSS/2012/06/14/unprefix-webkit-device-pixel-ratio/" title="Lisez à propos des requêtes médias à haute résolution">deux requêtes médias</a> pour servir des images à haute résolution à des appareils qui en bénéficieront (p.ex. écrans Retina).</p>
 
 		<figure>
-			<span data-pic="data-pic" data-alt="False Kiva dans les Canyonlands">
+			<span data-pic="data-pic" data-alt="False Kiva dans les Canyonlands" data-class="img-responsive">
 				<!-- Images pour différentes résolutions de l'appareil -->
 				<span data-src="img/cave-low-res.jpg"></span>
 				<span data-src="img/cave-high-res.jpg" data-media="(-webkit-min-device-pixel-ratio: 2),(min-resolution: 192dpi)"></span>
@@ -88,7 +88,7 @@
 		<details>
 			<summary>Visualiser le code</summary>
 			<pre><code>&lt;figure&gt;
-	&lt;span data-pic="data-pic" data-alt="False Kiva dans les Canyonlands"&gt;
+	&lt;span data-pic="data-pic" data-alt="False Kiva dans les Canyonlands" data-class="img-responsive"&gt;
 		&lt;!-- Images pour différentes résolutions de l'appareil --&gt;
 		&lt;span data-src="img/cave-low-res.jpg"&gt;&lt;/span&gt;
 		&lt;span data-src="img/cave-high-res.jpg" data-media="(-webkit-min-device-pixel-ratio: 2),(min-resolution: 192dpi)"&gt;&lt;/span&gt;

--- a/src/plugins/data-picture/data-picture.js
+++ b/src/plugins/data-picture/data-picture.js
@@ -13,7 +13,8 @@
  * not once per instance of plugin on the page. So, this is a good place to define
  * variables that are common to all instances of the plugin on a page.
  */
-var pluginName = "wb-pic",
+var imgClass,
+	pluginName = "wb-pic",
 	selector = "[data-pic]",
 	initedClass = pluginName + "-inited",
 	initEvent = "wb-init." + pluginName,
@@ -32,6 +33,10 @@ var pluginName = "wb-pic",
 		if ( !$elm.hasClass( initedClass ) ) {
 			wb.remove( selector );
 			$elm.addClass( initedClass );
+
+			// Store the class attribute of the plugin element.  It
+			// will be added to the image created by the plugin.
+			imgClass = $elm.data( "class" ) || "";
 
 			$elm.trigger( picturefillEvent );
 		}
@@ -63,9 +68,15 @@ var pluginName = "wb-pic",
 			if ( !img ) {
 				img = $document[ 0 ].createElement( "img" );
 				img.alt = elm.getAttribute( "data-alt" );
+				img.className = imgClass;
 			}
 			img.src = matchedElm.getAttribute( "data-src" );
 			matchedElm.appendChild( img );
+
+			// Fixes bug with IE8 constraining the height of the image
+			// when the .img-responsive class is used.
+			img.removeAttribute( "width" );
+			img.removeAttribute( "height" );
 
 		// No match and an image exists: delete it
 		} else if ( img ) {

--- a/src/plugins/data-picture/test.js
+++ b/src/plugins/data-picture/test.js
@@ -103,6 +103,14 @@ describe( "[data-pic] test suite", function() {
 			});
 		});
 
+		it( "should have set the responsive image's class attribute", function() {
+			var $elm;
+			$( "[data-pic]" ).each(function() {
+				$elm = $( this );
+				expect( $elm.find( "img" ).attr( "class" ) ).to.equal( $elm.data( "class" ) );
+			});
+		});
+
 		it( "should create a responsive image after the picfill.wb-pic event", function() {
 			var $img = $(
 					"<span data-pic data-alt='foo' class='test'>" +


### PR DESCRIPTION
Allows the user to apply a CSS class attribute to the image element create by the plugin.

I ended up creating a new `data-class` attribute for this because reading HTML elements inside a `<noscript>` element is inconsistent cross-browser.

Fixes #5105
