### PR TITLE
Various documentation improvements

### DIFF
--- a/site/pages/docs/bugs-en.hbs
+++ b/site/pages/docs/bugs-en.hbs
@@ -10,9 +10,9 @@
 Please try and answer these questions before you post:
 <ul>
 	<li>Is this issue specific to WET-BOEW or just a general coding question? You might find general solutions to HTML, CSS, and JavaScript questions on <a href="http://stackoverflow.com">StackOverflow</a>.</li>
-	<li><a href="https://github.com/wet-boew/wet-boew/issues">Have you searched the exsisting issues</a> to see if someone's already filed the same thing? You can filter the categories listed on the left or using the search box.</li>
+	<li><a href="https://github.com/wet-boew/wet-boew/issues">Have you searched the existing issues</a> to see if someone's already filed the same thing? You can filter the categories listed on the left or using the search box.</li>
 	<li>What version of WET is the affected experienced in (v3.1.1, v4.0.0, etc)? If it is not the latest stable version, does to the latest version resolve the issue?</li>
 	<li>What browser was the bug found in (IE8, FireFox 18, Chrome 24, or a combination of browsers)? If a assistive technology (AT) was involded, then please include the combination of AT and browser that was used.</li>
 	<li>Can a link to a page that can be used to reproduce the issue (demo or public URL) be provided? If a public page cannot be provided, a picture should be attached showing the issue (use GitHub's <a class="ui-link" href="https://github.com/blog/1347-issue-attachments">issue attachment feature</a>)</li>
-	<li>Was the issue encountered in a WET variant (Drupal, PHP, .Net, etc...) or the core framework? If it applies to core project, <a href="https://github.com/wet-boew/wet-boew/issues/new">post an issue in the WET-BOEW repository</a>.</li>
+	<li>Was the issue encountered in a WET variant (Drupal, PHP, .Net, etc.) or in the core framework? If it applies to the core project, <a href="https://github.com/wet-boew/wet-boew/issues/new">post an issue in the WET-BOEW repository</a>.</li>
 </ul>

--- a/site/pages/docs/bugs-fr.hbs
+++ b/site/pages/docs/bugs-fr.hbs
@@ -12,10 +12,10 @@
 Please try and answer these questions before you post:
 <ul>
 	<li>Is this issue specific to WET-BOEW or just a general coding question? You might find general solutions to HTML, CSS, and JavaScript questions on <a href="http://stackoverflow.com">StackOverflow</a>.</li>
-	<li><a href="https://github.com/wet-boew/wet-boew/issues">Have you searched the exsisting issues</a> to see if someone's already filed the same thing? You can filter the categories listed on the left or using the search box.</li>
+	<li><a href="https://github.com/wet-boew/wet-boew/issues">Have you searched the existing issues</a> to see if someone's already filed the same thing? You can filter the categories listed on the left or using the search box.</li>
 	<li>What version of WET is the affected experienced in (v3.1.1, v4.0.0, etc)? If it is not the latest stable version, does to the latest version resolve the issue?</li>
 	<li>What browser was the bug found in (IE8, FireFox 18, Chrome 24, or a combination of browsers)? If a assistive technology (AT) was involded, then please include the combination of AT and browser that was used.</li>
 	<li>Can a link to a page that can be used to reproduce the issue (demo or public URL) be provided? If a public page cannot be provided, a picture should be attached showing the issue (use GitHub's <a class="ui-link" href="https://github.com/blog/1347-issue-attachments">issue attachment feature</a>)</li>
-	<li>Was the issue encountered in a WET variant (Drupal, PHP, .Net, etc...) or the core framework? If it applies to core project, <a href="https://github.com/wet-boew/wet-boew/issues/new">post an issue in the WET-BOEW repository</a>.</li>
+	<li>Was the issue encountered in a WET variant (Drupal, PHP, .Net, etc.) or in the core framework? If it applies to the core project, <a href="https://github.com/wet-boew/wet-boew/issues/new">post an issue in the WET-BOEW repository</a>.</li>
 </ul>
 </div>

--- a/site/pages/docs/index-en.hbs
+++ b/site/pages/docs/index-en.hbs
@@ -7,25 +7,15 @@
 	"dateModified": "2014-03-27"
 }
 ---
-<p>WET operates on the principle of progressive enhancement, and implements well established techniques increasing the accessibility and usability of web content. If you are new to WET, please begin with our Getting Started section, which contains all the information anyone new requires to access, implement or contribute to the toolkit. Otherwise, see the Reference section.</p>
-<p id="change">The following are some guidelines if you wish to create or edit the existing documentation:</p>
-<ul>
-	<li>Any and all descriptions, guides, or instructions for WET should be included as HTML files in this repository.</li>
-	<li>Follow the <a href="ref/docstmpl-en.html">documentation example template</a>.</li>
-	<li>At least one working example should be provided for each WET feature, theme or component. Additional examples should be provided for each parameter or option.</li>
-</ul>
+<p>WET operates on the principle of progressive enhancement, and implements well-established techniques increasing the accessibility and usability of web content. If you are new to WET, please begin with our <a href="start-en.html">Getting Started</a> section, which contains information on how to to download, use or contribute to the toolkit. Otherwise, see the Reference section below.</p>
 
 <section>
-	<h2>Getting started</h2>
+	<h2><a href="start-en.html">Getting started</a></h2>
 	<ul>
-		<li><a href="start-en.html">Getting started</a>
-			<ul>
-				<li><a href="start-en.html#issues">I want to report a bug or ask a question about WET</a></li>
-				<li><a href="start-en.html#implement">I want to implement WET on my website</a></li>
-				<li><a href="start-en.html#develop">I want to fix or improve WET as a developer</a></li>
-				<li><a href="start-en.html#theme">I want to design a new WET theme</a></li>
-			</ul>
-		</li>
+		<li><a href="start-en.html#implement">I want to use WET on my website</a></li>
+		<li><a href="start-en.html#theme">I want to customize WET and design a new WET theme</a></li>
+		<li><a href="start-en.html#issues">I want to report a bug or ask a question about WET</a></li>
+		<li><a href="start-en.html#develop">I want to fix or improve WET as a developer</a></li>
 	</ul>
 </section>
 
@@ -49,3 +39,10 @@
 		<li><a href="ref/accolades-en.html">Articles, blogs, videos and implementations of WET</a></li>
 	</ul>
 </section>
+
+<p id="change">The following are some guidelines if you wish to create or edit the existing documentation:</p>
+<ul>
+	<li>Any and all descriptions, guides, or instructions for WET should be included as HTML files in this repository.</li>
+	<li>Follow the <a href="ref/docstmpl-en.html">documentation example template</a>.</li>
+	<li>At least one working example should be provided for each WET feature, theme or component. Additional examples should be provided for each parameter or option.</li>
+</ul>

--- a/site/pages/docs/index-fr.hbs
+++ b/site/pages/docs/index-fr.hbs
@@ -7,29 +7,21 @@
 	"dateModified": "2014-02-19"
 }
 ---
