### PR TITLE
Build: Use new Travis-CI Docker infrastrucutre

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ notifications:
 cache:
   directories:
   - node_modules
+  - lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "0.12"
 
 sudo: false
 
@@ -9,7 +9,6 @@ env:
     - TRAVIS_COMMIT_MSG="$(git log --format=%B --no-merges -n 1)"
 
 install:
-  - npm -g install npm@next
   - ./script/setup
   - bundle install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - "0.10"
 
+sudo: false
+
 env:
   global:
     - TRAVIS_COMMIT_MSG="$(git log --format=%B --no-merges -n 1)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ notifications:
   - "chat.freenode.net#wet-boew"
 
 cache:
+  bundler: true
   directories:
   - node_modules
   - lib
+  - vendor/cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,7 @@ after_success:
 notifications:
   irc:
   - "chat.freenode.net#wet-boew"
+
+cache:
+  directories:
+  - node_modules


### PR DESCRIPTION
Moves the build worker to the new container based version http://docs.travis-ci.com/user/migrating-from-legacy/

Notes;
- Not ensure that the Bundler caching is working full, but it did seem to speed up my build by 30% after the first build primed the asset cache.
- Since we run `npm install` rather than `npm update` in the scripts, this will keep the versions at a set install version while the semver is still respected
- The global npm installs (grunt-cli, bower) don't appear to be cached right now, but since the location is dynamic based on the version of Node that nvm loads, I parked trying to address that.
