### PR TITLE
SCSSLint: Ignore Geomap sprite

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -3,6 +3,7 @@ exclude:
   - "node_modules/**"
   - "dist/**"
   - "src/plugins/share/sprites/**"
+  - "src/plugins/geomap/sprites/**"
   - "wet-boew-dist/**"
 
 linters:


### PR DESCRIPTION
Fix for failing theme repos. May be changed later if the sprites are combined
