### PR TITLE
Proposal for Facebook plugin

### DIFF
--- a/site/pages/docs/ref/facebook/facebook-en.hbs
+++ b/site/pages/docs/ref/facebook/facebook-en.hbs
@@ -1,0 +1,79 @@
+---
+{
+	"title": "Facebook embedded pages",
+	"language": "en",
+	"category": "Plugins",
+	"categoryfile": "plugins",
+	"description": "Helps with implementing Facebook embedded pages.",
+	"altLangPrefix": "facebook",
+	"dateModified": "2015-08-03"
+}
+---
+<span class="wb-prettify all-pre hide"></span>
+
+<section>
+	<h2>Purpose</h2>
+	<p>Helps with implementing Facebook embedded pages.</p>
+</section>
+
+<section>
+	<h2>Working example</h2>
+	<ul>
+		<li><a href="../../../demos/facebook/facebook-en.html">English example</a></li>
+		<li><a href="../../../demos/facebook/facebook-fr.html">French example</a></li>
+	</ul>
+</section>
+
+<section>
+	<h2>How to implement</h2>
+	<ol>
+		<li>Create an embedded page on the <a rel="external" href="https://developers.facebook.com/docs/plugins/page-plugin">Facebook Page Plugin</a> documentation.</li>
+		<li>Press the "Get Code" button and copy only the HTML portion in the second section of the popup</li>
+		<li>For each area that will display a Facebook embedded page, create a <code>div</code> element with <code>class="wb-facebook"</code>.
+			<pre><code>&lt;div class="wb-facebook"&gt;&lt;/div&gt;</code></pre>
+		</li>
+		<li>Inside the div paste the HTML code from the "Get Code" button in the earlier step</li></ol>
+</section>
+
+<section>
+	<h2>Events</h2>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Event</th>
+				<th>Trigger</th>
+				<th>What it does</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>wb-init.wb-facebook</code></td>
+				<td>Triggered manually (e.g., <code>$( ".wb-facebook" ).trigger( "wb-init.wb-facebook" );</code>).</td>
+				<td>Used to manually initialize the Facebook embedded pages. <strong>Note:</strong> The Facebook embedded page will be initialized automatically unless the required markup is added after the page has already loaded.</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb-facebook</code> (v4.0.5+)</td>
+				<td>Triggered automatically after the Facebook embedded page initializes.</td>
+				<td>Used to identify where the Facebook embedded page was initialized (target of the event).
+					<pre><code>$( document ).on( "wb-ready.wb-facebook", ".wb-facebook", function( event ) {
+});</code></pre>
+					<pre><code>$( ".wb-facebook" ).on( "wb-ready.wb-facebook", function( event ) {
+});</code></pre>
+				</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb</code> (v4.0.5+)</td>
+				<td>Triggered automatically when WET has finished loading and executing.</td>
+				<td>Used to identify when all WET plugins and polyfills have finished loading and executing.
+					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
+});</code></pre>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+
+<section>
+	<h2>Source code</h2>
+	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/facebook">Facebook embedded pages plugin source code on GitHub</a></p>
+</section>

