### PR TITLE
Make secnav selector less restrictive (menu.js)

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -260,7 +260,7 @@ var componentName = "wb-menu",
 			// Add the secondary menu
 			if ( $secnav.length !== 0 ) {
 				allProperties.push( [
-					$secnav.find( "ul > li > *:first-child" ).get(),
+					$secnav.find( "ul" ).filter( ":not(li > ul)" ).find( " > li > *:first-child" ).get(),
 					"sec-pnl",
 					$secnav.find( "h2" ).html()
 				] );

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -260,7 +260,7 @@ var componentName = "wb-menu",
 			// Add the secondary menu
 			if ( $secnav.length !== 0 ) {
 				allProperties.push( [
-					$secnav.find( "> ul > li > *:first-child" ).get(),
+					$secnav.find( "ul > li > *:first-child" ).get(),
 					"sec-pnl",
 					$secnav.find( "h2" ).html()
 				] );


### PR DESCRIPTION
Some systems (like Drupal) need to have DIVs wrapping the secondary menu UL element. This makes the selector less restrictive. Otherwise the secondary menu will not get populated in the mobile menu.
