### PR TITLE
CSS fixes for details/summary polyfills and alerts

### DIFF
--- a/src/base/bootstrap-overrides/_base.scss
+++ b/src/base/bootstrap-overrides/_base.scss
@@ -208,16 +208,6 @@ a {
 	}
 }
 
-section {
-	&.alert {
-		> {
-			:first-child {
-				margin-left: 1.2em;
-			}
-		}
-	}
-}
-
 %label-alert-color-000 {
 	color: #000;
 }
@@ -270,11 +260,11 @@ section {
 	}
 }
 
-$label-alert-warning-border-icon-color: #278400;
+$label-alert-success-border-icon-color: #278400;
 
 %label-alert-success-bg-border-left {
 	background: #d8eeca;
-	border-color: $label-alert-warning-border-icon-color;
+	border-color: $label-alert-success-border-icon-color;
 }
 
 .label-success {
@@ -299,7 +289,7 @@ $label-alert-warning-border-icon-color: #278400;
 	> {
 		:first-child {
 			&:before {
-				color: $label-alert-warning-border-icon-color;
+				color: $label-alert-success-border-icon-color;
 				content: "\e084";
 			}
 		}
@@ -428,10 +418,17 @@ details {
 		}
 
 		> {
+			* {
+				margin-left: 0.7em;
+			}
+
 			:first-child {
+				margin-left: 0.4em;
+				
 				&:before {
 					color: #000;
 					content: "";
+					font-family: $font-family-base;
 				}
 			}
 		}
@@ -441,7 +438,7 @@ details {
 		@extend %label-alert-success-bg-border-left;
 
 		&:before {
-			color: $label-alert-warning-border-icon-color;
+			color: $label-alert-success-border-icon-color;
 			content: "\e084";
 		}
 	}
@@ -764,11 +761,21 @@ blockquote {
 		}
 	}
 
-	section {
+	details {
 		&.alert {
+			padding-right: 45px;
+
+			&:before {
+				margin-right: -1.3em;
+			}
+
 			> {
+				* {
+					margin-right: 0.7em;
+				}
+
 				:first-child {
-					margin-right: 1.2em;
+					margin-right: 0.4em;
 				}
 			}
 		}

--- a/src/base/details/_base.scss
+++ b/src/base/details/_base.scss
@@ -13,6 +13,15 @@ summary {
 		background: #ddd;
 		color: #000;
 	}
+
+	> {
+
+		// Only apply inline to first child to allow
+		// subsequent elements to use block layouts
+		:first-child {
+			display: inline;
+		}
+	}
 }
 
 details {
@@ -22,7 +31,8 @@ details {
 
 	> {
 		* {
-			margin-left: 1.3em;
+			margin-left: 1.5em;
+			margin-right: auto;
 		}
 
 		summary {
@@ -36,7 +46,7 @@ details {
 		> {
 			* {
 				margin-left: auto;
-				margin-right: 1.3em;
+				margin-right: 1.5em;
 			}
 
 			summary {

--- a/src/polyfills/details/details.scss
+++ b/src/polyfills/details/details.scss
@@ -5,10 +5,19 @@
 
 /* Details/summary polyfill */
 details {
+	&.alert {
+		> {
+			summary {
+				margin-left: 1.4em !important;
+			}
+		}
+	}
+
 	> {
 		summary {
 			&:before { /* Add the closed pointer */
 				content: "\25BA\a0" !important;
+				font-size: 84%;
 			}
 		}
 	}
@@ -29,10 +38,28 @@ details {
 /* Right to left (RTL) CSS */
 [dir="rtl"] {
 	details {
+		&.alert {
+			> {
+				summary {
+					margin-right: 1.4em !important;
+				}
+			}
+		}
+
 		> {
 			summary {
 				&:before { /* Add the close pointer */
-					content: "\25C0\a0" !important;
+					content: "\25C4\a0" !important;
+				}
+			}
+		}
+
+		&[open] {
+			> {
+				summary {
+					&:before { /* Add the opened pointer */
+						content: "\25BC\a0" !important;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
These fixes normalize a lot of the styling between native and polyfill implementations of details/summary elements, plus correct a few minor layout issues in RTL.

It also improves the layout of alerts when combined with details/summary.
