### PR TITLE
Lightbox: Add example for multimedia player in lightbox

### DIFF
--- a/src/plugins/lightbox/ajax/video-en.html
+++ b/src/plugins/lightbox/ajax/video-en.html
@@ -1,0 +1,16 @@
+<section class="modal-dialog modal-content overlay-def col-md-6">
+	<header class="modal-header">
+		<h2 class="modal-title">AJAX - Example of Multimedia Player in Lightbox</h2>
+	</header>
+	<div class="modal-body">
+		<figure class="wb-mltmd" data-wb-mltmd='{"shareUrl": "http://youtu.be/p2-1ZIHu1W0"}'>
+			<video poster="http://www.servicecanada.gc.ca/eng/video/images/te-lj-eng.jpg" title="Looking for a Job">
+				<source type="video/webm" src="http://video2.servicecanada.gc.ca/video/boew-wet/te-lj-eng.webm" />
+				<source type="video/mp4" src="http://video2.servicecanada.gc.ca/video/boew-wet/te-lj-eng.mp4" />
+			</video>
+			<figcaption>
+				<p>Looking for a Job (<a href="http://www.servicecanada.gc.ca/eng/video/lj.shtml">Transcript</a>)</p>
+			</figcaption>
+		</figure>
+	</div>
+</section>

--- a/src/plugins/lightbox/ajax/video-fr.html
+++ b/src/plugins/lightbox/ajax/video-fr.html
@@ -1,0 +1,15 @@
+<section class="modal-dialog modal-content overlay-def col-md-6">
+	<header class="modal-header">
+		<h2 class="modal-title">AJAX - Exemple d'un lecteur multimédia dans un lightbox</h2>
+	</header>
+	<div class="modal-body">
+		<figure class="wb-mltmd" data-wb-mltmd='{"shareUrl": "http://youtu.be/6hvfIm4eEdI"}'>
+			<video poster="http://www.servicecanada.gc.ca/fra/video/images/te-lj-fra.jpg" title="Trouver un emploi">
+				<source type="video/mp4" src="http://video2.servicecanada.gc.ca/video/boew-wet/te-lj-fra.mp4" />
+			</video>			
+			<figcaption>
+				<p>Trouver un emploi (<a href="http://www.servicecanada.gc.ca/fra/video/te.shtml">Transcription</a>)</p>
+			</figcaption>
+		</figure>
+	</div>
+</section>

--- a/src/plugins/lightbox/demo/lightbox.js
+++ b/src/plugins/lightbox/demo/lightbox.js
@@ -76,4 +76,9 @@ $document.on( "click vclick", "#lbx-open-btn", function( event ) {
 	}
 });
 
+// Trigger multimedia player when ajax video is loaded in a lightbox
+$( ".wb-lbx" ).on( "mfpAjaxContentAdded", function(e) {
+	$( ".mfp-content" ).find( ".wb-mltmd" ).trigger( "wb-init.wb-mltmd" );
+});
+
 })( jQuery, wb );

--- a/src/plugins/lightbox/lightbox-en.hbs
+++ b/src/plugins/lightbox/lightbox-en.hbs
@@ -57,6 +57,9 @@
 					<a class="wb-lbx" title="AJAX - Example 1 of AJAX content" href="ajax/ajax1-en.html">AJAX - Example 1</a>
 				</li>
 				<li>
+					<a class="wb-lbx" title="AJAX - Example of Multimedia Player" href="ajax/video-en.html">AJAX - Video</a>
+				</li>
+				<li>
 					AJAX - override default behaviour of image link with lbx-ajax<br />
 					<a class="wb-lbx lbx-ajax" title="AJAX - Example 1 of AJAX content" href="ajax/ajax1-en.html"><img src="demo/1_s.jpg" alt="Image 1" /></a>
 				</li>
@@ -127,6 +130,13 @@
 		&lt;a class="wb-lbx" title="AJAX - Example 1 of AJAX content" href="ajax/ajax-en.html"&gt;AJAX - Example 1&lt;/a&gt;
 	&lt;/li&gt;
 	&lt;li&gt;
