### PR TITLE
Build: Postbuild bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "grunt-modernizr": "~0.5.2",
     "grunt-sass": "^1.0.0",
     "grunt-saucelabs": "^8.5.0",
-    "grunt-wet-boew-postbuild": "wet-boew/grunt-wet-boew-postbuild#v0.1.2",
+    "grunt-wet-boew-postbuild": "^0.1.3",
     "grunt-wget": "~0.1.0",
     "load-grunt-tasks": "^3.2.0",
     "mocha": "^1.21.5",


### PR DESCRIPTION
Moves to the NPM published version to avoid repeated downloads when the Git tag is used.
