### PR TITLE
Geomap: Addition of srsCode property to the proj4 object.

### DIFF
--- a/src/plugins/deps/geomap-lib.js
+++ b/src/plugins/deps/geomap-lib.js
@@ -117,11 +117,13 @@ var componentName = "wb-geomap",
 			// Bind the merged settings to the element node for faster access in other events.
 			$elm.data( { settings: settings } );
 
-			// Set the proj4 dependency name to match OpenLayers
+			// Set the proj4s object so that openlayers can use proj4.
 			window.Proj4js = {
 				Proj: function( code ) {
-					return proj4( window.Proj4js.defs[ code ] );
-				},
+				var newProj4 = proj4( window.Proj4js.defs[ code ] );
+					newProj4.srsCode = code;
+					return newProj4;
+					},
 				defs: proj4.defs,
 				transform: proj4
 			};


### PR DESCRIPTION
Fixes #6117
Addition of srsCode property to the proj4 object. OL needs this property in order to be able to load ArcGis Mapserver layer.
