### PR TITLE
SCSS Text Highlight Plugin: Added customizable variables

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -236,3 +236,13 @@ $carousel-s2-tablist-controls-btn-radius: 999px !default;
 $carousel-s2-tablist-thumbnail-active-border-color: #666 !default;
 $carousel-s2-tablist-thumbnail-active-border-style: solid !default;
 $carousel-s2-tablist-thumbnail-active-border-width: 10px !default;
+
+
+//== Text Highlight
+//
+//##
+
+$txthl-bg-color: #ff0 !default;
+$txthl-color: #000 !default;
+$txthl-font-weight: 700 !default;
+

--- a/src/plugins/texthighlight/_base.scss
+++ b/src/plugins/texthighlight/_base.scss
@@ -4,8 +4,8 @@
  */
 .wb-txthl {
 	.txthl {
-		background-color: #ff0;
-		color: #000;
-		font-weight: 700;
+		background-color: $txthl-bg-color;
+		color: $txthl-color;
+		font-weight: $txthl-font-weight;
 	}
 }


### PR DESCRIPTION
Added customizable SCSS variables to text highlight plugin. 

Note that the original _base.scss file contained parameters that were overwritten, because it was not specifying that the parameters were for `mark`. The original `background-color` that was defined and not used was also wrong too.
