### PR TITLE
Core: Normalized encoding of the query string in Internet Explorer to prevent cross-site scripting issues

### DIFF
--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -32,7 +32,7 @@ var getUrlParts = function( url ) {
 			// A collection of the parameters of the query string part of the URL.
 			params: ( function() {
 				var results = {},
-					queryString = a.search.replace( /^\?/, "" ).split( "&" ),
+					queryString = encodeURI( decodeURI( a.search.replace( /^\?/, "" ) ) ).replace( /'/g, "%27" ).split( "&" ),
 					len = queryString.length,
 					key, strings, i;
 


### PR DESCRIPTION
Note that this is only being done to encode in IE what other browsers encode by default.
