### PR TITLE
Multimedia player: Increased specifity of keyboard shortcuts and fixed space key shortcut issues.

### DIFF
--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -12,6 +12,8 @@
 var componentName = "wb-mltmd",
 	selector = "." + componentName,
 	initEvent = "wb-init" + selector,
+	ctrls = selector + " .wb-mm-ctrls",
+	dispCtrls = selector + " .display," + ctrls,
 	template,
 	i18n, i18nText,
 	youtubeReadyEvent = "ready.youtube",
@@ -762,26 +764,38 @@ $document.on( "input change", selector, function( event ) {
 	}
 } );
 
-$document.on( "keydown", selector, function( event ) {
-	var $this = $( event.currentTarget ),
-		playerTarget = event.currentTarget,
+$document.on( "keydown", dispCtrls, function( event ) {
+	var playerTarget = event.currentTarget.parentNode,
 		which = event.which,
-		ctrls = ".wb-mm-ctrls",
 		volume = 0,
-		step = 0.05;
+		step = 0.05,
+		$playerTarget = $( playerTarget );
 
 	if ( !( event.ctrlKey || event.altKey || event.metaKey ) ) {
 		switch ( which ) {
 		case 32:
-			$this.find( ctrls + " .playpause" ).trigger( "click" );
+			// Mute/unmute if focused on the mute/unmute button or volume input.
+			if ( $( event.target ).hasClass( "mute" ) || event.target.nodeName === "INPUT" ) {
+				$playerTarget.find( ".mute" ).trigger( "click" );
+			}
+
+			// Show/hide captions if focused on the closed captions button.
+			else if ( $( event.target ).hasClass( "cc" ) ) {
+				$playerTarget.find( ".cc" ).trigger( "click" );
+			}
+
+			// Play/pause if focused on anything else (i.e. the video itself, play/pause button or progress bar).
+			else {
+				$playerTarget.find( ".playpause" ).trigger( "click" );
+			}
 			break;
 
 		case 37:
-			playerTarget.player( "setCurrentTime", this.player( "getCurrentTime" ) - this.player( "getDuration" ) * 0.05 );
+			playerTarget.player( "setCurrentTime", this.parentNode.player( "getCurrentTime" ) - this.parentNode.player( "getDuration" ) * 0.05 );
 			break;
 
 		case 39:
-			playerTarget.player( "setCurrentTime", this.player( "getCurrentTime" ) + this.player( "getDuration" ) * 0.05 );
+			playerTarget.player( "setCurrentTime", this.parentNode.player( "getCurrentTime" ) + this.parentNode.player( "getDuration" ) * 0.05 );
 			break;
 
 		case 38:
@@ -801,7 +815,7 @@ $document.on( "keydown", selector, function( event ) {
 	}
 } );
 
-$document.on( "keyup", selector, function( event ) {
+$document.on( "keyup", ctrls, function( event ) {
 	if ( event.which === 32 && !( event.ctrlKey || event.altKey || event.metaKey ) ) {
 
 		// Allows the spacebar to be used for play/pause without double triggering


### PR DESCRIPTION
- Limits the scope of the player's keyboard shortcurts to the video element and the player's controls. This prevents conflicts with other elements situated within the same figure element as the player (such as transcript details/summaries and cuepoint buttons).
- Allows the space key to be used to activate the mute/unmute and closed caption buttons. Pressing space on volume control will also mutes/unmute.
- Limits the scope of the space key shortcut for playing/resuming to the video element, play/pause button and progress bar.

CC @LaurentGoderre @rlambert27 @andrewnordlund @nicolasraymond