+		&lt;a class="wb-lbx" title="AJAX - Example of Multimedia Player" href="ajax/video.html"&gt;AJAX - Video&lt;/a&gt;
+	&lt;/li&gt;
+	&lt;li&gt;
+		AJAX - override default behaviour of image link with lbx-ajax&lt;br /&gt;
+		&lt;a class="wb-lbx lbx-ajax" title="AJAX - Example 1 of AJAX content" href="ajax/ajax1-en.html"&gt;&lt;img src="demo/1_s.jpg" alt="Image 1" /&gt;&lt;/a&gt;
+	&lt;/li&gt;
+	&lt;li&gt;
 		&lt;a class="wb-lbx" title="Example of inline content" href="#inline_content"&gt;Inline content&lt;/a&gt;
 		&lt;section id="inline_content" class="mfp-hide modal-dialog modal-content overlay-def"&gt;
 			&lt;header class="modal-header"&gt;
@@ -149,7 +159,14 @@
 			&lt;/div&gt;
 		&lt;/section&gt;
 	&lt;/li&gt;
-&lt;/ul&gt;</code></pre>
+&lt;/ul&gt;
+&lt;script&gt;
+// JavaScript code required to initialise multimedia player in lightbox
+$( ".wb-lbx" ).on( "mfpAjaxContentAdded", function(e) {
+	$( ".mfp-content" ).find( ".wb-mltmd" ).trigger( "wb-init.wb-mltmd" );
+});
+&lt;/script&gt;
+</code></pre>
 				</details>
 			</section>
 		</section>

--- a/src/plugins/lightbox/lightbox-fr.hbs
+++ b/src/plugins/lightbox/lightbox-fr.hbs
@@ -57,6 +57,9 @@
 					<a class="wb-lbx" title="AJAX - Exemple 1 de contenu AJAX" href="ajax/ajax1-fr.html">AJAX - Exemple 1</a>
 				</li>
 				<li>
+					<a class="wb-lbx" title="AJAX - Exemple d'un lecteur multimédia" href="ajax/video-fr.html">AJAX - Exemple d'un lecteur multimédia dans un lightbox</a>
+				</li>
+				<li>
 					AJAX - remplacer le comportement par defaut d'un lien sur une image avec lbx-ajax<br />
 					<a class="wb-lbx lbx-ajax" title="AJAX - Exemple 1 de contenu AJAX" href="ajax/ajax1-fr.html"><img src="demo/1_s.jpg" alt="Image 1" /></a>
 				</li>
@@ -126,6 +129,13 @@
 		&lt;a class="wb-lbx" title="Exemple de contenu AJAX" href="ajax/ajax-en.html"&gt;Contenu AJAX&lt;/a&gt;
 	&lt;/li&gt;
 	&lt;li&gt;
+		&lt;a class="wb-lbx" title="AJAX - Exemple d'un lecteur multimédia" href="ajax/video.html"&gt;AJAX - Exemple d'un lecteur multimédia dans un lightbox&lt;/a&gt;
+	&lt;/li&gt;
+	&lt;li&gt;
+		AJAX - remplacer le comportement par defaut d'un lien sur une image avec lbx-ajax&lt;br /&gt;
+		&lt;a class="wb-lbx lbx-ajax" title="AJAX - Exemple 1 de contenu AJAX" href="ajax/ajax1-en.html"&gt;&lt;img src="demo/1_s.jpg" alt="Image 1" /&gt;&lt;/a&gt;
+	&lt;/li&gt;
+	&lt;li&gt;
 		&lt;a class="wb-lbx" title="Exemple de contenu incorporé" href="#inline_content"&gt;Contenu incorporé&lt;/a&gt;
 
 		&lt;div id="inline_content" class="mfp-hide modal-dialog modal-content overlay-def"&gt;
@@ -154,7 +164,13 @@
 			&lt;/section&gt;
 		&lt;/div&gt;
 	&lt;/li&gt;
-&lt;/ul&gt;</code></pre>
+&lt;/ul&gt;
+&lt;script&gt;
+// Code JavaScript requis pour initialiser un lecteur multimédia dans un lightbox
+$( ".wb-lbx" ).on( "mfpAjaxContentAdded", function(e) {
+	$( ".mfp-content" ).find( ".wb-mltmd" ).trigger( "wb-init.wb-mltmd" );
+});
+&lt;/script&gt;</code></pre>
 				</details>
 			</section>
 		</section>


### PR DESCRIPTION
Added an example to load a multimedia player in a lightbox
@LaurentGoderre This example can help reproduce the error where the Flash fallback loads instead of HTML5 the second time the lightbox containing a video loads
