### PR TITLE
Update menu.js to fix a changing currentTarget on mouseleave 

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -494,12 +494,13 @@ $document.on( "timerpoke.wb " + initEvent + " ajax-fetched.wb ajax-failed.wb", s
 } );
 
 $document.on( "mouseleave", selector + " .menu", function( event ) {
-
+    var $currentTarget = $(event.currentTarget);
+    
 	// Clear the timeout for open/closing menus
 	clearTimeout( globalTimeout );
 
 	globalTimeout = setTimeout( function() {
-		menuClose( $( event.currentTarget ).find( ".active" ), true );
+		menuClose( $currentTarget.find( ".active" ), true );
 	}, hoverDelay );
 } );
 

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -494,8 +494,8 @@ $document.on( "timerpoke.wb " + initEvent + " ajax-fetched.wb ajax-failed.wb", s
 } );
 
 $document.on( "mouseleave", selector + " .menu", function( event ) {
-    var $currentTarget = $(event.currentTarget);
-    
+    var $currentTarget = $( event.currentTarget );
+
 	// Clear the timeout for open/closing menus
 	clearTimeout( globalTimeout );
 


### PR DESCRIPTION
We encountered a weird scope issue where by the time the setTimeout is executed, the event.currentTarget was changed to 'document' instead of the menu.

This caused all .active class on the page to be removed.

@LaurentGoderre proposed the following change which retains  the reference to the correct currentTarget.
