### PR TITLE
Form Validation: Allow using the styles without using the Javascript part

### DIFF
--- a/src/plugins/formvalid/_base.scss
+++ b/src/plugins/formvalid/_base.scss
@@ -11,7 +11,8 @@
 	font-size: 100%;
 }
 
-.wb-frmvld {
+.wb-frmvld,
+.wb-frm {
 	label {
 		strong {
 			&.error {


### PR DESCRIPTION
By using the `wb-frm` class you can now access the form validation styles without using the validation portion.
Fixes #6292
