### PR TITLE
HTML Proofer: Prevent empty alt attributes from causing failures.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,7 @@ task :test do
 			"../../../demos/texthighlight/texthighlight-en.html?txthl=influenza%20aviaire+monde+suffis+sympt%C3%B4mes%20semblables%20%C3%A0%20ceux%20de%20l'influenza+%C3%80%20titre%20de%20rappel...+%C3%80%20de%20rares%20occasions,%20des%20humains%20ont%20%C3%A9t%C3%A9%20infect%C3%A9s%20par%20ce%20virus.#exemple"
 		],
 		:disable_external => true,
+		:empty_alt_ignore => true,
 		:ext => ".html"
 	}).run
 end


### PR DESCRIPTION
Should cause PR #6703 to start passing Travis-CI builds.
