### PR TITLE
Front page improvements

### DIFF
--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -9,37 +9,21 @@
 <section>
 	<h2 id="about">What is the Web Experience Toolkit?</h2>
 	<ul>
-		<li>Collaborative open source project led by the Government of Canada</li>
-		<li><a href="docs/ref/accolades-en.html#awards">Award-winning</a> code library for building innovative websites that are:
-			<ul>
-				<li><a href="#accessibility">Accessible</a>, <a href="#usability">usable</a> and <a href="#interoperability">interoperable</a></li>
-				<li><a href="#mobile-friendly-responsive-design">Mobile friendly</a></li>
-				<li><a href="#multilingual">Multilingual</a></li>
-			</ul>
-		</li>
-		<li><a href="#themeable-and-reusable">Flexible and themeable templates and reusable components</a></li>
-		<li>Open source software
-			<ul>
-				<li>Free to use for commercial and non-commercial purposes (MIT license - <a href="License-en.html">Terms and conditions</a>)</li>
-				<li><a href="#collaborative-approach">Developed openly by the community on GitHub</a></li>
-			</ul>
-		</li>
+		<li>An <a href="docs/ref/accolades-en.html#awards">award-winning</a> front-end framework for building websites that are <a href="#accessibility">accessible</a>, <a href="#usability">usable</a>, <a href="#interoperability">interoperable</a>, <a href="#mobile-friendly-responsive-design">mobile friendly</a> and <a href="#multilingual">multilingual</a></li>
+		<li>A collection of <a href="#themeable-and-reusable">flexible and themeable templates and reusable components</a></li>
+		<li>A <a href="#collaborative-approach">collaborative open source project led by the Government of Canada</a></li>
 	</ul>
 </section>
 
 <section>
 	<h2 id="key">Key resources</h2>
 	<ul>
-		<li><a href="#benefits">Benefits</a></li>
-		<li><a href="demos/index-en.html">Working examples</a></li>
 		<li><a href="docs/index-en.html">Documentation</a></li>
 		<li><a href="docs/versions/dwnld-en.html">Downloads</a></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/">Main project</a></li>
-		<li><a href="License-en.html">Terms and conditions</a></li>
-		<li><a href="docs/start-en.html">Contributor guidelines</a></li>
-		<li><a href="docs/versions/version-info-en.html">Versioning</a></li>
-		<li><a href="docs/versions/index-en.html">Version history</a></li>
-		<li><a href="docs/versions/rdmp-en.html">Roadmap</a></li>
+		<li><a href="demos/index-en.html">Examples</a></li>
+		<li><a href="docs/versions/index-en.html">Version history</a> and <a href="docs/versions/rdmp-en.html">roadmap</a></li>
+		<li><a href="License-en.html">Terms and conditions</a> (MIT license)</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/">Source code repository</a></li>
 		<li><a href="docs/index-en.html#comms">Communications material</a></li>
 	</ul>
 </section>
@@ -130,9 +114,9 @@
 		<h3 id="themeable-and-reusable">Themeable and reusable</h3>
 		<ul>
 			<li>Flexible framework that supports custom themes</li>
-			<li>Includes support for 5 different themes including a “Base” theme to use as a template</li>
-			<li>Reusable templates, plugins and widgets</li>
-			<li>Adapted to various CMS and programming frameworks (Drupal, WordPress, SharePoint (in development), DotNetNuke (in development), PHP, SSI and Java/Maven)
+			<li>Includes support for <a href="docs/ref/themesstyle-en.html">5 different themes</a> including a <a href="http://wet-boew.github.io/themes-dist/theme-base/docs/ref/theme-base/theme-base-en.html">“Base” theme</a> to use as a template</li>
+			<li>Reusable templates, <a href="docs/ref/plugins-en.html">plugins</a> and widgets</li>
+			<li><a href="docs/ref/variants-en.html">Adapted to various CMS and programming frameworks</a> (Drupal, WordPress, SharePoint (in development), DotNetNuke (in development), PHP, SSI and Java/Maven)
 		</ul>
 	</section>
 

--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -3,7 +3,7 @@
 	"title": "Web Experience Toolkit (WET)",
 	"language": "en",
 	"altLangPrefix": "index",
-	"dateModified": "2014-02-19"
+	"dateModified": "2014-04-13"
 }
 ---
 <section>

--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -23,7 +23,7 @@
 		<li><a href="demos/index-en.html">Examples</a></li>
 		<li><a href="docs/versions/index-en.html">Version history</a> and <a href="docs/versions/rdmp-en.html">roadmap</a></li>
 		<li><a href="License-en.html">Terms and conditions</a> (MIT license)</li>
-		<li><a href="https://github.com/wet-boew/wet-boew/">Source code repository</a></li>
+		<li><a href="https://github.com/wet-boew/wet-boew/">Source code repository</a> and <a href="docs/start-en.html#develop">contributing guidelines</a></li>
 		<li><a href="docs/index-en.html#comms">Communications material</a></li>
 	</ul>
 </section>

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -3,43 +3,27 @@
 	"title": "Boîte à outils de l’expérience Web (BOEW)",
 	"language": "fr",
 	"altLangPrefix": "index",
-	"dateModified": "2014-02-19"
+	"dateModified": "2014-04-13"
 }
 ---
 <section>
 	<h2 id="apropos">Qu’est-ce que la Boîte à outils de l’expérience Web?</h2>
 	<ul>
