### PR TITLE
Tabs: Fix tabs equalheight adding both on and off class at the same time

### DIFF
--- a/src/plugins/tabs/tabs.js
+++ b/src/plugins/tabs/tabs.js
@@ -676,9 +676,8 @@ var componentName = "wb-tabs",
 						}
 
 						// Enable equal heights for large view or disable for small view
-						if ( isSmallView !== $elm.hasClass( equalHeightOffClass ) ) {
-							$elm.toggleClass( equalHeightClass + " " + equalHeightOffClass );
-						}
+						$elm.toggleClass( equalHeightClass, !isSmallView );
+						$elm.toggleClass( equalHeightOffClass, isSmallView );
 
 						$summary.attr( "aria-hidden", !isSmallView );
 						$tablist.attr( "aria-hidden", isSmallView );


### PR DESCRIPTION
I'm not even sure if equal heights is even working correctly with this fix, or if it ever worked.  I am looking into this tonight to see if I can make it work in earlier versions in any browser.