### PR TITLE
Build: Don't try and load the removed tasks folder

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1417,8 +1417,5 @@ module.exports = (grunt) ->
 	@loadNpmTasks "grunt-wget"
 	@loadNpmTasks "grunt-wet-boew-postbuild"
 
-	# Load custom grunt tasks form the tasks directory
-	@loadTasks "tasks"
-
 	require( "time-grunt" )( grunt )
 	@


### PR DESCRIPTION
The code previously stored there was moved to discrete plug-ins, so there is no folder/tasks to load anymore
