### PR TITLE
Build: Fix regex when replacing ".min." assets

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -287,7 +287,7 @@ module.exports = (grunt) ->
 				( file ) ->
 					contents = grunt.file.read( file )
 					contents = contents.replace( /\.\.\/(wet\-boew|theme\-wet\-boew)/g, "$1" )
-					contents = contents.replace( /\"(?!https:)([^\"]*)?\.(js|css)\"/g, "\"$1.min.$2\"" )
+					contents = contents.replace( /\"(?!https:\/\/github\.com)([^\"]*)?\.(js|css)\"/g, "\"$1.min.$2\"" )
 
 					grunt.file.write(file, contents);
 			);
@@ -1123,13 +1123,13 @@ module.exports = (grunt) ->
 						dest: "dist"
 						expand: true
 					}
-					
+
 					{
 						src: "*.txt"
 						dest: "<%= coreDist %>"
 						expand: true
 					}
-					
+
 					{
 						src: "*.txt"
 						dest: "<%= themeDist %>"
@@ -1348,7 +1348,7 @@ module.exports = (grunt) ->
 				src: [
 					"**/*.*"
 				]
-				
+
 			travis_theme_cdn:
 				options:
 					repo: process.env.THEME_CDN_REPO


### PR DESCRIPTION
The regex exluded the jQuery CDN link when it addressed the issue
explained in #5734. When the other method of using `environment.suffix`
was removed, there was no more replacement catching the jQuery links.
