### PR TITLE
Share: Removed underlining for space between link text and the share icon

### DIFF
--- a/src/plugins/share/_base.scss
+++ b/src/plugins/share/_base.scss
@@ -4,6 +4,12 @@
  */
 @import "sprites/sprites";
 
+.shr-opn {
+	span {
+		padding-right: 0.2em;
+	}
+}
+
 .shr-pg {
 	.shr-lnk {
 		font-size: 115%;
@@ -153,6 +159,13 @@
 }
 
 [dir=rtl] {
+	.shr-opn {
+		span {
+			padding-left: 0.2em;
+			padding-right: 0;
+		}
+	}
+
 	.shr-pg {
 		text-align: right;
 

--- a/src/plugins/share/share.js
+++ b/src/plugins/share/share.js
@@ -229,7 +229,9 @@ var pluginName = "wb-share",
 					"</p><div class='clearfix'></div></div></section>";
 				panelCount += 1;
 			}
-			link = "<a href='#" + id + "' aria-controls='" + id + "' class='shr-opn wb-lbx " + settings.lnkClass + "'><span class='glyphicon glyphicon-share'></span> " +
+			link = "<a href='#" + id + "' aria-controls='" + id +
+				"' class='shr-opn wb-lbx " + settings.lnkClass +
+				"'><span class='glyphicon glyphicon-share'></span>" +
 				shareText + "</a>";
 
 			$share = $( ( panel ? panel : "" ) + link );


### PR DESCRIPTION
@LaurentGoderre @rubinahaddad fyi
