### PR TITLE
Force display none for hidden slider polyfills

### DIFF
--- a/src/polyfills/slider/slider.scss
+++ b/src/polyfills/slider/slider.scss
@@ -20,7 +20,7 @@
 }
 
 %slider-display-none {
-	display: none;
+	display: none !important;
 }
 
 %slider-width-2 {


### PR DESCRIPTION
This fights specificity issue that arise by adding styles to non polyfilled slider control
