### PR TITLE
Site: Removed unnecessary role attributes (banner, navigation, main and contentinfo) from HTML5 code.

### DIFF
--- a/site/layouts/default.hbs
+++ b/site/layouts/default.hbs
@@ -18,7 +18,7 @@
 	</li>
 {{/is}}
 </ul>
-<header role="banner">
+<header>
 	<div id="wb-bnr">
 		<div id="wb-bar">
 			<div class="container">
@@ -55,7 +55,7 @@
 		</div>
 	</div>
 {{#isnt sitemenu "false"}}
-	<nav role="navigation" id="wb-sm" data-ajax-replace="{{#if page.altMenu}}{{page.altMenu}}{{else}}{{#if site.menuRoot}}{{site.menuRoot}}{{else}}{{assets}}{{/if}}/ajax/sitemenu{{/if}}-{{language}}.html" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement">
+	<nav id="wb-sm" data-ajax-replace="{{#if page.altMenu}}{{page.altMenu}}{{else}}{{#if site.menuRoot}}{{site.menuRoot}}{{else}}{{assets}}{{/if}}/ajax/sitemenu{{/if}}-{{language}}.html" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement">
 		{{>sitemenu}}
 	</nav>
 {{else}}
@@ -63,7 +63,7 @@
 {{/isnt}}
 {{#isnt breadcrumb "false"}}
 	{{#isnt assets "."}}
-		<nav role="navigation" id="wb-bc" property="breadcrumb">
+		<nav id="wb-bc" property="breadcrumb">
 			<h2>{{{i18n "you-are-here"}}}</h2>
 			{{>breadcrumbs}}
 		</nav>
@@ -75,7 +75,7 @@
 	<div class="container">
 		<div class="row">
 {{/is}}
-	<main role="main" property="mainContentOfPage" class="{{#is secondarymenu "true"}}col-md-9 col-md-push-3{{else}}{{#isnt fullwidthmain "true"}}container{{/isnt}}{{/is}}">
+	<main property="mainContentOfPage" class="{{#is secondarymenu "true"}}col-md-9 col-md-push-3{{else}}{{#isnt fullwidthmain "true"}}container{{/isnt}}{{/is}}">
 {{#isnt fullwidthmain "true"}}
 		{{>contenttitle}}
 		{{>sitewidemessages}}
@@ -87,7 +87,7 @@
 {{/if}}
 	</main>
 {{#is secondarymenu "true"}}
-			<nav role="navigation" id="wb-sec" typeof="SiteNavigationElement" class="col-md-3 col-md-pull-9 visible-md visible-lg">
+			<nav id="wb-sec" typeof="SiteNavigationElement" class="col-md-3 col-md-pull-9 visible-md visible-lg">
 				<h2>{{{i18n "tmpl-section-menu"}}}</h2>
 				{{>secondarymenu}}
 			</nav>
@@ -96,9 +96,9 @@
 {{/is}}
 
 {{#isnt footer "false"}}
-	<footer role="contentinfo" id="wb-info" class="visible-sm visible-md visible-lg wb-navcurr">
+	<footer id="wb-info" class="visible-sm visible-md visible-lg wb-navcurr">
 		<div class="container">
-			<nav role="navigation" class="row">
+			<nav class="row">
 				<h2>{{{i18n "tmpl-about-site"}}}</h2>
 				{{>footer}}
 			</nav>

--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -15,7 +15,7 @@
 		{{>headresources}}
 	</head>
 	<body vocab="http://schema.org/" typeof="WebPage">
-		<main role="main" property="mainContentOfPage" class="container">
+		<main property="mainContentOfPage" class="container">
 			<div class="row mrgn-tp-lg">
 				{{>body}}
 			</div>

--- a/site/layouts/splashpage.hbs
+++ b/site/layouts/splashpage.hbs
@@ -3,7 +3,7 @@
 	"layout": "core.hbs"
 }
 ---
-<header role="banner">
+<header>
 	<div id="wb-bnr">
 		<div class="container">
 			<div class="row mrgn-tp-lg mrgn-bttm-lg">
@@ -14,7 +14,7 @@
 		</div>
 	</div>
 </header>
-<main role="main" property="mainContentOfPage" class="container">
+<main property="mainContentOfPage" class="container">
 	<div class="row mrgn-tp-lg">
 		<div class="col-md-12">
 			{{>body}}

--- a/site/pages/docs/ref/menu/menu-en.hbs
+++ b/site/pages/docs/ref/menu/menu-en.hbs
@@ -30,7 +30,7 @@
 		<li>Add the following code to the <code>header</code> area of the page. <strong>Note:</strong> This step should already be done for most themes.
 			<ul>
 				<li><strong>English pages:</strong>
-					<pre><code>&lt;nav role="navigation" id="wb-sm" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;
+					<pre><code>&lt;nav id="wb-sm" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;
 	&lt;div class="container nvbar"&gt;
 		&lt;h2&gt;Topics menu&lt;/h2&gt;
 		&lt;div class="row"&gt;
@@ -44,7 +44,7 @@
 &lt;/nav&gt;</code></pre>
 				</li>
 				<li><strong>French pages:</strong>
-					<pre><code>&lt;nav role="navigation" id="wb-sm" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;
+					<pre><code>&lt;nav id="wb-sm" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;
 	&lt;div class="container nvbar"&gt;
 		&lt;h2&gt;Menu des sujets&lt;/h2&gt;
 		&lt;div class="row"&gt;
@@ -151,7 +151,7 @@
 &lt;/ul&gt;</code></pre>
 		</li>
 		<li><strong>Optional:</strong> Add <code>data-ajax-fetch="[url]"</code> to the element with <code>class="wb-menu"</code>, with <code>[url]</code> being the URL of the full menu to AJAX in.
-			<pre><code>&lt;nav role="navigation" id="wb-sm" data-ajax-fetch="ajax/menu-include-en.html" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;</code></pre>
+			<pre><code>&lt;nav id="wb-sm" data-ajax-fetch="ajax/menu-include-en.html" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;</code></pre>
 		</li>
 		<li><strong>Optional:</strong> Update <code>data-trgt</code> with the <code>id</code> of the target element for the mobile panel (in most cases this should not change).</li>
 	</ol>

--- a/site/pages/docs/ref/menu/menu-fr.hbs
+++ b/site/pages/docs/ref/menu/menu-fr.hbs
@@ -32,7 +32,7 @@
 		<li>Add the following code to the <code>header</code> area of the page. <strong>Note:</strong> This step should already be done for most themes.
 			<ul>
 				<li><strong>English pages:</strong>
-					<pre><code>&lt;nav role="navigation" id="wb-sm" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;
+					<pre><code>&lt;nav id="wb-sm" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;
 	&lt;div class="container nvbar"&gt;
 		&lt;h2&gt;Topics menu&lt;/h2&gt;
 		&lt;div class="row"&gt;
@@ -46,7 +46,7 @@
 &lt;/nav&gt;</code></pre>
 				</li>
 				<li><strong>French pages:</strong>
-					<pre><code>&lt;nav role="navigation" id="wb-sm" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;
+					<pre><code>&lt;nav id="wb-sm" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;
 	&lt;div class="container nvbar"&gt;
 		&lt;h2&gt;Menu des sujets&lt;/h2&gt;
 		&lt;div class="row"&gt;
@@ -153,7 +153,7 @@
 &lt;/ul&gt;</code></pre>
 		</li>
 		<li><strong>Optional:</strong> Add <code>data-ajax-fetch="[url]"</code> to the element with <code>class="wb-menu"</code>, with <code>[url]</code> being the URL of the full menu to AJAX in.
-			<pre><code>&lt;nav role="navigation" id="wb-sm" data-ajax-fetch="ajax/menu-include-en.html" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;</code></pre>
+			<pre><code>&lt;nav id="wb-sm" data-ajax-fetch="ajax/menu-include-en.html" data-trgt="mb-pnl" class="wb-menu visible-md visible-lg" typeof="SiteNavigationElement"&gt;</code></pre>
 		</li>
 		<li><strong>Optional:</strong> Update <code>data-trgt</code> with the <code>id</code> of the target element for the mobile panel (in most cases this should not change).</li>
 	</ol>


### PR DESCRIPTION
Prevents warnings in the W3C's NU HTML validator related to those roles serving the same purpose as the elements they've been set on.

Example of the warnings:
https://validator.w3.org/nu/?showsource=yes&doc=http%3A%2F%2Fwet-boew.github.io%2Fv4.0-ci%2Findex-en.html
