### PR TITLE
Carousel: Disabled borders in small view and below.

### DIFF
--- a/src/plugins/tabs/_screen-sm-max.scss
+++ b/src/plugins/tabs/_screen-sm-max.scss
@@ -6,6 +6,10 @@
 /**
  * Mobile-friendly styles
  */
+%carousel-border-0 {
+	border: 0;
+}
+
 %tabs-screen-sm-max-backwards-compat {
 	> {
 		details {
@@ -66,5 +70,13 @@
 				display: none;
 			}
 		}
+	}
+
+	&.carousel-s1 {
+		@extend %carousel-border-0;
+	}
+
+	&.carousel-s2 {
+		@extend %carousel-border-0;
 	}
 }


### PR DESCRIPTION
The small view borders were interfering with carousel style 1 and made carousel style 2 look inconsistent with its medium/large view counterparts. The borders are only useful in regular tabbed interface implementations.
