### PR TITLE
Build: Switch to official jQuery-Validation bower

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -292,7 +292,7 @@ module.exports = (grunt) ->
 						lang = filepath.replace "dist/unmin/js/i18n/", ""
 						# jQuery validation uses an underscore for locals
 						lang = lang.replace "_", "-"
-						validationPath = "lib/jquery.validation/localization/"
+						validationPath = "lib/jquery-validation/localization/"
 
 						# Check and append message file
 						messagesPath = validationPath + "messages_" + lang
@@ -921,8 +921,8 @@ module.exports = (grunt) ->
 						"flot/jquery.flot.pie.js"
 						"flot/jquery.flot.canvas.js"
 						"SideBySideImproved/jquery.flot.orderBars.js"
-						"jquery.validation/jquery.validate.js"
-						"jquery.validation/additional-methods.js"
+						"jquery-validation/jquery.validate.js"
+						"jquery-validation/additional-methods.js"
 						"magnific-popup/dist/jquery.magnific-popup.js"
 						"google-code-prettify/src/*.js"
 						"DataTables/media/js/jquery.dataTables.js"

--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "jquery": "2.1.0",
     "jquery-oldIE": "jquery#1.11.0",
     "jquery-pjax": "1.7.3",
-    "jquery.validation": "1.11.1",
+    "jquery-validation": "1.11.1",
     "magnific-popup": "0.9.8",
     "openlayers": "https://github.com/wet-boew/openlayers/releases/download/v2.13.1/OpenLayers-2.13.1.tar.gz",
     "proj4": "2.1.0",


### PR DESCRIPTION
The package has been renamed, and while the current old reference is still valid, the official version uses this slug.

There is a new version on jQuery Validation, but it will require some more testing before upgrading. A bunch of the aria is now baked in, so there is a need to evaluate what wrapping we can remove.
