### PR TITLE
Footnotes: Updated ID guidance for multi-referenced footnotes in documentation.

### DIFF
--- a/site/pages/docs/ref/footnotes/footnotes-en.hbs
+++ b/site/pages/docs/ref/footnotes/footnotes-en.hbs
@@ -44,7 +44,7 @@
 	<section>
 	<h3>Footnote Indicators</h3>
 	<p>Footnotes are generally denoted by numbers, but may also be represented by other kinds of indicators, such as single letters or symbols.</p>
-	<p>The numbers used throughout this documentation's footnote examples (including numbers within IDs) can be safely subsituted with alternate kinds of indicators.</p>
+	<p>The numbers used throughout this documentation's footnote examples (including numbers within IDs) can be safely substituted with alternate kinds of indicators.</p>
 	</section>
 
 	<section>
@@ -61,7 +61,7 @@
 			<h4>Link to a Footnote</h4>
 			<p>Use the following code as a basis to link to a particular footnote.</p>
 			<pre><code>&lt;sup id="fn1-rf"&gt;&lt;a class="fn-lnk" href="#fn1"&gt;&lt;span class="wb-inv"&gt;Footnote &lt;/span&gt;1&lt;/a&gt;&lt;/sup&gt;</code></pre>
-			<p><strong>Note:</strong> The ID attributes of links to a multi-referenced footnote should contain an alphabetically-ordered letter just after the number (e.g. <code>id="fn2a-rf"</code>, <code>id="fn2b-rf"</code>, <code>id="fn2c-rf"</code>, etc) to make it possible to programmatically distinguish one referrer link from another.</p>
+			<p><strong>Note:</strong> The ID attributes of links to a multi-referenced footnote should contain a hyphen and a letter just after the indicator (e.g. <code>id="fn2-1-rf"</code>, <code>id="fn2-2-rf"</code>, <code>id="fn2-3-rf"</code>, etc) to make it possible to programmatically distinguish one referrer link from another.</p>
 		</section>
 
 		<section>
@@ -106,10 +106,10 @@
 <pre><code>&lt;dt&gt;Footnote 2&lt;/dt&gt;
 &lt;dd id="fn2"&gt;
 	&lt;p&gt;Example of a footnote being referenced by multiple pieces of content.&lt;/p&gt;
-	&lt;p class="fn-rtn"&gt;&lt;a href="#fn2a-rf"&gt;&lt;span class="wb-inv"&gt;Return to &lt;span&gt;first&lt;/span&gt; footnote &lt;/span&gt;2&lt;span class="wb-inv"&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+	&lt;p class="fn-rtn"&gt;&lt;a href="#fn2-1-rf"&gt;&lt;span class="wb-inv"&gt;Return to &lt;span&gt;first&lt;/span&gt; footnote &lt;/span&gt;2&lt;span class="wb-inv"&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;/dd&gt;</code></pre>
 
-			<p><strong>Note 1:</strong> The <code>href</code> attributes of return links in multi-referenced footnotes should always contain an "a" after the footnote number (e.g. <code>href="#fn2a-rf"</code>).</p>
+			<p><strong>Note 1:</strong> The <code>href</code> attributes of return links in multi-referenced footnotes should always contain "-1" after the footnote indicator (e.g. <code>href="#fn2-1-rf"</code>).</p>
 			<p><strong>Note 2:</strong> The return link text of multi-referenced footnotes should always contain <code>&lt;span&gt;first&lt;/span&gt;</code>, to specifically denote their default destinations when JavaScript support isn't present.</p>
 		</section>
 

--- a/site/pages/docs/ref/footnotes/footnotes-fr.hbs
+++ b/site/pages/docs/ref/footnotes/footnotes-fr.hbs
@@ -49,7 +49,7 @@
 		<p><strong>Needs translation</strong></p>
 		<h3>Footnote Indicators</h3>
 		<p>Footnotes are generally denoted by numbers, but may also be represented by other kinds of indicators, such as single letters or symbols.</p>
-		<p>The numbers used throughout this documentation's footnote examples (including numbers within IDs) can be safely subsituted with alternate kinds of indicators.</p>
+		<p>The numbers used throughout this documentation's footnote examples (including numbers within IDs) can be safely substituted with alternate kinds of indicators.</p>
 	</section>
 	</div>
 
@@ -69,7 +69,7 @@
 		<p>Utiliser le code suivant pour rechercher le lien vers une note de bas de page particulière.</p>
 		<pre><code>&lt;sup id="fn1-rf"&gt;&lt;a class="fn-lnk" href="#fn1"&gt;&lt;span class="wb-inv"&gt;Note de bas de page &lt;/span&gt;1&lt;/a&gt;&lt;/sup&gt;</code></pre>
 
-		<p><strong>Remarque&#160;:</strong> Les attributs ID des liens vers une note de bas de page multiréférentielle devraient contenir une lettre classée par ordre alphabétique placée juste après le nombre (par exemple&#160;: <code>id="fn2a-rf"</code>, <code>id="fn2b-rf"</code>, <code>id="fn2c-rf"</code>, etc.) afin de pouvoir faire, à l’aide d’un programme, la distinction entre les liens de référence.</p>
+		<p><strong>Remarque&#160;:</strong> Les attributs ID des liens vers une note de bas de page multiréférentielle devraient contenir un trait d'union et un numéro placée juste après l’indicateur (par exemple&#160;: <code>id="fn2-1-rf"</code>, <code>id="fn2-2-rf"</code>, <code>id="fn2-3-rf"</code>, etc.) afin de pouvoir faire, à l’aide d’un programme, la distinction entre les liens de référence.</p>
 	</section>
 
 	<div lang="en">
@@ -117,10 +117,10 @@
 			<pre><code>&lt;dt&gt;Note de bas de page 2&lt;/dt&gt;
 &lt;dd id="fn2"&gt;
 	&lt;p&gt;Exemple de note de bas de page qui comporte de nombreux liens.&lt;/p&gt;
-	&lt;p class="fn-rtn"&gt;&lt;a href="#fn2a-rf"&gt;&lt;span class="wb-inv"&gt;Retour à la &lt;span&gt;première&lt;/span&gt; référence de la note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/p&gt;
+	&lt;p class="fn-rtn"&gt;&lt;a href="#fn2-1-rf"&gt;&lt;span class="wb-inv"&gt;Retour à la &lt;span&gt;première&lt;/span&gt; référence de la note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/p&gt;
 &lt;/dd&gt;</code></pre>
 
-			<p><strong>Remarque&#160;:</strong> Les attributs <code>href</code> des liens retour dans des notes de bas de page multiréférentielles devraient toujours contenir un « a » après le numéro de la note de bas de page (p. ex. <code>href="#fn2a-rf"</code>).</p>
+			<p><strong>Remarque&#160;:</strong> Les attributs <code>href</code> des liens retour dans des notes de bas de page multiréférentielles devraient toujours contenir «&#160;-1&#160;» après l’indicateur de la note de bas de page (p. ex. <code>href="#fn2-1-rf"</code>).</p>
 			<p><strong>Remarque 2&#160;:</strong> Le texte du lien retour de notes de bas de page multiréférentielles devrait toujours contenir <code>&lt;span&gt;première&lt;/span&gt;</code>, pour désigner spécifiquement leurs destinations par défaut quand il n’y a pas de prise en charge de JavaScript.</p>
 		</section>
 


### PR DESCRIPTION
Forgot to update guidance for it in #4019 (which resolved #3257).
