### PR TITLE
Form validation: Fixed label for minimum of 2 words example

### DIFF
--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2015-07-22"
+	"dateModified": "2015-10-19"
 }
 ---
 <section>
@@ -278,7 +278,7 @@
 				</details>
 
 				<div class="form-group">
-					<label for="word2"><span class="field-name">Maximum of 2 words</span></label>
+					<label for="word2"><span class="field-name">Minimum of 2 words</span></label>
 					<input class="form-control" id="word2" name="word2" type="text" data-rule-minWords="2" />
 				</div>
 				<details class="mrgn-bttm-md">


### PR DESCRIPTION
Fixes #7145
