### PR TITLE
Responsive tables - Initial commits - dev version

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -1,0 +1,31 @@
+{
+    "adjoining-classes": false,
+    "box-model": false,
+    "box-sizing": false,
+    "compatible-vendor-prefixes": false,
+    "duplicate-background-images": false,
+    "duplicate-properties": false,
+    "empty-rules": false,
+    "fallback-colors": false,
+    "floats": false,
+    "font-sizes": false,
+    "gradients": false,
+    "headings": false,
+    "ids": false,
+    "important": false,
+    // Need due to use of "\9" hacks for oldIE
+    "known-properties": false,
+    "outline-none": false,
+    "overqualified-elements": false,
+    "qualified-headings": false,
+    "regex-selectors": false,
+    "selector-max-approaching": false,
+    // Some Bootstrap mixins end up listing all the longhand properties
+    "shorthand": false,
+    "text-indent": false,
+    "unique-headings": false,
+    "universal-selector": false,
+    "unqualified-attributes": false,
+    // Zeros are output by some of the Bootstrap mixins, but shouldn't be used in our code
+    "zero-units": false
+}

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -984,6 +984,10 @@ module.exports = (grunt) ->
 						"DataTables/media/js/jquery.dataTables.js"
 						"proj4/dist/proj4.js"
 						"openlayers/OpenLayers.debug.js"
+						"tablesaw/dist/stackonly/tablesaw.stackonly.js"
+						"tablesaw/dist/customresponsive/tablesaw.customresponsive.js"
+						"tablesaw/dist/sortable/tablesaw.sortable.js"
+						"tablesaw/dist/tablesaw.css"
 					]
 					dest: "dist/unmin/js/deps"
 					rename: (dest, src) ->

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -35,9 +35,9 @@ module.exports = (grunt) ->
 			"checkDependencies"
 			"clean:dist"
 			"assets"
+			"sprites"
 			"css"
 			"js"
-			"imagemin"
 		]
 	)
 
@@ -48,6 +48,7 @@ module.exports = (grunt) ->
 			"js-min"
 			"css-min"
 			"assets-min"
+			"imagemin"
 		]
 	)
 
@@ -97,7 +98,8 @@ module.exports = (grunt) ->
 		"server"
 		"Run the Connect web server for local repo"
 		[
-			"connect:server:keepalive"
+			"connect:server"
+			"watch"
 		]
 	)
 
@@ -139,8 +141,7 @@ module.exports = (grunt) ->
 		"css"
 		"INTERNAL: Compiles Sass and copies third party CSS to the dist folder"
 		[
-			"sprites"
-			"sass:all"
+			"sass"
 			"autoprefixer"
 			"csslint:unmin"
 			"usebanner:css"
@@ -630,32 +631,19 @@ module.exports = (grunt) ->
 						"opera 12.1"
 					]
 				files: [
-					cwd: "dist/unmin/css"
-					src: [
-						"**/*.css"
-						"!**/polyfills/**/*.css"
-						"!**/*.min.css"
-					]
-					dest: "dist/unmin/css"
-					expand: true
-					flatten: true
-				,
 					cwd: "dist/unmin/css/polyfills"
 					src: [
 						"**/*.css"
-						"!**/*.min.css"
 					]
 					dest: "dist/unmin/css/polyfills/"
 					expand: true
 				,
-					cwd: "dist/unmin/demos"
-					src: "**/*.css"
-					dest: "dist/unmin/demos/"
-					expand: true
-				,
-					cwd: "dist/unmin/docs"
-					src: "**/*.css"
-					dest: "dist/unmin/docs/"
+					cwd: "dist/unmin/"
+					src: [
+						"demos/**/*.css"
+						"docs/**/*.css"
+					]
+					dest: "dist/unmin/"
 					expand: true
 				]
 
@@ -675,36 +663,7 @@ module.exports = (grunt) ->
 
 		csslint:
 			options:
-				"adjoining-classes": false
-				"box-model": false
-				"box-sizing": false
-				"compatible-vendor-prefixes": false
-				"duplicate-background-images": false
-				"duplicate-properties": false
-				# Can be turned off after https://github.com/dimsemenov/Magnific-Popup/pull/303 lands
-				"empty-rules": false
-				"fallback-colors": false
-				"floats": false
-				"font-sizes": false
-				"gradients": false
-				"headings": false
-				"ids": false
-				"important": false
-				# Need due to use of "\9" hacks for oldIE
-				"known-properties": false
-				"outline-none": false
-				"overqualified-elements": false
-				"qualified-headings": false
-				"regex-selectors": false
-				"selector-max-approaching": false
-				# Some Bootstrap mixins end up listing all the longhand properties
-				"shorthand": false
-				"text-indent": false
-				"unique-headings": false
-				"universal-selector": false
-				"unqualified-attributes": false
-				# Zeros are output by some of the Bootstrap mixins, but shouldn't be used in our code
-				"zero-units": false
+				csslintrc: ".csslintrc"
 
 			unmin:
 				options:
