### PR TITLE
Allow generic JSONP call through data-ajax

### DIFF
--- a/src/plugins/feeds/feeds.js
+++ b/src/plugins/feeds/feeds.js
@@ -203,6 +203,9 @@ var componentName = "wb-feeds",
 						fType =  "flickr";
 						callback = "jsoncallback";
 						$content.data( componentName + "-postProcess", [ ".wb-lbx" ] );
+					} else {
+						fType = "generic";
+						callback = "callback";
 					}
 
 					// We need a Gallery so lets add another plugin


### PR DESCRIPTION
Small change to allow internal JSONP calls using the plugin. 
Basically, it allows an internal JSONP source to be used as the datasource for the feeds. 

For reference: https://github.com/wet-boew/wet-boew/issues/7030
