### PR TITLE
Revert "CSS: Optimize tabs CSS"

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "grunt-jscs": "^0.7.1",
     "grunt-mocha": "~0.4.1",
     "grunt-modernizr": "~0.5.2",
-    "grunt-sass": "^0.16.1",
+    "grunt-sass": "^0.14.1",
     "grunt-saucelabs": "^8.2.0",
     "grunt-wget": "~0.1.0",
     "grunt-wet-boew-postbuild": "wet-boew/grunt-wet-boew-postbuild#v0.1.2",

--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -43,21 +43,6 @@ $medGray: #ccc;
 	}
 }
 
-%tab-figure {
-	figure {
-		@extend %tabs-position-relative;
-		@extend %tab-background-243850;
-	}
-
-	figcaption {
-		@extend %tab-figure-captions;
-
-		p {
-			@extend %tabs-margin-bottom-0;
-		}
-	}
-}
-
 %carousel-s2-prv-nxt-common {
 	background: none;
 	margin: 0;
@@ -232,8 +217,6 @@ $medGray: #ccc;
 	 * Style 1 - Basic carousel style
 	 */
 	&.carousel-s1 {
-		@extend %tab-figure;
-
 		border-top: 0;
 
 		[role="tablist"] {
@@ -283,14 +266,25 @@ $medGray: #ccc;
 				}
 			}
 		}
+
+		figure {
+			@extend %tabs-position-relative;
+			@extend %tab-background-243850;
+		}
+
+		figcaption {
+			@extend %tab-figure-captions;
+
+			p {
+				@extend %tabs-margin-bottom-0;
+			}
+		}
 	}
 
 	/**
 	 * Style 2 - Slider-like carousel style
 	 */
 	&.carousel-s2 {
-		@extend %tab-figure;
-
 		background: #eee;
 		padding-bottom: 4.375em;
 
@@ -381,14 +375,23 @@ $medGray: #ccc;
 		}
 
 		figure {
+			@extend %tabs-position-relative;
+			@extend %tab-background-243850;
+
 			img {
 				@extend %tab-width-100-height-auto;
 			}
 		}
 
 		figcaption {
+			@extend %tab-figure-captions;
+
 			a {
 				@extend %tab-figure-captions-links;
+			}
+
+			p {
+				@extend %tabs-margin-bottom-0;
 			}
 		}
 	}


### PR DESCRIPTION
Reverts wet-boew/wet-boew#6419

This is being reverted because the version bump is breaking the Tabbed interface examples. It is incorrectly generating the CSS.

``` scss
%tabs-screen-md-min-details {
    > {
        details {
            border: 1px solid #ccc;
            display: none;

            &[open] {
                display: block;

                > {
                    summary {
                        display: none !important;
                    }
                }
            }
        }
    }
}

.wb-tabs {
    @extend %tabs-screen-md-min-details; /* Only for backwards compatibility. Should be removed in v4.1. */

    > {
        .tabpanels {
            @extend %tabs-screen-md-min-details;
        }
    }
```

The above code previously generated:

``` css
.wb-tabs > .tabpanels > details {
    border: 1px solid #ccc;
    display: none;
}
.wb-tabs > .tabpanels > details[open] {
    display:block;
}
```

With the version bump it generated:

``` css
.wb-tabs > .tabpanels > details {
    border: 1px solid #ccc;
    display: none;
}
details[open] {
    display:block;
}
```

The end result is the details never got displayed because there was not enough specificity with the open attribute. We can't use the newer version until this issue is resolved.
