### PR TITLE
Prevents viewChange from removing all classes if executed too early

### DIFF
--- a/src/plugins/resize/resize.js
+++ b/src/plugins/resize/resize.js
@@ -83,7 +83,7 @@ var id = "wb-rsz",
 
 			// Change the breakpoint class on the html element
 			wb.html
-				.removeClass( currentView )
+				.removeClass( currentView || "" )
 				.addClass( viewName );
 
 			// Update the current view


### PR DESCRIPTION
This is a failsafe in cases viewChange is manually triggered too early.
Related to #5579
