### PR TITLE
Fixed the multimedia progress WebKit style being ignored.

### DIFF
--- a/src/plugins/multimedia/multimedia.scss
+++ b/src/plugins/multimedia/multimedia.scss
@@ -229,7 +229,10 @@
 		-webkit-appearance: none;
 		border: 0;
 
-		&::-webkit-progress-bar,
+		/* DO NOT combine the following selector because WebKit does not support it */
+		&::-webkit-progress-bar {
+			background: #fff;
+		}
 		&::-moz-progress-bar {
 			background: #fff;
 		}
@@ -245,7 +248,6 @@
 	}
 }
 
-//TODO: Cleanup placeholders when libsass supports nested selectors
 .xxsmallview {
 	.wb-mm-txtonly {
 		span {


### PR DESCRIPTION
Apparently, WebKit/Blink doesn't like it's pseudo-selector combine to other styles such as Firefox pseudo-selector.
Fixes #5171