-<p lang="en"><strong>Needs translation</strong> WET operates on the principle of progressive enhancement, and implements well established techniques increasing the accessibility and usability of web content. If you are new to WET, please begin with our Getting Started section, which contains all the information anyone new requires to access, implement or contribute to the toolkit. Otherwise, see the Reference section.</p>
-<p id="change">Voici quelques lignes directrices si vous désirez créer ou modifier de la documentation existante&#160;:</p>
-<ul>
-	<li>Verser tous les guides, les descriptions ou les directives pour la BOEW dans le répertoire de GitHub.</li>
-	<li>Suivre le <a href="ref/docstmpl-fr.html">modèle de documentation</a>.</li>
-	<li>Fournir au moins un exemple pour chaque attribut, thème ou élément de la BOEW. D’autres exemples doivent être donnés pour chaque paramètre ou option. </li>
-</ul>
+<p lang="en"><strong>Needs translation</strong> WET operates on the principle of progressive enhancement, and implements well established techniques increasing the accessibility and usability of web content. If you are new to WET, please begin with our <a href="start-fr.html">Getting Started</a> section, which contains information on how to to download, use or contribute to the toolkit. Otherwise, see the Reference section below.</p>
+
 <section>
-	<h2>Comment démarrer</h2>
+	<h2><a href="start-fr.html">Comment démarrer</a></h2>
+	<div lang="en">
+	<p><strong>Needs translation</strong></p>
 	<ul>
