### PR TITLE
Lightbox: Fixed incorrect closing of AJAX popups.

### DIFF
--- a/src/plugins/lightbox/ajax/ajax-en.html
+++ b/src/plugins/lightbox/ajax/ajax-en.html
@@ -1,30 +1,23 @@
-<!DOCTYPE html>
-<html lang="en">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<!-- DataAjaxFragmentStart -->
-	<section class="modal-dialog modal-content overlay-def">
-		<header class="modal-header">
-			<h2 class="modal-title">Title</h2>
-		</header>
-		<div class="modal-body">
-			<table>
-				<caption>Table caption default appearance</caption>
-				<thead>
-					<tr>
-						<th scope="col">Table header (<code>th</code>) default appearance</th>
-						<th scope="col">Table header (<code>th</code>) default appearance</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>Table data (<code>td</code>) default appearance</td>
-						<td>Table data (<code>td</code>) default appearance</td>
-					</tr>
-				</tbody>
-			</table>
-			<p><a href="#">Link default appearance</a></p>
-		</div>
-	</section>
-<!-- DataAjaxFragmentEnd -->
-</html>
+<section class="modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h2 class="modal-title">Title</h2>
+	</header>
+	<div class="modal-body">
+		<table>
+			<caption>Table caption default appearance</caption>
+			<thead>
+				<tr>
+					<th scope="col">Table header (<code>th</code>) default appearance</th>
+					<th scope="col">Table header (<code>th</code>) default appearance</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Table data (<code>td</code>) default appearance</td>
+					<td>Table data (<code>td</code>) default appearance</td>
+				</tr>
+			</tbody>
+		</table>
+		<p><a href="#">Link default appearance</a></p>
+	</div>
+</section>

--- a/src/plugins/lightbox/ajax/ajax-fr.html
+++ b/src/plugins/lightbox/ajax/ajax-fr.html
@@ -1,30 +1,23 @@
-<!DOCTYPE html>
-<html lang="fr">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<!-- DataAjaxFragmentStart -->
-	<section class="modal-dialog modal-content overlay-def">
-		<header class="modal-header">
-			<h2 class="modal-title">Titre</h2>
-		</header>
-		<div class="modal-body">
-			<table>
-				<caption>Légende de table - apparence par défaut</caption>
-				<thead>
-					<tr>
-						<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
-						<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>Données de table (<code>td</code>) - apparence par défaut</td>
-						<td>Données de table (<code>td</code>) - apparence par défaut</td>
-					</tr>
-				</tbody>
-			</table>
-			<p><a href="#">Lien - apparence par défaut</a></p>
-		</div>
-	</section>
-<!-- DataAjaxFragmentEnd -->
-</html>
+<section class="modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h2 class="modal-title">Titre</h2>
+	</header>
+	<div class="modal-body">
+		<table>
+			<caption>Légende de table - apparence par défaut</caption>
+			<thead>
+				<tr>
+					<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
+					<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Données de table (<code>td</code>) - apparence par défaut</td>
+					<td>Données de table (<code>td</code>) - apparence par défaut</td>
+				</tr>
+			</tbody>
+		</table>
+		<p><a href="#">Lien - apparence par défaut</a></p>
+	</div>
+</section>

