### PR TITLE
Build: Update grunt-jscs to new package name

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1244,7 +1244,7 @@ module.exports = (grunt) ->
 	@loadNpmTasks "grunt-htmlcompressor"
 	@loadNpmTasks "grunt-i18n-csv"
 	@loadNpmTasks "grunt-imagine"
-	@loadNpmTasks "grunt-jscs-checker"
+	@loadNpmTasks "grunt-jscs"
 	@loadNpmTasks "grunt-mocha"
 	@loadNpmTasks "grunt-modernizr"
 	@loadNpmTasks "grunt-sass"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "grunt-htmlcompressor": "~0.1.10",
     "grunt-i18n-csv": "^0.1.0",
     "grunt-imagine": "^0.3.4",
-    "grunt-jscs-checker": "^0.5.1",
+    "grunt-jscs": "^0.6.2",
     "grunt-mocha": "~0.4.1",
     "grunt-modernizr": "~0.4.0",
     "grunt-sass": "^0.14.0",


### PR DESCRIPTION
Package was renamed and dropped the "-checker". The new version doesn't seem to affect the project for now, but the upcoming inline rules will allow additional tightening of rules.