--- a/site/pages/docs/ref/facebook/facebook-fr.hbs
+++ b/site/pages/docs/ref/facebook/facebook-fr.hbs
@@ -1,0 +1,79 @@
+---
+{
+	"title": "Facebook embedded pages (TODO FR)",
+	"language": "fr",
+	"category": "Plugiciels",
+	"categoryfile": "plugins",
+	"description": "Helps with implementing Facebook embedded pages.",
+	"altLangPrefix": "facebook",
+	"dateModified": "2015-08-03"
+}
+---
+<span class="wb-prettify all-pre hide"></span>
+
+<section>
+	<h2>Purpose</h2>
+	<p>Helps with implementing Facebook embedded pages.</p>
+</section>
+
+<section>
+	<h2>Working example</h2>
+	<ul>
+		<li><a href="../../../demos/facebook/facebook-en.html">English example</a></li>
+		<li><a href="../../../demos/facebook/facebook-fr.html">French example</a></li>
+	</ul>
+</section>
+
+<section>
+	<h2>How to implement</h2>
+	<ol>
+		<li>Create an embedded page on the <a rel="external" href="https://developers.facebook.com/docs/plugins/page-plugin">Facebook Page Plugin</a> documentation.</li>
+		<li>Press the "Get Code" button and copy only the HTML portion in the second section of the popup</li>
+		<li>For each area that will display a Facebook embedded page, create a <code>div</code> element with <code>class="wb-facebook"</code>.
+			<pre><code>&lt;div class="wb-facebook"&gt;&lt;/div&gt;</code></pre>
+		</li>
+		<li>Inside the div paste the HTML code from the "Get Code" button in the earlier step</li></ol>
+</section>
+
+<section>
+	<h2>Events</h2>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Event</th>
+				<th>Trigger</th>
+				<th>What it does</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>wb-init.wb-facebook</code></td>
+				<td>Triggered manually (e.g., <code>$( ".wb-facebook" ).trigger( "wb-init.wb-facebook" );</code>).</td>
+				<td>Used to manually initialize the Facebook embedded pages. <strong>Note:</strong> The Facebook embedded page will be initialized automatically unless the required markup is added after the page has already loaded.</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb-facebook</code> (v4.0.5+)</td>
+				<td>Triggered automatically after the Facebook embedded page initializes.</td>
+				<td>Used to identify where the Facebook embedded page was initialized (target of the event).
+					<pre><code>$( document ).on( "wb-ready.wb-facebook", ".wb-facebook", function( event ) {
+});</code></pre>
+					<pre><code>$( ".wb-facebook" ).on( "wb-ready.wb-facebook", function( event ) {
+});</code></pre>
+				</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb</code> (v4.0.5+)</td>
+				<td>Triggered automatically when WET has finished loading and executing.</td>
+				<td>Used to identify when all WET plugins and polyfills have finished loading and executing.
+					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
+});</code></pre>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+
+<section>
+	<h2>Source code</h2>
+	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/facebook">Facebook embedded pages plugin source code on GitHub</a></p>
+</section>

--- a/src/plugins/facebook/facebook-en.hbs
+++ b/src/plugins/facebook/facebook-en.hbs
@@ -1,0 +1,39 @@
+---
+{
+	"title": "Facebook embedded pages",
+	"language": "en",
+	"category": "Plugins",
+	"description": "Helps with implementing Facebook embedded pages.",
+	"tag": "facebook",
+	"parentdir": "facebook",
+	"altLangPrefix": "facebook",
+	"dateModified": "2015-08-03"
+}
+---
+<span class="wb-prettify all-pre hide"></span>
+
+<section>
+	<h2>Purpose</h2>
+	<p>Helps with implementing Facebook embedded pages.</p>
+</section>
+
+<section>
+	<h2>Example</h2>
+
+	<div class="wb-facebook">
+		<div class="fb-page" data-href="https://www.facebook.com/ParksCanada" data-small-header="true" data-hide-cover="false" data-show-facepile="false" data-show-posts="true">
+			<div class="fb-xfbml-parse-ignore"><blockquote cite="https://www.facebook.com/ParksCanada"><a href="https://www.facebook.com/ParksCanada">Parks Canada Facebook</a></blockquote></div>
+		</div>
+	</div>
+
+	<section>
+		<h3>Code</h3>
+		<pre><code>&lt;div class=&quot;wb-facebook&quot;&gt;
+		&lt;div class=&quot;fb-page&quot; data-href=&quot;https://www.facebook.com/ParksCanada&quot; data-small-header=&quot;true&quot; data-hide-cover=&quot;false&quot; data-show-facepile=&quot;false&quot; data-show-posts=&quot;true&quot;&gt;
+			&lt;div class=&quot;fb-xfbml-parse-ignore&quot;&gt;&lt;blockquote cite=&quot;https://www.facebook.com/ParksCanada&quot;&gt;&lt;a href=&quot;https://www.facebook.com/ParksCanada&quot;&gt;Parks Canada Facebook&lt;/a&gt;&lt;/blockquote&gt;&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;</code></pre>
+	</section>
+
+	<p><a href="https://developers.facebook.com/docs/plugins/page-plugin#Settings">Facebook Embedded Pages configuration options</a></p>
+</section>

