### PR TITLE
Footnotes: Made minor adjustments to demos/docs.

### DIFF
--- a/site/pages/docs/ref/footnotes/footnotes-en.hbs
+++ b/site/pages/docs/ref/footnotes/footnotes-en.hbs
@@ -6,14 +6,14 @@
 	"categoryfile": "plugins",
 	"description": "Provides a consistent, accessible way of handling footnotes across websites.",
 	"altLangPrefix": "footnotes",
-	"dateModified": "2014-08-04"
+	"dateModified": "2016-06-10"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
 
 <section>
 	<h2>Purpose</h2>
-	<p>This component allows developers to easily embed footnotes into their Web pages, and helps to achieve WCAG 2.0 compliance when providing such footnotes.</p>
+	<p>This plugin allows developers to easily embed footnotes into their Web pages, and helps to achieve WCAG 2.0 compliance when providing such footnotes.</p>
 </section>
 
 <section>
@@ -76,11 +76,11 @@
 		<h3>Footnotes Section</h3>
 		<p>This section explains how to set-up a dedicated footnotes section.</p>
 		<p>Use the following code as a basis to create the section:</p>
-<pre><code>&lt;aside class="wb-fnote" role="note"&gt;
-		&lt;h2 id="fn"&gt;Footnotes&lt;/h2&gt;
-		&lt;dl&gt;
-			&lt;!--PLACE FOOTNOTES HERE--&gt;
-		&lt;/dl&gt;
+		<pre><code>&lt;aside class="wb-fnote" role="note"&gt;
+	&lt;h2 id="fn"&gt;Footnotes&lt;/h2&gt;
+	&lt;dl&gt;
+		&lt;!--PLACE FOOTNOTES HERE--&gt;
+	&lt;/dl&gt;
 &lt;/aside&gt;</code></pre>
 	</section>
 
@@ -92,7 +92,7 @@
 			<h4>Standard Footnote</h4>
 			<p>This is a footnote that is referenced only once within a given page's content.</p>
 			<p>Use the following code as a basis to create a standard footnote:</p>
-<pre><code>&lt;dt&gt;Footnote 1&lt;/dt&gt;
+			<pre><code>&lt;dt&gt;Footnote 1&lt;/dt&gt;
 &lt;dd id="fn1"&gt;
 	&lt;p&gt;Example of a standard footnote.&lt;/p&gt;
 	&lt;p class="fn-rtn"&gt;&lt;a href="#fn1-rf"&gt;&lt;span class="wb-inv"&gt;Return to footnote &lt;/span&gt;1&lt;span class="wb-inv"&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
@@ -103,7 +103,7 @@
 			<h4>Multi-referenced Footnote</h4>
 			<p>This is a footnote that is referenced two or more times within a given page's content. By default, its return link should point to (and explicitly identify) the first reference to the footnote. If JavaScript support is available, a supporting plugin will automatically remove the explicit identifier in the return link text, in addition to managing the return link's destination when the footnote is accessed via a different reference from the content.</p>
 			<p>Use the following code as a basis to create a footnote that can be referenced by multiple pieces of content:</p>
-<pre><code>&lt;dt&gt;Footnote 2&lt;/dt&gt;
+			<pre><code>&lt;dt&gt;Footnote 2&lt;/dt&gt;
 &lt;dd id="fn2"&gt;
 	&lt;p&gt;Example of a footnote being referenced by multiple pieces of content.&lt;/p&gt;
 	&lt;p class="fn-rtn"&gt;&lt;a href="#fn2-1-rf"&gt;&lt;span class="wb-inv"&gt;Return to &lt;span&gt;first&lt;/span&gt; footnote &lt;/span&gt;2&lt;span class="wb-inv"&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
@@ -117,7 +117,7 @@
 			<h4>Multi-paragraph Footnote</h4>
 			<p>Footnotes containing two or more paragraphs are supported. They can take the form of either a standard or multi-referenced footnote.</p>
 			<p>Use the following code as a basis to create a footnote containing multiple paragraphs:</p>
-<pre><code>&lt;dt&gt;Footnote 3&lt;/dt&gt;
+			<pre><code>&lt;dt&gt;Footnote 3&lt;/dt&gt;
 &lt;dd id="fn3"&gt;
 	&lt;p&gt;Example of a footnote containing multiple paragraphs (first paragraph).&lt;/p&gt;
 	&lt;p&gt;Example of a footnote containing multiple paragraphs (second paragraph).&lt;/p&gt;
