### PR TITLE
Details/summary polyfill: Set closed details visibility to hidden to make text nodes invisible (although still take up space)

### DIFF
--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -2,15 +2,21 @@
   WET-BOEW
   @title: Details/summary polyfill pre-Modernizr CSS
  */
+
 summary {
 	// Make sure summary remains visible
 	display: block !important;
+	visibility: visible !important;
 }
 
 details {
 	// Prevent FOUC
 	&:not([open]) {
+		visibility: hidden;
+
 		> {
+			// Need details and * to deal with specificity issues
+			details,
 			* {
 				display: none;
 			}
@@ -21,6 +27,8 @@ details {
 // Prevent FOUC when polyfill is disabled
 .wb-disable {
 	details {
+		visibility: visible !important;
+
 		> {
 			* {
 				display: block !important;

--- a/src/polyfills/details/_ie8.scss
+++ b/src/polyfills/details/_ie8.scss
@@ -4,14 +4,20 @@
  */
 .lt-ie9 {
 	details {
+		visibility: hidden;
+
 		> {
+			details,
 			* {
 				display: none;
 			}
 		}
 
 		&[open] {
+			visibility: visible;
+
 			> {
+				details,
 				* {
 					display: block !important;
 				}

--- a/src/polyfills/details/_noscript.scss
+++ b/src/polyfills/details/_noscript.scss
@@ -3,6 +3,8 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 details {
+	visibility: visible !important;
+
 	> {
 		* {
 			display: block !important;


### PR DESCRIPTION
Fixes #6166
