### PR TITLE
Fix btn-xs

### DIFF
--- a/src/base/bootstrap-overrides/_base.scss
+++ b/src/base/bootstrap-overrides/_base.scss
@@ -749,6 +749,14 @@ fieldset {
 
 
 /*
+ * btn-xs should be equal to btn-sm in >v4.0.*
+*/
+.btn-group-xs .btn,
+.btn.btn-xs {
+	min-height: 0;
+}
+
+/*
  *  Right-to-left support
  */
 [dir=rtl] {


### PR DESCRIPTION
Fixes #6905, in v4.1 btn-xs should be equal to btn-sm