### PR TITLE
Jscs/JSHint updates

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -18,6 +18,7 @@
 	"requireParenthesesAroundIIFE": true,
 	"disallowTrailingComma": true,
 	"requireMultipleVarDecl": "onevar",
+	"disallowTrailingWhitespace": true,
 	"excludeFiles": [
 		"node_modules/**",
 		"dist/**",

--- a/.jshintrc
+++ b/.jshintrc
@@ -9,7 +9,6 @@
 	"onevar": true,
 	"quotmark": "double",
 	"smarttabs": true,
-	"trailing": true,
 	"undef": true,
 	"unused": true,
 

--- a/.jshintrc
+++ b/.jshintrc
@@ -6,9 +6,6 @@
 	"expr": true,
 	"immed": true,
 	"noarg": true,
-	"onevar": true,
-	"quotmark": "double",
-	"smarttabs": true,
 	"undef": true,
 	"unused": true,
 

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1048,16 +1048,12 @@ module.exports = (grunt) ->
 				src: [
 					"src/**/*.js"
 					"theme/**/*.js"
-					"test/**/*.js"
 					"tasks/*.js"
 				]
 		jscs:
 			all:
 				src: [
-					"src/**/*.js"
-					"theme/**/*.js"
-					"test/**/*.js"
-					"tasks/*.js"
+					"<%= jshint.lib_test.src %>"
 				]
 
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "grunt-contrib-csslint": "~0.2.0",
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-imagemin": "~0.5.0",
-    "grunt-contrib-jshint": "~0.7.1",
+    "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-gh-pages": "~0.9.0",

--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -32,7 +32,7 @@
 	wb.jqEscape = function( selector ) {
 		return selector.replace( /([;&,\.\+\*\~':"\!\^#$%@\[\]\(\)=>\|])/g, "\\$1" );
 	};
-	
+
 	// RegEx used by formattedNumCompare
 	wb.formattedNumCompareRegEx = /(<[^>]*>|[^\d\.])/g;
 
@@ -59,7 +59,7 @@
 	wb.i18nTextCompare = function( a, b ) {
 		return wb.normalizeDiacritics( a ).localeCompare( wb.normalizeDiacritics( b ) );
 	};
-	
+
 	// Based upon https://gist.github.com/instanceofme/1731620
 	// Licensed under WTFPL v2 http://sam.zoy.org/wtfpl/COPYING
 	wb.normalizeDiacritics = function( str ) {


### PR DESCRIPTION
- Bump up the JSHint dependency
- Move JSHint depreciated settings to JSCS versions
- Drop duplication from JSHint ruleset that are covered by JSCS