--- a/src/plugins/facebook/facebook-fr.hbs
+++ b/src/plugins/facebook/facebook-fr.hbs
@@ -1,0 +1,39 @@
+---
+{
+	"title": "Facebook embedded pages (TODO FR)",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Helps with implementing Facebook embedded pages.",
+	"tag": "facebook",
+	"parentdir": "facebook",
+	"altLangPrefix": "facebook",
+	"dateModified": "2015-08-03"
+}
+---
+<span class="wb-prettify all-pre hide"></span>
+
+<section>
+	<h2>Purpose</h2>
+	<p>Helps with implementing Facebook embedded pages.</p>
+</section>
+
+<section>
+	<h2>Example</h2>
+
+	<div class="wb-facebook">
+		<div class="fb-page" data-href="https://www.facebook.com/ParcsCanada" data-small-header="true" data-hide-cover="false" data-show-facepile="false" data-show-posts="true">
+			<div class="fb-xfbml-parse-ignore"><blockquote cite="https://www.facebook.com/ParcsCanada"><a href="https://www.facebook.com/ParcsCanada">Parcs Canada Facebook</a></blockquote></div>
+		</div>
+	</div>
+
+	<section>
+		<h3>Code</h3>
+		<pre><code>&lt;div class=&quot;wb-facebook&quot;&gt;
+		&lt;div class=&quot;fb-page&quot; data-href=&quot;https://www.facebook.com/ParcsCanada&quot; data-small-header=&quot;true&quot; data-hide-cover=&quot;false&quot; data-show-facepile=&quot;false&quot; data-show-posts=&quot;true&quot;&gt;
+			&lt;div class=&quot;fb-xfbml-parse-ignore&quot;&gt;&lt;blockquote cite=&quot;https://www.facebook.com/ParcsCanada&quot;&gt;&lt;a href=&quot;https://www.facebook.com/ParcsCanada&quot;&gt;Parcs Canada Facebook&lt;/a&gt;&lt;/blockquote&gt;&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;</code></pre>
+	</section>
+
+	<p><a href="https://developers.facebook.com/docs/plugins/page-plugin#Settings">Facebook Embedded Pages configuration options</a></p>
+</section>

--- a/src/plugins/facebook/facebook.js
+++ b/src/plugins/facebook/facebook.js
@@ -1,0 +1,59 @@
+/**
+* @title WET-BOEW Facebook embedded page
+* @overview Helps with implementing Facebook embedded pages.
+* @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+* @author @pjackson28
+*/
+( function( $, window, wb ) {
+	"use strict";
+
+	/*
+	* Variable and function definitions.
+	* These are global to the plugin - meaning that they will be initialized once per page,
+	* not once per instance of plugin on the page. So, this is a good place to define
+	* variables that are common to all instances of the plugin on a page.
+	*/
+	var componentName = "wb-facebook",
+	selector = "." + componentName,
+	initEvent = "wb-init" + selector,
+	$document = wb.doc,
+	fbinited = false,
+
+	/**
+	* @method init
+	* @param {jQuery Event} event Event that triggered the function call
+	*/
+	init = function( event ) {
+
+		// Start initialization
+		// returns DOM object = proceed with init
+		// returns undefined = do not proceed with init (e.g., already initialized)
+		var ele = wb.init( event, componentName, selector ),
+			protocol = wb.pageUrlParts.protocol;
+
+		if ( ele ) {
+			Modernizr.load(
+				{
+					load: [ protocol.indexOf( "http" ) === -1 ? "http:" : protocol ) + "//connect.facebook.net/" + wb.lang + "_US/sdk.js" ],
+					complete: function() {
+						if ( !fbinited ) {
+							window.FB.init( {
+								version: "v2.4"
+							} );
+							fbinited = true;
+						}
+
+						window.FB.XFBML.parse( ele[ 0 ] );
+						wb.ready( $( ele ), componentName );
+					}
+				}
+			);
+		}
+	};
+
+	$document.on( "timerpoke.wb " + initEvent, selector, init );
+
+	// Add the timer poke to initialize the plugin
+	wb.add( selector );
+
+} )( jQuery, window, wb );