-		<li><a href="start-fr.html">Comment démarrer</a>
-			<div lang="en">
-			<p><strong>Needs translation</strong></p>
-			<ul>
-				<li><a href="start-fr.html#issues">I want to report a bug or ask a question about WET</a></li>
-				<li><a href="start-fr.html#implement">I want to implement WET on my website</a></li>
-				<li><a href="start-fr.html#develop">I want to fix or improve WET as a developer</a></li>
-				<li><a href="start-fr.html#theme">I want to design a new WET theme</a></li>
-			</ul>
-			</div>
-		</li>
+		<li><a href="start-fr.html#implement">I want to use WET on my website</a></li>
+		<li><a href="start-fr.html#theme">I want to customize WET and design a new WET theme</a></li>
+		<li><a href="start-fr.html#issues">I want to report a bug or ask a question about WET</a></li>
+		<li><a href="start-fr.html#develop">I want to fix or improve WET as a developer</a></li>
 	</ul>
+	</div>
 </section>
+
 <section>
 	<h2>Référence</h2>
 	<ul>
@@ -50,3 +42,10 @@
 		<li><a href="ref/accolades-fr.html">Articles, blogues, vidéos et implémentations de la BOEW</a></li>
 	</ul>
 </section>
+
+<p id="change">Voici quelques lignes directrices si vous désirez créer ou modifier de la documentation existante&#160;:</p>
+<ul>
+	<li>Verser tous les guides, les descriptions ou les directives pour la BOEW dans le répertoire de GitHub.</li>
+	<li>Suivre le <a href="ref/docstmpl-fr.html">modèle de documentation</a>.</li>
+	<li>Fournir au moins un exemple pour chaque attribut, thème ou élément de la BOEW. D’autres exemples doivent être donnés pour chaque paramètre ou option. </li>
+</ul>

--- a/site/pages/docs/pull-en.hbs
+++ b/site/pages/docs/pull-en.hbs
@@ -50,7 +50,7 @@
 			Validate your HTML markup as to ensure well-formed HTML5.
 			<ul>
 				<li>These tests will be run as part of the default build, or by calling <code>grunt htmllint</code> to run the task on your built HTML.
-				<li>You can manually test for well-formed markup using the <a rel="external" href="http://validator.w3.org/nu/">W3C HTML validatr</a>, validate with an XHTML5 preset and a checkmark next to "Be lax about HTTP Content-Type".</li>
+				<li>You can manually test for well-formed markup using the <a rel="external" href="http://validator.w3.org/nu/">W3C HTML validator</a>. Validate with an XHTML5 preset and a checkmark next to "Be lax about HTTP Content-Type".</li>
 			</ul>
 		</li>
 		<li>

--- a/site/pages/docs/start-en.hbs
+++ b/site/pages/docs/start-en.hbs
@@ -7,43 +7,46 @@
 	"dateModified": "2014-03-27"
 }
 ---
-Step 0 for all these instructions requires <a href="https://help.github.com/articles/signing-up-for-a-new-github-account">creating a GitHub account</a>. We suggest following GitHub's own guides on <a href="https://help.github.com/articles/set-up-git">setting up Git</a>. If you are working behind a proxy, you may want to look at the <a href="proxy-en.html">proxy troubleshootig guide</a>.
+<p>If you are working behind a proxy, you may want to look at the <a href="proxy-en.html">proxy troubleshooting guide</a>.</p>
 
 <section>
-	<h2 id="issues">I want to report a bug or ask a question about WET</h2>
-	<ul>
-		<li>Fill any style guide related questions by <a href="https://github.com/wet-boew/wet-boew-styleguide/issues/new">creating a new issue</a>.</li>
-		<li>Fill any bugs you encounter or feature requests by following the <a href="bugs-en.html">bug reporting guide</a>.</li>
-	</ul>
+	<h2 id="implement">I want to use WET on my website</h2>
+	<ol>
+		<li>Grab the latest stable release from the <a href="versions/dwnld-en.html">downloads page</a>.</li>
+		<li><a href="http://wet-boew.github.io/wet-boew-styleguide/v4/index-en.html">Review the style guide</a> for information on implementing WET on your site.</li>
+	</ol>
 </section>
 
 <section>
