### PR TITLE
Charts: Added option to safely include Flot plugins

### DIFF
--- a/src/plugins/charts/charts.js
+++ b/src/plugins/charts/charts.js
@@ -1085,6 +1085,7 @@
 		// returns DOM object = proceed with init
 		// returns undefined = do not proceed with init (e.g., already initialized)
 		var elm = wb.init( event, componentName, selector, true ),
+			settings = window[ componentName ],
 			elmId, modeJS, deps;
 
 		if ( elm ) {
@@ -1097,6 +1098,11 @@
 				"site!deps/jquery.flot.orderBars" + modeJS,
 				"site!deps/tableparser" + modeJS
 			];
+
+			//TODO: Revist this in the new plugin structure
+			if (settings && settings.plugins) {
+				deps = deps.concat(settings.plugins);
+			}
 
 			// Only initialize the i18nText once
 			if ( !i18nText ) {


### PR DESCRIPTION
Safely fixes #4466 and #6516

To Use:

``` html
<script>
(function() {
    window[ "wb-charts" ] = {
        plugins: [
            "site!deps/jquery.flot.navigate.js",
            "site!deps/jquery.flot.navigationControl.js"
        ]
    };
})();
</script>
```
