### PR TITLE
Build: Improve Saucelabs testing

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -5,6 +5,10 @@
     "browserName": "chrome",
     "platform": "Windows 7"
 },{
+    "browserName": "internet explorer",
+    "platform": "Windows 7",
+    "version": "8"
+},{
     "browserName": "safari",
     "platform": "OS X 10.8"
 },{

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "devDependencies": {
     "assemble": "~0.4.10",
     "assemble-contrib-i18n": "~0.1.2",
-    "expect.js": "~0.2.0",
+    "expect.js": "^0.3.1",
     "grunt": "~0.4.1",
     "grunt-autoprefixer": "^0.7.2",
     "grunt-check-dependencies": "~0.3.0",
@@ -53,9 +53,9 @@
     "grunt-mocha": "~0.4.1",
     "grunt-modernizr": "~0.4.0",
     "grunt-sass": "^0.11.0",
-    "grunt-saucelabs": "~4.1.2",
+    "grunt-saucelabs": "^5.1.2",
     "grunt-wget": "~0.1.0",
-    "mocha": "~1.13.0",
-    "sinon": "~1.7.3"
+    "mocha": "^1.18.2",
+    "sinon": "^1.9.1"
   }
 }


### PR DESCRIPTION
Switch from the Mocha reporter to the custom one that handles mocha better ...
Still encountering random errors, but pass rate is higher using the JS API.
- Changed concurrency to the new throttled option
- Bumped Expect.js, which also removes a package.json warning
- Bump Mocha to latest
- Bump Sinon to latest
