### PR TITLE
Details: Changed native summary to display as list-item.

### DIFF
--- a/src/plugins/collapsible-alerts/base.scss
+++ b/src/plugins/collapsible-alerts/base.scss
@@ -4,6 +4,7 @@ details {
 		border-radius: 0;
 		border-width: 0 0 0 4px;
 		padding-left: 45px;
+		position: relative;
 
 		&:before {
 			display: inline-block;
@@ -12,6 +13,7 @@ details {
 			margin-left: -1.3em;
 			margin-top: -3px;
 			position: absolute;
+			top: 15px;
 		}
 
 		summary {

--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -5,7 +5,7 @@
 
 summary {
 	// Make sure summary remains visible
-	display: block !important;
+	display: list-item !important;
 	visibility: visible !important;
 }
 

--- a/src/polyfills/details/details.scss
+++ b/src/polyfills/details/details.scss
@@ -34,6 +34,10 @@
 				}
 			}
 		}
+
+		summary {
+			display: block !important;
+		}
 	}
 
 	/* Right to left (RTL) CSS */


### PR DESCRIPTION
Prevents disclosure arrows from disappearing in Firefox 47 (if dom.details_element.enabled is set to true in about:config) and Firefox 48+.

Also bring's WET's native details CSS in line with WHATWG's HTML standard:
https://html.spec.whatwg.org/#the-details-and-summary-elements

Tested in FF Developer Edition 48.0a2, FF 45.0, IE11 and Opera beta.

**Before/After screenshots (from Firefox Developer Edition 48.0a2)...**

**[Details demo page](http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html) - before:**
![details_arrow_ff48 0a2_before](https://cloud.githubusercontent.com/assets/1907279/15724772/987062dc-2816-11e6-9a16-b9343439e7ce.png)

**[Details demo page](http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html) - after:**
![details_arrow_ff48 0a2_after](https://cloud.githubusercontent.com/assets/1907279/15724774/9a84e30e-2816-11e6-9344-aae74fdabfee.png)

**[Collapsible alerts demo page](http://wet-boew.github.io/v4.0-ci/demos/collapsible-alerts/collapsible-alerts-en.html) - before:**
![details_arrow_alert_ff48 0a2_before](https://cloud.githubusercontent.com/assets/1907279/15724776/9c92eb50-2816-11e6-9739-63c784d91ec8.png)

**[Collapsible alerts demo page](http://wet-boew.github.io/v4.0-ci/demos/collapsible-alerts/collapsible-alerts-en.html) - after:**
![details_arrow_alert_ff48 0a2_after](https://cloud.githubusercontent.com/assets/1907279/15724778/9dc73616-2816-11e6-8294-a147a5f0bf52.png)

**Note:** The alert icon isn't currently appearing in collapsed details elements in Firefox Developer Edition 48.0a2. I think it's due to a potential bug with its native details support. It's currently removing the details' ::before pseudo-element when collapsed.
