### PR TITLE
Theme: Fixed various RTL breadcrumb issues.

### DIFF
--- a/theme/breadcrumb/_base.scss
+++ b/theme/breadcrumb/_base.scss
@@ -1,6 +1,11 @@
 /*
  Breadcrumbs
  */
+
+%breadcrumb-no-icon {
+	display: none;
+}
+
 #wb-bc {
 	background: #f9f9f9;
 
@@ -16,20 +21,18 @@
 		text-overflow: ellipsis;
 		white-space: nowrap;
 
-		&:before,
-		&:after {
-			color: #333;
-			font-family: "Glyphicons Halflings";
-			font-size: 0.7em;
-		}
-
 		&:before {
+			color: #333;
 			content: "\e092";
+			font: {
+				family: "Glyphicons Halflings";
+				size: 0.7em;
+			}
 		}
 
 		&:first-child {
 			&:before {
-				display: none;
+				@extend %breadcrumb-no-icon;
 			}
 		}
 	}
@@ -39,19 +42,13 @@
 	#wb-bc {
 		li {
 			&:before {
-				content: "";
-				padding: 0;
-			}
-
-			&:after {
 				content: "\e091";
-				padding: 0 5px;
+				display: inline-block;
 			}
 
 			&:first-child {
-				&:after {
-					content: "";
-					padding: 0;
+				&:before {
+					@extend %breadcrumb-no-icon;
 				}
 			}
 		}


### PR DESCRIPTION
- Prevents arrows from getting mispositioned between items.
- Prevents text from unexpectedly getting cutoff and replaced with ellipses in WebKit browsers.

**PS:**
If anyone happens to have a working build system, I'd recommend quickly testing out this PR before merging.

I wasn't able to do a test build of these changes, since as usual, I'm unable to setup the build system no matter how much I troubleshoot. Having said that, I did test this PR's changes by manually modifying local copies of unminified theme CSS files. Seems to work fine in Firefox/Opera/IE11/Chrome.

**PS2:**
Once this gets merged in, I'll port the changes to the other theme repos.
