### PR TITLE
WET theme: Enabled secondary menu to work without the a element on the top header

### DIFF
--- a/site/includes/secondarymenu.hbs
+++ b/site/includes/secondarymenu.hbs
@@ -1,6 +1,6 @@
 <ul class="list-group menu list-unstyled">
 	<li>
-		<h3><a class="wb-navcurr">{{title}}</a></h3>
+		<h3 class="wb-navcurr">{{title}}</h3>
 		<ul class="list-group menu list-unstyled">
 			<li><a class="list-group-item" href="{{environment.root}}/index-{{language}}">{{{i18n "tmpl-item"}}}{{{i18n "space"}}}1</a></li>
 			<li><a class="list-group-item" href="{{environment.root}}/index-{{language}}">{{{i18n "tmpl-item"}}}{{{i18n "space"}}}2</a></li>

--- a/theme/sass/parts/_secMenu.scss
+++ b/theme/sass/parts/_secMenu.scss
@@ -15,11 +15,10 @@
 		margin: 0;
 		border: 1px solid #ddd;
 		border-bottom: 3px solid #666;
-		line-height: 0.8;
+		font-size: 1em;
 
 		a {
 			color: #333;
-			font-size: 0.7em;
 			text-decoration: none;
 		}
 	}


### PR DESCRIPTION
Note that the old way will continue to work as well so this is non-breaking.
