### PR TITLE
Fixed tests in browsers and SauceLabs

### DIFF
--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -283,7 +283,7 @@ var getUrlParts = function( url ) {
 
 				// If the selector returns no elements, remove the selector
 				} else {
-					this.remove( selector );
+					wb.remove( selector );
 				}
 			}
 		},


### PR DESCRIPTION
Using `this` can very problematic and is unsafe in many cases. In this case, it was causing a lot of issues with browser unit tests
