### PR TITLE
Tables: Fixed sorting and setting overrides to be compatible with DataTables 1.10 (fixes #5388 and #5389)

### DIFF
--- a/site/pages/demos/index-en.hbs
+++ b/site/pages/demos/index-en.hbs
@@ -46,7 +46,7 @@
 	]
 }
 ---
-<table id="components" class="wb-tables table table-striped table-hover" data-wb-tables='{"aoColumnDefs": [ { "bVisible": false, "aTargets": [ 3 ] } ], "aLengthMenu": [[10, 25, -1], [10, 25, "All"]], "iDisplayLength": -1 }'>
+<table id="components" class="wb-tables table table-striped table-hover" data-wb-tables='{"columnDefs": [ { "visible": false, "targets": [ 3 ] } ], "lengthMenu": [[10, 25, -1], [10, 25, "All"]], "pageLength": -1 }'>
 	<thead>
 		<tr>
 			<th>Name</th>

--- a/site/pages/demos/index-fr.hbs
+++ b/site/pages/demos/index-fr.hbs
@@ -46,7 +46,7 @@
 	]
 }
 ---
-<table id="components" class="wb-tables table table-striped table-hover" data-wb-tables='{"aoColumnDefs": [ { "bVisible": false, "aTargets": [ 3 ] } ], "aLengthMenu": [[10, 25, -1], [10, 25, "Toutes les"]], "iDisplayLength": -1 }'>
+<table id="components" class="wb-tables table table-striped table-hover" data-wb-tables='{"columnDefs": [ { "visible": false, "targets": [ 3 ] } ], "lengthMenu": [[10, 25, -1], [10, 25, "Toutes les"]], "pageLength": -1 }'>
 	<thead>
 		<tr>
 			<th>Nom</th>

