### PR TITLE
Build: Fix typo in call to gh-pages target

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -60,7 +60,7 @@ module.exports = (grunt) ->
 					"copy:deploy"
 					"gh-pages:travis"
 					"gh-pages:travis_cdn"
-					"gh-pages:travis_themes_cdn"
+					"gh-pages:travis_theme_cdn"
 					"wb-update-examples"
 				]
 	)


### PR DESCRIPTION
The build target "travis_theme_cdn" is singular.
This is causing the post_build to fail https://travis-ci.org/wet-boew/wet-boew/builds/71257436#L3946
