### PR TITLE
Form validation: Fixed undefined variable

### DIFF
--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -167,7 +167,8 @@ var componentName = "wb-frmvld",
 								prefixEnd = i18nText.colon + " </span>",
 								separator = i18nText.hyphen,
 								ariaLive = $form.parent().find( ".arialive" )[ 0 ],
-								$summaryContainer, summary, key, i, len, $error, prefix, $fieldName, $fieldset, label, labelString;
+								summary, key, i, len, $error, prefix, $fieldName, $fieldset, label, labelString,
+								$summaryContainer = $form.find( "#" + errorFormId );
 
 							// Correct the colouring of fields that are no longer invalid
 							$form


### PR DESCRIPTION
$summaryContainer was declared but undefined. The error happened when the $errors.length was equal to 0.
