### PR TITLE
Implement example of proposed new plugin structure

### DIFF
--- a/src/plugins/base/plugin.js
+++ b/src/plugins/base/plugin.js
@@ -1,0 +1,68 @@
+/**
+ * @title WET-BOEW Tables
+ * @overview Integrates the DataTables plugin into WET providing searching, sorting, filtering, pagination and other advanced features for tables.
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @andre-d
+ */
+(function( $, window, wb ) {
+"use strict";
+
+wb.plugin = {
+	dependencies: [],
+	idCount: 0,
+	pluginName: "wb-baseplugin",
+	initEvent: function() {
+		return "wb-init" + this.selector();
+	},
+	selector: function() {
+		return "." + this.pluginName;
+	},
+	initedClass: function() {
+		return this.pluginName + "-inited";
+	},
+	eventInit: function(event) {
+		var elm = event.target,
+			elmId = elm.id,
+			$elm, init;
+		if ( event.currentTarget === elm &&
+			elm.className.indexOf( this.initedClass() ) === -1 ) {
+			wb.remove( this.selector() );
+			elm.className += " " + this.initedClass();
+			if ( !elmId ) {
+				elmId = this.pluginName + "-id-" + this.idCount;
+				this.idCount += 1;
+				elm.id = elmId;
+			}
+			if ( !this.i18nText ) {
+				this.i18nText = this.i18nTextSetup(wb.i18n);
+			}
+			$elm = $( elm );
+			init = $.proxy(this.init, this, $elm);
+			Modernizr.load({
+				load: this.dependencies,
+				complete: init
+			});
+		}
+	},
+	init: function() {},
+	i18nTextSetup: function() {
+		return {};
+	},
+	setup: function() {
+		var eventInit = $.proxy(this.eventInit, this);
+		wb.doc.on( "timerpoke.wb " + this.initEvent(), this.selector(), eventInit );
+		wb.add( this.selector() );
+
+	},
+	extend: function(child) {
+		var extended = {};
+		$.extend(true, extended, this);
+		if (child) {
+			$.extend(true, extended, child);
+		}
+		extended.idCount = 0;
+		return extended;
+	}
+};
+wb.plugins = {};
+})( jQuery, window, wb );

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -7,79 +7,101 @@
 (function( $, window, wb ) {
 "use strict";
 
-/*
- * Variable and function definitions.
- * These are global to the plugin - meaning that they will be initialized once per page,
- * not once per instance of plugin on the page. So, this is a good place to define
- * variables that are common to all instances of the plugin on a page.
- */
-var pluginName = "wb-tables",
-	selector = "." + pluginName,
-	initedClass = pluginName + "-inited",
-	initEvent = "wb-init" + selector,
-	readyEvent = "wb-ready" + selector,
-	$document = wb.doc,
-	idCount = 0,
-	i18n, i18nText, defaults,
+wb.plugins.tables = wb.plugin.extend({
+	pluginName: "wb-tables",
+	dependencies: [ "site!deps/jquery.dataTables" + wb.getMode() + ".js" ],
+	readyEvent: function() {
+		return "wb-ready" + this.selector();
+	},
+	init: function($elm) {
+		var dataTableExt = $.fn.dataTableExt;
 
-	/**
-	 * Init runs once per plugin element on the page. There may be multiple elements.
-	 * It will run more than once per plugin if you don't remove the selector from the timer.
-	 * @method init
-	 * @param {jQuery Event} event `timerpoke.wb` event that triggered the function call
-	 */
-	init = function( event ) {
-		var elm = event.target,
-			elmId = elm.id;
+		/*
+		 * Extend sorting support
+		 */
+		$.extend( dataTableExt.type.order, {
+			// Enable internationalization support in the sorting
+			"html-pre": function( a ) {
+				return wb.normalizeDiacritics(
+					!a ? "" : a.replace ?
+						a.replace( /<.*?>/g, "" ).toLowerCase() : a + ""
+				);
+			},
+			"string-case-pre": function( a ) {
+				return wb.normalizeDiacritics( a );
+			},
+			"string-pre": function( a ) {
+				return wb.normalizeDiacritics( a );
+			},
 
-		// Filter out any events triggered by descendants
-		// and only initialize the element once
-		if ( event.currentTarget === elm &&
-			elm.className.indexOf( initedClass ) === -1 ) {
-
-			wb.remove( selector );
-			elm.className += " " + initedClass;
-
-			// Ensure there is a unique id on the element
-			if ( !elmId ) {
-				elmId = pluginName + "-id-" + idCount;
-				idCount += 1;
-				elm.id = elmId;
+			// Formatted number sorting
+			"formatted-num-asc": function( a, b ) {
+				return wb.formattedNumCompare( b, a );
+			},
+			"formatted-num-desc": function( a, b ) {
+				return wb.formattedNumCompare( a, b );
 			}
+		} );
 
-			// Only initialize the i18nText once
-			if ( !i18nText ) {
-				i18n = wb.i18n;
-				i18nText = {
-					aria: {
-						sortAscending: i18n( "sortAsc" ),
-						sortDescending: i18n( "sortDesc" )
-					},
-					emptyTable: i18n( "emptyTbl" ),
-					info: i18n( "infoEntr" ),
-					infoEmpty: i18n( "infoEmpty" ),
-					infoFiltered: i18n( "infoFilt" ),
-					lengthMenu: i18n( "lenMenu" ),
-					loadingRecords: i18n( "load" ),
-					paginate: {
-						first: i18n( "first" ),
-						last: i18n( "last" ),
-						next: i18n( "nxt" ),
-						previous: i18n( "prv" )
-					},
-					processing: i18n( "process" ),
-					search: i18n( "filter" ),
-					thousands: i18n( "info1000" ),
-					zeroRecords: i18n( "infoEmpty" )
-				};
+		/*
+		 * Extend type detection
+		 */
+		// Formatted numbers detection
+		// Based on: http://datatables.net/plug-ins/type-detection#formatted_numbers
+		dataTableExt.aTypes.unshift(
+			function( sData ) {
+
+				// Strip off HTML tags and all non-alpha-numeric characters (except minus sign)
+				var deformatted = sData.replace( /<[^>]*>/g, "" ).replace( /[^\d\-\/a-zA-Z]/g, "" );
+				if ( $.isNumeric( deformatted ) || deformatted === "-" ) {
+					return "formatted-num";
+				}
+				return null;
 			}
+		);
 
-			defaults = {
-				asStripeClasses: [],
-				language: i18nText,
-				dom: "<'top'ilf>rt<'bottom'p><'clear'>",
-				drawCallback: function( settings ) {
+		// Remove HTML tags before doing any filtering for formatted numbers
+		dataTableExt.type.search[ "formatted-num" ] = function( data ) {
+			return data.replace( /<[^>]*>/g, "" );
+		};
 
+		// Add the container or the sorting icons
+		$elm.find( "th" ).append( "<span class='sorting-cnt'><span class='sorting-icons'></span></span>" );
+
+		// Create the DataTable object
+		$elm.dataTable( $.extend( true, {}, this.defaults($elm), window[ this.pluginName ], wb.getData( $elm, this.pluginName ) ) );
+	},
+	i18nTextSetup: function(i18n) {
+		return {
+			aria: {
+				sortAscending: i18n( "sortAsc" ),
+				sortDescending: i18n( "sortDesc" )
+			},
+			emptyTable: i18n( "emptyTbl" ),
+			info: i18n( "infoEntr" ),
+			infoEmpty: i18n( "infoEmpty" ),
+			infoFiltered: i18n( "infoFilt" ),
+			lengthMenu: i18n( "lenMenu" ),
+			loadingRecords: i18n( "load" ),
+			paginate: {
+				first: i18n( "first" ),
+				last: i18n( "last" ),
+				next: i18n( "nxt" ),
+				previous: i18n( "prv" )
+			},
+			processing: i18n( "process" ),
+			search: i18n( "filter" ),
+			thousands: i18n( "info1000" ),
+			zeroRecords: i18n( "infoEmpty" )
+		};
+	},
+	defaults: function($elm) {
+		var readyEvent = this.readyEvent();
+		return {
+			asStripeClasses: [],
+			language: this.i18nText,
+			dom: "<'top'ilf>rt<'bottom'p><'clear'>",
+			drawCallback: function( settings ) {
 					// Update the aria-pressed properties on the pagination buttons
 					// Should be pushed upstream to DataTables
 					$( ".dataTables_paginate a" )
@@ -90,80 +112,10 @@ var pluginName = "wb-tables",
 								.attr( "aria-pressed", "true" );
 
 					// Trigger the wb-ready.wb-tables callback event
-					$( "#" + elmId ).trigger( readyEvent, [ this, settings ] );
+					$elm.trigger( readyEvent, [ this, settings ] );
 				}
-			};
-
-			Modernizr.load({
-				load: [ "site!deps/jquery.dataTables" + wb.getMode() + ".js" ],
-				complete: function() {
-					var $elm = $( "#" + elmId ),
-						dataTableExt = $.fn.dataTableExt;
-
-					/*
-					 * Extend sorting support
-					 */
-					$.extend( dataTableExt.type.order, {
-
-						// Enable internationalization support in the sorting
-						"html-pre": function( a ) {
-							return wb.normalizeDiacritics(
-								!a ? "" : a.replace ?
-									a.replace( /<.*?>/g, "" ).toLowerCase() : a + ""
-							);
-						},
-						"string-case-pre": function( a ) {
-							return wb.normalizeDiacritics( a );
-						},
-						"string-pre": function( a ) {
-							return wb.normalizeDiacritics( a );
-						},
-
-						// Formatted number sorting
-						"formatted-num-asc": function( a, b ) {
-							return wb.formattedNumCompare( b, a );
-						},
-						"formatted-num-desc": function( a, b ) {
-							return wb.formattedNumCompare( a, b );
-						}
-					} );
-
-					/*
-					 * Extend type detection
-					 */
-					// Formatted numbers detection
-					// Based on: http://datatables.net/plug-ins/type-detection#formatted_numbers
-					dataTableExt.aTypes.unshift(
-						function( sData ) {
-
-							// Strip off HTML tags and all non-alpha-numeric characters (except minus sign)
-							var deformatted = sData.replace( /<[^>]*>/g, "" ).replace( /[^\d\-\/a-zA-Z]/g, "" );
-							if ( $.isNumeric( deformatted ) || deformatted === "-" ) {
-								return "formatted-num";
-							}
-							return null;
-						}
-					);
-
-					// Remove HTML tags before doing any filtering for formatted numbers
-					dataTableExt.type.search[ "formatted-num" ] = function( data ) {
-						return data.replace( /<[^>]*>/g, "" );
-					};
-
-					// Add the container or the sorting icons
-					$elm.find( "th" ).append( "<span class='sorting-cnt'><span class='sorting-icons'></span></span>" );
-
-					// Create the DataTable object
-					$elm.dataTable( $.extend( true, {}, defaults, window[ pluginName ], wb.getData( $elm, pluginName ) ) );
-				}
-			});
-		}
-	};
-
-// Bind the init event of the plugin
-$document.on( "timerpoke.wb " + initEvent, selector, init );
-
-// Add the timer poke to initialize the plugin
-wb.add( selector );
-
+		};
+	}
+});
+wb.plugins.tables.setup();
 })( jQuery, window, wb );


### PR DESCRIPTION
As discussed in #5769.  Allows for extending plugins and removes code the current duplication with code common to plugins.  Some functionality in init() for tables could be moved to sub-functions to allow for better extension of the plugin, but currently defaults() is the example.
