### PR TITLE
Travis: Do not cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,3 @@ after_success:
 notifications:
   irc:
   - "chat.freenode.net#wet-boew"
-
-cache:
-  bundler: true
-  directories:
-  - node_modules
-  - lib
-  - vendor/cache

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -47,7 +47,6 @@ module.exports = (grunt) ->
 		[
 			"js-min"
 			"css-min"
-			"imagemin"
 		]
 	)
 
@@ -1170,13 +1169,6 @@ module.exports = (grunt) ->
 						if filepath.match(/\.css/)
 							return content.replace(/\.\.\/\.\.\/wet-boew\/(assets|fonts)/g, '../$1')
 						content
-
-		imagemin:
-			all:
-				cwd: "dist/"
-				src: "**/*.png"
-				dest: "dist/"
-				expand: true
 
 		clean:
 			dist: ["dist", "src/base/partials/*sprites*"]

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "grunt-contrib-csslint": "~0.4.0",
     "grunt-contrib-cssmin": "^0.9.0",
     "grunt-contrib-htmlmin": "^0.4.0",
-    "grunt-contrib-imagemin": "~0.9.4",
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-contrib-uglify": "~0.5.1",
     "grunt-contrib-watch": "~0.6.1",


### PR DESCRIPTION
Travis is caching old versions of modules and making for a very inconsistent build and hard to track down failures