### PR TITLE
Build: Skip minfication on parameterless Grunt call

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -6,9 +6,10 @@ module.exports = (grunt) ->
 	# External tasks
 	@registerTask(
 		"default"
-		"Default task that runs the production build"
+		"Default task that runs the core unminified build"
 		[
-			"dist"
+			"build"
+			"demos"
 		]
 	)
 
@@ -19,17 +20,12 @@ module.exports = (grunt) ->
 			"checkDependencies"
 			"test"
 			"build"
-			"assets-min"
+			"minify"
+			"pages:theme"
+			"pages:docs"
+			"pages:versions"
 			"demos-min"
-		]
-	)
-
-	@registerTask(
-		"debug"
-		"Produces unminified files"
-		[
-			"build"
-			"demos"
+			"htmllint"
 		]
 	)
 
@@ -46,9 +42,20 @@ module.exports = (grunt) ->
 	)
 
 	@registerTask(
+		"minify"
+		"Minify built files."
+		[
+			"js-min"
+			"css-min"
+			"assets-min"
+		]
+	)
+
+	@registerTask(
 		"deploy"
 		"Build and deploy artifacts to wet-boew-dist"
 		[
+			"dist"
 			"copy:deploy"
 			"gh-pages:travis"
 		]
@@ -107,6 +114,13 @@ module.exports = (grunt) ->
 			"concat:coreIE8"
 			"concat:pluginsIE8"
 			"concat:i18n"
+		]
+	)
+
+	@registerTask(
+		"js-min"
+		"INTERNAL: Minify the built Javascript files"
+		[
 			"uglify:polyfills"
 			"uglify:core"
 			"uglify:coreIE8"
@@ -124,6 +138,13 @@ module.exports = (grunt) ->
 			"autoprefixer"
 			"csslint:unmin"
 			"concat:css_addBanners"
+		]
+	)
+
+	@registerTask(
+		"css-min"
+		"INTERNAL: Minify the CSS files"
+		[
 			"cssmin:dist"
 			"cssmin:distIE8"
 			"ie8csscleaning"
@@ -142,10 +163,10 @@ module.exports = (grunt) ->
 		"demos"
 		"INTERNAL: Create unminified demos"
 		[
-			"i18n_csv:assemble"
 			"copy:demos"
 			"csslint:demos"
-			"pages"
+			"pages:demos"
+			"pages:ajax"
 		]
 	)
 
@@ -158,7 +179,6 @@ module.exports = (grunt) ->
 			"cssmin:demos_min"
 			"uglify:demos"
 			"pages:min"
-			"htmllint"
 		]
 	)
 
@@ -185,7 +205,8 @@ module.exports = (grunt) ->
 		"INTERNAL: prepare for running Mocha unit tests"
 		[
 			"copy:test"
-			"assemble:test"
+			"minify"
+			"pages:test"
 			"connect:test"
 		]
 	)
@@ -201,9 +222,12 @@ module.exports = (grunt) ->
 					"useMinAssets"
 				);
 			else
-				# Only use a target path for assemble if pages recieved one too
+				# Only use a target path for assemble if pages received one too
 				target = if target then ":" + target else ""
-				grunt.task.run( "assemble" + target );
+				grunt.task.run(
+					"i18n_csv:assemble"
+					"assemble" + target
+				);
 	)
 
 	@registerTask(

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -14,6 +14,16 @@ module.exports = (grunt) ->
 	)
 
 	@registerTask(
+		"travis"
+		"Default task that runs the core unminified build"
+		[
+			"dist"
+			"test-mocha"
+			"htmllint"
+		]
+	)
+
+	@registerTask(
 		"dist"
 		"Produces the production files"
 		[
@@ -25,7 +35,6 @@ module.exports = (grunt) ->
 			"pages:docs"
 			"pages:versions"
 			"demos-min"
-			"htmllint"
 		]
 	)
 

--- a/script/travis_script.sh
+++ b/script/travis_script.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -e
 
 scss-lint .
-grunt dist test test-mocha
+grunt travis


### PR DESCRIPTION
Only do the debug/core build unless the "dist" task called.

---

Probably requires some double checking from the theme repos to ensure they're not depending on the default build to create everything in their grunt-hub calls.
