### PR TITLE
Tabbed interface: Adjusted "row" SCSS class to prevent a scroll bar from appearing when it's used.

### DIFF
--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -213,6 +213,15 @@ $medGray: #ccc;
 		z-index: 1;
 	}
 
+	.tgl-panel {
+		> {
+			.row {
+				margin-left: 0;
+				margin-right: 0;
+			}
+		}
+	}
+
 	/**
 	 * Style 1 - Basic carousel style
 	 */


### PR DESCRIPTION
The scroll bar was introduced in PR #6302 to fix an unrelated issue.

**HTML5 code example...**

```
<div class="wb-tabs">
    <div class="tabpanels">
        <details id="details-panel1-1">
            <summary>Tab 1</summary>
            <div class="row">
                <div class="col-md-6">
                    <section class="panel panel-default mrgn-tp-md">
                        <div class="panel-heading">
                            <h2 class="mrgn-tp-0 mrgn-bttm-0">Panel</h2>
                        </div>
                        <div class="panel-body">
                            <p>Content</p>
                        </div>
                    </section>
                </div>
                <div class="col-md-6">
                    <section class="panel panel-default mrgn-tp-md">
                        <div class="panel-heading">
                            <h2 class="mrgn-tp-0 mrgn-bttm-0">Panel</h2>
                        </div>
                        <div class="panel-body">
                            <p>Content</p>
                        </div>
                    </section>
                </div>
            </div>
        </details>
    </div>
</div>
```

**Screenshot (before):**
![tabs-row-before](https://cloud.githubusercontent.com/assets/1907279/6231114/9989fec2-b692-11e4-943a-f7ae4dd90046.png)

**Screenshot (after):**
![tabs-row-after](https://cloud.githubusercontent.com/assets/1907279/6231116/9cb6e628-b692-11e4-8b09-a0fc0f8a0d26.png)