@@ -713,7 +672,7 @@ module.exports = (grunt) ->
 						id: "csslint-xml"
 						dest: "csslint-unmin.log"
 					]
-				src: "dist/unmin/css/*.css"
+				src: "dist/unmin/css/**/*.css"
 
 			demos:
 				options:
@@ -1146,46 +1105,32 @@ module.exports = (grunt) ->
 			dist: ["dist", "src/base/partials/*sprites*"]
 
 		watch:
-			lib_test:
-				files: "<%= jshint.lib_test.src %>"
-				tasks: "jshint:lib_test"
-
-			source:
+			options:
+				livereload: true
+			js:
+				files: "<%= jshint.all.src %>"
+				tasks: "js"
+			css:
 				files: [
-					"src/**/*.*"
-					"!src/**/*sprites*"
+					"src/**/*.scss"
+					"site/**/*.scss"
+					"theme/**/*.scss"
 				]
-				tasks: "dist"
-				options:
-					interval: 5007
-					livereload: true
+				tasks: "css"
 
 			demos:
-				files: [
-					"<%= assemble.demos.src %>"
-				]
-				tasks: [
-					"pages:demos"
-				]
-				options:
-					interval: 5007
-					livereload: true
+				files: "src/**/*.hbs"
+				tasks: "pages:demos"
 
 			docs:
-				files: [
-					"<%= assemble.docs.src %>"
-				]
-				tasks: [
-					"pages:docs"
-				]
-				options:
-					livereload: true
+				files: "site/pages/docs/**/*.hbs"
+				tasks: "pages:docs"
 
 		jshint:
 			options:
 				jshintrc: ".jshintrc"
 
-			lib_test:
+			all:
 				src: [
 					"src/**/*.js"
 					"theme/**/*.js"
@@ -1198,7 +1143,7 @@ module.exports = (grunt) ->
 					config: ".jscsrc"
 
 				src: [
-					"<%= jshint.lib_test.src %>"
+					"<%= jshint.all.src %>"
 				]
 
 		connect:

--- a/bower.json
+++ b/bower.json
@@ -38,7 +38,8 @@
     "proj4": "2.1.0",
     "respond": "1.4.0",
     "selectivizr": "1.0.2",
-    "SideBySideImproved": "https://github.com/pkoltermann/SideBySideImproved.git"
+    "SideBySideImproved": "https://github.com/pkoltermann/SideBySideImproved.git",
+	"tablesaw": "https://github.com/duboisp/tablesaw.git#master"
   },
   "moduleType": [
     "globals"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "grunt-contrib-concat": "~0.5.0",
     "grunt-contrib-connect": "~0.8.0",
     "grunt-contrib-copy": "~0.5.0",
-    "grunt-contrib-csslint": "~0.3.1",
+    "grunt-contrib-csslint": "~0.4.0",
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-htmlmin": "wet-boew/grunt-contrib-htmlmin#custom",
     "grunt-contrib-imagemin": "~0.9.2",

--- a/src/plugins/footnotes/_print.scss
+++ b/src/plugins/footnotes/_print.scss
@@ -30,6 +30,10 @@
 
 		a {
 			@extend %fnote-print-link-background-transparent-border-0-padding-0;
+
+			&:after {
+				content: none;
+			}
 		}
 	}
 }

--- a/src/plugins/geomap/_base.scss
+++ b/src/plugins/geomap/_base.scss
@@ -142,6 +142,7 @@
 
 .olControlAttribution {
 	bottom: 5px;
+	font-size: x-small;
 	right: 5px;
 }
 

