### PR TITLE
Data AJAX: Using .getAttribute instead of .data to retrieve data value to avoid caching by jQuery.

### DIFF
--- a/src/plugins/data-ajax/data-ajax.js
+++ b/src/plugins/data-ajax/data-ajax.js
@@ -39,9 +39,9 @@ var componentName = "wb-data-ajax",
 
 			$document.trigger({
 				type: "ajax-fetch.wb",
-				element: $( elm ),
+				element: $elm,
 				fetch: {
-					url: $elm.data( "ajax-" + ajaxType )
+					url: elm.getAttribute( "data-ajax-" + ajaxType )
 				}
 			});
 		}


### PR DESCRIPTION
Fixes #6072
