### PR TITLE
Testing: Change SauceLabs test runner back to Mocha

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -7,6 +7,7 @@
 	// Additional preset tightening
 	"requireBlocksOnNewline": true,
 	"requireSpaceBeforeBlockStatements": true,
+	"disallowMixedSpacesAndTabs": true,
 	"excludeFiles": [
 		"node_modules/**",
 		"dist/**",

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -68,7 +68,7 @@ module.exports = (grunt) ->
 		"Run tests on SauceLabs. Currently only for Travis builds"
 		[
 			"pre-mocha"
-			"saucelabs-custom"
+			"saucelabs-mocha"
 		]
 	)
 
@@ -1187,7 +1187,7 @@ module.exports = (grunt) ->
 					reporter: "Spec"
 					urls: ["http://localhost:8000/dist/unmin/test/test.html"]
 
-		"saucelabs-custom":
+		"saucelabs-mocha":
 			all:
 				options:
 					urls: ["http://localhost:8000/dist/unmin/test/test.html"]
@@ -1199,6 +1199,8 @@ module.exports = (grunt) ->
 						process.env.TRAVIS_BRANCH
 						process.env.TRAVIS_COMMIT
 					]
+					sauceConfig:
+						'video-upload-on-pass': false
 
 		"gh-pages":
 			options:

--- a/src/test.js
+++ b/src/test.js
@@ -7,24 +7,30 @@ wb.doc.on( "ready", function() {
 	var runner = mocha.run(),
 		failedTests = [];
 
-    runner.on( "end", function() {
-      window.mochaResults = runner.stats;
-      window.mochaResults.reports = failedTests;
-    });
+	runner.on( "end", function() {
+		window.mochaResults = runner.stats;
+		window.mochaResults.reports = failedTests;
+	});
 
-    runner.on( "fail", logFailure);
+	runner.on( "fail", logFailure);
 
-    function logFailure(test, err) {
+	function logFailure(test, err) {
 
-      var flattenTitles = function(test) {
-        var titles = [];
-        while (test.parent.title) {
-          titles.push(test.parent.title);
-          test = test.parent;
-        }
-        return titles.reverse();
-      };
+		var flattenTitles = function(test) {
+			var titles = [];
+			while (test.parent.title) {
+				titles.push(test.parent.title);
+				test = test.parent;
+			}
+			return titles.reverse();
+		};
 
-      failedTests.push( { name: test.title, result: false, message: err.message, stack: err.stack, titles: flattenTitles( test ) } );
-    }
+		failedTests.push({
+			name: test.title,
+			result: false,
+			message: err.message,
+			stack: err.stack,
+			titles: flattenTitles( test )
+		});
+	}
 });


### PR DESCRIPTION
Cleaned up the JS from the previous update to the runner, and tighten the JSCS config to prevent the spaces from creeping back in.

Note that the tests are failing in a few browsers, but it is actually being reported correctly now.