--- a/src/plugins/lightbox/ajax/ajax1-en.html
+++ b/src/plugins/lightbox/ajax/ajax1-en.html
@@ -1,30 +1,23 @@
-<!DOCTYPE html>
-<html lang="en">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<!-- DataAjaxFragmentStart -->
-	<section class="modal-dialog modal-content overlay-def">
-		<header class="modal-header">
-			<h2 class="modal-title">AJAX - Example 1</h2>
-		</header>
-		<div class="modal-body">
-			<table>
-				<caption>Table caption default appearance</caption>
-				<thead>
-					<tr>
-						<th scope="col">Table header (<code>th</code>) default appearance</th>
-						<th scope="col">Table header (<code>th</code>) default appearance</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>Table data (<code>td</code>) default appearance</td>
-						<td>Table data (<code>td</code>) default appearance</td>
-					</tr>
-				</tbody>
-			</table>
-			<p><a href="#">Link default appearance</a></p>
-		</div>
-	</section>
-<!-- DataAjaxFragmentEnd -->
-</html>
+<section class="modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h2 class="modal-title">AJAX - Example 1</h2>
+	</header>
+	<div class="modal-body">
+		<table>
+			<caption>Table caption default appearance</caption>
+			<thead>
+				<tr>
+					<th scope="col">Table header (<code>th</code>) default appearance</th>
+					<th scope="col">Table header (<code>th</code>) default appearance</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Table data (<code>td</code>) default appearance</td>
+					<td>Table data (<code>td</code>) default appearance</td>
+				</tr>
+			</tbody>
+		</table>
+		<p><a href="#">Link default appearance</a></p>
+	</div>
+</section>

--- a/src/plugins/lightbox/ajax/ajax1-fr.html
+++ b/src/plugins/lightbox/ajax/ajax1-fr.html
@@ -1,30 +1,23 @@
-<!DOCTYPE html>
-<html lang="fr">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<!-- DataAjaxFragmentStart -->
-	<section class="modal-dialog modal-content overlay-def">
-		<header class="modal-header">
-			<h2 class="modal-title">AJAX - Exemple 1</h2>
-		</header>
-		<div class="modal-body">
-			<table>
-				<caption>Légende de table - apparence par défaut</caption>
-				<thead>
-					<tr>
-						<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
-						<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
-					</tr>
-				</thead>
-				<tbody>
-					<tr>
-						<td>Données de table (<code>td</code>) - apparence par défaut</td>
-						<td>Données de table (<code>td</code>) - apparence par défaut</td>
-					</tr>
-				</tbody>
-			</table>
-			<p><a href="#">Lien - apparence par défaut</a></p>
-		</div>
-	</section>
-<!-- DataAjaxFragmentEnd -->
-</html>
+<section class="modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h2 class="modal-title">AJAX - Exemple 1</h2>
+	</header>
+	<div class="modal-body">
+		<table>
+			<caption>Légende de table - apparence par défaut</caption>
+			<thead>
+				<tr>
+					<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
+					<th scope="col">En-tête de table (<code>th</code>) - apparence par défaut</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Données de table (<code>td</code>) - apparence par défaut</td>
+					<td>Données de table (<code>td</code>) - apparence par défaut</td>
+				</tr>
+			</tbody>
+		</table>
+		<p><a href="#">Lien - apparence par défaut</a></p>
+	</div>
+</section>

--- a/src/plugins/lightbox/ajax/ajax2-en.html
+++ b/src/plugins/lightbox/ajax/ajax2-en.html
@@ -1,28 +1,21 @@
-<!DOCTYPE html>
-<html lang="en">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<!-- DataAjaxFragmentStart -->
-	<section class="modal-dialog modal-content overlay-def">
-		<header class="modal-header">
-			<h2 class="modal-title">AJAX - Example 2</h2>
-		</header>
-		<div class="modal-body">
-			<ol>
-				<li>ordered list (<code>ol</code>) - level 1 - default appearance</li>
-				<li>ordered list (<code>ol</code>) - level 1 - default appearance
-					<ol>
-						<li>ordered list (<code>ol</code>) - level 2 - default appearance</li>
-						<li>ordered list (<code>ol</code>) - level 2 - default appearance
-							<ol>
-								<li>ordered list (<code>ol</code>) - level 3 - default appearance</li>
-								<li>ordered list (<code>ol</code>) - level 3 - default appearance</li>
-							</ol>
-						</li>
-					</ol>
-				</li>
-			</ol>
-		</div>
-	</section>
-<!-- DataAjaxFragmentEnd -->
-</html>
+<section class="modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h2 class="modal-title">AJAX - Example 2</h2>
+	</header>
+	<div class="modal-body">
+		<ol>
+			<li>ordered list (<code>ol</code>) - level 1 - default appearance</li>
+			<li>ordered list (<code>ol</code>) - level 1 - default appearance
+				<ol>
+					<li>ordered list (<code>ol</code>) - level 2 - default appearance</li>
+					<li>ordered list (<code>ol</code>) - level 2 - default appearance
+						<ol>
+							<li>ordered list (<code>ol</code>) - level 3 - default appearance</li>
+							<li>ordered list (<code>ol</code>) - level 3 - default appearance</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+	</div>
+</section>