--- a/src/plugins/facebook/facebook.js
+++ b/src/plugins/facebook/facebook.js
@@ -34,7 +34,7 @@
 		if ( ele ) {
 			Modernizr.load(
 				{
-					load: [ protocol.indexOf( "http" ) === -1 ? "http:" : protocol ) + "//connect.facebook.net/" + wb.lang + "_US/sdk.js" ],
+					load: [ ( protocol.indexOf( "http" ) === -1 ? "http:" : protocol ) + "//connect.facebook.net/" + wb.lang + "_US/sdk.js" ],
 					complete: function() {
 						if ( !fbinited ) {
 							window.FB.init( {

--- a/src/plugins/facebook/test.js
+++ b/src/plugins/facebook/test.js
@@ -1,0 +1,56 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * @title Facebook Plugin Unit Tests
+ * @overview Test the favicon plugin behaviour
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+/* global jQuery, describe, it, expect, before, after */
+/* jshint unused:vars */
+( function( $, wb ) {
+
+/*
+ * Create a suite of related test cases using `describe`. Test suites can also be
+ * nested in other test suites if you want to use the same setup `before()` and
+ * teardown `after()` for more than one test suite (as is the case below.)
+*/
+
+describe( "Facebook test suite", function() {
+
+  /*
+   * Test the initialization and default behaviour of the plugin
+   */
+  var $elm,
+    $document = wb.doc,
+    $body = $document.find( "body" );
+
+  before( function( done ) {
+
+    // The facebook widget sometimes takes longer than two second to load
+    this.timeout( 5000 );
+
+    // Trigger plugin init
+    $elm = $( '<div class="wb-facebook"><div class="fb-page" data-href="https://www.facebook.com/canada150th"></div></div>' )
+      .appendTo( $body )
+      .trigger( "wb-init.wb-facebook" );
+
+    $document.on( "wb-ready.wb-facebook", ".wb-facebook", function() {
+      done();
+    } );
+  } );
+
+  after( function() {
+    $elm.remove();
+  } );
+
+  /*
+   * Test the initialization events of the plugin
+   */
+  describe( "init event", function() {
+    it( "should have added the wb-facebook-inited CSS class", function() {
+      expect( $elm.hasClass( "wb-facebook-inited" ) ).to.equal( true );
+    } );
+  } );
+
+} );
+
+}( jQuery, wb ) );

--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -27,33 +27,6 @@ var componentName = "wb-feeds",
 	 * @returns {string} modified string with appropiate markup/format for a entry object
 	 */
 	Templates = {
-
-		/**
-		 * [facebook template]
-		 * @param  {entry object} data
-		 * @return {string}	HTML string of formatted using Media Object (twitter bootstrap)
-		 */
-		facebook: function( data ) {
-
-			// Facebook feeds does not really do titles in ATOM RSS. It simply truncates content at 150 characters. We are using a JS based sentence
-			// detection algorithm to better split content and titles
-			var content = fromCharCode( data.content ),
-				title = content.replace( /(<([^>]+)>)/ig, "" ).match( /\(?[^\.\?\!]+[\.!\?]\)?/g ),
-				author = data.author.replace( /&amp;/g, "&" );
-
-			// Sanitize the HTML from Facebook - extra 'br' tags
-			content = content.replace( /(<br>\n?)+/gi, "<br />" );
-
-			return "<li class='media'><a class='pull-left' href=''><img src='" +
-				data.fIcon + "' alt='" + author +
-				"' height='64px' width='64px' class='media-object'/></a><div class='media-body'>" +
-				"<h4 class='media-heading'><a href='" + data.link + "'><span class='wb-inv'>" +
-				title[ 0 ] + " - </span>" + author + "</a><br />" +
-				( data.publishedDate !== "" ? " <small class='feeds-date text-right'><time>" +
-				wb.date.toDateISO( data.publishedDate, true ) + "</time></small>" : "" ) +
-				"</h4><p>" + content + "</p></div></li>";
-		},
-
 		/**
 		 * [fickr template]
 		 * @param  {entry object} data
@@ -229,9 +202,7 @@ var componentName = "wb-feeds",
 					fetch.url = url;
 
 					// Let's bind the template to the Entries
-					if ( url.indexOf( "facebook.com" ) !== -1 ) {
-						fType = "facebook";
-					} else if ( url.indexOf( "pinterest.com" ) > -1  ) {
+					if ( url.indexOf( "pinterest.com" ) > -1  ) {
 						fType = "pinterest";
 					} else {
 						fType = "generic";


### PR DESCRIPTION
As Facebook feeds functionality no longer functions, this plugin is a proposal to replace the functionality.  

This plugin uses Facebook embedded pages similar to the twitter plugin to allow embedding of Facebook pages which were previously used as feeds.

Updating the feed plugin to use the newer API is not suitable as it would require a private API key distributed for client side functionality.

My first revision of this attempted to integrate directly with the feeds plugin transparently but it did not integrate very well and I had concerns about the large visual change which would be placed on clients using the feed plugin for Facebook previously without notice.  Thus, I split it out.

Translation of docs still has to happen, however, the proposed functionality is all there.

Feeds documentation needs to be changed to point to the Facebook plugin.

![fb](https://cloud.githubusercontent.com/assets/13316676/9047206/4eec028a-39fe-11e5-8a8b-89f94d479003.png)
