### PR TITLE
Multimedia: Prevent SVG from receiving clicks

### DIFF
--- a/src/js/sass/includes/_multimedia.scss
+++ b/src/js/sass/includes/_multimedia.scss
@@ -36,9 +36,7 @@ video, object.video {
 	}
 
 	svg {
-		* {
-	 		pointer-events: none;
-	 	}
+	 	pointer-events: none;
 	}
 }
 


### PR DESCRIPTION
In more recent version of Chrome, not onl child of the SVG tag prevent event bubbling of the click event but the SVG element itself

Fixes #6025
