### PR TITLE
Bootstrap overrides: Increased specificity of pagination and pager's arr...

### DIFF
--- a/src/base/bootstrap-overrides/_base.scss
+++ b/src/base/bootstrap-overrides/_base.scss
@@ -578,18 +578,6 @@ blockquote {
 
 .pagination,
 .pager {
-	[rel="prev"] {
-		&:before {
-			@extend %pagination-left-arrow;
-		}
-	}
-
-	[rel="next"] {
-		&:after {
-			@extend %pagination-right-arrow;
-		}
-	}
-
 	&.disabled {
 		@extend %global-display-none;
 	}
@@ -601,6 +589,22 @@ blockquote {
 				display: inline-block;
 				margin-bottom: 0.5em;
 				padding: $padding-large-vertical $padding-large-horizontal;
+			}
+		}
+		
+		&:first-child {
+			[rel="prev"] {
+				&:before {
+					@extend %pagination-left-arrow;
+				}
+			}
+		}
+
+		&:last-child {
+			[rel="next"] {
+				&:after {
+					@extend %pagination-right-arrow;
+				}
 			}
 		}
 

--- a/src/base/bootstrap-overrides/_ie8.scss
+++ b/src/base/bootstrap-overrides/_ie8.scss
@@ -2,6 +2,22 @@
   WET-BOEW
   @title: Bootstrap IE8-specific overrides for WET-BOEW
  */
+.lt-ie9 {
+	.pagination, 
+	.pager {
+		> li {
+			&:first-child {
+				[rel="prev"] {
+					&:before {
+						content: none;
+						margin-right: -1px;
+					}
+				}
+			}
+		}
+	}
+}
+
 @media print {
 	.lt-ie9 {
 		abbr {


### PR DESCRIPTION
...ow SCSS selectors and disabled them in IE8...
- Prevents the arrows from appearing when rel attributes are set on numbered links that have the same destinations as the "Previous"/"Next" links.
- Arrows have been disabled in IE8 since it lacks support for :last-child (would look really strange if only :first-child arrows continued to be shown).
