### PR TITLE
Tabbed interface: Added class to allow tabs to wrap.

### DIFF
--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -220,6 +220,16 @@ $tab-margin-width: 10px;
 				top: 1px;
 			}
 		}
+
+		&.allow-wrap {
+			border-spacing: 0;
+			display: block;
+
+			li {
+				display: inline-block;
+				left: auto;
+			}
+		}
 	}
 
 	[role="tabpanel"] {


### PR DESCRIPTION
@crochefort this should do the trick as a quick fix for the problem we discussed the other day. Just add the class `allow-wrap` to your tab list and it'll revert to the previous behaviour before #6730.
