### PR TITLE
WET theme: Removed role='img' from logo link object to prevent object from being announced by screen readers

### DIFF
--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -1,4 +1,4 @@
 <a href="{{assets}}/index-{{language}}.html">
-	<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/assets/logo.svg"></object>
+	<object type="image/svg+xml" tabindex="-1" data="{{assets}}/assets/logo.svg"></object>
 	<span>{{{i18n "site-title"}}}<span class="wb-inv">{{{i18n "comma-space"}}}</span><small>{{{i18n "site-tagline"}}}</small></span>
 </a>


### PR DESCRIPTION
Needed since announcing of object is unneeded with the link text making the logo only decorative.
