### PR TITLE
Fixed the theme examples not being generated on a fresh copy.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -226,15 +226,6 @@ module.exports = (grunt) ->
 						return "http://localhost:8000/" + src
 					)
 
-		locales: grunt.file.expand(
-					filter: ( src ) ->
-						return true
-					"site/data/i18n/*.json"
-					).map( ( src ) ->
-						src = src.replace( "site/data/i18n/", "")
-						return src.replace( ".json", "" )
-					)
-
 		# Task configuration.
 		wget:
 			i18n:
@@ -365,7 +356,7 @@ module.exports = (grunt) ->
 					flatten: true,
 					plugins: ["assemble-contrib-i18n"]
 					i18n:
-						languages: "<%= locales %>"
+						languages: "<%= i18n_csv.assemble.locales %>"
 						templates: [
 							"site/pages/theme/*.hbs"
 							"!site/pages/theme/splashpage*.hbs"
@@ -417,7 +408,7 @@ module.exports = (grunt) ->
 					flatten: true,
 					plugins: ['assemble-contrib-i18n']
 					i18n:
-						languages: "<%= locales %>"
+						languages: "<%= i18n_csv.assemble.locales %>"
 						templates: [
 							'site/pages/theme/*.hbs',
 							"!site/pages/theme/splashpage*.hbs"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "grunt-gh-pages": "~0.9.0",
     "grunt-html": "~1.2.0",
     "grunt-htmlcompressor": "~0.1.10",
-    "grunt-i18n-csv": "^0.0.3",
+    "grunt-i18n-csv": "^0.0.5",
     "grunt-imagine": "http://github.com/LaurentGoderre/grunt-imagine/tarball/custom",
     "grunt-jscs-checker": "^0.4.0",
     "grunt-mocha": "~0.4.1",


### PR DESCRIPTION
Since now the i18n .json files are not commited, there is no way for the locales to be populated at load time. The output of the grunt-i18n-csv task is used instead.
Fix #5150