@@ -157,7 +157,7 @@
 			<tr>
 				<td><code>wb-ready.wb</code> (v4.0.5+)</td>
 				<td>Triggered automatically when WET has finished loading and executing.</td>
-				<td>Used to identify when all WET plugins and polyfills have finished loading and executing. 
+				<td>Used to identify when all WET plugins and polyfills have finished loading and executing.
 					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
 });</code></pre>
 				</td>

--- a/site/pages/docs/ref/footnotes/footnotes-fr.hbs
+++ b/site/pages/docs/ref/footnotes/footnotes-fr.hbs
@@ -6,14 +6,14 @@
 	"categoryfile": "plugins",
 	"description": "Une méthode cohérente et facile d’accès pour répertorier les notes de bas de page.",
 	"altLangPrefix": "footnotes",
-	"dateModified": "2014-08-04"
+	"dateModified": "2016-06-10"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
 
 <section>
-	<h2>Purpose</h2>
-	<p>Ce composant permet aux développeurs d’intégrer facilement des notes de bas de page dans leurs pages Web et facilite la conformité à WCAG 2.0 lors de l’intégration de ces notes de bas de page.</p>
+	<h2>But</h2>
+	<p>Ce plugiciel permet aux développeurs d’intégrer facilement des notes de bas de page dans leurs pages Web et facilite la conformité à WCAG 2.0 lors de l’intégration de ces notes de bas de page.</p>
 </section>
 
 <div lang="en">
@@ -89,10 +89,10 @@
 		<p>Cette section explique comment créer une section réservée aux notes de bas de page.</p>
 		<p>Utiliser le code suivant pour créer la section:</p>
 		<pre><code>&lt;aside class="wb-fnote" role="note"&gt;
-		&lt;h2 id="fn"&gt;Notes de bas de page&lt;/h2&gt;
-		&lt;dl&gt;
-			&lt;!--INSÉRER LES NOTES DE BAS DE PAGE ICI--&gt;
-		&lt;/dl&gt;
+	&lt;h2 id="fn"&gt;Notes de bas de page&lt;/h2&gt;
+	&lt;dl&gt;
+		&lt;!--INSÉRER LES NOTES DE BAS DE PAGE ICI--&gt;
+	&lt;/dl&gt;
 &lt;/aside&gt;</code></pre>
 	</section>
 

--- a/src/plugins/footnotes/footnotes-en.hbs
+++ b/src/plugins/footnotes/footnotes-en.hbs
@@ -7,85 +7,69 @@
 	"tag": "footnotes",
 	"parentdir": "footnotes",
 	"altLangPrefix": "footnotes",
-	"dateModified": "2014-07-21"
+	"dateModified": "2016-06-10"
 }
 ---
 <section>
 	<h2>Purpose</h2>
-	<p>The purpose of the Footnotes sub-project is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the <a href="#fn">Footnotes</a> section. Supporting CSS is used to lay out the footnotes and hide navigational aids.</p>
+	<p>The purpose of the Footnotes plugin is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the <a href="#fn">Footnotes</a> section. Supporting CSS is used to lay out the footnotes and hide navigational aids<sup id="fn1-rf"><a class="fn-lnk" href="#fn1"><span class="wb-inv">Footnote </span>1</a></sup>.</p>
 </section>
 
 <section>
-	<h2>Example</h2>
+	<h2>Benefits</h2>
+	<ul>
+		<li>Conforms to WCAG 2.0 AA<sup id="fn2-1-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
+		<li>Progressive enhancement approach</li>
+		<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
+		<li>Support for English and French</li>
+		<li>Configurable layout and design<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Footnote </span>3</a></sup></li>
+	</ul>
+</section>
 
-	<section>
-		<h3>Purpose</h3>
-		<p>The purpose of the Footnotes plugin is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the <a href="#fn">Footnotes</a> section. Supporting CSS is used to lay out the footnotes and hide navigational aids<sup id="fn1-rf"><a class="fn-lnk" href="#fn1"><span class="wb-inv">Footnote </span>1</a></sup>.</p>
-	</section>
+<section>
+	<h2>Recommended usage</h2>
+	<ul>
+		<li>Implementing footnotes in Web pages<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Footnote </span>*</a></sup></li>
+	</ul>
+</section>
 
