### PR TITLE
Chained Travis scripts to make it easier to find errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,7 @@ install:
   - bundle install
 
 script:
-  - scss-lint .
-  - travis_retry grunt travis
-  - bundle exec rake
+  - scss-lint . && travis_retry grunt travis && bundle exec rake
 
 after_success:
   - ./script/travis_artifacts.sh


### PR DESCRIPTION
Currently, one task failing does not stop the others from running which gives the illusion that the build passed when it didn't.
