### PR TITLE
Temporarily fix HTML minification

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -855,6 +855,7 @@ module.exports = (grunt) ->
 			options:
 				collapseWhitespace: true
 				preserveLineBreaks: true
+				preventAttributesEscaping: true
 			all:
 				cwd: "dist/unmin"
 				src: [

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-csslint": "~0.3.1",
     "grunt-contrib-cssmin": "^0.9.0",
-    "grunt-contrib-htmlmin": "^0.3.0",
+    "grunt-contrib-htmlmin": "wet-boew/grunt-contrib-htmlmin#custom",
     "grunt-contrib-imagemin": "~0.8.1",
     "grunt-contrib-jshint": "^0.10.0",
     "grunt-contrib-uglify": "~0.5.1",


### PR DESCRIPTION
Use a custom version of the html minification that prevents the escaping of JSON attributes. This can be reverted if the functionality lands upstream