-	<h2 id="implement">I want to implement WET on my website</h2>
+	<h2 id="theme">I want to customize WET and design a new WET theme</h2>
 	<ol>
-		<li>Grab the latest stable release from the <a href="versions/dwnld-en.html">downloads page</a>.</li>
-		<li><a href="http://wet-boew.github.io/wet-boew-styleguide/v4/index-en.html">Review the styleguide</a> for information on implementing WET on your site.</li>
+		<li><a href="http://nodejs.org/">Install NodeJS</a> for your platform.</li>
+		<li>Create a directory for your project.</li>
+		<li>Install the <a href="http://gruntjs.com/">Grunt <abbr title="Command Line Interface">CLI</abbr></a>, <a href="http://yeoman.io/">Yeoman</a>, and <a href="http://bower.io">Bower</a> packages globally by running <code>npm install -g grunt-cli yo bower</code> from the command line console (Command Prompt on Windows, Terminal on OS X, or other shell environment on Linux or Unix).</li>
+		<li>Install the WET theme generator by running <code>npm install -g generator-wet-boew-theme</code>.</li>
+		<li>Run <code>yo wet-boew-theme</code> from the command prompt, and answer the questions at the prompt to setup your theme project.</li>
+	</ol>
+</section>
+
+<section>
+	<h2 id="issues">I want to report a bug or ask a question about WET</h2>
+	<ol>
+		<li><a href="https://help.github.com/articles/signing-up-for-a-new-github-account">Create a GitHub account</a>.</li>
+		<li>Ask a question relating to the <a href="http://wet-boew.github.io/wet-boew-styleguide/v4/index-en.html">style guide</a> by <a href="https://github.com/wet-boew/wet-boew-styleguide/issues/new">creating a new issue on GitHub</a>.</li>
+		<li>Report a bug or request a feature by following the <a href="bugs-en.html">bug reporting guide</a>.</li>
 	</ol>
 </section>
 
 <section>
 	<h2 id="develop">I want to fix or improve WET as a developer</h2>
 	<ol>
-		<li>Fork the <code>wet-boew</code> repository by following the <a href="https://help.github.com/articles/fork-a-repo">GitHub forking guide</a>. Use the "upstream" URL of "https://github.com/wet-boew/wet-boew.git" when completing the steps.</li>
 		<li><a href="http://nodejs.org/">Install NodeJS</a> for your platform.</li>
-		<li>Run the setup script located in the "script" folder.</li>
-		<li>Run "grunt" to build the project, or <code>grunt --help</code> to see the build target descriptions.</li>
-		<li>The latest files will now be compiled to the "dist" folder.</li>
-		<li>To create a pull request to contribute back, follow the instructions on <a href="pull-en.html">how to create a pull request</a>.</li>
-	</ol>
-</section>
-
-<section>
-	<h2 id="theme">I want to design a new WET theme</h2>
-	<ol>
-		<li><a href="http://nodejs.org/">Install NodeJS</a> for your platform.</li>
-		<li>Create a directory for your project</li>
-		<li>Install the <a href="http://gruntjs.com/">Grunt <abbr title="Command Line Interface">CLI</abbr></a>, <a href="http://yeoman.io/">Yeoman</a>, and <a href="http://bower.io">Bower</a> globally if you have not already done so. Run <code>npm install -g grunt-cli yo bower</code> from the command line console (Command Prompt on Windows, Terminal on OSX, or other shell envronment on Unix).</li>
-		<li>Install the WET theme generator by running <code>npm install -g generator-wet-boew-theme</code>.</li>
-		<li>Run <code>yo wet-boew-theme</code> from the command prompt, and answer the questions at the prompt to setup your theme project.</li>
+		<li><a href="https://help.github.com/articles/signing-up-for-a-new-github-account">Create a GitHub account</a>.</li>
+		<li>Follow GitHub's guides on <a href="https://help.github.com/articles/set-up-git">setting up Git</a>.</li>
+		<li>Fork the <a href="https://github.com/wet-boew/wet-boew">wet-boew repository</a> by following the <a href="https://help.github.com/articles/fork-a-repo">GitHub forking guide</a>. Use the upstream URL of <code>https://github.com/wet-boew/wet-boew.git</code> in step 3.</li>
+		<li>Run <code>./script/setup</code> from the <code>wet-boew</code> directory in your command line console.</li>
+		<li>Run <code>grunt</code> to build the project. You may run <code>grunt --help</code> to see the build target descriptions.</li>
+		<li>The latest files will now be compiled to the <code>dist/</code> folder.</li>
+		<li>To contribute back, follow the instructions on <a href="pull-en.html">how to create a pull request</a>.</li>
 	</ol>
 </section>

