### PR TITLE
Date picker: Added input group wrapper

### DIFF
--- a/src/polyfills/datepicker/datepicker.js
+++ b/src/polyfills/datepicker/datepicker.js
@@ -109,11 +109,11 @@ var componentName = "wb-date",
 							.end()
 						.text(),
 			showFieldLabel = i18nText.show + fieldLabel,
-			objToggle = "<a href='javascript:;' button id='" + fieldId + "-picker-toggle' class='picker-toggle' href='javascript:;' title=\"" +
+			objToggle = "<span class='input-group-btn'><button class='btn btn-default picker-toggle' type='button' id='" + fieldId + "-picker-toggle' title=\"" +
 				showFieldLabel + "\"><span class='glyphicon glyphicon-calendar'></span><span class='wb-inv'>" +
-				showFieldLabel + "</span></a>";
+				showFieldLabel + "</span></button></span></div>";
 
-		$( "#" + fieldId ).wrap( "<span class='wb-date-wrap'/>" ).after( objToggle );
+		$( "#" + fieldId ).prev(".label").before("<div class='input-group'>").wrap( "<span class='wb-date-wrap'/>" ).after( objToggle );
 		$container.slideUp( 0 );
 	},
 

--- a/src/polyfills/datepicker/datepicker.scss
+++ b/src/polyfills/datepicker/datepicker.scss
@@ -41,25 +41,11 @@
 }
 
 .picker-field {
-	width: 7em;
+	width: 7em !important;
 }
 
-.picker-toggle {
-	background: none;
-	border: 0;
-	display: inline-block;
-	margin-left: 5px;
-	vertical-align: middle;
-
-	&:link,
-	&:visited,
-	&:focus {
-		color: #000;
-	}
-
-	span {
-		font-size: 1.3em;
-	}
+.input-group-btn {
+	width: auto !important;
 }
 
 .cal-days {


### PR DESCRIPTION
Enables the use of the date picker polyfill when the icon is not displayed.
Because of the addition of a button to click rather than only an icon, the polyfill is still triggerable even if the icon is not displayed.

Fixes #6599 
