### PR TITLE
Tabbed interface: Replaced selector with namespace in timerpoke init event.

### DIFF
--- a/src/plugins/tabs/tabs.js
+++ b/src/plugins/tabs/tabs.js
@@ -722,7 +722,7 @@ var componentName = "wb-tabs",
 	};
 
  // Bind the init event of the plugin
- $document.on( "timerpoke.wb " + initEvent + " " + shiftEvent + " " + selectEvent, selector, function( event ) {
+ $document.on( "timerpoke.wb " + initEvent + " " + shiftEvent + " " + selectEvent, namespace, function( event ) {
 	var eventTarget = event.target,
 		eventCurrentTarget = event.currentTarget,
 		$elm;


### PR DESCRIPTION
Prevents timerpoke from endlessly adding and removing IDs on several elements, due to its use of the :has() selector.

:has() isn't a native CSS selector. It's a jQuery extension. When it's used, jQuery temporarily adds and removes ID attributes to the elements that get checked by that selector. It's not desirable for timerpoke to use it since it runs every 500 milliseconds... which will result in continuous, unnecessary DOM manipulations. It also hurts the performance of browser DOM inspectors.

Thanks @fsnoddy for figuring out what :has() was doing :).
