### PR TITLE
JSCS: Bump to 1.5.x release

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,24 +1,12 @@
 {
 	"preset": "jquery",
+	// Preset overrides
 	"validateLineBreaks": null,
-	"disallowSpacesInNamedFunctionExpression": {
-		"beforeOpeningRoundBrace": true
-	},
-	"requireSpacesInNamedFunctionExpression": {
-		"beforeOpeningCurlyBrace": true
-	},
-	"disallowSpacesInAnonymousFunctionExpression": {
-		"beforeOpeningRoundBrace": true
-	},
-	"requireSpacesInAnonymousFunctionExpression": {
-		"beforeOpeningCurlyBrace": true
-	},
+	"requireCamelCaseOrUpperCaseIdentifiers": null,
+	"maximumLineLength": 500,
+	// Additional preset tightening
 	"requireBlocksOnNewline": true,
 	"requireSpaceBeforeBlockStatements": true,
-	"requireParenthesesAroundIIFE": true,
-	"disallowTrailingComma": true,
-	"requireMultipleVarDecl": "onevar",
-	"disallowTrailingWhitespace": true,
 	"excludeFiles": [
 		"node_modules/**",
 		"dist/**",

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1050,12 +1050,15 @@ module.exports = (grunt) ->
 					"theme/**/*.js"
 					"tasks/*.js"
 				]
+
 		jscs:
 			all:
+				options:
+					config: ".jscsrc"
+
 				src: [
 					"<%= jshint.lib_test.src %>"
 				]
-
 
 		connect:
 			options:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-htmlcompressor": "~0.1.10",
     "grunt-i18n-csv": "^0.0.7",
     "grunt-imagine": "http://github.com/LaurentGoderre/grunt-imagine/tarball/custom",
-    "grunt-jscs-checker": "^0.4.2",
+    "grunt-jscs-checker": "^0.5.1",
     "grunt-mocha": "~0.4.1",
     "grunt-modernizr": "~0.4.0",
     "grunt-sass": "^0.14.0",

--- a/src/plugins/charts/charts.js
+++ b/src/plugins/charts/charts.js
@@ -746,7 +746,7 @@
 			var $container = $( "<figure class='" + optionsCharts.graphclass + "'>" +
 
 				// Copy to the inner table caption
-				( captionHtml.length ? "<figcaption>" + captionHtml + "</figcaption>": "" ) +
+				( captionHtml.length ? "<figcaption>" + captionHtml + "</figcaption>" : "" ) +
 
 				// Image Container
 				"<div role='img' aria-label='" +
@@ -754,7 +754,7 @@
 
 				// Add Dimension
 				( withDimension ? "style='height:" + optionsCharts.height +
-				"px; width:" + optionsCharts.width + "px'": "" ) +
+				"px; width:" + optionsCharts.width + "px'" : "" ) +
 
 				"></div></figure>");
 

--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -59,10 +59,10 @@ var pluginName = "wb-feeds",
 			// Facebook feeds does not really do titles in ATOM RSS. It simply truncates content at 150 characters. We are using a JS based sentence
 			// detection algorithm to better split content and titles
 			var content = fromCharCode( data.content ),
-				title = content.replace( /(<([^>]+)>)/ig,"" ).match( /\(?[^\.\?\!]+[\.!\?]\)?/g );
+				title = content.replace( /(<([^>]+)>)/ig, "" ).match( /\(?[^\.\?\!]+[\.!\?]\)?/g );
 
 			// Sanitize the HTML from Facebook - extra 'br' tags
-			content = content.replace( /(<br>\n?)+/gi,"<br>" );
+			content = content.replace( /(<br>\n?)+/gi, "<br>" );
 
 			return "<li class='media'><a class='pull-left' href=''><img src='" + data.fIcon + "' alt='" + data.author +
 				"' height='64px' width='64px' class='media-object'/></a><div class='media-body'>" +

--- a/src/plugins/feeds/test.js
+++ b/src/plugins/feeds/test.js
@@ -25,22 +25,29 @@ describe( "Feeds test suite", function() {
 		// JSON-P for the request: http://sinonjs.org/docs/#json-p
 		stubs.ajax = sandbox.stub( $, "ajax" ).returns((function() {
 			var deferred = $.Deferred();
-			deferred.resolve( { responseData:	{
-				feed: {
-					entries: [ {
-						title: "Test entry 1",
-						link: "http://foo.com",
-						publishedDate: "Mon, 27 Jan 2014 21:00:00 -0500"
-					},{
-						title: "Test entry 2",
-						link: "http://bar.com",
-						publishedDate: "Wed, 29 Jan 2014 21:00:00 -0500"
-					},{
-						title: "Test entry 3",
-						link: "http://baz.com",
-						publishedDate: "Fri, 31 Jan 2014 21:00:00 -0500"
-					} ]
-				} } } );
+			deferred.resolve({
+				responseData: {
+					feed: {
+						entries: [
+							{
+								title: "Test entry 1",
+								link: "http://foo.com",
+								publishedDate: "Mon, 27 Jan 2014 21:00:00 -0500"
+							},
+							{
+								title: "Test entry 2",
+								link: "http://bar.com",
+								publishedDate: "Wed, 29 Jan 2014 21:00:00 -0500"
+							},
+							{
+								title: "Test entry 3",
+								link: "http://baz.com",
+								publishedDate: "Fri, 31 Jan 2014 21:00:00 -0500"
+							}
+						]
+					}
+				}
+			});
 			return deferred;
 		}()));
 	});


### PR DESCRIPTION
This introduces an updated jQuery preset so we can drop a bunch of our overrides. We should revisit the maximum line length as I currently set it arbitrarily high to get this in.