--- a/src/plugins/lightbox/ajax/ajax2-fr.html
+++ b/src/plugins/lightbox/ajax/ajax2-fr.html
@@ -1,28 +1,21 @@
-<!DOCTYPE html>
-<html lang="fr">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<!-- DataAjaxFragmentStart -->
-	<section class="modal-dialog modal-content overlay-def">
-		<header class="modal-header">
-			<h2 class="modal-title">AJAX - Exemple 2</h2>
-		</header>
-		<div class="modal-body">
-			<ol>
-				<li>liste ordonnée (<code>ol</code>) - niveau 1 - apparence par défaut</li>
-				<li>liste ordonnée (<code>ol</code>) - niveau 1 - apparence par défaut
-					<ol>
-						<li>liste ordonnée (<code>ol</code>) - niveau 2 - apparence par défaut</li>
-						<li>liste ordonnée (<code>ol</code>) - niveau 2 - apparence par défaut
-							<ol>
-								<li>liste ordonnée (<code>ol</code>) - niveau 3 - apparence par défaut</li>
-								<li>liste ordonnée (<code>ol</code>) - niveau 3 - apparence par défaut</li>
-							</ol>
-						</li>
-					</ol>
-				</li>
-			</ol>
-		</div>
-	</section>
-<!-- DataAjaxFragmentEnd -->
-</html>
+<section class="modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h2 class="modal-title">AJAX - Exemple 2</h2>
+	</header>
+	<div class="modal-body">
+		<ol>
+			<li>liste ordonnée (<code>ol</code>) - niveau 1 - apparence par défaut</li>
+			<li>liste ordonnée (<code>ol</code>) - niveau 1 - apparence par défaut
+				<ol>
+					<li>liste ordonnée (<code>ol</code>) - niveau 2 - apparence par défaut</li>
+					<li>liste ordonnée (<code>ol</code>) - niveau 2 - apparence par défaut
+						<ol>
+							<li>liste ordonnée (<code>ol</code>) - niveau 3 - apparence par défaut</li>
+							<li>liste ordonnée (<code>ol</code>) - niveau 3 - apparence par défaut</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+	</div>
+</section>

--- a/src/plugins/lightbox/ajax/ajax3-en.html
+++ b/src/plugins/lightbox/ajax/ajax3-en.html
@@ -1,35 +1,28 @@
-<!DOCTYPE html>
-<html lang="en">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<!-- DataAjaxFragmentStart -->
-	<section class="modal-dialog modal-content overlay-def">
-		<header class="modal-header">
-			<h2 class="modal-title">AJAX - Example 3</h2>
-		</header>
-		<div class="modal-body">
-			<form action="#" method="post">
-				<div>
-					<label for="data1">Form (<code>input</code>) - default appearance:</label> <input name="data1" type="text" id="data1" />
-				</div>
-				<div>
-					<label for="data2">Form (<code>textarea</code>) - default appearance:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea>
-				</div>
-				<div>
-					<label for="data4">Form (<code>select</code>) - default appearance:</label>
-					<select id="data4" name="data4">
-						<option value="Option 1">Option 1</option>
-						<option value="Option 2">Option 2</option>
-						<option value="Option 3">Option 3</option>
-						<option value="Option 4">Option 4</option>
-					</select>
-				</div>
-				<div>
-					<input name="submit" type="submit" id="submit" value="Submit - default appearance" />
-					<input name="reset" type="reset" id="reset" value="Reset - default appearance" />
-				</div>
-			</form>
-		</div>
-	</section>
-<!-- DataAjaxFragmentEnd -->
-</html>
+<section class="modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h2 class="modal-title">AJAX - Example 3</h2>
+	</header>
+	<div class="modal-body">
+		<form action="#" method="post">
+			<div>
+				<label for="data1">Form (<code>input</code>) - default appearance:</label> <input name="data1" type="text" id="data1" />
+			</div>
+			<div>
+				<label for="data2">Form (<code>textarea</code>) - default appearance:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea>
+			</div>
+			<div>
+				<label for="data4">Form (<code>select</code>) - default appearance:</label>
+				<select id="data4" name="data4">
+					<option value="Option 1">Option 1</option>
+					<option value="Option 2">Option 2</option>
+					<option value="Option 3">Option 3</option>
+					<option value="Option 4">Option 4</option>
+				</select>
+			</div>
+			<div>
+				<input name="submit" type="submit" id="submit" value="Submit - default appearance" />
+				<input name="reset" type="reset" id="reset" value="Reset - default appearance" />
+			</div>
+		</form>
+	</div>
+</section>

