### PR TITLE
Tabbed interface: Increased performance and fixed/enhanced 1 tab implementations.

### DIFF
--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -338,6 +338,10 @@ $tab-margin-width: 10px;
 			padding-bottom: 4.375em;
 		}
 
+		&.exclude-controls {
+			padding-bottom: 0;
+		}
+
 		[role="tabpanel"] {
 			@extend %carousel-link;
 		}

--- a/src/plugins/tabs/tabs.js
+++ b/src/plugins/tabs/tabs.js
@@ -14,12 +14,11 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var componentName = "wb-tabs",
-	namespace = "." + componentName,
-	selector = namespace + ":has( > .tabpanels > [role='tabpanel']:nth-of-type(2), > .tabpanels > details:nth-of-type(2), > [role='tabpanel']:nth-of-type(2), > details:nth-of-type(2))",
-	initEvent = "wb-init" + namespace,
-	shiftEvent = "wb-shift" + namespace,
-	selectEvent = "wb-select" + namespace,
-	updatedEvent = "wb-updated" + namespace,
+	selector = "." + componentName,
+	initEvent = "wb-init" + selector,
+	shiftEvent = "wb-shift" + selector,
+	selectEvent = "wb-select" + selector,
+	updatedEvent = "wb-updated" + selector,
 	setFocusEvent = "setfocus.wb",
 	controls = selector + " ul[role=tablist] a, " + selector + " ul[role=tablist] .tab-count",
 	initialized = false,
@@ -73,6 +72,13 @@ var componentName = "wb-tabs",
 			$tablist = $elm.children( "[role=tablist]" );
 			isCarousel = $tablist.length !== 0;
 
+			// If a carousel contains only 1 panel, remove its controls, visually-hide its thumbnails and prevent it from attempting to play
+			if ( isCarousel && $panels.length === 1 ) {
+
+				$elm.removeClass( "show-thumbs playing" );
+				$elm.addClass( "exclude-controls" );
+			}
+
 			activeId = wb.jqEscape( wb.pageUrlParts.hash.substring( 1 ) );
 			hashFocus = activeId.length !== 0;
 			$openPanel = hashFocus ? $panels.filter( "#" + activeId ) : undefined;
@@ -87,6 +93,7 @@ var componentName = "wb-tabs",
 					interval: $elm.hasClass( "slow" ) ?
 								9 : $elm.hasClass( "fast" ) ?
 									3 : defaults.interval,
+					excludeControls: $elm.hasClass( "exclude-controls" ),
 					excludePlay: $elm.hasClass( "exclude-play" ),
 					updateHash: $elm.hasClass( "update-hash" ),
 					playing: $elm.hasClass( "playing" ),
@@ -319,8 +326,9 @@ var componentName = "wb-tabs",
 		var prevText = i18nText.prev,
 			nextText = i18nText.next,
 			spaceText = i18nText.space,
+			excludeControls = settings.excludeControls,
 			excludePlay = settings.excludePlay,
-			isPlaying = !excludePlay && settings.playing,
+			isPlaying = !excludeControls && !excludePlay && settings.playing,
 			state = isPlaying ? i18nText.pause : i18nText.play,
 			hidden = isPlaying ? i18nText.rotStop : i18nText.rotStart,
 			glyphiconStart = "<span class='glyphicon glyphicon-",
@@ -353,8 +361,11 @@ var componentName = "wb-tabs",
 				"</span>" + wbInvStart + spaceText + i18nText.hyphen + spaceText +
 				hidden + btnEnd;
 
-		$tablist.prepend( prevControl + tabCount + nextControl );
-		if ( !excludePlay ) {
+		if ( !excludeControls ) {
+			$tablist.prepend( prevControl + tabCount + nextControl );
+		}
+
+		if ( !excludeControls && !excludePlay ) {
 			$tablist.append( playControl );
 		}
 
@@ -722,7 +733,7 @@ var componentName = "wb-tabs",
 	};
 
  // Bind the init event of the plugin
- $document.on( "timerpoke.wb " + initEvent + " " + shiftEvent + " " + selectEvent, namespace, function( event ) {
+ $document.on( "timerpoke.wb " + initEvent + " " + shiftEvent + " " + selectEvent, selector, function( event ) {
 	var eventTarget = event.target,
 		eventCurrentTarget = event.currentTarget,
 		$elm;


### PR DESCRIPTION
- Stopped using :has() in order to improve performance. Its presence was causing jQuery to add/remove id attributes to all id-less elements on all pages. This happened every time timerpoke attempted to initialize the tabbed interface (even on pages that weren't using it) and any time carousel panels rotated.
- Restores compatibility with standard tabbed interface implementations that only contain 1 tab (they were previously not appearing at all).
- Retains compatibility with 1 tab carousels, but now processes them. This allows the plugin to add extra ARIA attributes to 1 tab carousels.
- Partially-based on #7441.

CC @shawnthompson @LaurentGoderre @masterbee @duboisp @MaximMartel
