### PR TITLE
Fixed secondary menu links in small view in IE8

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -201,7 +201,7 @@ var pluginName = "wb-menu",
 				sectionHtml + "</ul></nav>";
 		}
 
-		return panel.replace( /list-group-item/gi, "" ) + "</div>";
+		return panel.replace( /['"]?list-group-item['"]?/gi, "\"\"" ) + "</div>";
 	},
 
 	/**


### PR DESCRIPTION
The issue is caused by the fact that IE8 HTML view doesn't use quotes around class. The search and replace created the followin markup `<A class= href="/v4.0-ci/index-en">Item 1</A>` which was interpretted as `<A class='href="/v4.0-ci/index-en"'>Item 1</A>`
Fixes: https://github.com/wet-boew/theme-gc-intranet/issues/62
