### PR TITLE
Build: Update grunt-contrib-jshint 0.11.2

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,7 +12,8 @@
 	"globals": {
 		"wb": true,
 		"Modernizr": true,
-		"yepnope": true
+		"yepnope": true,
+		"JSON": true
 	},
 	"jquery": true,
 	"browser": true,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-htmlmin": "^0.4.0",
     "grunt-contrib-imagemin": "~0.9.2",
-    "grunt-contrib-jshint": "^0.10.0",
+    "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-uglify": "~0.5.1",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-cssmin-ie8-clean": "0.0.1",


### PR DESCRIPTION
This now runs JSHint 2.8, which exposed some conflicting options. ES3
didn’t support JSON, but IE8 did so we can safely assume it should be
in all supported browsers.
