### PR TITLE
Secondary menu: Fix hover issue for contrast ratio on base WET theme.

### DIFF
--- a/theme/secondary-menu/_base.scss
+++ b/theme/secondary-menu/_base.scss
@@ -2,7 +2,7 @@
  * Secondary menu
  */
 %secmenu-wet-theme-menuitem-curr-hover-focus {
-	background: darken($clrWhite, 50%);
+	background: darken($clrWhite, 60%);
 	color: lighten($clrDark, 75%);
 }
 


### PR DESCRIPTION
Contrast ratio fails at 3.0:1, fixed to 60% and achieves 5.7:1.
