### PR TITLE
Capture current version of jQuery

### DIFF
--- a/src/polyfills/details/details.js
+++ b/src/polyfills/details/details.js
@@ -4,7 +4,7 @@
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @pjackson28
  */
-(function( window, wb ) {
+(function( $, window, wb ) {
 "use strict";
 
 /*
@@ -98,4 +98,4 @@ $document.on( "click keydown toggle." + componentName, selector, function( event
 // Add the timer poke to initialize the plugin
 wb.add( selector );
 
-})( window, wb );
+})( jQuery, window, wb );


### PR DESCRIPTION
Do not assume $ will be available in the global scope.  This polyfill currently breaks in FF 31.0.
