### PR TITLE
Added the message to the stack trace for saucelabs

### DIFF
--- a/src/test.js
+++ b/src/test.js
@@ -29,7 +29,7 @@ wb.doc.on( "ready", function() {
 			name: test.title,
 			result: false,
 			message: err.message,
-			stack: err.stack,
+			stack: err.message + "\n" + err.stack,
 			titles: flattenTitles( test )
 		});
 	}


### PR DESCRIPTION
Saucelabs currently doesn't show which part of the test fails. This adds the message to the stack trace like mocha does in browsers
