### PR TITLE
Show warning when missing <main> element.

### DIFF
--- a/src/polyfills/datepicker/datepicker.js
+++ b/src/polyfills/datepicker/datepicker.js
@@ -79,7 +79,13 @@ var componentName = "wb-date",
 				// Disable the tabbing of all the links when calendar is hidden
 				$container.find( "a" ).attr( "tabindex", "-1" );
 
-				$( "main" ).after( $container );
+				var $main = $( "main" );
+
+				if (!$main.length) {
+					console.warn('<main> element is required for the datepicker to work properly.');
+				};
+
+				$main.after( $container );
 			}
 
 			if ( elmId ) {


### PR DESCRIPTION
There should be some sort of warning if you don't have a <main> element on the page.  The datepicker will fail in FF and Safari, if it is not present.  Perhaps we could change this to $( "body" )?
