### PR TITLE
formvalid: Clear out current error summar properly.

### DIFF
--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -263,7 +263,7 @@ var componentName = "wb-frmvld",
 								if ( ariaLive.innerHTML.length !== 0 ) {
 									ariaLive.innerHTML = "";
 								}
-								$summaryContainer.detach();
+								$form.find( "#" + errorFormId ).detach();
 							}
 
 						}, /* End of showErrors() */


### PR DESCRIPTION
Related to #7304 but awaiting confirmation that it only does not clear out the error fully, but never prevents the form from submitting.