--- a/site/pages/docs/versions/dwnld-en.hbs
+++ b/site/pages/docs/versions/dwnld-en.hbs
@@ -32,7 +32,7 @@
 					<td rowspan="6"><a href="v4.0/v4.0.0-en.html">Release notes<span class="wb-inv"> - v4.0.0</span></a></td>
 				</tr>
 				<tr class="active">
-					<td><strong>Base<strong></td>
+					<td><strong>Base</strong></td>
 					<td><a href="https://github.com/wet-boew/theme-base/archive/v4.0.0.zip">Download<span class="wb-inv"> - v4.0.0 source code- Base theme</span> (theme only)</a></td>
 					<td><strong><a href="https://github.com/wet-boew/theme-base/releases/download/v4.0.0/themes-dist-4.0.0-theme-base.zip">Download<span class="wb-inv"> - v4.0.0 production files - Base theme</span></a></strong></td>
 				</tr>

--- a/site/pages/docs/versions/dwnld-en.hbs
+++ b/site/pages/docs/versions/dwnld-en.hbs
@@ -24,34 +24,34 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr id="v400">
+				<tr id="v400" class="active">
 					<td rowspan="6">v4.0.0</td>
-					<td>Web Experience Toolkit (WET)</td>
+					<td><strong>Web Experience Toolkit (WET)</strong></td>
 					<td><a href="https://github.com/wet-boew/wet-boew/archive/v4.0.0.zip">Download<span class="wb-inv"> - v4.0.0 source code - Web Experience Toolkit (WET) theme</span></a></td>
-					<td><a href="https://github.com/wet-boew/wet-boew/releases/download/v4.0.0/wet-boew-dist-4.0.0.zip">Download<span class="wb-inv"> - v4.0.0 production files - Web Experience Toolkit (WET) theme</span></a></td>
+					<td><strong><a href="https://github.com/wet-boew/wet-boew/releases/download/v4.0.0/wet-boew-dist-4.0.0.zip">Download<span class="wb-inv"> - v4.0.0 production files - Web Experience Toolkit (WET) theme</span></a></strong></td>
 					<td rowspan="6"><a href="v4.0/v4.0.0-en.html">Release notes<span class="wb-inv"> - v4.0.0</span></a></td>
 				</tr>
-				<tr>
-					<td>Base</td>
+				<tr class="active">
+					<td><strong>Base<strong></td>
 					<td><a href="https://github.com/wet-boew/theme-base/archive/v4.0.0.zip">Download<span class="wb-inv"> - v4.0.0 source code- Base theme</span> (theme only)</a></td>
-					<td><a href="https://github.com/wet-boew/theme-base/releases/download/v4.0.0/themes-dist-4.0.0-theme-base.zip">Download<span class="wb-inv"> - v4.0.0 production files - Base theme</span></a></td>
+					<td><strong><a href="https://github.com/wet-boew/theme-base/releases/download/v4.0.0/themes-dist-4.0.0-theme-base.zip">Download<span class="wb-inv"> - v4.0.0 production files - Base theme</span></a></strong></td>
 				</tr>
