### PR TITLE
Fix details background disappearing in collapsible alerts

### DIFF
--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -22,6 +22,12 @@ details {
 			}
 		}
 	}
+
+	&.alert {
+		&:not([open]) {
+			visibility: visible;
+		}
+	}
 }
 
 .tabpanels {

--- a/src/polyfills/details/_ie8.scss
+++ b/src/polyfills/details/_ie8.scss
@@ -23,5 +23,9 @@
 				}
 			}
 		}
+
+		&.alert {
+			visibility: visible;
+		}
 	}
 }


### PR DESCRIPTION
This fixes an issue introduced with commit: https://github.com/wet-boew/wet-boew/commit/b93001a45b02a9344447e25600549489069f3547

See issue: https://github.com/wet-boew/wet-boew/issues/6339