-	<section>
-		<h3>Benefits</h3>
-		<ul>
-			<li>Conforms to WCAG 2.0 AA<sup id="fn2-1-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
-			<li>Progressive enhancement approach</li>
-			<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
-			<li>Support for English and French</li>
-			<li>Configurable layout and design<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Footnote </span>3</a></sup></li>
-		</ul>
-	</section>
+<aside class="wb-fnote" role="note">
+	<h2 id="fn">Footnotes</h2>
+	<dl>
+		<dt>Footnote 1</dt>
+		<dd id="fn1">
+			<p>Example of a standard footnote.</p>
+			<p class="fn-rtn"><a href="#fn1-rf"><span class="wb-inv">Return to footnote </span>1<span class="wb-inv"> referrer</span></a></p>
+		</dd>
+		<dt>Footnote 2</dt>
+		<dd id="fn2">
+			<p>Example of a footnote being referenced by multiple pieces of content.</p>
+			<p class="fn-rtn"><a href="#fn2-1-rf"><span class="wb-inv">Return to <span>first</span> footnote </span>2<span class="wb-inv"> referrer</span></a></p>
+		</dd>
+		<dt>Footnote 3</dt>
+		<dd id="fn3">
+			<p>Example of a footnote containing multiple paragraphs (first paragraph).</p>
+			<p>Example of a footnote containing multiple paragraphs (second paragraph).</p>
+			<p>Example of a footnote containing multiple paragraphs (third paragraph).</p>
+			<p class="fn-rtn"><a href="#fn3-rf"><span class="wb-inv">Return to footnote </span>3<span class="wb-inv"> referrer</span></a></p>
+		</dd>
+		<dt>Footnote *</dt>
+		<dd id="fn*">
+			<p>Example of a standard footnote, denoted by a symbol.</p>
+			<p class="fn-rtn"><a href="#fn*-rf"><span class="wb-inv">Return to footnote </span>*<span class="wb-inv"> referrer</span></a></p>
+		</dd>
+	</dl>
+</aside>
 
-	<section>
-		<h3>Recommended usage</h3>
-		<ul>
-			<li>Implementing footnotes in Web pages<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Footnote </span>*</a></sup></li>
-		</ul>
-	</section>
-
-	<aside class="wb-fnote" role="note">
-		<h3 id="fn">Footnotes</h3>
-		<dl>
-			<dt>Footnote 1</dt>
-			<dd id="fn1">
-				<p>Example of a standard footnote.</p>
-				<p class="fn-rtn">
-					<a href="#fn1-rf"><span class="wb-inv">Return to footnote </span>1<span class="wb-inv"> referrer</span></a>
-				</p>
-			</dd>
-			<dt>Footnote 2</dt>
-			<dd id="fn2">
-				<p>Example of a footnote being referenced by multiple pieces of content.</p>
-				<p class="fn-rtn">
-					<a href="#fn2-1-rf"><span class="wb-inv">Return to <span>first</span> footnote </span>2<span class="wb-inv"> referrer</span></a>
-				</p>
-			</dd>
-			<dt>Footnote 3</dt>
-			<dd id="fn3">
-				<p>Example of a footnote containing multiple paragraphs (first paragraph).</p>
-				<p>Example of a footnote containing multiple paragraphs (second paragraph).</p>
-				<p>Example of a footnote containing multiple paragraphs (third paragraph).</p>
-				<p class="fn-rtn">
-					<a href="#fn3-rf"><span class="wb-inv">Return to footnote </span>3<span class="wb-inv"> referrer</span></a>
-				</p>
-			</dd>
-			<dt>Footnote *</dt>
-			<dd id="fn*">
-				<p>Example of a standard footnote, denoted by a symbol.</p>
-				<p class="fn-rtn">
-					<a href="#fn*-rf"><span class="wb-inv">Return to footnote </span>*<span class="wb-inv"> referrer</span></a>
-				</p>
-			</dd>
-		</dl>
-	</aside>
-
-	<section>
-		<h3>Code</h3>
-		<pre><code>&lt;section&gt;
-	&lt;h3&gt;Purpose&lt;/h3&gt;
+<section class="wb-prettify all-pre">
+	<h2>Code</h2>
+	<pre><code>&lt;section&gt;
+	&lt;h2&gt;Purpose&lt;/h2&gt;
 	&lt;p&gt;The purpose of the Footnotes plugin is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the &lt;a href=&quot;#fn&quot;&gt;Footnotes&lt;/a&gt; section. Supporting CSS is used to lay out the footnotes and hide navigational aids&lt;sup id=&quot;fn1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn1&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;1&lt;/a&gt;&lt;/sup&gt;.&lt;/p&gt;
 &lt;/section&gt;
 
 &lt;section&gt;
