### PR TITLE
Fixes colour contrast failure: "Search and menus"

### DIFF
--- a/theme/banner/_base.scss
+++ b/theme/banner/_base.scss
@@ -18,6 +18,10 @@
 	color: #fff;
 	min-height: 2.2em;
 	z-index: 1;
+
+	#mb-pnl header.modal-header div.modal-title {
+		color: #fff;
+	}
 }
 
 #wb-lng ul,


### PR DESCRIPTION
Reference issue #7709 - updated.

Ensures that the title text "Search and Menus" which appears at the top of mobile menus is white by default. This is the colour used by all current themes.

Michael Milette
