### PR TITLE
Feeds: Fixed bug in processEntries().

### DIFF
--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -323,6 +323,8 @@ var componentName = "wb-feeds",
 				entries.length = $content.data( "loadLimit" );
 			}
 
+			$content.data( "entries", entries );
+
 			parseEntries( entries, $content.data( "startAt" ), $content.data( "displayLimit" ), $content.data("loadLimit"), $content, $content.data( "feedType" ) );
 		}
 


### PR DESCRIPTION
`$elm.data( "entries" )` was relied upon for the pagination but wasn't updated with the latest entries until the end of `processEntries()`.

For #6173.
