### PR TITLE
[Carousel style 2] Added an option to toggle thumbnail controls on medium-and-above screens.

### DIFF
--- a/src/plugins/tabs/_screen-md-min.scss
+++ b/src/plugins/tabs/_screen-md-min.scss
@@ -30,4 +30,22 @@
 			@extend %tabs-screen-md-min-details;
 		}
 	}
+	
+	&.carousel-s2 {
+		&.show-thumbs {
+			[role="tablist"] {
+				li {
+					&[role="presentation"] {
+						display: inline-block;
+					}
+
+					&.prv,
+					&.tab-count,
+					&.nxt {
+						display: none;
+					}
+				}
+			}
+		}
+	}
 }

--- a/src/plugins/tabs/tabs-carousel-en.hbs
+++ b/src/plugins/tabs/tabs-carousel-en.hbs
@@ -184,6 +184,89 @@
 </section>
 
 <section>
+	<h2 id="carousel-s2-thmb">Carousel style 2 with thumbnails example (<code>carousel-s2 show-thumbs</code>)</h2>
+	<div class="wb-tabs carousel-s2 show-thumbs">
+		<ul role="tablist">
+			<li class="active"><a href="#panel30"><img src="img/protect-environment.jpg" alt="tab 1" /></a></li>
+			<li><a href="#panel31"><img src="img/banff.jpg" alt="tab 2" /></a></li>
+			<li><a href="#panel32"><img src="img/investinourfuture.jpg" alt="tab 3" /></a></li>
+		</ul>
+		<div class="tabpanels">
+			<div role="tabpanel" id="panel30" class="in fade">
+				<figure>
+					<img src="img/protect-environment.jpg" alt="Panel 1" />
+					<figcaption>
+						<p>
+							Take Note: <a href="http://www.tc.gc.ca/eng/civilaviation/opssvs/general-personnel-changes-1814.htm">Renewal of the Aviation Document Booklet</a>&#160;<br />
+							Learn more about&#160;<a href="http://www.tc.gc.ca/eng/air-menu.htm">air transportation</a> in Canada.
+						</p>
+					</figcaption>
+				</figure>
+			</div>
+			<div role="tabpanel" id="panel31" class="out fade">
+				<figure>
+					<img src="img/banff.jpg" alt="Panel 2" />
+					<figcaption>
+						<p>
+							Take Note: <a href="http://www.tc.gc.ca/eng/railsafety/publications-46.htm">Grade Crossing Improvement Program (GCIP)</a><br />
+							Learn more about <a href="http://www.tc.gc.ca/eng/rail-menu.htm">rail transportation</a> in Canada.
+						</p>
+					</figcaption>
+				</figure>
+			</div>
+			<div role="tabpanel" id="panel32" class="out fade">
+				<figure>
+					<img src="img/investinourfuture.jpg" alt="Panel 3" />
+					<figcaption>
+						<p>
+							Take Note: <a href="http://www.tc.gc.ca/eng/tankersafetyexpertpanel/menu.htm">Tanker Safety Expert Panel</a><br />
+							Learn more about&#160;<a href="http://www.tc.gc.ca/eng/marine-menu.htm">marine transportation</a> in Canada.
+						</p>
+					</figcaption>
+				</figure>
+			</div>
+		</div>
+	</div>
+
+	<section>
+		<h3>Code</h3>
+		<details>
+			<summary>View code</summary>
+			<pre><code>&lt;div class=&quot;wb-tabs carousel-s2&quot;&gt;
+	&lt;ul role=&quot;tablist&quot;&gt;
+		&lt;li class=&quot;active&quot;&gt;&lt;a href=&quot;#panel30&quot;&gt;&lt;img src=&quot;img/protect-environment.jpg&quot; alt=&quot;tab 1&quot; /&gt;&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#panel31&quot;&gt;&lt;img src=&quot;img/banff.jpg&quot; alt=&quot;tab 2&quot; /&gt;&lt;/a&gt;&lt;/li&gt;
+		...
+	&lt;/ul&gt;
+	&lt;div class=&quot;tabpanels&quot;&gt;
+		&lt;div role=&quot;tabpanel&quot; id=&quot;panel30&quot; class=&quot;in fade&quot;&gt;
+			&lt;figure&gt;
+				&lt;img src=&quot;img/protect-environment.jpg&quot; alt=&quot;Panel 1&quot; /&gt;
+				&lt;figcaption&gt;
+					&lt;p&gt;
+						...
+					&lt;/p&gt;
+				&lt;/figcaption&gt;
+			&lt;/figure&gt;
+		&lt;/div&gt;
+		&lt;div role=&quot;tabpanel&quot; id=&quot;panel31&quot; class=&quot;out fade&quot;&gt;
+			&lt;figure&gt;
+				&lt;img src=&quot;img/banff.jpg&quot; alt=&quot;Panel 2&quot; /&gt;
+				&lt;figcaption&gt;
+					&lt;p&gt;
+						...
+					&lt;/p&gt;
+				&lt;/figcaption&gt;
+			&lt;/figure&gt;
+		&lt;/div&gt;
+		...
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+		</details>
+	</section>
+</section>
+
+<section>
 	<h2>Grids example</h2>
 	<div class="row">
 		<section class="col-sm-6 col-md-4">

