### PR TITLE
Calendar of Events: added fluid-width display option

### DIFF
--- a/src/plugins/cal-events/_base.scss
+++ b/src/plugins/cal-events/_base.scss
@@ -49,3 +49,10 @@
 		}
 	}
 }
+
+.cal-cnt-fluid {
+	&.cal-cnt,
+	table.cal-cnt {
+		width: 100%;
+	}
+}

--- a/src/plugins/cal-events/cal-events-en.hbs
+++ b/src/plugins/cal-events/cal-events-en.hbs
@@ -83,9 +83,77 @@
 		<h3>List Filtering</h3>
 		<p>This option filters out events from the list that are not for the current month. Enable this option by adding the <code>cal-disp-onshow</code> class to each event that should be filtered by month.</p>
 		<p>Events that do not have the <em>cal-disp-onshow</em> class will always be visible.</p>
-		<div id="calendar3"></div>
 
+		<div id="calendar3"></div>
 		<div class="wb-calevt evt-anchor" data-calevt-src="calendar3">
+			<section>
+				<h4>Events List 1</h4>
+				<ol>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.ec.gc.ca" rel="external">Event 1</a></h5>
+							<p><time datetime="2013-03-11">March 11th, 2013</time></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.canada.ca" rel="external">Event 2</a></h5>
+							<p><time datetime="2013-03-11">March 11th, 2013</time></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5>World Expo Shanghai (Shanghai, China)</h5>
+							<p><time datetime="2013-03-22">March 22nd, 2013</time> to <time datetime="2013-04-26">April 26th, 2013</time></p>
+							<p>The Canada Pavilion celebrates the vibrancy and the vitality of Canadian communities and the people within them.</p>
+							<p>For more information about Canada at Expo 2010 Shanghai, visit: <a href="http://www.expo2010canada.gc.ca/index-eng.cfm" rel="external">www.expo2010canada.gc.ca/index-eng.cfm</a></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.ic.gc.ca" rel="external">Event 4</a></h5>
+							<p><time datetime="2013-03-24">March 24th, 2013</time></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.ec.gc.ca" rel="external">Event 6</a></h5>
+							<p><time datetime="2013-04-11">April 11th, 2013</time></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.canada.ca" rel="external">Event 7</a></h5>
+							<p><time datetime="2013-04-23">April 23rd, 2013</time></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.canada.ca" rel="external">Event 17</a></h5>
+							<p><time datetime="2013-04-23">April 23rd, 2013</time></p>
+						</section>
+					</li>
+				</ol>
+			</section>
+		</div>
+	</section>
+
+	<section>
+		<h3>Fluid-width Calendar</h3>
+		<details>
+			<summary>View code</summary>
+			<pre>
+				<code>
+&lt;div id="calendar4" class="cal-cnt-fluid"&gt;&lt;/div&gt;
+&lt;div class="wb-calevt evt-anchor" data-calevt-src="calendar4"&gt;
+	// Events list...
+&lt;/div&gt;
+				</code>
+			</pre>
+		</details>
+		<br>
+		<div id="calendar4" class="cal-cnt-fluid"></div>
+		<div class="wb-calevt evt-anchor" data-calevt-src="calendar4">
 			<section>
 				<h4>Events List 1</h4>
 				<ol>

--- a/src/plugins/cal-events/cal-events-fr.hbs
+++ b/src/plugins/cal-events/cal-events-fr.hbs
@@ -84,8 +84,74 @@
 		<p>Cette option filtre des événements de la liste qui ne sont pas pour le mois actuel. Rendre capable cette option en ajoutant la classe <code>calender-display-onshow</code> à chaque événement qui devrait être filtré par le mois.</p>
 		<p>Les événements qui n'ont pas la classe <code>cal-disp-onshow</code> seront visible toujours.</p>
 		<div id="calendar3"></div>
-
 		<div class="wb-calevt evt-anchor" data-calevt-src="calendar3">
+			<section>
+				<h4>Événements - Liste 1</h4>
+				<ol>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.ec.gc.ca" rel="external">Événement 1</a></h5>
+							<p><time datetime="2013-03-11">11 mars 2013</time></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.canada.ca" rel="external">Événement 2</a></h5>
+							<p><time datetime="2013-03-11">11 mars 2013</time></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5>Expo 2010 Shanghai</h5>
+							<p>Le <time datetime="2013-03-22">22 mars 2013</time> au <time datetime="2013-04-26">26 avril 2013</time></p>
+							<p>Le Pavillon du Canada souligne le dynamisme et la vitalité des villes canadiennes et de leurs résidents.</p>
+							<p>Pour obtenir de plus amples renseignements, visitez le site Web de Canada à Expo 2010 Shanghai à l’adresse suivante&#160;: <a href="http://www.expo2010canada.gc.ca/index-fra.cfm" rel="external">www.expo2010canada.gc.ca/index-fra.cfm</a></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.ic.gc.ca" rel="external">Événement 4</a></h5>
+							<p><time datetime="2013-03-24">24 mars 2013</time></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.ec.gc.ca" rel="external">Événement 6</a></h5>
+							<p><time datetime="2013-04-11">4 avril 2013</time></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.canada.ca" rel="external">Événement 7</a></h5>
+							<p><time datetime="2013-04-23">23 avril 2013</time></p>
+						</section>
+					</li>
+					<li class="cal-disp-onshow">
+						<section>
+							<h5><a href="http://www.canada.ca" rel="external">Événement 17</a></h5>
+							<p><time datetime="2013-04-23">23 avril 2013</time></p>
+						</section>
+					</li>
+				</ol>
+			</section>
+		</div>
+	</section>
+	<section>
+		<h3>Calendrier de largeur fluide</h3>
+		<details>
+			<summary>Visualiser le code</summary>
+			<pre>
+				<code>
+&lt;div id="calendar4" class="cal-cnt-fluid"&gt;&lt;/div&gt;
+&lt;div class="wb-calevt evt-anchor" data-calevt-src="calendar4"&gt;
+	// Events list...
+&lt;/div&gt;
+				</code>
+			</pre>
+		</details>
+		<br>
+		<div id="calendar4" class="cal-cnt-fluid"></div>
+		<div class="wb-calevt evt-anchor" data-calevt-src="calendar4">
 			<section>
 				<h4>Événements - Liste 1</h4>
 				<ol>


### PR DESCRIPTION
The calendar of events should have a fluid-width option, so I made a quick CSS edit to the existing plugin. With this update, you just have to add `cal-responsive` class to calendar containing `div`.

(Note: I updated the examples in English, but not French)
