### PR TITLE
Date Picker: Position the calendar before showing it

### DIFF
--- a/src/polyfills/datepicker/datepicker.js
+++ b/src/polyfills/datepicker/datepicker.js
@@ -223,6 +223,8 @@ var componentName = "wb-date",
 		updateState.call( field );
 		calendar.reInit( field.state );
 
+		position();
+
 		$container
 			.addClass( "open" )
 			.attr( {
@@ -231,8 +233,6 @@ var componentName = "wb-date",
 				"aria-hidden": "false"
 			} )
 			.get( 0 ).focus();
-
-		position();
 
 		$( "#" + fieldId + toggleSuffix )
 			.attr( "title", closeText )


### PR DESCRIPTION
Avoids the focus jumping to the bottom when the calendar is opened. Fixes #7395