--- a/src/plugins/tablesaw/tablesaw-en.hbs
+++ b/src/plugins/tablesaw/tablesaw-en.hbs
@@ -1,0 +1,868 @@
+---
+{
+	"title": "Responsive Tables",
+	"language": "en",
+	"category": "Plugins",
+	"description": "Integrates the TableSaw plugin into WET providing responsiveness for tables.",
+	"tag": "tables",
+	"parentdir": "tablesaw",
+	"altLangPrefix": "tablesaw",
+	"dateModified": "2015-02-13"
+}
+---
+
+<section>
+	<h2>Defaults - Demo, under developement</h2>
+	
+
+	<pre>&lt;table class="table"&gt;</pre>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Rendering engine</th>
+				<th>Browser</th>
+				<th>Platform(s)</th>
+				<th>Engine version</th>
+				<th>CSS grade</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="gradeX">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 4.0</td>
+				<td>Win 95+</td>
+				<td class="center">4</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 5.0</td>
+				<td>Win 95+</td>
+				<td class="center">5</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 5.5</td>
+				<td>Win 95+</td>
+				<td class="center">5.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 6</td>
+				<td>Win 98+</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet Explorer 7</td>
+				<td>Win XP SP2+</td>
+				<td class="center">7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>AOL browser (AOL desktop)</td>
+				<td>Win XP</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.5</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 2.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 3.0</td>
+				<td>Win 2k+ / OSX.3+</td>
+				<td class="center">1.9</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.0</td>
+				<td>OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.5</td>
+				<td>OSX.3+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape 7.2</td>
+				<td>Win 95+ / Mac OS 8.6-9.2</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Browser 8</td>
+				<td>Win 98SE+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Navigator 9</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.0</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.1</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.2</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.2</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.3</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.4</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.4</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.5</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.6</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.7</td>
+				<td>Win 98+ / OSX.1+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.8</td>
+				<td>Win 98+ / OSX.1+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Seamonkey 1.1</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Epiphany 2.20</td>
+				<td>Gnome</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.2</td>
+				<td>OSX.3</td>
+				<td class="center">125.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.3</td>
+				<td>OSX.3</td>
+				<td class="center">312.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 2.0</td>
+				<td>OSX.4+</td>
+				<td class="center">419.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 3.0</td>
+				<td>OSX.4+</td>
+				<td class="center">522.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>OmniWeb 5.5</td>
+				<td>OSX.4+</td>
+				<td class="center">420</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>iPod Touch / iPhone</td>
+				<td>iPod</td>
+				<td class="center">420.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>S60</td>
+				<td>S60</td>
+				<td class="center">413</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 7.0</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 7.5</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 8.0</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 8.5</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.0</td>
+				<td>Win 95+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.2</td>
+				<td>Win 88+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.5</td>
+				<td>Win 88+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera for Wii</td>
+				<td>Wii</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Nokia N800</td>
+				<td>N800</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Nintendo DS browser</td>
+				<td>Nintendo DS</td>
+				<td class="center">8.5</td>
+				<td class="center">C/A<sup>1</sup></td>
+			</tr>
+			<tr class="gradeC">
+				<td>KHTML</td>
+				<td>Konqureror 3.1</td>
+				<td>KDE 3.1</td>
+				<td class="center">3.1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>KHTML</td>
+				<td>Konqureror 3.3</td>
+				<td>KDE 3.3</td>
+				<td class="center">3.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>KHTML</td>
+				<td>Konqureror 3.5</td>
+				<td>KDE 3.5</td>
+				<td class="center">3.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Tasman</td>
+				<td>Internet Explorer 4.5</td>
+				<td>Mac OS 8-9</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Tasman</td>
+				<td>Internet Explorer 5.1</td>
+				<td>Mac OS 7.6-9</td>
+				<td class="center">1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Tasman</td>
+				<td>Internet Explorer 5.2</td>
+				<td>Mac OS 8-X</td>
+				<td class="center">1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Misc</td>
+				<td>NetFront 3.1</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Misc</td>
+				<td>NetFront 3.4</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Misc</td>
+				<td>Dillo 0.8</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Misc</td>
+				<td>Links</td>
+				<td>Text only</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Misc</td>
+				<td>Lynx</td>
+				<td>Text only</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Misc</td>
+				<td>IE Mobile</td>
+				<td>Windows Mobile 6</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Misc</td>
+				<td>PSP browser</td>
+				<td>PSP</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeU">
+				<td>Other browsers</td>
+				<td>All others</td>
+				<td>-</td>
+				<td class="center">-</td>
+				<td class="center">U</td>
+			</tr>
+		</tbody>
+	</table>
+
+</section>
+
+
+<section>
+	<h2>Swipe mode - Demo, under developement</h2>
+	
+<!-- <table class="wb-tablesaw table" data-tablesaw-mode="stack"> 
+<table class="wb-tablesaw table">
+<table class="table" data-tablesaw="{'mode':'stack'}" >
+<table class="table" data-tablesaw-mode="swipe" data-tablesaw-minimap>
+
+-->
+
+	<pre>&lt;table class="table" data-tablesaw='{ "mode": "swipe" }'&gt;</pre>
+	<p>Please take note that the first cell at the first data row is a cell heading. This is needed to auto-configure the tableSaw plugin to make work the swipe mode.</p>
+	<table class="table" data-tablesaw='{ "mode": "swipe" }'>
+		<thead>
+			<tr>
+				<th>Rendering engine</th>
+				<th>Browser</th>
+				<th>Platform(s)</th>
+				<th>Engine version</th>
+				<th>CSS grade</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="gradeX">
+				<th>Trident</th>
+				<td>Internet
+					 Explorer 4.0</td>
+				<td>Win 95+</td>
+				<td class="center">4</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 5.0</td>
+				<td>Win 95+</td>
+				<td class="center">5</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 5.5</td>
+				<td>Win 95+</td>
+				<td class="center">5.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 6</td>
+				<td>Win 98+</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet Explorer 7</td>
+				<td>Win XP SP2+</td>
+				<td class="center">7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>AOL browser (AOL desktop)</td>
+				<td>Win XP</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.5</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 2.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 3.0</td>
+				<td>Win 2k+ / OSX.3+</td>
+				<td class="center">1.9</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.0</td>
+				<td>OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.5</td>
+				<td>OSX.3+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape 7.2</td>
+				<td>Win 95+ / Mac OS 8.6-9.2</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Browser 8</td>
+				<td>Win 98SE+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Navigator 9</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.0</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.1</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.2</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.2</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.3</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.4</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.4</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.5</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.6</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.7</td>
+				<td>Win 98+ / OSX.1+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.8</td>
+				<td>Win 98+ / OSX.1+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Seamonkey 1.1</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Epiphany 2.20</td>
+				<td>Gnome</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.2</td>
+				<td>OSX.3</td>
+				<td class="center">125.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.3</td>
+				<td>OSX.3</td>
+				<td class="center">312.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 2.0</td>
+				<td>OSX.4+</td>
+				<td class="center">419.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 3.0</td>
+				<td>OSX.4+</td>
+				<td class="center">522.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>OmniWeb 5.5</td>
+				<td>OSX.4+</td>
+				<td class="center">420</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>iPod Touch / iPhone</td>
+				<td>iPod</td>
+				<td class="center">420.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>S60</td>
+				<td>S60</td>
+				<td class="center">413</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 7.0</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 7.5</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 8.0</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 8.5</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.0</td>
+				<td>Win 95+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.2</td>
+				<td>Win 88+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.5</td>
+				<td>Win 88+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera for Wii</td>
+				<td>Wii</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Nokia N800</td>
+				<td>N800</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Nintendo DS browser</td>
+				<td>Nintendo DS</td>
+				<td class="center">8.5</td>
+				<td class="center">C/A<sup>1</sup></td>
+			</tr>
+			<tr class="gradeC">
+				<td>KHTML</td>
+				<td>Konqureror 3.1</td>
+				<td>KDE 3.1</td>
+				<td class="center">3.1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>KHTML</td>
+				<td>Konqureror 3.3</td>
+				<td>KDE 3.3</td>
+				<td class="center">3.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>KHTML</td>
+				<td>Konqureror 3.5</td>
+				<td>KDE 3.5</td>
+				<td class="center">3.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Tasman</td>
+				<td>Internet Explorer 4.5</td>
+				<td>Mac OS 8-9</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Tasman</td>
+				<td>Internet Explorer 5.1</td>
+				<td>Mac OS 7.6-9</td>
+				<td class="center">1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Tasman</td>
+				<td>Internet Explorer 5.2</td>
+				<td>Mac OS 8-X</td>
+				<td class="center">1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Misc</td>
+				<td>NetFront 3.1</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Misc</td>
+				<td>NetFront 3.4</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Misc</td>
+				<td>Dillo 0.8</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Misc</td>
+				<td>Links</td>
+				<td>Text only</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Misc</td>
+				<td>Lynx</td>
+				<td>Text only</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Misc</td>
+				<td>IE Mobile</td>
+				<td>Windows Mobile 6</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Misc</td>
+				<td>PSP browser</td>
+				<td>PSP</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeU">
+				<td>Other browsers</td>
+				<td>All others</td>
+				<td>-</td>
+				<td class="center">-</td>
+				<td class="center">U</td>
+			</tr>
+		</tbody>
+	</table>
+
+</section>

