### PR TITLE
Footnotes: Added minor SCSS improvements.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -170,7 +170,7 @@ $cal-mnth-arrows-active-color: $clrMedium !default;
 //##
 
 $spacing: .375em !default;
-$ddRtnWidth: 3.375em !default;
+$ddRtnWidth: 3.5em !default;
 
 
 //== Multimedia player

--- a/src/plugins/footnotes/_base.scss
+++ b/src/plugins/footnotes/_base.scss
@@ -36,7 +36,7 @@
 	border-color: $clrMedium;
 	border-style: solid;
 	border-width: 1px 0;
-	margin: 2em 10px 0;
+	margin: 2em 0 0;
 
 	h2 {
 		@extend %fnote-margin-top-spacing;
@@ -85,6 +85,7 @@
 		padding: 0 $spacing $spacing;
 
 		&:first-child {
+			margin-top: .11em;
 			padding-top: $spacing;
 		}
 	}
@@ -114,6 +115,7 @@
 		a {
 			@extend %fnote-link-background-light-border-medium-padding-whitespace;
 			display: inline-block;
+			margin-top: 0;
 			padding-bottom: 0;
 
 			&:hover,


### PR DESCRIPTION
- Increased total width of the footnotes section by removing unnecessary left/right margins (old carry-overs from WET 3.x).
- Slightly increased widths of return links to prevent right borders from disappearing in 2 column pages when 3 digit numbers are used.
- Adjusted vertical positioning of return links and nearby paragraphs to make them appear exactly on the same line.
