### PR TITLE
Docs: Add Git proxy configuration

### DIFF
--- a/site/pages/docs/proxy-en.hbs
+++ b/site/pages/docs/proxy-en.hbs
@@ -23,13 +23,26 @@
 </section>
 
 <section>
+	<h2>Setting the proxy for Git</h2>
+	<ol>
+		<li>Open a command prompt</li>
+		<li>Run the following commands replacing <code>USERNAME</code>, <code>PASSWORD</code>, <code>PROXY_ADDRESS</code>, and <code>PROXY_PORT</code> with your network's information:
+			<ol>
+				<li><code>git config --global --add http.proxy http://USERNAME:PASSWORD@PROXY_ADDRESS:PROXY_PORT</code></li>
+				<li><code>git config --global --add https.proxy http://USERNAME:PASSWORD@PROXY_ADDRESS:PROXY_PORT</code></li>
+			</ol>
+		</li>
+	</ol>
+</section>
+
+<section>
 	<h2>Setting the proxy for other tasks</h2>
 	<p>Many plugins will also look for environmental variables of <code>HTTP_PROXY</code> and <code>HTTPS_PROXY</code> when they need to call out to the internet.</p>
 	<ol>
 		<li>You can set these variables with the value <code>http://USERNAME:PASSWORD@PROXY_ADDRESS:PROXY_PORT</code> each session by calling:
 			<ol>
-				<li>Windows Command Prompt: <code>set http://HTTP_PROXY=USERNAME:PASSWORD@PROXY_ADDRESS:PROXY_PORT</code></li>
-				<li>Bash Shell: <code>export http://HTTP_PROXY=USERNAME:PASSWORD@PROXY_ADDRESS:PROXY_PORT</code></li>
+				<li>Windows Command Prompt: <code>set HTTP_PROXY=http://USERNAME:PASSWORD@PROXY_ADDRESS:PROXY_PORT</code></li>
+				<li>Bash Shell: <code>export HTTPS_PROXY=http://USERNAME:PASSWORD@PROXY_ADDRESS:PROXY_PORT</code></li>
 			</ol>
 		</li>
 		<li>To avoid doing this every time, you can add these commands to your console's "RC" file. If you are using the Git Bash Shell on Windows, you can add the export statements to the ".bashrc" file in the root of your user profile (<code>C:\Users\USERNAME</code>). That file is run every time you open a Git Bash session, so the environmental variables will be available from the command line. You may need to create that file with a text editor, since Windows doesn't allow creating files starting with a period in Windows Explorer.</li>

--- a/site/pages/docs/proxy-fr.hbs
+++ b/site/pages/docs/proxy-fr.hbs
@@ -25,13 +25,25 @@ Toutes ces méthodes vont emmagasiner votre mot de passe en texte clair, alors f
 </section>
 
 <section>
+	<h2>Configurer le proxy pour Git</h2>
+	<ol>
+		<li>Ouvrir une invite de commande</li>
+		<li>Exécuter les commandes suivantes en remplacant <code>USAGER</code>, <code>MOT_DE_PASSE</code>, <code>ADRESSE_PROXY</code>, et <code>PORT_PROXY</code> avec les informations de votre réseau :
+			<ol>
+				<li><code>git config --global --add proxy http://USAGER:MOT_DE_PASSE@ADRESSE_PROXY:PORT_PROXY</code></li>
+				<li><code>git config --global --add https-proxy http://USAGER:MOT_DE_PASSE@ADRESSE_PROXYS:PORT_PROXY</code></li>
+			</ol>
+		</li>
+	</ol>
+</section>
+<section>
 	<h2>Configurer le proxy pour d'autres tâches</h2>
 	<p>Plusieurs modules d'extension vérifient aussi pour les variables environnementales <code>PROXY_HTTP</code> et <code>PROXY_HTTPS</code> lorsq'ils ont besoin de faire un appel extérieur à l'Internet.</p>
 	<ol>
 		<li>Vous pouvez configurer ces variables avec la valeur <code>http://USAGER:MOT_DE_PASSE@ADRESSE_PROXY:PORT_PROXY</code> à chaque session en apellant :
 			<ol>
-				<li>Invite de commande Windows : <code>set http://PROXY_HTTP=USAGER:MOT_DE_PASSE@ADRESSE_PROXY:PORT_PROXY</code></li>
-				<li><span lang="en">Bash Shell</span> : <code>export http://PROXY_HTTP=USAGER:MOT_DE_PASSE@ADRESSE_PROXY:PORT_PROXY</code></li>
+				<li>Invite de commande Windows : <code>set HTTP_PROXY=http://USAGER:MOT_DE_PASSE@ADRESSE_PROXY:PORT_PROXY</code></li>
+				<li><span lang="en">Bash Shell</span> : <code>export HTTPS_PROXY=http://USAGER:MOT_DE_PASSE@ADRESSE_PROXY:PORT_PROXY</code></li>
 			</ol>
 		</li>
 		<li>Pour éviter de faire cet action à chaque fois, vous pouvez ajouter ces commandes à votre fichier console "RC". 


### PR DESCRIPTION
- Add additional instructions for Git since those are used for
  cloning/push operations if a global version isn't found
- Fix generic section URL formats
