### PR TITLE
formatting fix to stop travis scss lint failures

### DIFF
--- a/src/plugins/geomap/sprites/_sprites_geomap.scss
+++ b/src/plugins/geomap/sprites/_sprites_geomap.scss
@@ -1,0 +1,15 @@
+%_sprites_geomap_scss {
+	background: url("../assets/sprites_geomap.png") no-repeat;
+}
+
+%locate-active {
+	@extend %_sprites_geomap_scss;
+	background-position: 0 0;
+}
+
+%locate {
+	@extend %_sprites_geomap_scss;
+	background-position: 0 -40px;
+}
+
+


### PR DESCRIPTION
- Several builds now in WET Themes are failing do to SCSS lint issues that are occurring. This is a bit of a blind PR that corrects the spacing in hopes to allow other PR's to start building again.
