### PR TITLE
Plugin Footnotes: adds alternative footnote mark-up/styling

### DIFF
--- a/src/plugins/footnotes/_base.scss
+++ b/src/plugins/footnotes/_base.scss
@@ -72,7 +72,7 @@
 			ul,
 			ol {
 				margin: 0 $spacing $spacing (($spacing * 2) + $ddRtnWidth);
-				
+
 				&:first-child {
 					@extend %fnote-margin-top-spacing;
 				}
@@ -88,15 +88,102 @@
 			padding-top: $spacing;
 		}
 	}
-	
+
 	ul,
 	ol {
 		margin-bottom: $spacing;
 	}
-	
+
 	table {
 		margin: 0 $spacing $spacing (($spacing * 2) + $ddRtnWidth);
-		
+
+		&:first-child {
+			@extend %fnote-margin-top-spacing;
+		}
+	}
+
+	.fn-rtn {
+		margin: 0;
+		overflow: hidden;
+		padding-right: 0;
+		padding-top: $spacing;
+		position: absolute;
+		top: 0;
+		width: $ddRtnWidth;
+
+		a {
+			@extend %fnote-link-background-light-border-medium-padding-whitespace;
+			display: inline-block;
+			padding-bottom: 0;
+
+			&:hover,
+			&:focus {
+				@extend %fnote-link-highlight;
+			}
+		}
+	}
+}
+
+.wb-fnote2 {
+	border-color: $clrMedium;
+	border-style: solid;
+	border-width: 1px 0;
+	margin: 2em 10px 0;
+
+	h2,
+	h3 {
+		@extend %fnote-margin-top-spacing;
+		margin-left: 0;
+		margin-right: 0;
+	}
+
+	ul,
+	ol {
+		list-style-type: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	li {
+		border: 1px solid transparent;
+		margin: $spacing 0;
+		position: relative;
+
+		&:focus {
+			background-color: $clrLight;
+			border-color: $clrDark;
+
+			.fn-rtn {
+				a {
+					@extend %fnote-link-highlight;
+				}
+			}
+		}
+
+		> {
+			ul,
+			ol {
+				margin: 0 $spacing $spacing (($spacing * 2) + $ddRtnWidth);
+
+				&:first-child {
+					@extend %fnote-margin-top-spacing;
+				}
+			}
+		}
+	}
+
+	p {
+		margin: 0 0 0 ($spacing + $ddRtnWidth);
+		padding: 0 $spacing $spacing;
+
+		&:first-child {
+			padding-top: $spacing;
+		}
+	}
+
+	table {
+		margin: 0 $spacing $spacing (($spacing * 2) + $ddRtnWidth);
+
 		&:first-child {
 			@extend %fnote-margin-top-spacing;
 		}
@@ -134,6 +221,17 @@
 	}
 
 	.wb-fnote {
+		p {
+			margin: 0 ($spacing + $ddRtnWidth) 0 0;
+		}
+
+		.fn-rtn {
+			margin-right: 0;
+			padding-right: 0;
+		}
+	}
+
+	.wb-fnote2 {
 		p {
 			margin: 0 ($spacing + $ddRtnWidth) 0 0;
 		}

--- a/src/plugins/footnotes/footnotes-en.hbs
+++ b/src/plugins/footnotes/footnotes-en.hbs
@@ -75,10 +75,9 @@
 				</p>
 			</dd>
 		</dl>
-	</aside>
-
-	<section>
-		<h3>Code</h3>
+		<br>
+		<details>
+			<summary>Example code</summary>
 		<pre><code>&lt;section&gt;
 	&lt;h3&gt;Purpose&lt;/h3&gt;
 	&lt;p&gt;The purpose of the Footnotes plugin is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the &lt;a href=&quot;#fn&quot;&gt;Footnotes&lt;/a&gt; section. Supporting CSS is used to lay out the footnotes and hide navigational aids&lt;sup id=&quot;fn1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn1&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;1&lt;/a&gt;&lt;/sup&gt;.&lt;/p&gt;
@@ -137,5 +136,81 @@
 		&lt;/dd&gt;
 	&lt;/dl&gt;
 &lt;/aside&gt;</code></pre>
+		</details>
+		<br>
+	</aside>
+
+	<section>
+		<h2>Footnotes: Alternative</h2>
+		<h3>Benefits</h3>
+		<ul>
+			<li>Conforms to WCAG 2.0 AA<sup id="fn4-1-rf"><a class="fn-lnk" href="#fn4"><span class="wb-inv">Footnote </span>4</a></sup></li>
+			<li>Progressive enhancement approach</li>
+			<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fn4-2-rf"><a class="fn-lnk" href="#fn4"><span class="wb-inv">Footnote </span>4</a></sup></li>
+			<li>Support for English and French</li>
+			<li>Configurable layout and design<sup id="fn5-rf"><a class="fn-lnk" href="#fn5"><span class="wb-inv">Footnote </span>5</a></sup>&#160;<sup id="fn6-rf"><a class="fn-lnk" href="#fn6"><span class="wb-inv">Footnote </span>6</a></sup></li>
+		</ul>
+		<aside class="wb-fnote2" role="note">
+			<h2 id="notes">Footnotes</h2>
+			<ol>
+				<li id="fn4">
+					<p>Example of a standard footnote.</p>
+					<p class="fn-rtn">
+						<a href="#fn4-1-rf"><span class="wb-inv">Return to footnote </span>4<span class="wb-inv"> referrer</span></a>
+					</p>
+				</li>
+				<li id="fn5">
+					<p>Example of a footnote being referenced by multiple pieces of content.</p>
+					<p class="fn-rtn">
+						<a href="#fn5-rf"><span class="wb-inv">Return to <span>first</span> footnote </span>5<span class="wb-inv"> referrer</span></a>
+					</p>
+				</li>
+				<li id="fn6">
+					<p>Example of a footnote containing multiple paragraphs (first paragraph).</p>
+					<p>Example of a footnote containing multiple paragraphs (second paragraph).</p>
+					<p>Example of a footnote containing multiple paragraphs (third paragraph).</p>
+					<p class="fn-rtn">
+						<a href="#fn6-rf"><span class="wb-inv">Return to footnote </span>6<span class="wb-inv"> referrer</span></a>
+					</p>
+				</li>
+			</ol>
+			<br>
+			<details>
+				<summary>Example code</summary>
+				<pre>
+					<code>
+&lt;aside class=&quot;wb-fnote2&quot; role=&quot;note&quot;&gt;
+	&lt;h3 id=&quot;fn&quot;&gt;Footnotes&lt;/h2&gt;
+	&lt;dl&gt;
+		&lt;dt&gt;Footnote 4&lt;/dt&gt;
+		&lt;dd id=&quot;fn4&quot;&gt;
+			&lt;p&gt;Example of a standard footnote.&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;
+				&lt;a href=&quot;#fn4-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;4&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;
+			&lt;/p&gt;
+		&lt;/dd&gt;
+		&lt;dt&gt;Footnote 5&lt;/dt&gt;
+		&lt;dd id=&quot;fn5&quot;&gt;
+			&lt;p&gt;Example of a footnote being referenced by multiple pieces of content.&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;
+				&lt;a href=&quot;#fn5-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to &lt;span&gt;first&lt;/span&gt; footnote &lt;/span&gt;5&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;
+			&lt;/p&gt;
+		&lt;/dd&gt;
+		&lt;dt&gt;Footnote 6&lt;/dt&gt;
+		&lt;dd id=&quot;fn6&quot;&gt;
+			&lt;p&gt;Example of a footnote containing multiple paragraphs (first paragraph).&lt;/p&gt;
+			&lt;p&gt;Example of a footnote containing multiple paragraphs (second paragraph).&lt;/p&gt;
+			&lt;p&gt;Example of a footnote containing multiple paragraphs (third paragraph).&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;
+				&lt;a href=&quot;#fn6-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;6&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;
+			&lt;/p&gt;
+		&lt;/dd&gt;
+	&lt;/dl&gt;
+&lt;/aside&gt;
+					</code>
+				</pre>
+			</details>
+			<br>
+		</aside>
 	</section>
 </section>


### PR DESCRIPTION
Public Safety is currently use an ordered list for footnotes. Changing to the definition list (as in the current footnote plugin), would require considerable effort, while not providing much apparent value. I consider an ordered list for footnotes to be just as, possibly more, semantic as the definition list option. I'm not suggesting a replacement, just an alternative so that we can use the WET4 Footnote plugin, just in the context of an ordered list.

Thanks!
