### PR TITLE
fixes 7191

### DIFF
--- a/src/plugins/cal-events/cal-events.js
+++ b/src/plugins/cal-events/cal-events.js
@@ -242,7 +242,7 @@ var componentName = "wb-calevt",
 
 					events.list[ events.iCount ] = {
 						title: title,
-						date: new Date(date.getTime()),
+						date: new Date( date.getTime() ),
 						href: href,
 						target: target
 					};

--- a/src/plugins/cal-events/cal-events.js
+++ b/src/plugins/cal-events/cal-events.js
@@ -242,7 +242,7 @@ var componentName = "wb-calevt",
 
 					events.list[ events.iCount ] = {
 						title: title,
-						date: date,
+						date: new Date(date.getTime()),
 						href: href,
 						target: target
 					};


### PR DESCRIPTION
Variable named 'date' was inside a loop and being overwritten in the next iteration of the loop. Fixed by setting date to date = new Date (date.getTime())
