### PR TITLE
Build: Run html proofer on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,11 @@ env:
 
 install:
   - ./script/setup
-  - gem install scss-lint --no-ri --version '=0.26.2'
+  - bundle install
 
 script:
   - travis_retry ./script/travis_script.sh
+  - bundle exec rake
   - ./script/travis_saucelabs.sh
 
 after_success:

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "scss-lint"
+gem "html-proofer"
+gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,36 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colored (1.2)
+    ethon (0.7.1)
+      ffi (>= 1.3.0)
+    ffi (1.9.3)
+    html-proofer (1.4.0)
+      colored (~> 1.2)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.5)
+      parallel (~> 1.3)
+      typhoeus (~> 0.6.7)
+      yell (~> 2.0)
+    mercenary (0.3.4)
+    mini_portile (0.6.0)
+    nokogiri (1.6.3.1)
+      mini_portile (= 0.6.0)
+    parallel (1.3.2)
+    rainbow (2.0.0)
+    rake (10.3.2)
+    sass (3.4.4)
+    scss-lint (0.28.0)
+      rainbow (~> 2.0)
+      sass (~> 3.4.0)
+    typhoeus (0.6.9)
+      ethon (>= 0.7.1)
+    yell (2.0.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  html-proofer
+  rake
+  scss-lint

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -497,6 +497,7 @@ module.exports = (grunt) ->
 						cwd: "site/pages"
 						src: [
 							"**/*.hbs",
+							"!**/test.hbs"
 							"!ajax/**/*.hbs"
 							"!docs/**/*.hbs"
 						]

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -30,7 +30,7 @@ module.exports = (grunt) ->
 			"build"
 			"minify"
 			"pages:theme"
-			"pages:docs"
+			"docs-min"
 			"demos-min"
 			"htmllint"
 		]
@@ -182,6 +182,15 @@ module.exports = (grunt) ->
 		"INTERNAL: Create unminified docs"
 		[
 			"pages:docs"
+		]
+	)
+
+	@registerTask(
+		"docs-min"
+		"INTERNAL: Create minified docs"
+		[
+			"pages:docs"
+			"cssmin:docs_min"
 		]
 	)
 
@@ -583,6 +592,12 @@ module.exports = (grunt) ->
 					src: "**/demo/*.scss"
 					dest: "dist/unmin/demos/"
 					ext: ".css"
+				,
+					expand: true
+					cwd: "site/pages/docs/css"
+					src: "**/*.scss"
+					dest: "dist/unmin/docs/css/"
+					ext: ".css"
 				]
 
 		autoprefixer:
@@ -640,6 +655,11 @@ module.exports = (grunt) ->
 					cwd: "dist/unmin/demos"
 					src: "**/*.css"
 					dest: "dist/unmin/demos/"
+					expand: true
+				,
+					cwd: "dist/unmin/docs"
+					src: "**/*.css"
+					dest: "dist/unmin/docs/"
 					expand: true
 				]
 
@@ -817,6 +837,17 @@ module.exports = (grunt) ->
 					"**/demo/*.css"
 				]
 				dest: "dist/demos/"
+				ext: ".min.css"
+
+			docs_min:
+				options:
+					banner: "@charset \"utf-8\";\n<%= banner %>"
+				expand: true
+				cwd: "dist/unmin/docs/"
+				src: [
+					"**/*.css"
+				]
+				dest: "dist/docs/"
 				ext: ".min.css"
 
 		htmlmin:

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 require "html/proofer"
 
 task :default => [:test]