-	&lt;h3&gt;Benefits&lt;/h3&gt;
+	&lt;h2&gt;Benefits&lt;/h2&gt;
 	&lt;ul&gt;
 		&lt;li&gt;Conforms to WCAG 2.0 AA&lt;sup id=&quot;fn2-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;li&gt;Progressive enhancement approach&lt;/li&gt;
@@ -96,46 +80,37 @@
 &lt;/section&gt;
 
 &lt;section&gt;
-	&lt;h3&gt;Recommended usage&lt;/h3&gt;
+	&lt;h2&gt;Recommended usage&lt;/h2&gt;
 	&lt;ul&gt;
 		&lt;li&gt;Implementing footnotes in Web pages&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/section&gt;
 
 &lt;aside class=&quot;wb-fnote&quot; role=&quot;note&quot;&gt;
-	&lt;h3 id=&quot;fn&quot;&gt;Footnotes&lt;/h3&gt;
+	&lt;h2 id=&quot;fn&quot;&gt;Footnotes&lt;/h2&gt;
 	&lt;dl&gt;
 		&lt;dt&gt;Footnote 1&lt;/dt&gt;
 		&lt;dd id=&quot;fn1&quot;&gt;
 			&lt;p&gt;Example of a standard footnote.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;
-				&lt;a href=&quot;#fn1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;1&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;
-			&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;1&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Footnote 2&lt;/dt&gt;
 		&lt;dd id=&quot;fn2&quot;&gt;
 			&lt;p&gt;Example of a footnote being referenced by multiple pieces of content.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;
-				&lt;a href=&quot;#fn2-1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to &lt;span&gt;first&lt;/span&gt; footnote &lt;/span&gt;2&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;
-			&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn2-1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to &lt;span&gt;first&lt;/span&gt; footnote &lt;/span&gt;2&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Footnote 3&lt;/dt&gt;
 		&lt;dd id=&quot;fn3&quot;&gt;
 			&lt;p&gt;Example of a footnote containing multiple paragraphs (first paragraph).&lt;/p&gt;
 			&lt;p&gt;Example of a footnote containing multiple paragraphs (second paragraph).&lt;/p&gt;
 			&lt;p&gt;Example of a footnote containing multiple paragraphs (third paragraph).&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;
-				&lt;a href=&quot;#fn3-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;3&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;
-			&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn3-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;3&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Footnote *&lt;/dt&gt;
 		&lt;dd id=&quot;fn*&quot;&gt;
 			&lt;p&gt;Example of a standard footnote, denoted by a symbol.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;
-				&lt;a href=&quot;#fn*-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;*&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;
-			&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn*-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;*&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 	&lt;/dl&gt;
 &lt;/aside&gt;</code></pre>
-	</section>
 </section>

--- a/src/plugins/footnotes/footnotes-fr.hbs
+++ b/src/plugins/footnotes/footnotes-fr.hbs
@@ -7,85 +7,69 @@
 	"tag": "footnotes",
 	"parentdir": "footnotes",
 	"altLangPrefix": "footnotes",
-	"dateModified": "2014-07-21"
+	"dateModified": "2016-06-10"
 }
 ---
 <section>
 	<h2>But</h2>
-	<p>Le sous-projet Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section <a href="#fn">Notes de bas de page</a>. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation.</p>
+	<p>Le plugiciel Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section <a href="#fn">Notes de bas de page</a>. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation<sup id="fn1-rf"><a class="fn-lnk" href="#fn1"><span class="wb-inv">Note de bas de page </span>1</a></sup>.</p>
 </section>
 
 <section>
-	<h2>Exemple</h2>
+	<h2>Avantages</h2>
+	<ul>
+		<li>Conformes à WCAG 2.0 AA<sup id="fn2-1-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
+		<li>Approche d'amélioration progressive</li>
+		<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
+		<li>Soutien pour l'anglais et le français</li>
+		<li>Mise en page et conception configurable<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Note de bas de page </span>3</a></sup></li>
+	</ul>
+</section>
 