--- a/src/plugins/tablesaw/tablesaw-fr.hbs
+++ b/src/plugins/tablesaw/tablesaw-fr.hbs
@@ -1,0 +1,866 @@
+---
+{
+	"title": "Tableaux adapatifs",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Ajoutes des fonctionnalités aux tableaux telles que l'adaptation à l'écran.",
+	"tag": "tables",
+	"parentdir": "tablesaw",
+	"altLangPrefix": "tablesaw",
+	"dateModified": "2015-02-13"
+}
+---
+
+<section>
+	<h2>Par défaut, pour tous les tableaux, présentement en dévelopment</h2>
+
+	<pre>&lt;table class="table"&gt;</pre>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Moteur de rendu</th>
+ 				<th>Navigateur</th>
+ 				<th>Platformes</th>
+ 				<th>Version de moteur</th>
+ 				<th>Niveau de CSS</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="gradeX">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 4.0</td>
+				<td>Win 95+</td>
+				<td class="center">4</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 5.0</td>
+				<td>Win 95+</td>
+				<td class="center">5</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 5.5</td>
+				<td>Win 95+</td>
+				<td class="center">5.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 6</td>
+				<td>Win 98+</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet Explorer 7</td>
+				<td>Win XP SP2+</td>
+				<td class="center">7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Navigateur AOL (AOL desktop)</td>
+				<td>Win XP</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.5</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 2.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 3.0</td>
+				<td>Win 2k+ / OSX.3+</td>
+				<td class="center">1.9</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.0</td>
+				<td>OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.5</td>
+				<td>OSX.3+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape 7.2</td>
+				<td>Win 95+ / Mac OS 8.6-9.2</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Browser 8</td>
+				<td>Win 98SE+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Navigator 9</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.0</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.1</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.2</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.2</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.3</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.4</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.4</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.5</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.6</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.7</td>
+				<td>Win 98+ / OSX.1+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.8</td>
+				<td>Win 98+ / OSX.1+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Seamonkey 1.1</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Epiphany 2.20</td>
+				<td>Gnome</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.2</td>
+				<td>OSX.3</td>
+				<td class="center">125.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.3</td>
+				<td>OSX.3</td>
+				<td class="center">312.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 2.0</td>
+				<td>OSX.4+</td>
+				<td class="center">419.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 3.0</td>
+				<td>OSX.4+</td>
+				<td class="center">522.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>OmniWeb 5.5</td>
+				<td>OSX.4+</td>
+				<td class="center">420</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>iPod Touch / iPhone</td>
+				<td>iPod</td>
+				<td class="center">420.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>S60</td>
+				<td>S60</td>
+				<td class="center">413</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 7.0</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 7.5</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 8.0</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 8.5</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.0</td>
+				<td>Win 95+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.2</td>
+				<td>Win 88+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.5</td>
+				<td>Win 88+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera for Wii</td>
+				<td>Wii</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Nokia N800</td>
+				<td>N800</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Nintendo DS browser</td>
+				<td>Nintendo DS</td>
+				<td class="center">8.5</td>
+				<td class="center">C/A<sup>1</sup></td>
+			</tr>
+			<tr class="gradeC">
+				<td>KHTML</td>
+				<td>Konqureror 3.1</td>
+				<td>KDE 3.1</td>
+				<td class="center">3.1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>KHTML</td>
+				<td>Konqureror 3.3</td>
+				<td>KDE 3.3</td>
+				<td class="center">3.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>KHTML</td>
+				<td>Konqureror 3.5</td>
+				<td>KDE 3.5</td>
+				<td class="center">3.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Tasman</td>
+				<td>Internet Explorer 4.5</td>
+				<td>Mac OS 8-9</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Tasman</td>
+				<td>Internet Explorer 5.1</td>
+				<td>Mac OS 7.6-9</td>
+				<td class="center">1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Tasman</td>
+				<td>Internet Explorer 5.2</td>
+				<td>Mac OS 8-X</td>
+				<td class="center">1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Divers</td>
+				<td>NetFront 3.1</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Divers</td>
+				<td>NetFront 3.4</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Divers</td>
+				<td>Dillo 0.8</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Divers</td>
+				<td>Liens</td>
+				<td>Texte seulement</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Divers</td>
+				<td>Lynx</td>
+				<td>Texte seulement</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Divers</td>
+				<td>IE Mobile</td>
+				<td>Windows Mobile 6</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Divers</td>
+				<td>Navigateur PSP</td>
+				<td>PSP</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeU">
+				<td>Autres navigateurs</td>
+				<td>Tous les autres</td>
+				<td>-</td>
+				<td class="center">-</td>
+				<td class="center">U</td>
+			</tr>
+		</tbody>
+	</table>
+
+</section>
+
+
+<section>
+	<h2>Swipe mode - Demo, under developement</h2>
+	
+<!-- <table class="wb-tablesaw table" data-tablesaw-mode="stack"> 
+<table class="wb-tablesaw table">
+<table class="table" data-tablesaw="{'mode':'stack'}" >
+<table class="table" data-tablesaw-mode="swipe" data-tablesaw-minimap>
+
+-->
+
+	<pre>&lt;table class="table" data-tablesaw='{ "mode": "swipe" }'&gt;</pre>
+	<p>Notez que la première cellule de la première ligne de donnée est un entête, cela est requis afain d'auto-configurer le tablesaw en mode swipe</p>
+	<table class="table" data-tablesaw='{ "mode": "swipe" }'>
+		<thead>
+			<tr>
+				<th>Moteur de rendu</th>
+ 				<th>Navigateur</th>
+ 				<th>Platformes</th>
+ 				<th>Version de moteur</th>
+ 				<th>Niveau de CSS</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="gradeX">
+				<th>Trident</th>
+				<td>Internet
+					 Explorer 4.0</td>
+				<td>Win 95+</td>
+				<td class="center">4</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 5.0</td>
+				<td>Win 95+</td>
+				<td class="center">5</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 5.5</td>
+				<td>Win 95+</td>
+				<td class="center">5.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					 Explorer 6</td>
+				<td>Win 98+</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet Explorer 7</td>
+				<td>Win XP SP2+</td>
+				<td class="center">7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Navigateur AOL (AOL desktop)</td>
+				<td>Win XP</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.5</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 2.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 3.0</td>
+				<td>Win 2k+ / OSX.3+</td>
+				<td class="center">1.9</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.0</td>
+				<td>OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.5</td>
+				<td>OSX.3+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape 7.2</td>
+				<td>Win 95+ / Mac OS 8.6-9.2</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Browser 8</td>
+				<td>Win 98SE+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Navigator 9</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.0</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.1</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.2</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.2</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.3</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.4</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.4</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.5</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.6</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">1.6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.7</td>
+				<td>Win 98+ / OSX.1+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Mozilla 1.8</td>
+				<td>Win 98+ / OSX.1+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Seamonkey 1.1</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Epiphany 2.20</td>
+				<td>Gnome</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.2</td>
+				<td>OSX.3</td>
+				<td class="center">125.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.3</td>
+				<td>OSX.3</td>
+				<td class="center">312.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 2.0</td>
+				<td>OSX.4+</td>
+				<td class="center">419.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 3.0</td>
+				<td>OSX.4+</td>
+				<td class="center">522.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>OmniWeb 5.5</td>
+				<td>OSX.4+</td>
+				<td class="center">420</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>iPod Touch / iPhone</td>
+				<td>iPod</td>
+				<td class="center">420.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>S60</td>
+				<td>S60</td>
+				<td class="center">413</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 7.0</td>
+				<td>Win 95+ / OSX.1+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 7.5</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 8.0</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 8.5</td>
+				<td>Win 95+ / OSX.2+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.0</td>
+				<td>Win 95+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.2</td>
+				<td>Win 88+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera 9.5</td>
+				<td>Win 88+ / OSX.3+</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Opera for Wii</td>
+				<td>Wii</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Nokia N800</td>
+				<td>N800</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Presto</td>
+				<td>Nintendo DS browser</td>
+				<td>Nintendo DS</td>
+				<td class="center">8.5</td>
+				<td class="center">C/A<sup>1</sup></td>
+			</tr>
+			<tr class="gradeC">
+				<td>KHTML</td>
+				<td>Konqureror 3.1</td>
+				<td>KDE 3.1</td>
+				<td class="center">3.1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>KHTML</td>
+				<td>Konqureror 3.3</td>
+				<td>KDE 3.3</td>
+				<td class="center">3.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>KHTML</td>
+				<td>Konqureror 3.5</td>
+				<td>KDE 3.5</td>
+				<td class="center">3.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Tasman</td>
+				<td>Internet Explorer 4.5</td>
+				<td>Mac OS 8-9</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Tasman</td>
+				<td>Internet Explorer 5.1</td>
+				<td>Mac OS 7.6-9</td>
+				<td class="center">1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Tasman</td>
+				<td>Internet Explorer 5.2</td>
+				<td>Mac OS 8-X</td>
+				<td class="center">1</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Divers</td>
+				<td>NetFront 3.1</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Divers</td>
+				<td>NetFront 3.4</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Divers</td>
+				<td>Dillo 0.8</td>
+				<td>Appareils intégrés</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Divers</td>
+				<td>Liens</td>
+				<td>Texte seulement</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeX">
+				<td>Divers</td>
+				<td>Lynx</td>
+				<td>Texte seulement</td>
+				<td class="center">-</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Divers</td>
+				<td>IE Mobile</td>
+				<td>Windows Mobile 6</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Divers</td>
+				<td>Navigateur PSP</td>
+				<td>PSP</td>
+				<td class="center">-</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeU">
+				<td>Autres navigateurs</td>
+				<td>Tous les autres</td>
+				<td>-</td>
+				<td class="center">-</td>
+				<td class="center">U</td>
+			</tr>
+		</tbody>
+	</table>
+</section>

