### PR TITLE
Fixed generation of unique id values

### DIFF
--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -1094,7 +1094,7 @@
 	 * Originally from http://stackoverflow.com/a/2117523/455535
 	 */
 	wb.guid = function() {
-		return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function( replacementChar ) {
+		return "wb-xxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function( replacementChar ) {
 			var rand = Math.random() * 16 | 0,
 				newChar = replacementChar === "x" ? rand : ( rand & 0x3 | 0x8 );
 			return newChar.toString(16);


### PR DESCRIPTION
Fixes #6371.

This resolves an odd bug where the guid() function on occasion generates unique id values that start with a number, which can trip up querySelector and querySelectorAll.

/cc @LaurentGoderre