--- a/src/plugins/lightbox/ajax/ajax3-fr.html
+++ b/src/plugins/lightbox/ajax/ajax3-fr.html
@@ -1,35 +1,28 @@
-<!DOCTYPE html>
-<html lang="fr">
-<!-- Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
-wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
-<!-- DataAjaxFragmentStart -->
-	<section class="modal-dialog modal-content overlay-def">
-		<header class="modal-header">
-			<h2 class="modal-title">AJAX - Exemple 3</h2>
-		</header>
-		<div class="modal-body">
-			<form action="#" method="post">
-				<div>
-					<label for="data1">Formulaire (<code>input</code>) - apparence par défaut:</label> <input name="data1" type="text" id="data1" />
-				</div>
-				<div>
-					<label for="data2">Formulaire (<code>textarea</code>) - apparence par défaut:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea>
-				</div>
-				<div>
-					<label for="data4">Formulaire (<code>select</code>) - apparence par défaut:</label>
-					<select id="data4" name="data4">
-						<option value="Option 1">Option 1</option>
-						<option value="Option 2">Option 2</option>
-						<option value="Option 3">Option 3</option>
-						<option value="Option 4">Option 4</option>
-					</select>
-				</div>
-				<div>
-					<input name="submit" type="submit" id="submit" value="Soumettre - apparence par défaut" />
-					<input name="reset" type="reset" id="reset" value="Réinitialiser - apparence par défaut" />
-				</div>
-			</form>
-		</div>
-	</section>
-<!-- DataAjaxFragmentEnd -->
-</html>
+<section class="modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h2 class="modal-title">AJAX - Exemple 3</h2>
+	</header>
+	<div class="modal-body">
+		<form action="#" method="post">
+			<div>
+				<label for="data1">Formulaire (<code>input</code>) - apparence par défaut:</label> <input name="data1" type="text" id="data1" />
+			</div>
+			<div>
+				<label for="data2">Formulaire (<code>textarea</code>) - apparence par défaut:</label> <textarea name="data2" cols="15" rows="3" id="data2"></textarea>
+			</div>
+			<div>
+				<label for="data4">Formulaire (<code>select</code>) - apparence par défaut:</label>
+				<select id="data4" name="data4">
+					<option value="Option 1">Option 1</option>
+					<option value="Option 2">Option 2</option>
+					<option value="Option 3">Option 3</option>
+					<option value="Option 4">Option 4</option>
+				</select>
+			</div>
+			<div>
+				<input name="submit" type="submit" id="submit" value="Soumettre - apparence par défaut" />
+				<input name="reset" type="reset" id="reset" value="Réinitialiser - apparence par défaut" />
+			</div>
+		</form>
+	</div>
+</section>


### PR DESCRIPTION
Fixes #5594. Fixes #5391.

Issue caused by doctype, html element and comments in the AJAXed content. Seems to trip up Magnific Popup by making mfp.content[0] into a text object (which breaks the $.contains checks). This seems to be a bug with Magnific Popup but removing doctype, html and comments from the AJAXed in content is successful as a workaround.
