### PR TITLE
Awards, articles and videos: added article

### DIFF
--- a/site/pages/docs/ref/accolades-en.hbs
+++ b/site/pages/docs/ref/accolades-en.hbs
@@ -4,7 +4,7 @@
 	"language": "en",
 	"description": "Awards, articles and videos - Documentation - Web Experience Toolkit (WET)",
 	"altLangPrefix": "accolades",
-	"dateModified": "2014-05-30"
+	"dateModified": "2014-07-31"
 }
 ---
 <p>The goal of this page is to compile a list of accolades and positive mentions for the Web Experience Toolkit. Please help out by adding any accolades or positive mentions that have not already been listed.</p>
@@ -51,6 +51,12 @@
 			</tr>
 		</thead>
 		<tbody>
+			<tr>
+				<td><a href="http://www.nngroup.com/articles/keyboard-accessibility/">Keyboard-Only Navigation for Improved Accessibility (WET on CIC used as example)</a></td>
+				<td><time>2014-04-06</time></td>
+				<td>Marieke McCloskey</td>
+				<td>Nielsen Norman Group</td>
+			</tr>
 			<tr>
 				<td><a href="http://www.canadiangovernmentexecutive.ca/category/item/1469-open-source-driving-digital-innovation.html">Open source driving digital innovation</a></td>
 				<td><time>2014-02-04</time></td>

--- a/site/pages/docs/ref/accolades-fr.hbs
+++ b/site/pages/docs/ref/accolades-fr.hbs
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"description": "Primes, articles et vidéos - Documentation - Boîte à outils de l'expérience Web (BOEW)",
 	"altLangPrefix": "accolades",
-	"dateModified": "2014-05-30"
+	"dateModified": "2014-07-31"
 }
 ---
 <p>Le but de cette page est de compiler une liste de distinctions et mentions positives pour la Boîte à outils de l'expérience Web. S'il vous plaît aider en ajoutant des distinctions ou des mentions positives qui n'ont pas déjà été énumérés.</p>
@@ -51,6 +51,12 @@
 			</tr>
 		</thead>
 		<tbody>
+			<tr>
+				<td><a href="http://www.nngroup.com/articles/keyboard-accessibility/">Keyboard-Only Navigation for Improved Accessibility (WET on CIC used as example)</a></td>
+				<td><time>2014-04-06</time></td>
+				<td>Marieke McCloskey</td>
+				<td>Nielsen Norman Group</td>
+			</tr>
 			<tr>
 				<td><a href="http://www.canadiangovernmentexecutive.ca/category/item/1469-open-source-driving-digital-innovation.html">Open source driving digital innovation</a></td>
 				<td><time>2014-02-04</time></td>


### PR DESCRIPTION
Added an article from the Nielsen Norman Group that uses Canada.ca as an example.
