### PR TITLE
Build: Bump Grunt-Bootlint to 0.9.1

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -897,11 +897,15 @@ module.exports = (grunt) ->
 				options:
 					relaxerror: [
 						# We recommend handling this through the server headers so it never appears in the markup
-						"<head> is missing X-UA-Compatible <meta> tag that disables old IE compatibility modes"
+						"W002" # `<head>` is missing X-UA-Compatible `<meta>` tag that disables old IE compatibility modes
+						"W005" # Unable to locate jQuery, which is required for Bootstrap's JavaScript plugins to work; however, you might not be using Bootstrap's JavaScript
 						# TODO: The rules below should be resolved
-						"Only columns (.col-*-*) may be children of `.row`s"
-						"Unable to locate jQuery, which is required for Bootstrap's JavaScript plugins to work"
-						"Columns (.col-*-*) can only be children of `.row`s or `.form-group`s"
+						"W009" # Using empty spacer columns isn't necessary with Bootstrap's grid. So instead of having an empty grid column with `class="col-xs-12"` , just add `class="col-xs-offset-12"` to the next grid column.
+						"W010" # Using `.pull-left` or `.pull-right` as part of the media object component is deprecated as of Bootstrap v3.3.0. Use `.media-left` or `.media-right` instead.
+						"E013" # Only columns (`.col-*-*`) may be children of `.row`s
+						"E014" # Columns (`.col-*-*`) can only be children of `.row`s or `.form-group`s
+						"E031" # Glyphicon classes must only be used on elements that contain no text content and have no child elements.
+						"E032" # `.modal-content` must be a child of `.modal-dialog`
 					]
 				src: [
 					"dist/**/*.html"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt": "~0.4.5",
     "grunt-autoprefixer": "^3.0.3",
     "grunt-banner": "^0.3.1",
-    "grunt-bootlint": "^0.2.1",
+    "grunt-bootlint": "^0.9.1",
     "grunt-check-dependencies": "~0.6.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-concat": "~0.5.0",


### PR DESCRIPTION
The suppressed errors should be addressed, but since most require chagnes to the markup, they may need to land with a 4.1 release.
Fixes #6517
Closes #6524
