### PR TITLE
Fixes colour contrast failure: "Search and menus"

### DIFF
--- a/src/plugins/overlay/_base.scss
+++ b/src/plugins/overlay/_base.scss
@@ -99,6 +99,7 @@
 	}
 
 	.modal-title {
+        color: #fff;
 		font-size: 1.15em;
 		padding: 10px 0;
 	}


### PR DESCRIPTION
Reference issue #7709.

Ensures that the title text "Search and Menus" which appears at the top of mobile menus is white by default. This is the colour used by all current themes.

Michael Milette
