### PR TITLE
Lightbox: Add ability to filter Ajax response to selector

### DIFF
--- a/site/pages/docs/ref/lightbox/lightbox-en.hbs
+++ b/site/pages/docs/ref/lightbox/lightbox-en.hbs
@@ -30,7 +30,7 @@
 		<h3>Single items</h3>
 		<ol>
 			<li>Add a link element to the page with the class <code>wb-lbx</code>.</li>
-			<li>Add an <code>href</code> attribute on the link element that points to the image (e.g., <code>href="demo/1_b.jpg"</code>), the file containing the content (e.g., <code>ajax/ajax.html</code>) or the id of the inline content (e.g., <code>href="#inline-content</code>).</li>
+			<li>Add an <code>href</code> attribute on the link element that points to the image (e.g., <code>href="demo/1_b.jpg"</code>), the file containing the content (e.g., <code>ajax/ajax.html</code>), an element within the file containing the content (e.g., <code>ajax/ajax.html#element</code>) or the id of the inline content (e.g., <code>href="#inline-content</code>).</li>
 			<li>Add a <code>title</code> attribute to the link element with the caption text.</li>
 		</ol>
 	</section>
@@ -39,7 +39,7 @@
 		<ol>
 			<li>Add a <code>section</code> or other element to the page with the classes <code>wb-lbx</code> and <code>lbx-gal</code>.</li>
 			<li>Add within the <code>section</code> or other element a link element for each item in the gallery.</li>
-			<li>Add an <code>href</code> attribute on each link element that points to the image (e.g., <code>href="demo/1_b.jpg"</code>), the file containing the content (e.g., <code>ajax/ajax.html</code>) or the id of the inline content (e.g., <code>href="#inline-content</code>).</li>
+			<li>Add an <code>href</code> attribute on each link element that points to the image (e.g., <code>href="demo/1_b.jpg"</code>), the file containing the content (e.g., <code>ajax/ajax.html</code>), an element within the file containing the content (e.g., <code>ajax/ajax.html#element</code>) or the id of the inline content (e.g., <code>href="#inline-content</code>).</li>
 			<li>Add a <code>title</code> attribute to each link element with the caption text.</li>
 		</ol>
 	</section>

--- a/src/plugins/lightbox/ajax/ajax4-en.html
+++ b/src/plugins/lightbox/ajax/ajax4-en.html
@@ -1,0 +1,16 @@
+<section>
+	<p>This content will not be shown for AJAX requests.</p>
+</section>
+
+<section id="modal" class="modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h2 class="modal-title">AJAX - Example 4</h2>
+	</header>
+	<div class="modal-body">
+		<p>This content will be shown for AJAX requests.</p>
+	</div>
+</section>
+
+<section>
+	<p>This content will not be shown for AJAX requests.</p>
+</section>

--- a/src/plugins/lightbox/ajax/ajax4-fr.html
+++ b/src/plugins/lightbox/ajax/ajax4-fr.html
@@ -1,0 +1,16 @@
+<section>
+	<p>Ce contenu ne sera pas affiché pour les requêtes AJAX.</p>
+</section>
+
+<section id="modal" class="modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h2 class="modal-title">AJAX - Exemple 4</h2>
+	</header>
+	<div class="modal-body">
+		<p>Ce contenu sera affiché pour les requêtes AJAX.</p>
+	</div>
+</section>
+
+<section>
+	<p>Ce contenu ne sera pas affiché pour les requêtes AJAX.</p>
+</section>

--- a/src/plugins/lightbox/lightbox-en.hbs
+++ b/src/plugins/lightbox/lightbox-en.hbs
@@ -107,6 +107,9 @@
 						</div>
 					</section>
 				</li>
+				<li>
+					<a class="wb-lbx" title="AJAX - Content fragment" href="ajax/ajax4-en.html#modal">AJAX - Content Fragment</a>
+				</li>
 			</ul>
 
 			<section>

--- a/src/plugins/lightbox/lightbox-fr.hbs
+++ b/src/plugins/lightbox/lightbox-fr.hbs
@@ -106,6 +106,9 @@
 						</div>
 					</section>
 				</li>
+				<li>
+					<a class="wb-lbx" title="AJAX - fragment contenu" href="ajax/ajax4-fr.html#modal">AJAX - fragment contenu</a>
+				</li>
 			</ul>
 
 			<section>

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -201,6 +201,16 @@ var componentName = "wb-lbx",
 							.first()
 							.attr( "id", "lbx-title" );
 					}
+				},
+				parseAjax: function( mfpResponse ) {
+					var urlHash = this.currItem.src.split( "#" )[ 1 ];
+
+					// Provide the ability to filter the AJAX response HTML
+					// by the URL hash
+					// TODO: Should be dealt with upstream by Magnific Popup
+					if ( urlHash ) {
+						mfpResponse.data = $( mfpResponse.data ).find( "#" + urlHash );
+					}
 				}
 			};
 		}


### PR DESCRIPTION
I need the ability to filter the Ajax response HTML to a particular 
selector before displaying it in the modal.

In the documentation for Magnific Popup [Ajax Type](http://dimsemenov.com/plugins/magnific-popup/documentation.html#ajax_type), it states you should do this 
via the parseAjax method.

I chose to include the data-\* on the anchor, since the target selector can
vary based on the resource.

Hopefully something to this effect can be worked into the code.

Thanks guys
