### PR TITLE
HTML minification: Preserved line breaks to make it easier to implement the templates.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -760,6 +760,7 @@ module.exports = (grunt) ->
 			options:
 				type: "html"
 				concurrentProcess: 5
+				preserveLineBreaks: true
 			all:
 				cwd: "dist/unmin"
 				src: [


### PR DESCRIPTION
Ideally there would be a way to collapse multiple line breaks into a single line break (like with white space) but it doesn't seem to be possible through HTML Compressor at this point. Hopefully it can be added to HTML Compressor or done through a separate plugin.
