### PR TITLE
Build: Bump grunt-sass to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "grunt-jscs": "^1.5.0",
     "grunt-mocha": "~0.4.12",
     "grunt-modernizr": "~0.5.2",
-    "grunt-sass": "^0.14.1",
+    "grunt-sass": "^1.0.0",
     "grunt-saucelabs": "^8.5.0",
     "grunt-wet-boew-postbuild": "wet-boew/grunt-wet-boew-postbuild#v0.1.2",
     "grunt-wget": "~0.1.0",


### PR DESCRIPTION
I used KDiff3 to compare the dist outputs from the grunt/node-sass to the last build from the wet-boew-dist, and here is what I noticed:
- rgba(0, 0, 0, 0) to "transparent"
- single quotes to double in some cases
- selectors moved to new lines
- `@charset "UTF-8"` added automatically if it wasn't added manually
- strip leading zeros from values
- second green digit rounded down in some cases in the `.text-` classes in Bootrap. This may just be a precision difference for the `darken($color, 10%)`, since there is no difference to things like the grids
- removed media query blocks that contain only comments
- removed duplicate selectors when found on a class declaration. Ex: `.foo, bar, .foo` becomes `.foo, bar`
