### PR TITLE
Texthighlight: Fix wrapping of demo querystring

### DIFF
--- a/src/plugins/texthighlight/texthighlight-en.hbs
+++ b/src/plugins/texthighlight/texthighlight-en.hbs
@@ -34,10 +34,12 @@
 			<li>Don't Forget...</li>
 			<li>causes sickness in birds, it can also infect people.</li>
 		</ul>
+		<section>
+			<h4>Query string</h4>
+			<pre><code>?txthl=avian%20influenza+world+cook+flu-like%20symptoms+Don't%20Forget...+causes%20sickness%20in%20birds,%20it%20can%20also%20infect%20people.</code></pre>
 
-		<p><strong>Query string:</strong> <code>?txthl=avian%20influenza+world+cook+flu-like%20symptoms+Don't%20Forget...+causes%20sickness%20in%20birds,%20it%20can%20also%20infect%20people.</code></p>
-
-		<p><a href="?txthl=avian%20influenza+world+cook+flu-like%20symptoms+Don't%20Forget...+causes%20sickness%20in%20birds,%20it%20can%20also%20infect%20people.#example">Highlight example text that meets the search criteria</a></p>
+			<p><a href="?txthl=avian%20influenza+world+cook+flu-like%20symptoms+Don't%20Forget...+causes%20sickness%20in%20birds,%20it%20can%20also%20infect%20people.#example">Highlight example text that meets the search criteria</a></p>
+		</section>
 	</section>
 
 	<section id="example" class="wb-txthl">

--- a/src/plugins/texthighlight/texthighlight-fr.hbs
+++ b/src/plugins/texthighlight/texthighlight-fr.hbs
@@ -34,10 +34,12 @@
 			<li>À titre de rappel</li>
 			<li>À de rares occasions, des humains ont été infectés par ce virus.</li>
 		</ul>
+		<section>
+			<h4>La chaîne d'interrogation&#160;</h4>
+			<pre><code>?<span lang="en">txthl</span>=influenza%20aviaire+monde+suffis+symptômes%20semblables%20à%20ceux%20de%20l'influenza+À%20titre%20de%20rappel...+À%20de%20rares%20occasions,%20des%20humains%20ont%20été%20infectés%20par%20ce%20virus.</code></pre>
 
-		<p><strong>La chaîne d'interrogation&#160;:</strong> <code>?<span lang="en">txthl</span>=influenza%20aviaire+monde+suffis+symptômes%20semblables%20à%20ceux%20de%20l'influenza<br />+À%20titre%20de%20rappel...+À%20de%20rares%20occasions,%20des%20humains%20ont%20été%20infectés%20par%20ce%20virus.</code></p>
-
-		<p><a href="?txthl=influenza%20aviaire+monde+suffis+sympt%C3%B4mes%20semblables%20%C3%A0%20ceux%20de%20l'influenza+%C3%80%20titre%20de%20rappel...+%C3%80%20de%20rares%20occasions,%20des%20humains%20ont%20%C3%A9t%C3%A9%20infect%C3%A9s%20par%20ce%20virus.#exemple">Mise en surbrillance le texte qui satisfait les critères de recherche</a></p>
+			<p><a href="?txthl=influenza%20aviaire+monde+suffis+sympt%C3%B4mes%20semblables%20%C3%A0%20ceux%20de%20l'influenza+%C3%80%20titre%20de%20rappel...+%C3%80%20de%20rares%20occasions,%20des%20humains%20ont%20%C3%A9t%C3%A9%20infect%C3%A9s%20par%20ce%20virus.#exemple">Mise en surbrillance le texte qui satisfait les critères de recherche</a></p>
+		</section>
 	</section>
 
 	<section id="exemple" class="wb-txthl">


### PR DESCRIPTION
Adds a `<pre>` element so the text will flow regardless of word breaks
Fixes gh-5349