--- a/src/plugins/tablesaw/tablesaw.js
+++ b/src/plugins/tablesaw/tablesaw.js
@@ -1,0 +1,270 @@
+/**
+ * @title WET-BOEW TableSaw
+ * @overview Integrates the TableSaw plugin into WET providing responsiveness for tables.
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @duboisp
+ */
+(function( $, window, wb ) {
+"use strict";
+
+/**
+ * Variable and function definitions.
+ * These are global to the plugin - meaning that they will be initialized once per page,
+ * not once per instance of plugin on the page. So, this is a good place to define
+ * variables that are common to all instances of the plugin on a page.
+ */
+ var componentName = "wb-tablesaw",
+	selector = "table",
+	pluginSelector = "." + componentName,
+	pluginTableSaw = "table",
+	initEvent = "wb-init" + pluginSelector,
+	$document = wb.doc,
+	tablesawInitSelector = "table[data-tablesaw-mode],table[data-tablesaw-sortable]",
+	idCount,
+	i18n, i18nText,
+	deps = [ // stack only mode
+		"site!deps/tablesaw.stackonly" + wb.getMode() + ".js"
+	],
+	depCss = "site!deps/tablesaw.css",
+	depsColResponsive = [
+		"site!deps/tablesaw.customresponsive" + wb.getMode() + ".js"
+	],
+	depsSortable = [
+		"site!deps/tablesaw.customresponsive" + wb.getMode() + ".js",
+		"site!deps/tablesaw.sortable" + wb.getMode() + ".js"
+	],
+
+	/**
+	 * @method init
+	 * @param {jQuery Event} event Event that triggered the function call
+	 */
+	init = function( event ) {
+
+		// Start initialization
+		// returns DOM object = proceed with init
+		// returns undefined = do not proceed with init (e.g., already initialized)
+		var elm = wb.init( event, componentName, selector ),
+			elmId;
+
+		if ( elm ) {
+			elmId = elm.id;
+
+			// Ensure there is a unique id on the element
+			if ( !elmId ) {
+				elmId = componentName + "-id-" + idCount;
+				idCount += 1;
+				elm.id = elmId;
+			}
+
+			// Only initialize the i18nText once
+			if ( !i18nText ) {
+				i18n = wb.i18n;
+				i18nText = {
+					tableMention: i18n( "hyphen" ) + i18n( "tbl-txt" ),
+					tableFollowing: i18n( "hyphen" ) + i18n( "tbl-dtls" )
+				};
+			}
+			
+			// Load the default Library - stack only
+			Modernizr.load({
+				load: deps,
+				complete: function() {
+					var $elm = $( "#" + elmId ),
+					config = wb.getData($elm, "tablesaw");
+
+					// Evaluate if we are in default mode or if we need to move into an enhanced mode like swipe or toggle.
+					if ( $elm.is( tablesawInitSelector ) ) {
+						console.log("Swap CONFIG triggered");
+						$elm.trigger("swapConfig" + pluginSelector);
+					} else if ( config && config.mode === "swipe" ) {
+						console.log("Swipe Mode triggered");
+						$elm.trigger("swipe" + pluginSelector);
+					} else if ( config && config.mode === "columntoggle" ) {
+						console.log("Toggle Mode triggered");
+						$elm.trigger("toggle" + pluginSelector);
+					} else {
+						console.log("Stack Mode triggered");
+						$elm.trigger("stack" + pluginSelector);
+					}
+					
+					if ( config && config.sorting ) {
+						console.log("Sorting triggered");
+						$elm.trigger("sorting" + pluginSelector);
+					}
+				}
+			});
+			Modernizr.load(depCss);
+			
+		}
+	};
+
+
+// Swipe Mode
+$document.on( "swipe" + pluginSelector, selector, function( event ) {
+	var eventTarget = event.target,
+		$eventTarget = $( eventTarget );
+	
+	// TODO: Run the table parser to know the nature of each cell, vector and group
+	// For now, Just do a simple test
+	//   Assumed, The first row define the column and the data row start at the second row.
+	//   Assumed, that no cell span more than one column
+	
+	// Get the length of the column header.
+	var trs = $eventTarget.find( 'tr' ),
+		firstRowCells = trs.get(0).childNodes,
+		secondRowCells = trs.get(1).childNodes,
+		i, i_len,
+		
+		nbDataCell = 1;
+	
+	
+	// Get How many cell represent the column header, that is for persistance
+	for ( i = 0, i_len = secondRowCells.length; i <  i_len; i += 1 ) {
+		var nodeName = secondRowCells[ i ].nodeName.toLowerCase();
+		if ( nodeName === "th" ) {
+			$( firstRowCells[ i ] ).attr('data-tablesaw-priority', 'persist');
+		} else if ( nodeName === "td" ) {
+			$( firstRowCells[ i ] ).attr('data-tablesaw-priority', nbDataCell);
+			nbDataCell += 1;
+		}
+	}
+	
+	// Add what require to enable table swap mode
+	$eventTarget.addClass( 'tablesaw' ).
+		attr('data-tablesaw-mode', 'swipe').
+		attr('data-minimap');
+	
+	// Load additional plugin and start the plugin
+	Modernizr.load({
+		load: depsColResponsive,
+		complete: function() {
+			$eventTarget[ pluginTableSaw ]();
+			// Identify that initialization has completed
+			wb.ready( $eventTarget, componentName );
+		}
+	});
+});
+
+// Toggle Mode
+$document.on( "toggle" + pluginSelector, selector, function( event ) {
+	var eventTarget = event.target,
+		$eventTarget = $( eventTarget );
+	
+	// Prepare the table to be enhanced 
+	
+	
+	// Load additional plugin and start the plugin
+	Modernizr.load({
+		load: depsColResponsive,
+		complete: function() {
+			$eventTarget[ pluginTableSaw ]();
+			// Identify that initialization has completed
+			wb.ready( $eventTarget, componentName );
+		}
+	});
+});
+
+// Sorting Mode
+$document.on( "sorting" + pluginSelector, selector, function( event ) {
+	var eventTarget = event.target,
+		$eventTarget = $( eventTarget );
+	
+	// Prepare the table to be sortable
+	
+	// Load additional plugin and start the plugin
+	Modernizr.load({
+		load: depsSortable,
+		complete: function() {
+			$eventTarget[ pluginTableSaw ]();
+			// Identify that initialization has completed
+			wb.ready( $eventTarget, componentName );
+		}
+	});
+	
+	// $( eventTarget ).trigger( 'run' + pluginSelector );
+});
+
+// Stack Mode, Default mode
+$document.on( "stack" + pluginSelector, selector, function( event ) {
+	var eventTarget = event.target,
+		$eventTarget = $( eventTarget );
+
+	// Add required tablesaw parameter
+	$eventTarget.addClass( 'tablesaw tablesaw-stack' ).
+		attr('data-tablesaw-mode', 'stack')
+	
+	// Run the tableSaw plugin
+	$eventTarget[ pluginTableSaw ]();
+
+	// Identify that initialization has completed
+	wb.ready( $eventTarget, componentName );
+});
+
+
+/*// Load deps and run the third party plugin
+$document.on( 'run' + pluginSelector, selector, function( event ) {
+	var eventTarget = event.target;
+	
+	// Load the required dependencies
+	Modernizr.load({
+
+		// For loading multiple dependencies
+		load: deps,
+		complete: function() {
+
+			// Transpose the attribute data-tablesaw={} into a format that the plugin use
+			//if ($elm.data().tablesaw) {
+			//	console.log("Data Attribute");
+			//	console.log($elm.data().tablesaw);
+			//}
+
+			// Evaluate if we are in default mode or if we need to move into an enhanced mode like swipe or toggle.
+
+			
+
+			// Run tableSaw plugin
+			//$document.trigger( 'enhance.tablesaw');
+			$( eventTarget ).trigger( 'enhance.tablesaw' );
+		}
+	});
+
+});
+*/
+
+// TODO: Complete the following function
+// Swap the config
+$document.on( "swapConfig" + pluginSelector, selector, function( event ) {
+	var eventTarget = event.target;
+	
+	// Triggered if we have found that the editor has used the Current Filament group docs, in order to control the widget.
+	// The intend of this events is to map, the tablesaw config into WET architecture, then remove reference to it
+	// Then lunch the widget.
+	
+});
+
+// Bind the init event of the plugin
+$document.on( "timerpoke.wb " + initEvent, selector, function( event ) {
+	var eventTarget = event.target;
+
+	switch ( event.type ) {
+
+	/*
+	 * Init
+	 */
+	case "timerpoke":
+	case "wb-init":
+		init( event );
+		break;
+	}
+
+	/*
+	 * Since we are working with events we want to ensure that we are being passive about our control,
+	 * so returning true allows for events to always continue
+	 */
+	return true;
+});
+
+// Add the timer poke to initialize the plugin
+wb.add( selector );
+
+})( jQuery, window, wb );


### PR DESCRIPTION
Under developpement version, this is for early testing

This pull request include 2 demos, 
- First demo is about the TableSaw "stack" mode that was implemented by default for all table
- Second demo is about the TableSaw "swipe" mode, initiated with `data-tablesaw='{ "mode": "swipe" }'` then auto-configured from the table structure.

See #6351 for more information