@@ -6,12 +8,17 @@ task :test do
 	HTML::Proofer.new("dist/", {
 		:href_ignore => [
 			"#",
+			# The additional anchor link is picked up from the Geomap JSON, but shouldn't be flagged
+			"\\\"#\\\"",
 			"/v4.0-ci/index.html",
 			"/v4.0-ci/index-en.html",
 			"/v4.0-ci/index-fr.html",
 			"/v4.0-ci/unmin/index.html",
 			"/v4.0-ci/unmin/index-en.html",
 			"/v4.0-ci/unmin/index-fr.html",
+			# The texthighlight plug-in has some non-escaped characters in the query string
+			"texthighlight/texthighlight-fr.html?txthl=influenza%20aviaire+monde+suffis+symptômes%20semblables%20à%20ceux%20de%20l'influenza+À%20titre%20de%20rappel...+À%20de%20rares%20occasions,%20des%20humains%20ont%20été%20infectés%20par%20ce%20virus.",
+			"../../../demos/texthighlight/texthighlight-en.html?txthl=influenza%20aviaire+monde+suffis+sympt%C3%B4mes%20semblables%20%C3%A0%20ceux%20de%20l'influenza+%C3%80%20titre%20de%20rappel...+%C3%80%20de%20rares%20occasions,%20des%20humains%20ont%20%C3%A9t%C3%A9%20infect%C3%A9s%20par%20ce%20virus.#exemple"
 		],
 		:disable_external => true,
 		:ext => ".html"

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,19 @@
+require "html/proofer"
+
+task :default => [:test]
+
+task :test do
+	HTML::Proofer.new("dist/", {
+		:href_ignore => [
+			"#",
+			"/v4.0-ci/index.html",
+			"/v4.0-ci/index-en.html",
+			"/v4.0-ci/index-fr.html",
+			"/v4.0-ci/unmin/index.html",
+			"/v4.0-ci/unmin/index-en.html",
+			"/v4.0-ci/unmin/index-fr.html",
+		],
+		:disable_external => true,
+		:ext => ".html"
+	}).run
+end

--- a/site/pages/docs/ref/tablevalidator/tablevalidator-fr.hbs
+++ b/site/pages/docs/ref/tablevalidator/tablevalidator-fr.hbs
@@ -3,7 +3,7 @@
 	"title": "Validateur de tableau",
 	"language": "fr",
 	"category": "Autre",
-	"categoryfile": "Other",
+	"categoryfile": "other",
 	"description": "Outils pour les éditeur web qui fourni une assistance afin de produire des tableaux conforme au norme WCAG",
 	"altLangPrefix": "tablevalidator",
 	"dateModified": "2014-08-04"
@@ -118,7 +118,7 @@ Example of multi-line code</code></pre>
 			<tr>
 				<td><code>wb-ready.wb</code> (v4.0.5+)</td>
 				<td>Triggered automatically when WET has finished loading and executing.</td>
-				<td>Used to identify when all WET plugins and polyfills have finished loading and executing. 
+				<td>Used to identify when all WET plugins and polyfills have finished loading and executing.
 					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
 });</code></pre>
 				</td>

--- a/site/pages/docs/versions/v3.1/v3.1.3-en.hbs
+++ b/site/pages/docs/versions/v3.1/v3.1.3-en.hbs
@@ -9,7 +9,7 @@
 ---
 <ul>
 	<li><strong>Release date:</strong> <time>2013-08-06</time></li>
-	<li><a href="../dwnld-en.html#v310a3">Downloads</a></li>
+	<li><a href="../dwnld-en.html#v313">Downloads</a></li>
 </ul>
 
 <section>

--- a/site/pages/test/test.hbs
+++ b/site/pages/test/test.hbs
@@ -2,7 +2,7 @@
 {
 	"title": "Mocha Tests",
 	"language": "en",
-	"altLangPrefix": "test",
+	"altLangPrefix": "../index",
 	"dateModified": "2014-04-23",
 	"js": "<%= mochaUrls %>",
 	"css": ["mocha"]


### PR DESCRIPTION
The previous performance issues have been mostly ironed out and the run only adds around 40 seconds to the build. I've pruned out some other fixes as @EricDunsworth fixed them in #6036.

@LaurentGoderre not sure if it's better to drop the Rake stuff, but that was how all the example config setups were done since it is a Ruby lib.
