### PR TITLE
Build: Updated minimum time-grunt version to 1.3.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "load-grunt-tasks": "^3.2.0",
     "mocha": "^1.21.5",
     "sinon": "~1.12.2",
-    "time-grunt": "~1.0.0"
+    "time-grunt": "~1.3.0"
   }
 }


### PR DESCRIPTION
Should prevent random invalid array length errors from appearing when it calculates bar lengths.
