### PR TITLE
Feeds: Fixed bug in processEntries()

### DIFF
--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -316,7 +316,6 @@ var componentName = "wb-feeds",
 				return compare( b.publishedDate, a.publishedDate );
 			});
 			parseEntries( entries, $content.data( "startAt" ), $content.data( "displayLimit" ), $content.data("loadLimit"), $content, $content.data( "feedType" ) );
-			return 0;
 		}
 
 		toProcess -= 1 ;


### PR DESCRIPTION
When multiple feeds are included in one feed widget, the entries for the last feed were never stored in memory.

Part of #6173.
