### PR TITLE
Tabbed interface: Stop the list of tabs from wrapping when there are too many tabs or when their labels are too long.

### DIFF
--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -3,6 +3,8 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 
+$tab-margin-width: 10px;
+
 %tabs-position-relative {
 	position: relative;
 }
@@ -135,6 +137,8 @@
 	}
 
 	[role="tablist"] {
+		border-spacing: $tab-margin-width 0;
+		display: table;
 		list-style: none;
 		margin: 0;
 		padding: 0;
@@ -150,6 +154,8 @@
 			}
 			color: $carousel-tablist-tabcount-color;
 			cursor: pointer;
+			display: table-cell;
+			left: -$tab-margin-width;
 			margin: 0 10px 0 0;
 			position: relative;
 			text-align: center;


### PR DESCRIPTION
Fix for #6719.

This will ensure that tabs themselves don't wrap and stay in a single row. The labels of the tabs will now wrap instead.
