### PR TITLE
Fix overlapping extra borders on small view tabs.

### DIFF
--- a/src/plugins/tabs/_screen-sm-max.scss
+++ b/src/plugins/tabs/_screen-sm-max.scss
@@ -9,7 +9,10 @@
 %tabs-screen-sm-max-backwards-compat {
 	> {
 		details {
+			border: 0;
 			border-bottom: $tablist-screen-sm-seperator-border-color $tablist-screen-sm-seperator-border-style $tablist-screen-sm-seperator-border-width;
+			border-bottom-left-radius: 0;
+			border-bottom-right-radius: 0;
 
 			&:last-of-type {
 				border-bottom: 0;
@@ -19,9 +22,16 @@
 				min-height: 0 !important;
 			}
 
+			> {
+				summary {
+					border: 0;
+				}
+			}
+
 			&[open] {
 				> {
 					summary {
+						border: 0;
 						margin-bottom: 0;
 					}
 				}


### PR DESCRIPTION
Before:
![before](https://cloud.githubusercontent.com/assets/13316676/11285013/48966a38-8edb-11e5-9246-b0c8d05279f8.png)


After:

![after](https://cloud.githubusercontent.com/assets/13316676/11285018/4c452d72-8edb-11e5-98de-5775d9b939aa.png)
