### PR TITLE
Bump autoprefixer & fix linear-gradient errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "assemble-contrib-i18n": "~0.1.2",
     "expect.js": "^0.3.1",
     "grunt": "~0.4.5",
-    "grunt-autoprefixer": "^1.0.1",
+    "grunt-autoprefixer": "^3.0.3",
     "grunt-banner": "^0.3.1",
     "grunt-bootlint": "^0.2.1",
     "grunt-check-dependencies": "~0.6.0",

--- a/src/polyfills/meter/meter.scss
+++ b/src/polyfills/meter/meter.scss
@@ -12,7 +12,7 @@ meter {
 
 	div {
 		background: #b4e391;
-		background-image: linear-gradient(top, #b4e391 0, #4a0 35%, #b4e391 100%);
+		background-image: linear-gradient(to bottom, #b4e391 0, #4a0 35%, #b4e391 100%);
 		border-right: 1px solid #000;
 		display: block;
 		height: 20px;
@@ -22,7 +22,7 @@ meter {
 	&.meterValueTooLow {
 		div {
 			background: #ffd65e;
-			background-image: linear-gradient(top, #ffd65e 0, #fbff47 35%, #febf04 100%);
+			background-image: linear-gradient(to bottom, #ffd65e 0, #fbff47 35%, #febf04 100%);
 		}
 	}
 

--- a/src/polyfills/slider/slider.scss
+++ b/src/polyfills/slider/slider.scss
@@ -176,7 +176,7 @@
 	@extend %slider-padding-0;
 	@extend %slider-position-absolute;
 	@extend %slider-z-index-3;
-	background-image: linear-gradient(left, #89a5bd, #165c91);
+	background-image: linear-gradient(to right, #89a5bd, #165c91);
 	left: 11px;
 	line-height: 2px;
 	top: 9px;
@@ -260,7 +260,7 @@ body {
 
 	.fd-slider-bar {
 		background-color: #555;
-		background-image: linear-gradient(left, #666, #333);
+		background-image: linear-gradient(to right, #666, #333);
 		border: 1px solid #888;
 		border: 1px solid rgba(136, 136, 136, .8);
 		border-bottom: 1px solid #999;
@@ -272,7 +272,7 @@ body {
 
 	.fd-slider-range {
 		background-color: #222;
-		background-image: linear-gradient(left, #222, #000);
+		background-image: linear-gradient(to right, #222, #000);
 		cursor: auto !important;
 	}
 }


### PR DESCRIPTION
Bumping the dependency highlighted errors in the polyfills linear-gradient syntax. This was likely caused during my original conversion of the upstream CSS to SCSS.

The proper result can be viewed in IE and iOS Safari, since they are the last browsers to require the polyfill.
