### PR TITLE
Allowed caching of the openlayer dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "jquery-pjax": "1.7.3",
     "jquery-validation": "1.11.1",
     "magnific-popup": "0.9.9",
-    "openlayers": "https://github.com/wet-boew/openlayers/releases/download/v2.13.1/OpenLayers-2.13.1.tar.gz",
+    "openlayers": "release-2.13.1",
     "proj4": "2.1.0",
     "respond": "1.4.0",
     "selectivizr": "1.0.2",


### PR DESCRIPTION
Because they don't use SEMVER or a package.json, bowering openlayers is akwards but using a tag instead of a tar allows caching of the package. This will significantly speed up the npm install command.

/cc @nschonni 
