### PR TITLE
Feeds: Escape quotes on properties.

### DIFF
--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -1101,6 +1101,10 @@
 		} );
 	};
 
+	wb.propsafe = function( str ) {
+		return str.replace( /'/g, "&#39;" ).replace( /"/g, "&#34;" );
+	};
+
 } )( wb );
 
 ( function( $, undef ) {

--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -1101,7 +1101,7 @@
 		} );
 	};
 
-	wb.propsafe = function( str ) {
+	wb.escapeAttribute = function( str ) {
 		return str.replace( /'/g, "&#39;" ).replace( /"/g, "&#34;" );
 	};
 

--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -69,7 +69,7 @@ var componentName = "wb-feeds",
 				};
 
 			// due to CORS we cannot default to simple ajax pulls of the image. We have to inline the content box
-			return "<li><a class='feed-flickr' href='javascript:;' data-flickr='" + JSON.stringify( flickrData ) + "'><img src='" + flickrData.thumbnail + "' alt='" + flickrData.title + "' title='" + flickrData.title + "' class='img-responsive'/></a></li>";
+			return "<li><a class='feed-flickr' href='javascript:;' data-flickr='" + wb.propsafe( JSON.stringify( flickrData ) ) + "'><img src='" + flickrData.thumbnail + "' alt='" + wb.propsafe( flickrData.title ) + "' title='" + wb.propsafe( flickrData.title ) + "' class='img-responsive'/></a></li>";
 		},
 
 		/**
@@ -84,7 +84,7 @@ var componentName = "wb-feeds",
 			};
 
 			// Due to CORS we cannot default to simple ajax pulls of the image. We have to inline the content box
-			return "<li class='col-md-4 col-sm-6 feed-youtube' data-youtube='" + JSON.stringify( youtubeDate ) + "'><a href='javascript:;'><img src='http://img.youtube.com/vi/" + youtubeDate.videoId + "/mqdefault.jpg' alt='" + youtubeDate.title + "' title='" + youtubeDate.title + "' class='img-responsive' /></a></li>";
+			return "<li class='col-md-4 col-sm-6 feed-youtube' data-youtube='" + wb.propsafe( JSON.stringify( youtubeDate ) ) + "'><a href='javascript:;'><img src='http://img.youtube.com/vi/" + youtubeDate.videoId + "/mqdefault.jpg' alt='" + wb.propsafe( youtubeDate.title ) + "' title='" + wb.propsafe( youtubeDate.title ) + "' class='img-responsive' /></a></li>";
 		},
 		/**
 		 * [pinterest template]

--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -69,7 +69,7 @@ var componentName = "wb-feeds",
 				};
 
 			// due to CORS we cannot default to simple ajax pulls of the image. We have to inline the content box
-			return "<li><a class='feed-flickr' href='javascript:;' data-flickr='" + wb.propsafe( JSON.stringify( flickrData ) ) + "'><img src='" + flickrData.thumbnail + "' alt='" + wb.propsafe( flickrData.title ) + "' title='" + wb.propsafe( flickrData.title ) + "' class='img-responsive'/></a></li>";
+			return "<li><a class='feed-flickr' href='javascript:;' data-flickr='" + wb.escapeAttribute( JSON.stringify( flickrData ) ) + "'><img src='" + flickrData.thumbnail + "' alt='" + wb.escapeAttribute( flickrData.title ) + "' title='" + wb.escapeAttribute( flickrData.title ) + "' class='img-responsive'/></a></li>";
 		},
 
 		/**
@@ -84,7 +84,7 @@ var componentName = "wb-feeds",
 			};
 
 			// Due to CORS we cannot default to simple ajax pulls of the image. We have to inline the content box
-			return "<li class='col-md-4 col-sm-6 feed-youtube' data-youtube='" + wb.propsafe( JSON.stringify( youtubeDate ) ) + "'><a href='javascript:;'><img src='http://img.youtube.com/vi/" + youtubeDate.videoId + "/mqdefault.jpg' alt='" + wb.propsafe( youtubeDate.title ) + "' title='" + wb.propsafe( youtubeDate.title ) + "' class='img-responsive' /></a></li>";
+			return "<li class='col-md-4 col-sm-6 feed-youtube' data-youtube='" + wb.escapeAttribute( JSON.stringify( youtubeDate ) ) + "'><a href='javascript:;'><img src='http://img.youtube.com/vi/" + youtubeDate.videoId + "/mqdefault.jpg' alt='" + wb.escapeAttribute( youtubeDate.title ) + "' title='" + wb.escapeAttribute( youtubeDate.title ) + "' class='img-responsive' /></a></li>";
 		},
 		/**
 		 * [pinterest template]


### PR DESCRIPTION
Fixes #6997 and a potential issue with youtube videos with `'` in their title.  Ideally these would be generating DOM directly but I am not sure if there are speed concerns there.