### PR TITLE
Add "docs" task to quickly rebuild docs pages

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -415,6 +415,22 @@ module.exports = (grunt) ->
 						expand: true
 				]
 
+			versions:
+				options:
+					environment:
+						root: "/v4.0-ci/unmin"
+						jqueryVersion: "<%= jqueryVersion.version %>"
+						jqueryOldIEVersion: "<%= jqueryOldIEVersion.version %>"
+					assets: "dist/unmin"
+				files: [
+						cwd: "site/pages"
+						src: [
+							"docs/versions/**/*.hbs"
+						]
+						dest: "dist/unmin"
+						expand: true
+				]
+
 			theme_min:
 				options:
 					environment:
@@ -1013,6 +1029,16 @@ module.exports = (grunt) ->
 				]
 				tasks: [
 					"assemble:docs"
+				]
+				options:
+					livereload: true
+
+			versions:
+				files: [
+					"site/pages/docs/versions/**/*.hbs"
+				]
+				tasks: [
+					"assemble:versions"
 				]
 				options:
 					livereload: true

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -397,6 +397,24 @@ module.exports = (grunt) ->
 						expand: true
 				]
 
+			docs:
+				options:
+					environment:
+						root: "/v4.0-ci/unmin"
+						jqueryVersion: "<%= jqueryVersion.version %>"
+						jqueryOldIEVersion: "<%= jqueryOldIEVersion.version %>"
+					assets: "dist/unmin"
+				files: [
+						cwd: "site/pages"
+						src: [
+							"docs/**/*.hbs"
+							"!docs/ref/**/*.hbs"
+							"!docs/versions/**/*.hbs"
+						]
+						dest: "dist/unmin"
+						expand: true
+				]
+
 			theme_min:
 				options:
 					environment:
@@ -987,6 +1005,16 @@ module.exports = (grunt) ->
 				]
 				options:
 					interval: 5007
+					livereload: true
+
+			docs:
+				files: [
+					"site/pages/docs/**/*.hbs"
+				]
+				tasks: [
+					"assemble:docs"
+				]
+				options:
 					livereload: true
 
 		jshint:


### PR DESCRIPTION
Needed when making changes to documentation locally.

This makes it possible to see the changes in the browser 3 seconds after saving a file. Much better than 20+ seconds as reported in #5219.

I also added a task to rebuild `versions/`. I suppose I can write one to rebuild `refs/` too. Building them all in one task is just too slow.