-	<section>
-		<h3>But</h3>
-		<p>Le sous-projet Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section <a href="#fn">Notes de bas de page</a>. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation<sup id="fn1-rf"><a class="fn-lnk" href="#fn1"><span class="wb-inv">Note de bas de page </span>1</a></sup>.</p>
-	</section>
-
-	<section>
-		<h3>Avantages</h3>
+<section>
+	<h2>Utilisation recommandée</h2>
 		<ul>
-			<li>Conformes à WCAG 2.0 AA<sup id="fn2-1-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
-			<li>Approche d'amélioration progressive</li>
-			<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
-			<li>Soutien pour l'anglais et le français</li>
-			<li>Mise en page et conception configurable<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Note de bas de page </span>3</a></sup></li>
+			<li>Exécuter les notes de bas de page dans les pages Web<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Note de bas de page </span>*</a></sup></li>
 		</ul>
-	</section>
+</section>
 
-	<section>
-		<h3>Utilisation recommandée</h3>
-			<ul>
-				<li>Exécuter les notes de bas de page dans les pages Web<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Note de bas de page </span>*</a></sup></li>
-			</ul>
-	</section>
+<aside class="wb-fnote" role="note">
+	<h2 id="fn">Notes de bas de page</h2>
+	<dl>
+		<dt>Note de bas de page 1</dt>
+		<dd id="fn1">
+			<p>Exemple de note de bas de page standard.</p>
+			<p class="fn-rtn"><a href="#fn1-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>1</a></p>
+		</dd>
+		<dt>Note de bas de page 2</dt>
+		<dd id="fn2">
+			<p>Exemple de note de bas de page qui comporte de nombreux liens.</p>
+			<p class="fn-rtn"><a href="#fn2-1-rf"><span class="wb-inv">Retour à la <span>première</span> référence de la note de bas de page </span>2</a></p>
+		</dd>
+		<dt>Note de bas de page 3</dt>
+		<dd id="fn3">
+			<p>Exemple de note de bas de page qui compte plusieurs paragraphes (premier paragraphe).</p>
+			<p>Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).</p>
+			<p>Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).</p>
+			<p class="fn-rtn"><a href="#fn3-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>3</a></p>
+		</dd>
+		<dt>Note de bas de page *</dt>
+		<dd id="fn*">
+			<p>Exemple de note de bas de page standard, représentée par un symbole.</p>
+			<p class="fn-rtn"><a href="#fn*-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>*</a></p>
+		</dd>
+	</dl>
+</aside>
 
-	<aside class="wb-fnote" role="note">
-		<h3 id="fn">Notes de bas de page</h3>
-		<dl>
-			<dt>Note de bas de page 1</dt>
-			<dd id="fn1">
-				<p>Exemple de note de bas de page standard.</p>
-				<p class="fn-rtn">
-					<a href="#fn1-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>1</a>
-				</p>
-			</dd>
-			<dt>Note de bas de page 2</dt>
-			<dd id="fn2">
-				<p>Exemple de note de bas de page qui comporte de nombreux liens.</p>
-				<p class="fn-rtn">
-					<a href="#fn2-1-rf"><span class="wb-inv">Retour à la <span>première</span> référence de la note de bas de page </span>2</a>
-				</p>
-			</dd>
-			<dt>Note de bas de page 3</dt>
-			<dd id="fn3">
-				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (premier paragraphe).</p>
-				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).</p>
-				<p>Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).</p>
-				<p class="fn-rtn">
-					<a href="#fn3-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>3</a>
-				</p>
-			</dd>
-			<dt>Note de bas de page *</dt>
-			<dd id="fn*">
-				<p>Exemple de note de bas de page standard, représentée par un symbole.</p>
-				<p class="fn-rtn">
-					<a href="#fn*-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>*</a>
-				</p>
-			</dd>
-		</dl>
-	</aside>
-
-	<section>
-		<h3>Code</h3>
-		<pre><code>&lt;section&gt;
-	&lt;h3&gt;But&lt;/h3&gt;
-	&lt;p&gt;Le sous-projet Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section &lt;a href=&quot;#fn&quot;&gt;Notes de bas de page&lt;/a&gt;. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation&lt;sup id=&quot;fn1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn1&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;1&lt;/a&gt;&lt;/sup&gt;.&lt;/p&gt;
+<section class="wb-prettify all-pre">
+	<h2>Code</h2>
+	<pre><code>&lt;section&gt;
+	&lt;h2&gt;But&lt;/h2&gt;
+	&lt;p&gt;Le plugiciel Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section &lt;a href="#fn"&gt;Notes de bas de page&lt;/a&gt;. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation&lt;sup id="fn1-rf"&gt;&lt;a class="fn-lnk" href="#fn1"&gt;&lt;span class="wb-inv"&gt;Note de bas de page &lt;/span&gt;1&lt;/a&gt;&lt;/sup&gt;.&lt;/p&gt;
 &lt;/section&gt;
 
 &lt;section&gt;