--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -32,7 +32,34 @@
 	wb.jqEscape = function( selector ) {
 		return selector.replace( /([;&,\.\+\*\~':"\!\^#$%@\[\]\(\)=>\|])/g, "\\$1" );
 	};
+	
+	// RegEx used by formattedNumCompare
+	wb.formattedNumCompareRegEx = /(<[^>]*>|[^\d\.])/g;
 
+	// Compares two formatted numbers (e.g., 1.2.12 or 1,000,345)
+	wb.formattedNumCompare = function( a, b ) {
+		var regEx = wb.formattedNumCompareRegEx,
+			aMultiple = a.indexOf( "-" ) === -1 ? 1 : -1,
+			aNumbers = ( ( a === "-" || a === "" ) ? 0 : a.replace( regEx, "" ) ).split( "." ),
+			bMultiple = b.indexOf( "-" ) === -1 ? 1 : -1,
+			bNumbers = ( ( b === "-" || b === "" ) ? 0 : b.replace( regEx, "" ) ).split( "." ),
+			len = aNumbers.length,
+			i, result;
+
+		for ( i = 0; i !== len; i += 1 ) {
+			result = parseInt( aNumbers[ i ], 10 ) * aMultiple - parseInt( bNumbers[ i ], 10 ) * bMultiple;
+			if ( result !== 0 ) {
+				break;
+			}
+		}
+		return result;
+	};
+
+	// Compare two strings with special characters (e.g., Cyrillic or Chinese characters)
+	wb.i18nTextCompare = function( a, b ) {
+		return wb.normalizeDiacritics( a ).localeCompare( wb.normalizeDiacritics( b ) );
+	};
+	
 	// Based upon https://gist.github.com/instanceofme/1731620
 	// Licensed under WTFPL v2 http://sam.zoy.org/wtfpl/COPYING
 	wb.normalizeDiacritics = function( str ) {

--- a/src/plugins/tables/_base.scss
+++ b/src/plugins/tables/_base.scss
@@ -208,13 +208,13 @@ table {
 				&:before {
 					@extend %table_icons;
 					content: "\e093";
-					padding: 0 0.1em 0 0.2em;
+					padding: 0 0.2em;
 				}
 
 				&:after {
 					@extend %table_icons;
 					content: "\e094";
-					padding: 0 0.1em 0 0.2em;
+					padding: 0 0.2em;
 				}
 			}
 

--- a/src/plugins/tables/tables-en.hbs
+++ b/src/plugins/tables/tables-en.hbs
@@ -436,8 +436,8 @@
 
 	<h3>Options Example</h3>
 	<p>The <a href="http://www.datatables.net/ref">DataTables API</a> is fully accessible through the <code>data-wb-tables</code> attribute using a JSON array.</p>
-	<pre>&lt;table class="wb-tables table table-striped table-hover" data-wb-tables='{ "bSort" : false }'&gt;</pre>
-	<table class="wb-tables table table-striped table-hover" data-wb-tables='{ "bSort" : false }'>
+	<pre>&lt;table class="wb-tables table table-striped table-hover" data-wb-tables='{ "ordering" : false }'&gt;</pre>
+	<table class="wb-tables table table-striped table-hover" data-wb-tables='{ "ordering": false }'>
 		<thead>
 			<tr>
 				<th>Rendering engine</th>

--- a/src/plugins/tables/tables-fr.hbs
+++ b/src/plugins/tables/tables-fr.hbs
@@ -437,8 +437,8 @@
 
 	<h3>Exemple d'options</h3>
 	<p>Le <a href="http://www.datatables.net/ref">DataTables API</a> (en anglais seulement) est entièrement accessible par le <code>data-wb-tables</code> attribut à l'aide d'un tableau JSON.</p>
-	<pre>&lt;table class="wb-tables table table-striped table-hover" data-wb-tables='{ "bSort" : false }'&gt;</pre>
-	<table class="wb-tables table table-striped table-hover" data-wb-tables='{ "bSort" : false }'>
+	<pre>&lt;table class="wb-tables table table-striped table-hover" data-wb-tables='{ "ordering": false }'&gt;</pre>
+	<table class="wb-tables table table-striped table-hover" data-wb-tables='{ "ordering": false }'>
 		<thead>
 			<tr>
 				<th>Moteur de rendu</th>

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -50,34 +50,34 @@ var pluginName = "wb-tables",
 			if ( !i18nText ) {
 				i18n = wb.i18n;
 				i18nText = {
-					oAria: {
-						sSortAscending: i18n( "sortAsc" ),
-						sSortDescending: i18n( "sortDesc" )
+					aria: {
+						sortAscending: i18n( "sortAsc" ),
+						sortDescending: i18n( "sortDesc" )
 					},
-					oPaginate: {
-						sFirst: i18n( "first" ),
-						sLast: i18n( "last" ),
-						sNext: i18n( "nxt" ),
-						sPrevious: i18n( "prv" )
+					emptyTable: i18n( "emptyTbl" ),
+					info: i18n( "infoEntr" ),
+					infoEmpty: i18n( "infoEmpty" ),
+					infoFiltered: i18n( "infoFilt" ),
+					lengthMenu: i18n( "lenMenu" ),
+					loadingRecords: i18n( "load" ),
+					paginate: {
+						first: i18n( "first" ),
+						last: i18n( "last" ),
+						next: i18n( "nxt" ),
+						previous: i18n( "prv" )
 					},
-					sEmptyTable: i18n( "emptyTbl" ),
-					sInfo: i18n( "infoEntr" ),
-					sInfoEmpty: i18n( "infoEmpty" ),
-					sInfoFiltered: i18n( "infoFilt" ),
-					sInfoThousands: i18n( "info1000" ),
-					sLengthMenu: i18n( "lenMenu" ),
-					sLoadingRecords: i18n( "load" ),
-					sProcessing: i18n( "process" ),
-					sSearch: i18n( "filter" ),
-					sZeroRecords: i18n( "infoEmpty" )
+					processing: i18n( "process" ),
+					search: i18n( "filter" ),
+					thousands: i18n( "info1000" ),
+					zeroRecords: i18n( "infoEmpty" )
 				};
 			}
 
 			defaults = {
 				asStripeClasses: [],
-				oLanguage: i18nText,
-				sDom: "<'top'ilf>rt<'bottom'p><'clear'>",
-				fnDrawCallback: function() {
+				language: i18nText,
+				dom: "<'top'ilf>rt<'bottom'p><'clear'>",
+				drawCallback: function() {
 					$( "#" + elmId ).trigger( "tables-draw.wb" );
 				}
 			};
@@ -86,51 +86,33 @@ var pluginName = "wb-tables",
 				load: [ "site!deps/jquery.dataTables" + wb.getMode() + ".js" ],
 				complete: function() {
 					var $elm = $( "#" + elmId ),
-						i18nSortAscend = function( x, y ) {
-							return wb.normalizeDiacritics( x ).localeCompare( wb.normalizeDiacritics( y ) );
-						},
-						i18nSortDescend = function( x, y ) {
-							return wb.normalizeDiacritics( y ).localeCompare( wb.normalizeDiacritics( x ) );
-						},
-						formattedNumCompare = function( a, b ) {
-							var aMultiple = a[ 0 ],
-								aNumbers = a[ 1 ],
-								bMultiple = b[ 0 ],
-								bNumbers = b[ 1 ],
-								len = aNumbers.length,
-								i, result;
-							for ( i = 0; i !== len; i += 1 ) {
-								result = parseInt( aNumbers[ i ], 10 ) * aMultiple - parseInt( bNumbers[ i ], 10 ) * bMultiple;
-								if ( result !== 0 ) {
-									break;
-								}
-							}
-							return result;
-						};
-
-					// Enable internationalization support in the sorting
-					$.fn.dataTableExt.oSort[ "html-asc" ] = i18nSortAscend;
-					$.fn.dataTableExt.oSort[ "html-desc" ] = i18nSortDescend;
-					$.fn.dataTableExt.oSort[ "string-case-asc" ] = i18nSortAscend;
-					$.fn.dataTableExt.oSort[ "string-case-desc" ] = i18nSortDescend;
+						dataTableExt = $.fn.dataTableExt;
 
 					/*
 					 * Extend sorting support
 					 */
-					$.extend( $.fn.dataTableExt.oSort, {
+					$.extend( dataTableExt.type.order, {
+
+						// Enable internationalization support in the sorting
+						"html-pre": function( a ) {
+							return wb.normalizeDiacritics(
+								!a ? "" : a.replace ?
+									a.replace( /<.*?>/g, "" ).toLowerCase() : a + ""
+							);
+						},
+						"string-case-pre": function( a ) {
+							return wb.normalizeDiacritics( a );
+						},
+						"string-pre": function( a ) {
+							return wb.normalizeDiacritics( a );
+						},
 
 						// Formatted number sorting
-						// Based on: datatables.net/plug-ins/sorting#formatted_numbers
-						"formatted-num-pre": function( a ) {
-							var multiple = a.indexOf( "-" ) === -1 ? 1 : -1;
-							a = ( a === "-" || a === "" ) ? 0 : a.replace( /<[^>]*>/g, "" ).replace( /[^\d\.]/g, "" );
-							return [ multiple, a.split( "." ) ];
-						},
 						"formatted-num-asc": function( a, b ) {
-							return formattedNumCompare( b, a );
+							return wb.formattedNumCompare( b, a );
 						},
 						"formatted-num-desc": function( a, b ) {
-							return formattedNumCompare( a, b );
+							return wb.formattedNumCompare( a, b );
 						}
 					} );
 
@@ -139,7 +121,7 @@ var pluginName = "wb-tables",
 					 */
 					// Formatted numbers detection
 					// Based on: http://datatables.net/plug-ins/type-detection#formatted_numbers
-					$.fn.dataTableExt.aTypes.unshift(
+					dataTableExt.aTypes.unshift(
 						function( sData ) {
 
 							// Strip off HTML tags and all non-alpha-numeric characters (except minus sign)
@@ -151,7 +133,10 @@ var pluginName = "wb-tables",
 						}
 					);
 
+					// Add the container or the sorting icons
 					$elm.find( "th" ).append( "<span class='sorting-cnt'><span class='sorting-icons'></span></span>" );
+
+					// Create the DataTable object
 					$elm.dataTable( $.extend( true, {}, defaults, window[ pluginName ], wb.getData( $elm, pluginName ) ) );
 				}
 			});


### PR DESCRIPTION
As part of this, added a couple compare functions to helpers.js, rather than keeping to just tables.js, for use later on by other plugins (or by implementers in custom code). 
