### PR TITLE
Collapsible alerts: Fixed arrow underline, hover/focus outline and linked area overflow issues.

### DIFF
--- a/src/plugins/collapsible-alerts/base.scss
+++ b/src/plugins/collapsible-alerts/base.scss
@@ -4,6 +4,7 @@ details {
 		border-radius: 0;
 		border-width: 0 0 0 4px;
 		padding-left: 45px;
+		padding-right: 0;
 		position: relative;
 
 		&:before {
@@ -18,6 +19,21 @@ details {
 
 		summary {
 			border-width: 0;
+			margin-right: 15px;
+			padding-left: 5px;
+
+			&:focus,
+			&:hover {
+				text-decoration: none;
+
+				h2,
+				h3,
+				h4,
+				h5,
+				h6 {
+					text-decoration: underline;
+				}
+			}
 		}
 
 		> {


### PR DESCRIPTION
- Prevents broken arrow underline effect from appearing when hovering/focusing on summary elements in IE.
- Prevents left of focus outline from overlaying itself on top of the summary arrow in browsers that rely the details/summary polyfill.
- Prevents the summary's linked area from overflowing beyond the boundaries of the alert boxes.

**Screenshots...**

**IE11 - before:**
![collapsible_alert_ie11_before](https://cloud.githubusercontent.com/assets/1907279/15939631/97dd7234-2e46-11e6-8b5a-d84f91b7199b.png)

**IE11 - after:**
![collapsible_alert_ie11_after](https://cloud.githubusercontent.com/assets/1907279/15939634/9a9317cc-2e46-11e6-9af5-11db1762a3a0.png)

**PS:** Tested in Firefox 46.0.1, Firefox Developer Edition 48.0a2, IE11 and Opera beta.