-	&lt;h3&gt;Avantages&lt;/h3&gt;
+	&lt;h2&gt;Avantages&lt;/h2&gt;
 	&lt;ul&gt;
 		&lt;li&gt;Conformes à WCAG 2.0 AA&lt;sup id=&quot;fn2-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;li&gt;Approche d'amélioration progressive&lt;/li&gt;
@@ -96,46 +80,37 @@
 &lt;/section&gt;
 
 &lt;section&gt;
-	&lt;h3&gt;Utilisation recommandée&lt;/h3&gt;
+	&lt;h2&gt;Utilisation recommandée&lt;/h2&gt;
 		&lt;ul&gt;
 			&lt;li&gt;Exécuter les notes de bas de page dans les pages Web&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;/ul&gt;
 &lt;/section&gt;
 
 &lt;aside class=&quot;wb-fnote&quot; role=&quot;note&quot;&gt;
-	&lt;h3 id=&quot;fn&quot;&gt;Notes de bas de page&lt;/h3&gt;
+	&lt;h2 id=&quot;fn&quot;&gt;Notes de bas de page&lt;/h2&gt;
 	&lt;dl&gt;
 		&lt;dt&gt;Note de bas de page 1&lt;/dt&gt;
 		&lt;dd id=&quot;fn1&quot;&gt;
 			&lt;p&gt;Exemple de note de bas de page standard.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;
-				&lt;a href=&quot;#fn1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la référence de la note de bas de page &lt;/span&gt;1&lt;/a&gt;
-			&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la référence de la note de bas de page &lt;/span&gt;1&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Note de bas de page 2&lt;/dt&gt;
 		&lt;dd id=&quot;fn2&quot;&gt;
 			&lt;p&gt;Exemple de note de bas de page qui comporte de nombreux liens.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;
-				&lt;a href=&quot;#fn2-1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la &lt;span&gt;première&lt;/span&gt; référence de la note de bas de page &lt;/span&gt;2&lt;/a&gt;
-			&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn2-1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la &lt;span&gt;première&lt;/span&gt; référence de la note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Note de bas de page 3&lt;/dt&gt;
 		&lt;dd id=&quot;fn3&quot;&gt;
 			&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (premier paragraphe).&lt;/p&gt;
 			&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).&lt;/p&gt;
 			&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;
-				&lt;a href=&quot;#fn3-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la référence de la note de bas de page &lt;/span&gt;3&lt;/a&gt;
-			&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn3-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la référence de la note de bas de page &lt;/span&gt;3&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Note de bas de page *&lt;/dt&gt;
 		&lt;dd id=&quot;fn*&quot;&gt;
 			&lt;p&gt;Exemple de note de bas de page standard, représentée par un symbole.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;
-				&lt;a href=&quot;#fn*-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la référence de la note de bas de page &lt;/span&gt;*&lt;/a&gt;
-			&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn*-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la référence de la note de bas de page &lt;/span&gt;*&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 	&lt;/dl&gt;
 &lt;/aside&gt;</code></pre>
-	</section>
 </section>


### PR DESCRIPTION
- Removed the demo's "Example" heading/section, kept all pre-existing content and increased all of its heading levels. This allows the "Footnotes" heading to go back to being an H2 (i.e. what it's supposed to be).
- Changed all "sub-project"/"component" references to "plugin" in the demo's "Purpose" section ("sous-projet"/"composant" to "plugiciel" in French).
- Enabled prettify on the demo's code example.
- Fixed indenting/line separation issues across demo/documentation's HTML code and examples.
- Changed "Purpose" heading to "But" in French documentation.