-				<tr>
+				<tr class="active">
 					<td>Canada.ca</td>
 					<td><a href="https://github.com/wet-boew/GCWeb/archive/v4.0.0.zip">Download<span class="wb-inv"> - v4.0.0 source code - Canada.ca theme</span> (theme only)</a></td>
 					<td><a href="https://github.com/wet-boew/GCWeb/releases/download/v4.0.0/themes-dist-4.0.0-gcweb.zip">Download<span class="wb-inv"> - v4.0.0 production files - Canada.ca theme</span></a></td>
 				</tr>
-				<tr>
+				<tr class="active">
 					<td>Government of Canada Web Usability</td>
 					<td><a href="https://github.com/wet-boew/theme-gcwu-fegc/archive/v4.0.0.zip">Download<span class="wb-inv"> - v4.0.0 source code - Government of Canada Web Usability theme</span> (theme only)</a></td>
 					<td><a href="https://github.com/wet-boew/theme-gcwu-fegc/releases/download/v4.0.0/themes-dist-4.0.0-theme-gcwu-fegc.zip">Download<span class="wb-inv"> - v4.0.0 production files - Government of Canada Web Usability theme</span></a></td>
 				</tr>
-				<tr>
+				<tr class="active">
 					<td>Government of Canada Intranet</td>
 					<td><a href="https://github.com/wet-boew/theme-gc-intranet/archive/v4.0.0.zip">Download<span class="wb-inv"> - v4.0.0 source code - Government of Canada Intranet theme</span> (theme only)</a></td>
 					<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/download/v4.0.0/themes-dist-4.0.0-theme-gc-intranet.zip">Download<span class="wb-inv"> - v4.0.0 production files - Government of Canada Intranet theme</span></a></td>
 				</tr>
-				<tr>
+				<tr class="active">
 					<td>Open Government Platform (OGPL)</td>
 					<td><a href="https://github.com/wet-boew/theme-ogpl/archive/v4.0.0.zip">Download<span class="wb-inv"> - v4.0.0 source code - Open Government Platform (OGPL) theme</span> (theme only)</a></td>
 					<td><a href="https://github.com/wet-boew/theme-ogpl/releases/download/v4.0.0/themes-dist-4.0.0-theme-ogpl.zip">Download<span class="wb-inv"> - v4.0.0 production files - Open Government Platform (OGPL) theme</span></a></td>

--- a/site/pages/docs/versions/dwnld-fr.hbs
+++ b/site/pages/docs/versions/dwnld-fr.hbs
@@ -24,34 +24,34 @@
 				</tr>
 			</thead>
 			<tbody>
-				<tr id="v400">
+				<tr id="v400" class="active">
 					<td rowspan="6">v4.0.0</td>
-					<td>Boîte à outils de l'expérience Web (BOEW)</td>
+					<td><strong>Boîte à outils de l'expérience Web (BOEW)</strong></td>
 					<td><a href="https://github.com/wet-boew/wet-boew/archive/v4.0.0.zip">Télécharger<span class="wb-inv"> - Code source de v4.0.0 - Thème de la Boîte à outils de l'expérience Web (BOEW)</span></a></td>
-					<td><a href="https://github.com/wet-boew/wet-boew/releases/download/v4.0.0/wet-boew-dist-4.0.0.zip">Télécharger<span class="wb-inv"> - Fichiers de production de v4.0.0 - Thème de la Boîte à outils de l'expérience Web (BOEW)</span></a></td>
+					<td><strong><a href="https://github.com/wet-boew/wet-boew/releases/download/v4.0.0/wet-boew-dist-4.0.0.zip">Télécharger<span class="wb-inv"> - Fichiers de production de v4.0.0 - Thème de la Boîte à outils de l'expérience Web (BOEW)</span></a></strong></td>
 					<td rowspan="6"><a href="v4.0/v4.0.0-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.0</span></a></td>
 				</tr>
-				<tr>
-					<td>Base</td>
+				<tr class="active">
+					<td><strong>Base</strong></td>
 					<td><a href="https://github.com/wet-boew/theme-base/archive/v4.0.0.zip">Télécharger<span class="wb-inv"> - Code source de v4.0.0 - Thème de base</span> (thème seulement)</a></td>
