### PR TITLE
Plugin Overlay : Darken background to allow a better contrast

### DIFF
--- a/src/plugins/overlay/_base.scss
+++ b/src/plugins/overlay/_base.scss
@@ -84,6 +84,10 @@
 	width: 100%;
 }
 
+.mfp-bg {
+	opacity: 0.97;
+}
+
 /*
  *	Overlay parts
  */


### PR DESCRIPTION
Hello Wet developers!

I was thinking of adding a second option to the issue filled by @shawnthompson https://github.com/wet-boew/wet-boew/issues/6791 that just darkens the background of the overlay.

This is what it looks likes

![2015-06-12_09-31-57](https://cloud.githubusercontent.com/assets/3018441/8131118/25751234-10e6-11e5-9ad0-ef9350464ff8.jpg)

Hope to hear your thoughts on this,

Thank you!