--- a/src/plugins/tabs/tabs-carousel-fr.hbs
+++ b/src/plugins/tabs/tabs-carousel-fr.hbs
@@ -184,6 +184,89 @@
 </section>
 
 <section>
+	<h2 id="carousel-s2-thmb">Carrousel - Style 2 avec imagette - Exemple (<code>carousel-s2 show-thumbs</code>)</h2>
+	<div class="wb-tabs carousel-s2 show-thumbs">
+		<ul role="tablist">
+			<li class="active"><a href="#panel30"><img src="img/protect-environment.jpg" alt="onglet 1" /></a></li>
+			<li><a href="#panel31"><img src="img/banff.jpg" alt="onglet 2" /></a></li>
+			<li><a href="#panel32"><img src="img/investinourfuture.jpg" alt="onglet 3" /></a></li>
+		</ul>
+		<div class="tabpanels">
+			<div role="tabpanel" id="panel30" class="in fade">
+				<figure>
+					<img src="img/protect-environment.jpg" alt="Panneau 1" />
+					<figcaption>
+						<p>
+							Prenez note : <a href="http://www.tc.gc.ca/fra/aviationcivile/opssvs/generale-personnel-changements-1814.htm">Renouvellement du carnet de documents d'aviation</a><br />
+							En savoir plus sur <a href="http://www.tc.gc.ca/fra/aerien-menu.htm">le transport aérien</a> au Canada.
+						</p>
+					</figcaption>
+				</figure>
+			</div>
+			<div role="tabpanel" id="panel31" class="out fade">
+				<figure>
+					<img src="img/banff.jpg" alt="Panneau 2" />
+					<figcaption>
+						<p>
+							Prenez note : <a href="http://www.tc.gc.ca/fra/securiteferroviaire/publications-46.htm">Programme d'amélioration des passages à niveau (PAPN)</a><br />
+							En savoir plus sur <a href="http://www.tc.gc.ca/fra/ferroviaire-menu.htm">le transport ferroviaire</a> au Canada.
+						</p>
+					</figcaption>
+				</figure>
+			</div>
+			<div role="tabpanel" id="panel32" class="out fade">
+				<figure>
+					<img src="img/investinourfuture.jpg" alt="Panneau 3" />
+					<figcaption>
+						<p>
+							Prenez note : <a href="http://www.tc.gc.ca/fra/comiteexpertssecuritenaviresciternes/menu.htm">Tanker Groupe d'experts sur la sécurité</a><br />
+							En savoir plus sur <a href="http://www.tc.gc.ca/fra/maritime-menu.htm">le transport maritime</a> au Canada.
+						</p>
+					</figcaption>
+				</figure>
+			</div>
+		</div>
+	</div>
+
+	<section>
+		<h3>Code</h3>
+		<details>
+			<summary>Visualiser le code</summary>
+			<pre><code>&lt;div class=&quot;wb-tabs carousel-s2&quot;&gt;
+	&lt;ul role=&quot;tablist&quot;&gt;
+		&lt;li class=&quot;active&quot;&gt;&lt;a href=&quot;#panel30&quot;&gt;&lt;img src=&quot;img/protect-environment.jpg&quot; alt=&quot;onglet 1&quot; /&gt;&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;#panel31&quot;&gt;&lt;img src=&quot;img/banff.jpg&quot; alt=&quot;onglet 2&quot; /&gt;&lt;/a&gt;&lt;/li&gt;
+		...
+	&lt;/ul&gt;
+	&lt;div class=&quot;tabpanels&quot;&gt;
+		&lt;div role=&quot;tabpanel&quot; id=&quot;panel30&quot; class=&quot;in fade&quot;&gt;
+			&lt;figure&gt;
+				&lt;img src=&quot;img/protect-environment.jpg&quot; alt=&quot;Panneau 1&quot; /&gt;
+				&lt;figcaption&gt;
+					&lt;p&gt;
+						...
+					&lt;/p&gt;
+				&lt;/figcaption&gt;
+			&lt;/figure&gt;
+		&lt;/div&gt;
+		&lt;div role=&quot;tabpanel&quot; id=&quot;panel31&quot; class=&quot;out fade&quot;&gt;
+			&lt;figure&gt;
+				&lt;img src=&quot;img/banff.jpg&quot; alt=&quot;Panneau 2&quot; /&gt;
+				&lt;figcaption&gt;
+					&lt;p&gt;
+						...
+					&lt;/p&gt;
+				&lt;/figcaption&gt;
+			&lt;/figure&gt;
+		&lt;/div&gt;
+		...
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+		</details>
+	</section>
+</section>
+
+<section>
 	<h2>Exemple en grilles</h2>
 	<div class="row">
 		<section class="col-sm-6 col-md-4">


### PR DESCRIPTION
**Done:**
- Added CSS to hide the `item n of x` controls and display the thumbnail controls when class `show-thumbs` is added to carousel style 2.
- Updated the working examples to include an example of the carousel style 2 with thumbnails.

**To do:**
- Style the thumbnails so that they appear at the correct size and in the correct location.
- Update the documentation.

cc/@zachfalsetto
