### PR TITLE
Plugin lightbox : add a background color to the description 

### DIFF
--- a/src/plugins/lightbox/_base.scss
+++ b/src/plugins/lightbox/_base.scss
@@ -61,14 +61,26 @@
 
 /* Should fix upstream in Magnific Popup rather than overriding in WET */
 .mfp-bottom-bar {
+	background-color: $clrMedium;
+	margin-bottom: 5px;
+	padding: 10px;
+
+
 	.mfp-title {
+		color: $clrDarkBlue;
+		display: inline-block;
 		padding-right: 5px;
 		width: 75%;
+
 	}
 
 	.mfp-counter {
+		color: $clrDarkBlue;
+		display: inline-block;
 		font-size: 1em;
+		position: static;
 		text-align: right;
+		vertical-align: top;
 		width: 25%;
 	}
 }


### PR DESCRIPTION
I added a background color to the lightbox in reference of this issue :
https://github.com/wet-boew/wet-boew/issues/6791

![2015-06-07_21-20-53](https://cloud.githubusercontent.com/assets/3018441/8027656/b4b268c8-0d69-11e5-8d17-f6f8c6dd9f85.jpg)

I tested the contrast, you can see the result here :
http://jxnblk.com/colorable/demos/text/?background=%23ccc&foreground=%23243850