-		<li>Un projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</li>
-		<li>Une bibliothèque de code <a href="docs/ref/accolades-fr.html#primes">primée</a> pour construire des sites Web innovants&#160;:
-			<ul>
-				<li><a href="#accessibilit">Accessibles</a>, <a href="#facilit-demploi">faciles d'emploi</a> et <a href="#interoprabilit">interopérables</a></li>
-				<li><a href="#conception-optimise-pour-les-appareils-mobiles-et-ractive">Optimisés pour les appareils mobiles</a></li>
-				<li><a href="#multilingue">Multilingues</a></li>
-			</ul>
-		</li>
+		<li>Une bibliothèque de code <a href="docs/ref/accolades-fr.html#primes">primée</a> pour construire des sites Web <a href="#accessibilit">accessibles</a>, <a href="#facilit-demploi">faciles d'emploi</a>, <a href="#interoprabilit">interopérables</a>, <a href="#conception-optimise-pour-les-appareils-mobiles-et-ractive">optimisés pour les appareils mobiles</a> et <a href="#multilingue">multilingues</a></li>
 		<li><a href="#personnalisable-et-rutilisable">Des modèles, ainsi que des composants réutilisables, qui sont flexibles et personnalisables</a></li>
-		<li>Un logiciel libre
-			<ul>
-				<li>Libre d'utilisation à des fins commerciales et non commerciales (licence MIT - <a href="Licence-fr.html">Conditions régissant l'utilisation</a>)</li>
-				<li><a href="#approche-collaborative">Développé ouvertement sur GitHub par la communauté</a></li>
-			</ul>
-		</li>
+		<li>Un <a href="#approche-collaborative">projet à source ouverte collaboratif dirigé par le Gouvernement du Canada</a></li>
 	</ul>
 </section>
 
 <section>
 	<h2 id="cles">Ressources clés</h2>
 	<ul>
-		<li><a href="#avantages">Avantages</a></li>
-		<li><a href="demos/index-fr.html">Exemples pratiques</a></li>
 		<li><a href="docs/index-fr.html">Documentation</a></li>
 		<li><a href="docs/versions/dwnld-fr.html">Téléchargements</a></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/">Projet principal</a></li>
-		<li><a href="Licence-fr.html">Conditions régissant l'utilisation</a></li>
-		<li><a href="docs/start-en.html">Lignes directrices pour les contributeurs</a></li>
-		<li><a href="docs/versions/version-info-fr.html">Contrôle des versions</a></li>
-		<li><a href="docs/versions/index-fr.html">Historique des versions</a></li>
-		<li><a href="docs/versions/rdmp-fr.html">Feuille de route</a></li>
+		<li><a href="demos/index-fr.html">Exemples pratiques</a></li>
+		<li><a href="docs/versions/index-fr.html">Historique des versions</a> et <a href="docs/versions/rdmp-fr.html">feuille de route</a></li>
+		<li><a href="Licence-fr.html">Conditions régissant l'utilisation</a> (licence MIT)</li>
+		<li><a href="https://github.com/wet-boew/wet-boew/">Dépôt de code source</a></li>
 		<li><a href="docs/index-fr.html#comms">Matériel de communications</a></li>
 	</ul>
 </section>
@@ -130,9 +114,9 @@
 		<h3 id="personnalisable-et-rutilisable">Personnalisable et réutilisable</h3>
 		<ul>
 			<li>Cadre flexible qui supporte des thèmes personnalisés</li>
-			<li>Soutien 5 thèmes différents, y compris un thème de base servant comme modèle</li>
-			<li>Modèles, plugiciels et gadgets réutilisables</li>
-			<li>Adapté aux différents systèmes de gestion de contenu et cadres de programmation (Drupal, WordPress, SharePoint (en développement), DotNetNuke (en développement), PHP, SSI, Java/Maven)</li>
+			<li>Soutien <a href="docs/ref/themesstyle-fr.html">5 thèmes différents</a>, y compris un <a href="http://wet-boew.github.io/themes-dist/theme-base/docs/ref/theme-base/theme-base-fr.html">thème de base</a> servant comme modèle</li>
+			<li>Modèles, <a href="docs/ref/plugins-fr.html">plugiciels</a> et gadgets réutilisables</li>
+			<li><a href="docs/ref/variants-fr.html">Adapté aux différents systèmes de gestion de contenu et cadres de programmation</a> (Drupal, WordPress, SharePoint (en développement), DotNetNuke (en développement), PHP, SSI, Java/Maven)</li>
 		</ul>
 	</section>
 

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -23,7 +23,7 @@
 		<li><a href="demos/index-fr.html">Exemples pratiques</a></li>
 		<li><a href="docs/versions/index-fr.html">Historique des versions</a> et <a href="docs/versions/rdmp-fr.html">feuille de route</a></li>
 		<li><a href="Licence-fr.html">Conditions régissant l'utilisation</a> (licence MIT)</li>
-		<li><a href="https://github.com/wet-boew/wet-boew/">Dépôt de code source</a></li>
+		<li><a href="https://github.com/wet-boew/wet-boew/">Dépôt de code source</a> et <a href="docs/start-fr.html#develop">lignes directrices pour les contributeurs</a></li>
 		<li><a href="docs/index-fr.html#comms">Matériel de communications</a></li>
 	</ul>
 </section>


### PR DESCRIPTION
- Abbreviate 'What is the Web Experience Toolkit?'
  - It repeats itself, and repeats content under benefits that needn't be promoted up here
- Re-order and abbreviate 'Key resources'
  - It's not necessary to link to "Versioning", since both "Version history" and "Roadmap" link to it
  - "Contributor guidelines" did not link to any contributor guidelines...
- Add links under 'Benefits'
