### PR TITLE
WET theme: Removed aria-label from logo link since unnecessary duplication with text in the link itself (non-breaking markup change)

### DIFF
--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -1,4 +1,4 @@
 <a href="{{assets}}/index-{{language}}.html">
-	<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/assets/logo.svg" aria-label="{{{i18n "site-title"}}}"></object>
+	<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/assets/logo.svg"></object>
 	<span>{{{i18n "site-title"}}}<span class="wb-inv">{{{i18n "comma-space"}}}</span><small>{{{i18n "site-tagline"}}}</small></span>
 </a>


### PR DESCRIPTION
Needed to prevent NVDA from reading off the same text three times.
