### PR TITLE
Scss lint 0.23.1

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -18,7 +18,9 @@ linters:
   SelectorDepth:
     enabled: false
   PropertySortOrder:
-    enabled: false
+    exclude:
+      # Ignore because of greyscale hack
+      - "src/plugins/tabs/tabs.scss"
   CapitalizationInSelector:
     exclude:
       - "src/plugins/charts/charts.scss"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
 
 before_install:
   - ./script/setup
-  - gem install scss-lint --no-ri --version '=0.22.0'
+  - gem install scss-lint --no-ri --version '=0.23.1'
 
 script:
   - travis_retry ./script/travis_script.sh

--- a/src/base/partials/_bootstrap-overrides.scss
+++ b/src/base/partials/_bootstrap-overrides.scss
@@ -216,6 +216,13 @@ a {
 			}
 		}
 	}
+
+	/*
+	 * List unstyled RTL fix
+	 */
+	.list-unstyled {
+		padding-right: 0;
+	}
 }
 
 %label-alert-color-000 {
@@ -415,7 +422,7 @@ $label-alert-danger-border-icon-color: #d3080c;
 }
 
 /*
- *	Increase font weight of headings to 700
+ *	Heading top margins
  */
 
 %font-weight-700 {
@@ -425,31 +432,37 @@ $label-alert-danger-border-icon-color: #d3080c;
 h1,
 .h1 {
 	@extend %font-weight-700;
+	margin-top: 0;
 }
 
 h2,
 .h2 {
 	@extend %font-weight-700;
+	margin-top: ceil($line-height-computed * $font-scale-xxl);
 }
 
 h3,
 .h3 {
 	@extend %font-weight-700;
+	margin-top: ceil($line-height-computed * $font-scale-xl);
 }
 
 h4,
 .h4 {
 	@extend %font-weight-700;
+	margin-top: ceil($line-height-computed * $font-scale-lg);
 }
 
 h5,
 .h5 {
 	@extend %font-weight-700;
+	margin-top: $line-height-computed;
 }
 
 h6,
 .h6 {
 	@extend %font-weight-700;
+	margin-top: ceil($line-height-computed * $font-scale-sm);
 }
 
 /*
@@ -457,15 +470,6 @@ h6,
  */
 code {
 	white-space: normal;
-}
-
-/*
- * List unstyled RTL fix
- */
-[dir=rtl] {
-	.list-unstyled {
-		padding-right: 0;
-	}
 }
 
 /*
@@ -619,37 +623,4 @@ blockquote {
 	fieldset[disabled] & {
 		border-style: solid;
 	}
-}
-
-/*
- *	Heading top margins
- */
-h1,
-.h1 {
-	margin-top: 0;
-}
-
-h2,
-.h2 {
-	margin-top: ceil($line-height-computed * $font-scale-xxl);
-}
-
-h3,
-.h3 {
-	margin-top: ceil($line-height-computed * $font-scale-xl);
-}
-
-h4,
-.h4 {
-	margin-top: ceil($line-height-computed * $font-scale-lg);
-}
-
-h5,
-.h5 {
-	margin-top: $line-height-computed;
-}
-
-h6,
-.h6 {
-	margin-top: ceil($line-height-computed * $font-scale-sm);
 }

--- a/src/base/partials/_bootstrap-overrides.scss
+++ b/src/base/partials/_bootstrap-overrides.scss
@@ -172,8 +172,8 @@ a {
 
 %label-alert-common {
 	border-radius: 0;
-	border-width: 0 0 0 4px;
 	border-style: solid;
+	border-width: 0 0 0 4px;
 }
 
 .alert {
@@ -181,14 +181,14 @@ a {
 
 	> {
 		:first-child {
-			margin-top: auto;
 			margin-left: 1.2em;
+			margin-top: auto;
 
 			&:before {
-				position: absolute;
-				margin-left: -1.3em;
 				display: inline-block;
 				font-family: "Glyphicons Halflings";
+				margin-left: -1.3em;
+				position: absolute;
 			}
 		}
 
@@ -238,8 +238,8 @@ a {
 }
 
 %label-default-bg-border-left {
-	border-color: #acacac;
 	background: #eee;
+	border-color: #acacac;
 }
 
 .label-default {
@@ -258,8 +258,8 @@ a {
 }
 
 %label-primary-bg-border-left {
-	border-color: #083c6c;
 	background: #e8f2f4;
+	border-color: #083c6c;
 }
 
 .label-primary {
@@ -280,8 +280,8 @@ a {
 $label-alert-warning-border-icon-color: #278400;
 
 %label-alert-success-bg-border-left {
-	border-color: $label-alert-warning-border-icon-color;
 	background: #d8eeca;
+	border-color: $label-alert-warning-border-icon-color;
 }
 
 .label-success {
@@ -306,8 +306,8 @@ $label-alert-warning-border-icon-color: #278400;
 	> {
 		:first-child {
 			&:before {
-				content: "\e084";
 				color: $label-alert-warning-border-icon-color;
+				content: "\e084";
 			}
 		}
 	}
@@ -316,8 +316,8 @@ $label-alert-warning-border-icon-color: #278400;
 $label-alert-info-border-icon-color: #269abc;
 
 %label-alert-info-bg-border-left {
-	border-color: $label-alert-info-border-icon-color;
 	background: #d7faff;
+	border-color: $label-alert-info-border-icon-color;
 }
 
 .label-info {
@@ -342,8 +342,8 @@ $label-alert-info-border-icon-color: #269abc;
 	> {
 		:first-child {
 			&:before {
-				content: "\e086";
 				color: $label-alert-info-border-icon-color;
+				content: "\e086";
 			}
 		}
 	}
@@ -352,8 +352,8 @@ $label-alert-info-border-icon-color: #269abc;
 $label-alert-warning-border-icon-color: #f90;
 
 %label-alert-warning-bg-border-left {
-	border-color: $label-alert-warning-border-icon-color;
 	background: #f9f4d4;
+	border-color: $label-alert-warning-border-icon-color;
 }
 
 .label-warning {
@@ -378,8 +378,8 @@ $label-alert-warning-border-icon-color: #f90;
 	> {
 		:first-child {
 			&:before {
-				content: "\e107";
 				color: $label-alert-warning-border-icon-color;
+				content: "\e107";
 			}
 		}
 	}
@@ -388,8 +388,8 @@ $label-alert-warning-border-icon-color: #f90;
 $label-alert-danger-border-icon-color: #d3080c;
 
 %label-alert-danger-bg-border-left {
-	border-color: $label-alert-danger-border-icon-color;
 	background: #f3e9e8;
+	border-color: $label-alert-danger-border-icon-color;
 }
 
 .label-danger {
@@ -414,8 +414,8 @@ $label-alert-danger-border-icon-color: #d3080c;
 	> {
 		:first-child {
 			&:before {
-				content: "\e101";
 				color: $label-alert-danger-border-icon-color;
+				content: "\e101";
 			}
 		}
 	}
@@ -559,8 +559,8 @@ blockquote {
  *	greater than the available width.
  */
 .form-control {
-	width: auto;
 	max-width: 100%;
+	width: auto;
 }
 
 /*
@@ -603,8 +603,8 @@ blockquote {
 				span {
 					&:hover,
 					&:focus {
-						color: $pagination-hover-color;
 						border-color: $pagination-hover-border;
+						color: $pagination-hover-color;
 					}
 				}
 			}

--- a/src/base/partials/_details.scss
+++ b/src/base/partials/_details.scss
@@ -9,8 +9,8 @@ summary {
 	// Add focus styles (for keyboard accessibility)
 	&:hover,
 	&:focus {
-		color: #000;
 		background: #ddd;
+		color: #000;
 	}
 }
 

--- a/src/base/partials/_language-selector.scss
+++ b/src/base/partials/_language-selector.scss
@@ -5,9 +5,9 @@
 
 //	Sourced from http://css-tricks.com/snippets/css/clear-fix/
 %clear-fix {
+	clear: both;
 	content: "";
 	display: table;
-	clear: both;
 }
 
 //	Horizontal language selector

--- a/src/base/partials/_proximity.scss
+++ b/src/base/partials/_proximity.scss
@@ -85,8 +85,8 @@
  *	Fix for missing bullets in Chrome and Safari
  */
 [class*=clmn-] {
-	padding-left: 1.3em;
 	list-style: outside;
+	padding-left: 1.3em;
 
 	> {
 		li {
@@ -263,8 +263,8 @@
  *	Fix for missing bullets in Chrome and Safari
  */
 [class*=colcount-] {
-	padding-left: 1.3em;
 	list-style: outside;
+	padding-left: 1.3em;
 
 	> {
 		li {
@@ -273,8 +273,8 @@
 	}
 
 	&.list-unstyled {
-		padding-left: 0;
 		list-style: none outside none;
+		padding-left: 0;
 
 		li {
 			margin-left: 0;

--- a/src/base/partials/_transitions.scss
+++ b/src/base/partials/_transitions.scss
@@ -9,28 +9,28 @@
 */
 
 .in {
-	animation-timing-function: ease-out;
 	animation-duration: 350ms;
+	animation-timing-function: ease-out;
 }
 
 .out {
-	animation-timing-function: ease-in;
 	animation-duration: 225ms;
+	animation-timing-function: ease-in;
 }
 
 .pop {
 	transform-origin: 50% 50%;
 
 	.in {
-		transform: scale(1);
-		animation-name: popin;
 		animation-duration: 350ms;
+		animation-name: popin;
 		opacity: 1;
+		transform: scale(1);
 	}
 
 	.out {
-		animation-name: fadeout;
 		animation-duration: 100ms;
+		animation-name: fadeout;
 		opacity: 0;
 	}
 
@@ -40,33 +40,33 @@
 		}
 
 		.out {
-			transform: scale(0.8);
 			animation-name: popout;
+			transform: scale(0.8);
 		}
 	}
 }
 
 @keyframes popin {
 	from {
-		transform: scale(0.8);
 		opacity: 0;
+		transform: scale(0.8);
 	}
 
 	to {
-		transform: scale(1);
 		opacity: 1;
+		transform: scale(1);
 	}
 }
 
 @keyframes popout {
 	from {
-		transform: scale(1);
 		opacity: 1;
+		transform: scale(1);
 	}
 
 	to {
-		transform: scale(0.8);
 		opacity: 0;
+		transform: scale(0.8);
 	}
 }
 
@@ -115,29 +115,29 @@
 .slide {
 	.out,
 	.in {
-		animation-timing-function: ease-out;
 		animation-duration: 350ms;
+		animation-timing-function: ease-out;
 	}
 
 	.out {
-		transform: translateX(-100%);
 		animation-name: slideouttoleft;
+		transform: translateX(-100%);
 	}
 
 	.in {
-		transform: translateX(0);
 		animation-name: slideinfromright;
+		transform: translateX(0);
 	}
 
 	&.reverse {
 		.out {
-			transform: translateX(100%);
 			animation-name: slideouttoright;
+			transform: translateX(100%);
 		}
 
 		.in {
-			transform: translateX(100%);
 			animation-name: slideouttoright;
+			transform: translateX(100%);
 		}
 	}
 
@@ -146,26 +146,26 @@
 /* slide down */
 .slidedown {
 	.out {
-		animation-name: fadeout;
 		animation-duration: 100ms;
+		animation-name: fadeout;
 	}
 
 	.in {
-		transform: translateY(0);
-		animation-name: slideinfromtop;
 		animation-duration: 250ms;
+		animation-name: slideinfromtop;
+		transform: translateY(0);
 	}
 
 	&.reverse {
 		.out {
-			transform: translateY(-100%);
-			animation-name: slideouttotop;
 			animation-duration: 200ms;
+			animation-name: slideouttotop;
+			transform: translateY(-100%);
 		}
 
 		.in {
-			animation-name: fadein;
 			animation-duration: 150ms;
+			animation-name: fadein;
 		}
 	}
 }
@@ -213,15 +213,15 @@
 
 .fade {
 	.out {
-		opacity: 0;
 		animation-duration: 125ms;
 		animation-name: fadeout;
+		opacity: 0;
 	}
 
 	.in {
-		opacity: 1;
 		animation-duration: 225ms;
 		animation-name: fadein;
+		opacity: 1;
 	}
 }
 
@@ -248,28 +248,28 @@
 
 .slidefade {
 	.out {
-		transform: translateX(-100%);
-		animation-name: slideouttoleft;
 		animation-duration: 225ms;
+		animation-name: slideouttoleft;
+		transform: translateX(-100%);
 	}
 
 	.in {
-		transform: translateX(0);
-		animation-name: fadein;
 		animation-duration: 200ms;
+		animation-name: fadein;
+		transform: translateX(0);
 	}
 
 	&.reverse {
 		.out {
-			transform: translateX(100%);
-			animation-name: slideouttoright;
 			animation-duration: 200ms;
+			animation-name: slideouttoright;
+			transform: translateX(100%);
 		}
 
 		.in {
-			transform: translateX(0);
-			animation-name: fadein;
 			animation-duration: 200ms;
+			animation-name: fadein;
+			transform: translateX(0);
 		}
 	}
 }
@@ -277,26 +277,26 @@
 /* slide up */
 .slideup {
 	.out {
-		animation-name: fadeout;
 		animation-duration: 100ms;
+		animation-name: fadeout;
 	}
 
 	.in {
-		transform: translateY(0);
-		animation-name: slideinfrombottom;
 		animation-duration: 250ms;
+		animation-name: slideinfrombottom;
+		transform: translateY(0);
 	}
 
 	&.reverse {
 		.in {
-			animation-name: fadein;
 			animation-duration: 150ms;
+			animation-name: fadein;
 		}
 
 		.out {
-			transform: translateY(100%);
-			animation-name: slideouttobottom;
 			animation-duration: 200ms;
+			animation-name: slideouttobottom;
+			transform: translateY(100%);
 		}
 	}
 }

--- a/src/base/wet-boew.scss
+++ b/src/base/wet-boew.scss
@@ -10,7 +10,7 @@
 // Hack for Bootstrap 3.1.1, since it doesn't convert the "fadein" LESS method.
 // Pending fix release in https://github.com/twbs/bootstrap-sass/commit/df7be4f0412497e22f1d271d94d6e9835f61113e
 @function fadein($colour, $pct) {
-	@return opacify($colour, $pct / 100.0);
+	@return opacify($colour, $pct / 100);
 }
 
 // Override Bootstrap's expected font path

--- a/src/base/wet-boew.scss
+++ b/src/base/wet-boew.scss
@@ -22,21 +22,21 @@ $icon-font-path: "../fonts/";
  Global placeholders
  */
 %accessible-invisible {
-	height: 1px;
-	width: 1px;
 	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	margin: 0;
 	overflow: hidden;
 	position: absolute;
-	margin: 0;
+	width: 1px;
 }
 
 %accessible-invisible-show {
-	height: inherit;
-	width: inherit;
 	clip: rect(auto, auto, auto, auto);
+	height: inherit;
+	margin: inherit;
 	overflow: inherit;
 	position: static;
-	margin: inherit;
+	width: inherit;
 }
 
 %global-display-none {

--- a/src/other/archived/demo/archived.scss
+++ b/src/other/archived/demo/archived.scss
@@ -6,16 +6,16 @@
 	background-color: #fd0;
 
 	p {
-		text-align: center;
 		margin: 0;
+		text-align: center;
 	}
 
 	a {
-		display: block;
-		padding: 0.75em 44px;
 		color: #000;
-		text-decoration: none;
+		display: block;
 		font-weight: 700;
+		padding: 0.75em 44px;
+		text-decoration: none;
 
 		&:hover,
 		&:focus {

--- a/src/plugins/cal-events/cal-events.scss
+++ b/src/plugins/cal-events/cal-events.scss
@@ -3,17 +3,17 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 .ev-details {
-	color: #000;
 	background-color: $clrWhite;
-	padding: 0;
-	position: absolute;
-	z-index: 5;
 	border: 1px solid #333;
-	width: 10em;
+	color: #000;
+	list-style-type: none;
 	margin: 0;
 	margin-top: -0.5em;
-	list-style-type: none;
-	
+	padding: 0;
+	position: absolute;
+	width: 10em;
+	z-index: 5;
+
 	a {
 		&:hover,
 		&:focus {
@@ -25,8 +25,8 @@
 .cal-days {
 	a {
 		&.cal-evt {
-			color: $clrWhite;
 			background: #176ca7;
+			color: $clrWhite;
 		}
 	}
 }

--- a/src/plugins/calendar/calendar-base.scss
+++ b/src/plugins/calendar/calendar-base.scss
@@ -14,9 +14,6 @@
 .cal-cnt {
 	width: 18em;
 	text-shadow: none;
-}
-
-.cal-cnt {
 	background: #fff;
 
 	* {

--- a/src/plugins/calendar/calendar-base.scss
+++ b/src/plugins/calendar/calendar-base.scss
@@ -12,9 +12,9 @@
 }
 
 .cal-cnt {
-	width: 18em;
-	text-shadow: none;
 	background: #fff;
+	text-shadow: none;
+	width: 18em;
 
 	* {
 		font-size: 100%;
@@ -23,8 +23,8 @@
 	.cal-hd {
 		overflow: hidden;
 		padding: 0.5em 4px;
-		text-align: center;
 		position: relative;
+		text-align: center;
 	}
 
 	.cal-mnth {
@@ -50,8 +50,8 @@
 		@extend %cal-position-relative;
 
 		input {
-			padding: 0.1em 0.2em;
 			min-width: 5em;
+			padding: 0.1em 0.2em;
 		}
 	}
 
@@ -64,11 +64,11 @@
 
 .cal-nxtmnth,
 .cal-prvmnth {
-	display: inline-block;
 	background: none;
 	border: 0;
-	width: 2.5em;
+	display: inline-block;
 	height: 2.5em;
+	width: 2.5em;
 
 	&:focus {
 		outline: 1px dotted;
@@ -81,8 +81,8 @@
 }
 
 .cal-wd {
-	color: #fff;
 	border: 1px solid #333;
+	color: #fff;
 	padding: 0.5em 0;
 	text-align: center;
 }

--- a/src/plugins/charts/charts.scss
+++ b/src/plugins/charts/charts.scss
@@ -4,7 +4,7 @@
  */
 figure .pieLabel {
 	background-color: #fff;
-	color: #000;
 	border: solid #000 1px;
+	color: #000;
 	padding: 1px;
 }

--- a/src/plugins/data-ajax/demo/data-ajax.scss
+++ b/src/plugins/data-ajax/demo/data-ajax.scss
@@ -3,8 +3,8 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 %data-ajax-demo-padding-border {
-	padding: 5px;
 	border: 1px solid #000;
+	padding: 5px;
 }
 
 .original {

--- a/src/plugins/data-inview/demo/data-inview.scss
+++ b/src/plugins/data-inview/demo/data-inview.scss
@@ -12,10 +12,10 @@
 }
 
 .bar-demo {
-	margin: 0 0 20px;
 	border: 1px solid #ddd;
 	border-radius: 4px;
 	box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
+	margin: 0 0 20px;
 
 	p {
 		@extend %data-inview-bar-demo-gutter;

--- a/src/plugins/equalheight/demo/equalheight.scss
+++ b/src/plugins/equalheight/demo/equalheight.scss
@@ -2,15 +2,14 @@
 
 .wb-eqht {
 	section {
-		display: inline-block;
-		width: 100%;
-		padding: 15px;
-		margin-bottom: 15px;
-
 		border: 1px solid #ddd;
 		border-radius: 4px;
-		box-sizing: border-box;
 		box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
+		box-sizing: border-box;
+		display: inline-block;
+		margin-bottom: 15px;
+		padding: 15px;
+		width: 100%;
 
 		@media (min-width: $smallViewMin) {
 			width: 49%;

--- a/src/plugins/footnotes/footnotes-printView.scss
+++ b/src/plugins/footnotes/footnotes-printView.scss
@@ -15,14 +15,14 @@
 .wb-fnote {
 	border-left: 0;
 	border-right: 0;
+	margin-bottom: 1em;
 	margin-left: 0;
 	margin-right: 0;
-	margin-bottom: 1em;
 
 	dd {
 		border: 0;
-		width: 100%;
 		display: inline-block;
+		width: 100%;
 	}
 
 	.fn-rtn {

--- a/src/plugins/footnotes/footnotes.scss
+++ b/src/plugins/footnotes/footnotes.scss
@@ -6,9 +6,9 @@
 @import "../../variables";
 
 %fnote-link-highlight {
-	color: $clrWhite !important;
 	background-color: $clrDark;
 	border-color: $clrDark;
+	color: $clrWhite !important;
 }
 
 %fnote-link-background-light-border-medium-padding-whitespace {
@@ -28,10 +28,10 @@
 }
 
 .wb-fnote {
-	margin: 2em 10px 0;
-	border-width: 1px 0;
-	border-style: solid;
 	border-color: $clrMedium;
+	border-style: solid;
+	border-width: 1px 0;
+	margin: 2em 10px 0;
 
 	h2 {
 		margin-left: 0;
@@ -48,9 +48,9 @@
 	}
 
 	dd {
-		position: relative;
-		margin: $spacing 0;
 		border: 1px solid transparent;
+		margin: $spacing 0;
+		position: relative;
 
 		&:focus {
 			background-color: $clrLight;
@@ -74,13 +74,13 @@
 	}
 
 	.fn-rtn {
-		top: 0;
 		margin: 0;
-		padding-top: $spacing;
-		padding-right: 0;
-		position: absolute;
-		width: $ddRtnWidth;
 		overflow: hidden;
+		padding-right: 0;
+		padding-top: $spacing;
+		position: absolute;
+		top: 0;
+		width: $ddRtnWidth;
 
 		a {
 			@extend %fnote-link-background-light-border-medium-padding-whitespace;

--- a/src/plugins/geomap/geomap.scss
+++ b/src/plugins/geomap/geomap.scss
@@ -7,10 +7,10 @@
 }
 
 %geomap-position-absolute-bg-color-fff-opacity-05-font-size-1 {
-	position: absolute;
 	background-color: #fff;
-	opacity: 0.5;
 	font-size: 1px;
+	opacity: 0.5;
+	position: absolute;
 }
 
 /**
@@ -21,12 +21,12 @@
 	width: 25px;
 
 	img {
-		left: 0;
-		top: 0;
-		height: 25px;
-		width: 25px;
 		float: left;
+		height: 25px;
+		left: 0;
 		margin: 0;
+		top: 0;
+		width: 25px;
 	}
 }
 
@@ -56,8 +56,8 @@
 }
 
 .olMap {
-	z-index: 0;
 	cursor: default;
+	z-index: 0;
 }
 
 .olMapViewport {
@@ -74,27 +74,27 @@
 
 .olControlMousePosition {
 	bottom: 5px;
-	left: 100px;
 	display: block;
-	position: absolute;
 	font-family: Arial;
 	font-size: smaller;
+	left: 100px;
+	position: absolute;
 }
 
 .olControlScale {
-	right: 3px;
 	bottom: 3em;
 	display: block;
-	position: absolute;
 	font-size: smaller;
+	position: absolute;
+	right: 3px;
 }
 
 .olControlScaleLine {
-	display: block;
-	position: absolute;
-	left: 10px;
 	bottom: 15px;
+	display: block;
 	font-size: xx-small;
+	left: 10px;
+	position: absolute;
 }
 
 .olControlScaleLineBottom {
@@ -130,8 +130,8 @@
 }
 
 .olFramedCloudPopupContent {
-	padding: 5px;
 	overflow: auto;
+	padding: 5px;
 }
 
 %olPopupMargin {
@@ -225,9 +225,9 @@
  * GeoMap
  */
 .wb-geomap-map {
-	position: relative;
-	outline: 1px solid #ccc;
 	margin-bottom: 30px;
+	outline: 1px solid #ccc;
+	position: relative;
 
 	&.active {
 		outline-color: #07f;
@@ -235,8 +235,8 @@
 }
 
 .wb-geomap-detail {
-	margin-top: 10px;
 	margin-bottom: 10px;
+	margin-top: 10px;
 }
 
 .geomap-legend-detail {

--- a/src/plugins/lightbox/demo/lightbox.scss
+++ b/src/plugins/lightbox/demo/lightbox.scss
@@ -3,13 +3,13 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 %lightbox-demo-box {
-	display: block;
-	width: 150px;
-	height: 150px;
-	border: 1px solid #000;
-	text-align: center;
-	line-height: 148px;
 	background: #eee;
+	border: 1px solid #000;
+	display: block;
+	height: 150px;
+	line-height: 148px;
+	text-align: center;
+	width: 150px;
 }
 
 .wb-lbx-demo {
@@ -33,8 +33,8 @@
 			&:hover,
 			&:focus,
 			&:active {
-				text-decoration: underline;
 				background: #fff;
+				text-decoration: underline;
 			}
 		}
 	}

--- a/src/plugins/lightbox/lightbox.scss
+++ b/src/plugins/lightbox/lightbox.scss
@@ -7,15 +7,14 @@
 @import "../../../lib/magnific-popup/src/css/main";
 
 %lightbox-button-outline {
-	outline: 1px dotted;
+	outline: 1px dotted #fff;
 	outline-offset: -2px;
-	outline-color: #fff;
 }
 
 .lbx-hide-gal {
 	li {
-		list-style-type: none;
 		display: none;
+		list-style-type: none;
 
 		&:first-child {
 			display: block;
@@ -24,9 +23,9 @@
 }
 
 .modal-dialog {
+	left: auto;
 	padding: 0;
 	position: relative;
-	left: auto;
 }
 
 .modal-content {
@@ -56,13 +55,13 @@
 /* Should fix upstream in Magnific Popup rather than overriding in WET */
 .mfp-bottom-bar {
 	.mfp-title {
-		width: 75%;
 		padding-right: 5px;
+		width: 75%;
 	}
 
 	.mfp-counter {
 		font-size: 1em;
-		width: 25%;
 		text-align: right;
+		width: 25%;
 	}
 }

--- a/src/plugins/menu/menu.scss
+++ b/src/plugins/menu/menu.scss
@@ -7,25 +7,32 @@
  * Menu Sass
  */
 .expicon {
-	font-size: 0.8em;
-	margin: 0 -0.35em 0 0.7em;
+	border-left: 0.35em solid transparent;
+	border-right: 0.35em solid transparent;
+	border-top: 0.4em solid #fff;
+	height: 0;
+	left: 0.75em;
+	margin-right: 0.35em;
+	position: relative;
+	top: 0.8em;
+	width: 0;
 }
 
 .wb-menu {
 	.sm {
 		display: none;
-		position: relative;
 		max-height: 0;
 		overflow: hidden;
+		position: relative;
 
 		&.open {
+			display: inline;
 			max-height: 1000px;
 			min-width: 12.5em;
-			display: inline;
 			position: absolute;
-			z-index: 500;
 			text-transform: none;
 			top: auto;
+			z-index: 500;
 
 			li {
 				@extend %global-display-block;
@@ -38,20 +45,20 @@
 	}
 
 	.menu {
-		position: relative;
 		margin-left: 0;
+		position: relative;
 
 		> {
 			li {
+				float: left;
 				margin: 0;
 				padding: 0;
-				float: left;
 
 				a {
 					@extend %global-text-decoration-none;
-					text-align: center;
 					display: block;
 					padding: 1em;
+					text-align: center;
 
 					&:hover,
 					&:focus {
@@ -115,9 +122,9 @@
 		}
 
 		li {
+			line-height: normal;
 			padding-left: 10px;
 			padding-right: 0;
-			line-height: normal;
 
 			a {
 				padding: 5px;
@@ -154,9 +161,9 @@
 		}
 
 		a {
+			display: inline-block;
 			margin: 6px 0 6px -6px;
 			padding: 0 6px;
-			display: inline-block;
 
 			&.wb-navcurr {
 				@extend %menu-mb-pnl-wb-navcurr;
@@ -263,7 +270,10 @@
 	}
 
 	.expicon {
-		margin: 0 0.7em 0 -0.35em;
+		left: auto;
+		margin-left: 0.35em;
+		margin-right: 0;
+		right: 0.75em;
 	}
 
 	#mb-pnl {

--- a/src/plugins/multimedia/multimedia.scss
+++ b/src/plugins/multimedia/multimedia.scss
@@ -24,20 +24,20 @@ $mm-ctrl-bg-color: #000;
 }
 
 %multimedia_loading {
+	bottom: 0;
 	content: " ";
 	height: 100px;
-	width: 100px;
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
 	left: 0;
 	margin: auto;
+	position: absolute;
+	right: 0;
+	top: 0;
+	width: 100px;
 }
 
 %captions_hidden {
-	padding: 0;
 	max-height: 0;
+	padding: 0;
 }
 
 .wb-mltmd {
@@ -46,15 +46,15 @@ $mm-ctrl-bg-color: #000;
 	display: block;
 
 	video {
-		width: 100%;
 		height: auto;
+		width: 100%;
 	}
 
 	.btn {
-		border-top-right-radius: 0 !important;
-		border-top-left-radius: 0 !important;
 		background: transparent;
 		border: 0;
+		border-top-left-radius: 0 !important;
+		border-top-right-radius: 0 !important;
 		color: $mm-ctrl-fg-color;
 	}
 
@@ -80,31 +80,31 @@ $mm-ctrl-bg-color: #000;
 	}
 
 	.display {
-		position: relative;
 		background: #000;
+		position: relative;
 
 		.wb-mm-ovrly {
+			height: 100%;
 			position: absolute;
 			width: 100%;
-			height: 100%;
 			z-index: 1;
 		}
 
 		video,
 		object,
 		iframe {
-			width: 100%;
 			margin-bottom: -7px;
+			width: 100%;
 		}
 
 		&.waiting {
 			&:after {
 				@extend %multimedia_loading;
-				background: url("../assets/loading.png") center center no-repeat;
-				animation-name: spin;
 				animation-duration: 1000ms;
 				animation-iteration-count: infinite;
+				animation-name: spin;
 				animation-timing-function: linear;
+				background: url("../assets/loading.png") center center no-repeat;
 				z-index: 2;
 			}
 
@@ -119,10 +119,10 @@ $mm-ctrl-bg-color: #000;
 
 	.wb-mm-ovrly {
 		background: transparent;
-		direction: ltr;
-		text-indent: -9999px;
 		border: 0;
+		direction: ltr;
 		padding: 0;
+		text-indent: -9999px;
 
 		img {
 			width: 100%;
@@ -141,8 +141,8 @@ $mm-ctrl-bg-color: #000;
 
 	&.cc_on {
 		.wb-mm-cc {
-			padding: 0.5em;
 			max-height: 999em;
+			padding: 0.5em;
 		}
 
 		.cc {
@@ -159,8 +159,8 @@ $mm-ctrl-bg-color: #000;
 	//TODO: Remove this when captions works in chromeless api with controls
 	&.youtube {
 		.wb-mm-ctrls {
-			margin-top: -35px;
 			border-bottom: 10px solid #fff;
+			margin-top: -35px;
 		}
 	}
 
@@ -168,8 +168,8 @@ $mm-ctrl-bg-color: #000;
 	  Light Skinning of mediacontrols
 	 */
 	&.skn-lt {
-		color: #000;
 		border-bottom: 1px solid #ddd;
+		color: #000;
 
 		.wb-mm-ctrls {
 			background: #fff;
@@ -178,8 +178,8 @@ $mm-ctrl-bg-color: #000;
 
 		.btn {
 			background: #fff;
-			color: #000;
 			border: 0;
+			color: #000;
 		}
 	}
 
@@ -194,14 +194,14 @@ $mm-ctrl-bg-color: #000;
 }
 
 %pnl {
-	vertical-align: middle;
 	display: table-cell;
+	vertical-align: middle;
 }
 
 .wb-mm-ctrls {
-	display: table;
 	background: $mm-ctrl-bg-color;
 	color: $mm-ctrl-fg-color;
+	display: table;
 	position: relative;
 	width: 100%;
 
@@ -222,8 +222,8 @@ $mm-ctrl-bg-color: #000;
 
 		.wb-mm-tmln-crrnt,
 		.wb-mm-tmln-ttl {
-			margin: 0;
 			float: left;
+			margin: 0;
 		}
 
 		.wb-mm-tmln-ttl {
@@ -243,14 +243,14 @@ $mm-ctrl-bg-color: #000;
 
 	/* Progress Bar */
 	progress {
-		width: 100%;
-		height: 16px;
-		display: block;
 		/* Important Thing */
 		-webkit-appearance: none;
+		background: $mm-progress-bg-color;
 		border: 0;
 		color: $mm-progress-fg-color;
-		background: $mm-progress-bg-color;
+		display: block;
+		height: 16px;
+		width: 100%;
 
 		&::-webkit-progress-bar {
 			background: $mm-progress-bg-color;

--- a/src/plugins/overlay/overlay.scss
+++ b/src/plugins/overlay/overlay.scss
@@ -7,11 +7,11 @@
  *	Overlay base
  */
 .wb-overlay {
-	background-color: #fff;
-	display: none;
-	border-radius: 0;
-	border: 0;
 	background-clip: border-box;
+	background-color: #fff;
+	border: 0;
+	border-radius: 0;
+	display: none;
 	z-index: 1050;
 
 	&.wb-inview {
@@ -19,22 +19,22 @@
 	}
 
 	&.open {
-		position: fixed;
 		display: inline-block;
+		position: fixed;
 	}
 }
 
 %overlay-panel {
-	top: 0;
 	height: 100%;
 	max-width: 90%;
+	top: 0;
 }
 
 %overlay-bar {
+	border-bottom: 0;
+	left: 0;
 	max-height: 90%;
 	min-width: 100%;
-	left: 0;
-	border-bottom: 0;
 }
 
 %overlay-popup {
@@ -68,18 +68,18 @@
 .wb-popup-mid {
 	@extend %overlay-popup;
 	border-radius: 6px;
-	top: 0;
 	bottom: 0;
 	left: 0;
-	right: 0;
 	margin: auto;
+	right: 0;
+	top: 0;
 }
 
 .wb-popup-full {
-	width: 100%;
 	height: 100%;
-	top: 0;
 	left: 0;
+	top: 0;
+	width: 100%;
 }
 
 /*
@@ -119,17 +119,17 @@
 		background-color: #000;
 		border-radius: 999px;
 		height: 1em;
-		width: 1em;
 		line-height: 1em;
-		margin-top: 10px;
 		margin-right: 20px;
+		margin-top: 10px;
+		width: 1em;
 	}
 }
 
 [dir=rtl] {
 	.mfp-close {
-		right: auto;
 		left: 0;
+		right: auto;
 	}
 
 	.wb-panel-l {
@@ -138,8 +138,8 @@
 	}
 
 	.wb-panel-r {
-		right: auto;
 		left: 0;
+		right: auto;
 	}
 
 	.overlay-def {

--- a/src/plugins/session-timeout/session-timeout.scss
+++ b/src/plugins/session-timeout/session-timeout.scss
@@ -5,7 +5,7 @@
 
 #wb-sessto-modal {
 	.modal-footer {
-		margin-top: 0;
 		background: #fff;
+		margin-top: 0;
 	}
 }

--- a/src/plugins/share/share.scss
+++ b/src/plugins/share/share.scss
@@ -6,21 +6,21 @@
 
 .wb-share {
 	.shr-lnk {
-		width: 100%;
-		min-height: 32px;
+		font-size: 115%;
 		line-height: 32px;
 		margin-bottom: 8px;
+		min-height: 32px;
 		text-align: left;
 		text-decoration: none;
-		font-size: 115%;
+		width: 100%;
 
 		&:before {
 			content: " ";
 			display: inline-block;
 			height: 32px;
-			width: 32px;
 			margin-right: 0.6em;
 			vertical-align: middle;
+			width: 32px;
 		}
 	}
 
@@ -57,10 +57,10 @@
 
 	.email {
 		&:before {
+			content: "\2709";
 			display: inline-block;
 			font-family: "Glyphicons Halflings";
 			font-size: 32px;
-			content: "\2709";
 			margin-right: 0.3em;
 		}
 	}
@@ -149,8 +149,8 @@
 
 	ul {
 		list-style-type: none;
-		padding: 0;
 		margin: 10px;
+		padding: 0;
 	}
 }
 
@@ -160,15 +160,15 @@
 			text-align: right;
 
 			&:before {
-				margin-right: auto;
 				margin-left: 0.4em;
+				margin-right: auto;
 			}
 		}
 
 		.email {
 			&:before {
-				margin-right: auto;
 				margin-left: 0.6em;
+				margin-right: auto;
 			}
 		}
 

--- a/src/plugins/tables/tables.scss
+++ b/src/plugins/tables/tables.scss
@@ -163,8 +163,8 @@ table {
 .paginate_enabled_previous,
 .paginate_disabled_next,
 .paginate_enabled_next {
-	cursor: pointer;
 	color: #111 !important;
+	cursor: pointer;
 
 	&:active {
 		@extend %tables-outline-none;
@@ -173,8 +173,8 @@ table {
 
 %table-icon-disabled {
 	color: #757575 !important;
-	text-decoration: none;
 	cursor: default;
+	text-decoration: none;
 }
 
 .paginate_disabled_next {
@@ -191,8 +191,8 @@ table {
 
 	&:before {
 		@extend %table_icons;
-		margin-right: 5px;
 		content: "\e091";
+		margin-right: 5px;
 	}
 }
 
@@ -202,18 +202,18 @@ table {
 
 	&:after {
 		@extend %table_icons;
-		margin-left: 5px;
 		content: "\e092";
+		margin-left: 5px;
 	}
 }
 
 /* Full number pagination */
 %tables-paginate-button-active {
 	border: 1px solid #aaa;
-	padding: 2px 5px;
-	margin: 0 3px;
-	cursor: pointer;
 	color: #333 !important;
+	cursor: pointer;
+	margin: 0 3px;
+	padding: 2px 5px;
 }
 
 .paging_full_numbers {
@@ -247,19 +247,19 @@ table {
  * Processing indicator
  */
 .dataTables_processing {
-	position: absolute;
-	top: 50%;
-	left: 50%;
-	width: 250px;
+	background-color: #fff;
+	border: 1px solid #ddd;
+	color: #999;
+	font-size: 14px;
 	height: 30px;
+	left: 50%;
 	margin-left: -125px;
 	margin-top: -15px;
 	padding: 14px 0 2px;
-	border: 1px solid #ddd;
+	position: absolute;
 	text-align: center;
-	color: #999;
-	font-size: 14px;
-	background-color: #fff;
+	top: 50%;
+	width: 250px;
 }
 
 /*
@@ -276,8 +276,8 @@ table {
 	&:after {
 		@extend %table_icons;
 		@extend %tables-sorting-margin-left-5-position-absolute;
-		content: "\e150";
 		color: #757575;
+		content: "\e150";
 	}
 }
 
@@ -330,8 +330,8 @@ table {
 }
 
 %tables-th-padding-right-8-padding-left-15em {
-	padding-right: 8px;
 	padding-left: 15em;
+	padding-right: 8px;
 }
 
 [dir=rtl] {

--- a/src/plugins/tabs/tabs-mediumViewOver.scss
+++ b/src/plugins/tabs/tabs-mediumViewOver.scss
@@ -4,23 +4,23 @@
  */
 
 %tabs-mediumview-prv-nxt-common {
-	top: 0;
 	bottom: 0;
 	height: 100%;
+	top: 0;
 	width: 3em;
 }
 
 %tabs-mediumview-prv-nxt-a-common {
-	position: absolute;
-	top: 0;
 	bottom: 0;
 	left: 0;
+	position: absolute;
+	top: 0;
 }
 
 %tabs-mediumview-prv-nxt-glyphicon-common {
+	bottom: 0;
 	position: absolute;
 	top: 0;
-	bottom: 0;
 }
 
 %tabs-mediumview-right-0 {
@@ -63,8 +63,8 @@
 							@extend %tabs-mediumview-prv-nxt-glyphicon-common;
 							bottom: 0;
 							left: .25em;
-							padding-top: 1px;
 							padding-right: 2px;
+							padding-top: 1px;
 						}
 
 						&:focus,
@@ -103,8 +103,8 @@
 
 	> {
 		details {
-			display: none;
 			border: 1px solid #ccc;
+			display: none;
 			margin-top: -1px;
 
 			&[open] {

--- a/src/plugins/tabs/tabs-smallViewUnder.scss
+++ b/src/plugins/tabs/tabs-smallViewUnder.scss
@@ -19,18 +19,18 @@
 }
 
 .wb-tabs {
-	border-top: 1px solid #adadad;
 	border-radius: 4px;
+	border-top: 1px solid #adadad;
 	margin-bottom: 15px;
 
 	&.carousel-s1,
 	&.carousel-s2 {
 		figcaption {
-			position: relative;
-			top: auto;
-			right: 0;
 			bottom: 0;
 			left: 0;
+			position: relative;
+			right: 0;
+			top: auto;
 		}
 	}
 
@@ -56,8 +56,8 @@
 					&.active,
 					&:focus,
 					&:hover {
-						top: 0;
 						cursor: default;
+						top: 0;
 					}
 				}
 			}
@@ -66,13 +66,13 @@
 
 	&.carousel-s2 {
 		$smallViewToolbarSize: 4.375em;
+		background: #eee;
 		margin-bottom: auto;
 		padding-bottom: $smallViewToolbarSize;
-		background: #eee;
 
 		[role="tablist"] {
-			height: auto;
 			bottom: 0;
+			height: auto;
 			margin-top: -$smallViewToolbarSize;
 
 			li {

--- a/src/plugins/tabs/tabs.scss
+++ b/src/plugins/tabs/tabs.scss
@@ -30,14 +30,14 @@ $medGray: #ccc;
 
 //TODO:Combine with previous placeholder when libsass supports nested selectors
 %tab-width-100-height-auto {
-	width: 100%;
 	height: auto;
+	width: 100%;
 }
 
 %tab-figure-captions {
-	position: absolute;
 	color: #fff;
 	padding: 0.5em 1em;
+	position: absolute;
 	z-index: 101;
 }
 
@@ -53,21 +53,21 @@ $medGray: #ccc;
 }
 
 %carousel-s2-prv-nxt-a-common {
-	width: 100%;
-	color: $drabBlue;
 	border: 0;
+	color: $drabBlue;
+	width: 100%;
 }
 
 %carousel-s2-prv-nxt-glyphicon-common {
-	margin: auto 0;
-	height: 1.75em;
-	width: 1.75em;
-	font-size: 1.75em;
-	line-height: 1.75em;
-	text-align: center;
 	background: #fff;
 	border-radius: 999px;
 	box-shadow: 0 0 4px $drabBlue;
+	font-size: 1.75em;
+	height: 1.75em;
+	line-height: 1.75em;
+	margin: auto 0;
+	text-align: center;
+	width: 1.75em;
 }
 
 %tabs-background-transparent {
@@ -90,27 +90,27 @@ $medGray: #ccc;
 	@extend %tabs-position-relative;
 
 	[role ="tablist"] {
-		position: relative;
 		list-style: none;
 		margin: 0;
 		padding: 0;
+		position: relative;
 
 		li {
-			display: inline-block;
-			cursor: pointer;
-			margin: 0 10px 0 0;
-			color: #000;
 			background: #ebf2fc;
 			border: 1px solid $medGray;
-			text-align: center;
+			color: #000;
+			cursor: pointer;
+			display: inline-block;
+			margin: 0 10px 0 0;
 			position: relative;
+			text-align: center;
 
 			a {
-				text-decoration: none;
 				color: #000;
 				display: inline-block;
 				// changed padding and margin from em to px to fix web-kit layout issue
 				padding: 10px;
+				text-decoration: none;
 			}
 
 			&:focus,
@@ -120,14 +120,14 @@ $medGray: #ccc;
 			}
 
 			&.active {
-				padding-bottom: 1px;
-				border-bottom: 0;
 				background: #fff;
+				border-bottom: 0;
 				cursor: default;
+				padding-bottom: 1px;
 
 				a {
-					cursor: default;
 					border-top: 4px solid #666;
+					cursor: default;
 					padding-top: 6px;
 				}
 			}
@@ -177,8 +177,8 @@ $medGray: #ccc;
 
 		figcaption {
 			@extend %tab-figure-captions;
-			top: 3em;
 			right: 1em;
+			top: 3em;
 
 			a {
 				@extend %tab-figure-captions-links;
@@ -196,21 +196,21 @@ $medGray: #ccc;
 
 		[role="tablist"] {
 			@extend %tab-position-relative;
-			width: 100%;
 			height: 100%;
+			width: 100%;
 
 			li {
 				@extend %tab-zindex-100;
 				background: transparent;
-				display: none;
 				border: 0;
+				display: none;
 
 				&[role="presentation"] {
+					background: $lightGray;
+					background: transparentize($lightGray, .1);
 					display: inline-block;
 					padding: 4px;
 					top: 100%;
-					background: $lightGray;
-					background: transparentize($lightGray, .1);
 
 					&.active,
 					&:focus,
@@ -295,8 +295,8 @@ $medGray: #ccc;
 					background: none;
 					border: 0;
 					display: inline-block !important;
-					top: 100%;
 					padding: 2px 10px;
+					top: 100%;
 
 					span {
 						color: #000 !important;

--- a/src/plugins/toggle/demo/toggle.scss
+++ b/src/plugins/toggle/demo/toggle.scss
@@ -4,13 +4,13 @@
  */
 main {
 	.box {
+		background-color: #d9edf7;
+		border-radius: 4px;
 		display: inline-block;
-		width: 30px;
 		height: 30px;
 		margin-right: 15px;
-		border-radius: 4px;
-		background-color: #d9edf7;
 		transition: background-color 0.5s;
+		width: 30px;
 
 		&.on {
 			background-color: #428bca;

--- a/src/plugins/twitter/twitter.scss
+++ b/src/plugins/twitter/twitter.scss
@@ -65,16 +65,16 @@
 
 	a {
 		&.twitter-timeline {
-			display: block;
-			direction: ltr;
-			text-indent: -9999px;
-			font-size: 90%;
-			min-height: 50px;
-			overflow: auto;
 			background: #fff;
 			border: 1px solid #ccc;
+			direction: ltr;
+			display: block;
+			font-size: 90%;
 			margin: 0 !important;
+			min-height: 50px;
+			overflow: auto;
 			padding: 5px !important;
+			text-indent: -9999px;
 		}
 	}
 }

--- a/src/polyfills/datalist/datalist.scss
+++ b/src/polyfills/datalist/datalist.scss
@@ -3,28 +3,28 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 .wb-al {
-	position: absolute;
-	margin-top: -6px;
-	padding-left: 0;
-	z-index: 50;
 	background: #fff;
-	max-height: 18em;
-	overflow: auto;
-	width: 100%;
-	list-style-type: none;
 	border: 1px solid #666;
 	border-top: 0;
+	list-style-type: none;
+	margin-top: -6px;
+	max-height: 18em;
+	overflow: auto;
+	padding-left: 0;
+	position: absolute;
+	width: 100%;
+	z-index: 50;
 
 	.al-lbl {
-		padding-left: 10px;
 		float: right;
+		padding-left: 10px;
 	}
 
 	a {
-		text-decoration: none;
 		color: #000;
 		display: block;
 		padding-left: 10px;
+		text-decoration: none;
 
 		&:hover,
 		&:focus {

--- a/src/polyfills/datepicker/datepicker.scss
+++ b/src/polyfills/datepicker/datepicker.scss
@@ -12,9 +12,9 @@
 
 .cal-cnt {
 	&.picker-overlay {
+		margin-top: -2em;
 		position: absolute;
 		z-index: 498 !important;
-		margin-top: -2em;
 	}
 }
 
@@ -45,10 +45,10 @@
 }
 
 .picker-toggle {
-	display: inline-block;
-	margin-left: 5px;
 	background: none;
 	border: 0;
+	display: inline-block;
+	margin-left: 5px;
 	vertical-align: middle;
 
 	&:link,

--- a/src/polyfills/meter/meter.scss
+++ b/src/polyfills/meter/meter.scss
@@ -4,18 +4,18 @@
  */
 // Based on code from https://gist.github.com/667320
 meter {
-	display: block;
 	border: 1px outset;
+	display: block;
 	height: 20px;
-	width: 100px;
 	overflow: hidden;
+	width: 100px;
 
 	div {
-		display: block;
-		border-right: 1px solid #000;
-		height: 20px;
 		background: #b4e391;
 		background-image: linear-gradient(top, #b4e391 0, #4a0 35%, #b4e391 100%);
+		border-right: 1px solid #000;
+		display: block;
+		height: 20px;
 	}
 
 	&.meterValueTooHigh,

--- a/src/polyfills/slider/slider.scss
+++ b/src/polyfills/slider/slider.scss
@@ -108,14 +108,14 @@
 }
 
 .fd-slider {
-	@extend %slider-width-100perc;
-	@extend %slider-height-20;
-	@extend %slider-display-block;
 	@extend %slider-border-none;
-	margin: 0 0 10px;
-	text-align: center;
-	position: relative;
+	@extend %slider-display-block;
+	@extend %slider-height-20;
+	@extend %slider-width-100perc;
 	cursor: pointer;
+	margin: 0 0 10px;
+	position: relative;
+	text-align: center;
 	text-decoration: none;
 	user-select: none;
 }
@@ -142,18 +142,18 @@
 	@extend %slider-background-color-ddd;
 	@extend %slider-border-radius-2;
 	@extend %slider-background-clip-padding-box;
-	top: 8px;
-	right: 10px;
-	left: 10px;
-	z-index: 2;
+	background-image: linear-gradient(#ececec, #ccc);
 	border: 1px solid #606060;
 	border: 1px solid rgba(187, 187, 187, .8);
 	border-bottom: 1px solid #aaa;
 	border-bottom: 1px solid rgba(170, 170, 170, .8);
 	border-right: 1px solid #aaa;
 	border-right: 1px solid rgba(170, 170, 170, .8);
+	left: 10px;
 	line-height: 4px;
-	background-image: linear-gradient(#ececec, #ccc);
+	right: 10px;
+	top: 8px;
+	z-index: 2;
 }
 
 .fd-slider-focused {
@@ -166,20 +166,20 @@
 }
 
 .fd-slider-range {
-	@extend %slider-display-block;
-	@extend %slider-position-absolute;
-	@extend %slider-z-index-3;
-	@extend %slider-height-2;
-	@extend %slider-margin-0;
-	@extend %slider-padding-0;
-	@extend %slider-overflow-hidden;
+	@extend %slider-background-clip-padding-box;
 	@extend %slider-background-color-165c91;
 	@extend %slider-border-radius-2;
-	@extend %slider-background-clip-padding-box;
-	top: 9px;
+	@extend %slider-display-block;
+	@extend %slider-height-2;
+	@extend %slider-margin-0;
+	@extend %slider-overflow-hidden;
+	@extend %slider-padding-0;
+	@extend %slider-position-absolute;
+	@extend %slider-z-index-3;
+	background-image: linear-gradient(left, #89a5bd, #165c91);
 	left: 11px;
 	line-height: 2px;
-	background-image: linear-gradient(left, #89a5bd, #165c91);
+	top: 9px;
 }
 
 .fd-slider-handle {
@@ -200,8 +200,8 @@
 		position: 0 0;
 	}
 	cursor: W-resize;
-	line-height: 20px;
 	font-size: 10px;
+	line-height: 20px;
 	/* Are these needed?
 	@if $experimental-support-for-mozilla {-moz-outline: 0 none;}
 	@if $experimental-support-for-webkit {-webkit-touch-callout: none;}
@@ -243,41 +243,41 @@ body {
 	&.fd-slider-drag-horizontal,
 	&.fd-slider-drag-horizontal * {
 		cursor: N-resize !important;
-		user-select: none;
 		cursor: W-resize !important;
+		user-select: none;
 	}
 }
 
 .fd-slider-disabled {
-	opacity: 0.8;
 	cursor: default;
+	opacity: 0.8;
 
 	.fd-slider-handle {
-		cursor: default !important;
 		background-position: 0 -40px;
+		cursor: default !important;
 		opacity: 1;
 	}
 
 	.fd-slider-bar {
-		cursor: auto !important;
-		border: 1px solid #888;
-		border-bottom: 1px solid #999;
-		border-right: 1px solid #999;
-		border: 1px solid rgba(136, 136, 136, .8);
-		border-bottom: 1px solid rgba(153, 153, 153, .8);
-		border-right: 1px solid rgba(153, 153, 153, .8);
 		background-color: #555;
 		background-image: linear-gradient(left, #666, #333);
+		border: 1px solid #888;
+		border: 1px solid rgba(136, 136, 136, .8);
+		border-bottom: 1px solid #999;
+		border-bottom: 1px solid rgba(153, 153, 153, .8);
+		border-right: 1px solid #999;
+		border-right: 1px solid rgba(153, 153, 153, .8);
+		cursor: auto !important;
 	}
 
 	.fd-slider-range {
-		cursor: auto !important;
 		background-color: #222;
 		background-image: linear-gradient(left, #222, #000);
+		cursor: auto !important;
 	}
 }
 
-keyframes fd-pulse {
+@keyframes fd-pulse {
 	0% {
 		box-shadow: 0 0 3px rgba(100, 130, 170, 0.55);
 	}
@@ -304,10 +304,10 @@ keyframes fd-pulse {
 }
 
 #fd-slider-describedby {
-	padding: 1em;
-	border: 3px solid #a84444;
 	background: #fff;
+	border: 3px solid #a84444;
 	border-radius: 8px;
+	padding: 1em;
 }
 
 input {
@@ -317,8 +317,8 @@ input {
 }
 
 #html5shim-2-out {
-	font-weight: 400;
 	font-style: italic;
+	font-weight: 400;
 }
 
 #html5shim-4 {
@@ -327,6 +327,6 @@ input {
 }
 
 .visu {
-	font: normal 3em impact, helvetica, sans serif;
 	color: #6cc;
+	font: normal 3em impact, helvetica, sans serif;
 }

--- a/theme/sass/_defaults.scss
+++ b/theme/sass/_defaults.scss
@@ -11,10 +11,10 @@
 }
 
 %accessible-invisible {
-	height: 1px;
-	width: 1px;
 	clip: rect(1px, 1px, 1px, 1px);
+	height: 1px;
+	margin: 0;
 	overflow: hidden;
 	position: absolute;
-	margin: 0;
+	width: 1px;
 }

--- a/theme/sass/parts/_banner-smallViewUnder.scss
+++ b/theme/sass/parts/_banner-smallViewUnder.scss
@@ -3,17 +3,17 @@
  */
 #wb-sttl {
 	a {
+		padding-top: 1.125em;
 		position: relative;
 		z-index: 1;
-		padding-top: 1.125em;
 	}
 
 	object,
 	img {
-		position: absolute;
-		top: 0;
 		height: 1em;
 		margin: 0;
+		position: absolute;
+		top: 0;
 		width: 2.17em;
 	}
 }

--- a/theme/sass/parts/_banner.scss
+++ b/theme/sass/parts/_banner.scss
@@ -8,10 +8,10 @@
 
 #wb-bar {
 	background: #474747;
-	color: #fff;
 	border-bottom: 1px solid #fff;
-	z-index: 1;
+	color: #fff;
 	min-height: 2.2em;
+	z-index: 1;
 }
 
 #wb-lng ul,
@@ -21,8 +21,8 @@
 
 	li {
 		border-left: 1px solid #777;
-		list-style-type: none;
 		float: left;
+		list-style-type: none;
 		padding: 6px 15px;
 
 		&:first-child {
@@ -47,11 +47,11 @@
 		}
 
 		a {
-			font-size: 1.5em;
-			display: block;
-			width: 100%;
 			color: #474747;
+			display: block;
+			font-size: 1.5em;
 			line-height: 1em;
+			width: 100%;
 		}
 	}
 }
@@ -61,8 +61,8 @@
 		color: #fff;
 		font-size: 1.9em;
 		line-height: normal;
-		text-shadow: 1px 1px 1px #333;
 		text-decoration: none;
+		text-shadow: 1px 1px 1px #333;
 	}
 
 	small {
@@ -77,10 +77,10 @@
 
 	object,
 	img {
+		float: left;
 		height: 1.5em;
 		margin: 9px 15px 9px 0;
 		width: 3.25em;
-		float: left;
 	}
 }
 

--- a/theme/sass/parts/_breadcrumb.scss
+++ b/theme/sass/parts/_breadcrumb.scss
@@ -11,16 +11,16 @@
 	}
 
 	li {
-		white-space: nowrap;
 		max-width: 100%;
 		overflow: hidden;
 		text-overflow: ellipsis;
+		white-space: nowrap;
 
 		&:before,
 		&:after {
+			color: #333;
 			font-family: "Glyphicons Halflings";
 			font-size: 0.7em;
-			color: #333;
 		}
 
 		&:before {

--- a/theme/sass/parts/_language.scss
+++ b/theme/sass/parts/_language.scss
@@ -1,14 +1,14 @@
 #wb-lng {
 	.btn-group {
-		text-align: right;
-		margin: 5px 0;
 		float: right;
+		margin: 5px 0;
+		text-align: right;
 	}
 
 	.curr {
-		display: block;
-		color: #ccc;
 		background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAFCAYAAAB8ZH1oAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAAB90RVh0U29mdHdhcmUATWFjcm9tZWRpYSBGaXJld29ya3MgOLVo0ngAAAA6SURBVAiZY/z//z8DMvj14+s+BgYGBjYObicUif///8Pxz+9f9v2HAigbLodVETbFOBWhK8arCFkxABifl5syjffvAAAAAElFTkSuQmCC") no-repeat scroll center bottom;
+		color: #ccc;
+		display: block;
 
 		span {
 			@extend %accessible-invisible;

--- a/theme/sass/parts/_main.scss
+++ b/theme/sass/parts/_main.scss
@@ -9,6 +9,6 @@ main {
 
 #wb-cont {
 	border-bottom: 1px solid #eee;
-	padding-bottom: 5px;
 	margin-top: 0.45em;
+	padding-bottom: 5px;
 }

--- a/theme/sass/parts/_search.scss
+++ b/theme/sass/parts/_search.scss
@@ -2,9 +2,9 @@
  Search
  */
 #wb-srch {
-	text-align: right;
-	padding-top: 0.9em;
 	padding-right: 10px;
+	padding-top: 0.9em;
+	text-align: right;
 
 	.form-group {
 		width: 70%;

--- a/theme/sass/parts/_secMenu.scss
+++ b/theme/sass/parts/_secMenu.scss
@@ -11,11 +11,11 @@
 	padding-bottom: 2em;
 
 	h3 {
-		padding: 15px;
-		margin: 0;
 		border: 1px solid #ddd;
 		border-bottom: 3px solid #666;
 		font-size: 1em;
+		margin: 0;
+		padding: 15px;
 
 		a {
 			color: #333;
@@ -29,8 +29,8 @@
 		a {
 			&.list-group-item {
 				background: $clrWhite;
-				color: $clrDark;
 				border-radius: 0;
+				color: $clrDark;
 				margin-top: -1px;
 				text-decoration: none;
 

--- a/theme/sass/parts/_siteMenu.scss
+++ b/theme/sass/parts/_siteMenu.scss
@@ -7,24 +7,24 @@
 }
 
 %wet-theme-wb-menu-hover-active {
-	color: #000;
 	background: #ccc;
 	border-color: #ccc;
+	color: #000;
 }
 
 #wb-sm {
 	background: #0e4164;
 
 	.menu {
-		text-shadow: 1px 1px 1px #666;
 		margin-bottom: 0;
+		text-shadow: 1px 1px 1px #666;
 
 		> {
 			li {
 				> {
 					a {
-						color: #fff;
 						border-left: 1px solid #999;
+						color: #fff;
 
 						&.wb-navcurr {
 							@extend %wet-theme-wb-sm-wb-navcurr;
@@ -58,21 +58,21 @@
 
 	.sm {
 		&.open {
+			background: #ccc;
+			border-bottom: 5px solid #243850;
 			border-left: 0;
 			border-right: 0;
-			border-bottom: 5px solid #243850;
 			padding: 0;
-			background: #ccc;
 
 			li {
 				a,
 				summary {
-					color: #444;
 					border-left: 0;
 					border-right: 0;
-					text-shadow: none;
+					color: #444;
 					padding: 5px 10px;
 					text-decoration: none;
+					text-shadow: none;
 
 					&.wb-navcurr {
 						@extend %wet-theme-wb-sm-wb-navcurr;
@@ -184,8 +184,8 @@
 		.srch-pnl {
 			.form-group {
 				float: right;
-				margin-right: auto;
 				margin-left: 5px;
+				margin-right: auto;
 				width: 75%;
 			}
 		}

--- a/theme/sass/parts/_skipLinks.scss
+++ b/theme/sass/parts/_skipLinks.scss
@@ -31,9 +31,9 @@
 
 	&:focus {
 		color: #fff;
-		text-decoration: none;
-		z-index: 501;
 		/* Shouldn't be needed. Only here because Bootstrap forces an outline colour */
 		outline-color: #fff;
+		text-decoration: none;
+		z-index: 501;
 	}
 }


### PR DESCRIPTION
Enables new rules
- DuplicateRoot, which suggests root selectors that should be combined
- UnnecessaryMantissa, which suggests precision that can be dropped
- Turned on PropertySortOrder

Fixed bug in slider where `@keyframes` was missing the `@`