-					<td><a href="https://github.com/wet-boew/theme-base/releases/download/v4.0.0/themes-dist-4.0.0-theme-base.zip">Télécharger<span class="wb-inv"> - Fichiers de production de v4.0.0 - Thème de base</span></a></td>
+					<td><strong><a href="https://github.com/wet-boew/theme-base/releases/download/v4.0.0/themes-dist-4.0.0-theme-base.zip">Télécharger<span class="wb-inv"> - Fichiers de production de v4.0.0 - Thème de base</span></a></strong></td>
 				</tr>
-				<tr>
+				<tr class="active">
 					<td>Canada.ca</td>
 					<td><a href="https://github.com/wet-boew/GCWeb/archive/v4.0.0.zip">Télécharger<span class="wb-inv"> - Code source de v4.0.0 - Thème Canada.ca</span> (thème seulement)</a></td>
 					<td><a href="https://github.com/wet-boew/GCWeb/releases/download/v4.0.0/themes-dist-4.0.0-gcweb.zip">Télécharger<span class="wb-inv"> - Fichiers de production de v4.0.0 - Thème Canada.ca</span></a></td>
 				</tr>
-				<tr>
+				<tr class="active">
 					<td>Facilité d’emploi Web du gouvernement du Canada</td>
 					<td><a href="https://github.com/wet-boew/theme-gcwu-fegc/archive/v4.0.0.zip">Télécharger<span class="wb-inv"> - Code source de v4.0.0 - Thème de la facilité d’emploi Web du gouvernement du Canada</span> (thème seulement)</a></td>
 					<td><a href="https://github.com/wet-boew/theme-gcwu-fegc/releases/download/v4.0.0/themes-dist-4.0.0-theme-gcwu-fegc.zip">Télécharger<span class="wb-inv"> - Fichiers de production de v4.0.0 - Thème de la facilité d’emploi Web du gouvernement du Canada</span></a></td>
 				</tr>
-				<tr>
+				<tr class="active">
 					<td>Gouvernement du Canada pour les sites intranet</td>
 					<td><a href="https://github.com/wet-boew/theme-gc-intranet/archive/v4.0.0.zip">Télécharger<span class="wb-inv"> - Code source de v4.0.0 - Thème du gouvernement du Canada pour les sites intranet</span> (thème seulement)</a></td>
 					<td><a href="https://github.com/wet-boew/theme-gc-intranet/releases/download/v4.0.0/themes-dist-4.0.0-theme-gc-intranet.zip">Télécharger<span class="wb-inv"> - Fichiers de production de v4.0.0 - Thème du gouvernement du Canada pour les sites intranet</span></a></td>
 				</tr>
-				<tr>
+				<tr class="active">
 					<td>Plate-forme de gouvernement ouvert (PGO)</td>
 					<td><a href="https://github.com/wet-boew/theme-ogpl/archive/v4.0.0.zip">Télécharger<span class="wb-inv"> - Code source de v4.0.0 - Thème de la Plate-forme de gouvernement ouvert (PGO)</span> (thème seulement)</a></td>
 					<td><a href="https://github.com/wet-boew/theme-ogpl/releases/download/v4.0.0/themes-dist-4.0.0-theme-ogpl.zip">Télécharger<span class="wb-inv"> - Fichiers de production de v4.0.0 - Thème de la Plate-forme de gouvernement ouvert (PGO)</span></a></td>


### PR DESCRIPTION
The goal of this pull request is to make it easier for people to adopt WET.

For example, the "Getting Started" page started with "reporting a bug". I think most people who want to "get started" with WET are looking to **use it**. The next mostly likely action is to customize WET to fit their design better. Two things I couldn't change:
- [ ] "Communications material" does not belong under "Documentation". Please put it on its own page.
- [ ] "I want to report a bug or ask a question about WET" doesn't tell you how to ask a question about WET.

Summary of commits:
- Improve documentation page
  - Move instructions on how to improve the docs to the bottom of the page.
  - Promote using and customizing WET to be the top options.
  - Use more direct language and links in first paragraph.
  - Remove repetition of "Getting started".
- Getting started improvements
  - Move using and customizing WET to top
  - Remove "Step 0" of creating a GitHub account, which is not needed in two out of four activities
  - Improve clarity of instructions
- Highlight the current stable version on the downloads page
- Correct typo on pull request page
- Correct typos on bugs page
