### PR TITLE
Fieldflow plugin - Initial commit, transform a basic list into a selectable list.

### DIFF
--- a/site/pages/docs/ref/fieldflow/fieldflow-en.hbs
+++ b/site/pages/docs/ref/fieldflow/fieldflow-en.hbs
@@ -1,0 +1,1542 @@
+---
+{
+	"title": "Field flow",
+	"language": "en",
+	"category": "Plugins",
+	"categoryfile": "plugins",
+	"description": "Transform a basic list into a drop down.",
+	"altLangPrefix": "fieldflow",
+	"dateModified": "2016-11-30"
+}
+---
+
+
+<div class="wb-prettify all-pre"></div>
+
+<section>
+	<h2>Purpose</h2>
+	<p>Provide an alternative user interface when a page contain a really long list. This plugin have two action phase, the first phase, initiation, is creating a drop down to let the user to select an option. The second phase, action, will provide result to the user like redirecting him, ajax-in content, toggle content, creating a second drop down.</p>
+
+	<p>This plugin is highly customizable and work in three phases</p>
+	<ol>
+		<li>Generate the user interface</li>
+		<li>Action upon selection</li>
+		<li>Action upon submission</li>
+	</ol>
+
+</section>
+
+<section>
+	<h2>Usage</h2>
+
+	<div class="row wb-eqht mrgn-tp-lg mrgn-bttm-xl">
+		<div class="col-md-6">
+			<h3 class="mrgn-tp-0 text-success h4">Use when <span class="glyphicon glyphicon-ok-circle"></span></h3>
+			<ul>
+				<li>Provide an alternative way to navigate easier in long listing.</li>
+				<li>Steamline complex navigation through multiple option.</li>
+			</ul>
+		</div>
+
+		<div class="col-md-6 brdr-lft">
+			<h3 class="mrgn-tp-0 text-danger h4">Do not use when <span class="glyphicon glyphicon-remove-circle"></span></h3>
+			<ul>
+				<li>For list 3 items or less, take time to reconsider the default rendering interface.</li>
+				<li>Simple navigation mechanism (like: tabs, expand/collapse (details/summary)) is more suitable for your use case.</li>
+			</ul>
+		</div>
+	</div>
+
+	<div class="well">
+		<h3 class="mrgn-tp-0 text-warning h4">Be carreful when <span class="glyphicon glyphicon-exclamation-sign"></span></h3>
+		<ul>
+			<li>Creating complex user interface, you may need to follow additional required for acessibilty (WCAG) or progressive enhancement, like to providing an alternative representation.</li>
+			<li>Amazing thing could be done, depending how you configure it you can make your page failing WCAG.</li>
+		</ul>
+	</div>
+</section>
+
+
+<section>
+	<h2>Working example</h2>
+
+	<p>English:</p>
+	<ul>
+		<li><a href="../../../demos/fieldflow/fieldflow-en.html">Working example</a></li>
+		<li><a href="../../../demos/fieldflow/basic-en.html">Basic configuration</a></li>
+		<li><a href="../../../demos/fieldflow/advanced-en.html">Advanced</a></li>
+	</ul>
+
+	<p>French:</p>
+	<ul>
+		<li><a href="../../../demos/fieldflow/fieldflow-fr.html" hreflang="fr" lang="fr">Example pratique de déroulement de champs</a></li>
+		<li><a href="../../../demos/fieldflow/basic-fr.html" hreflang="fr" lang="fr">Déroulement de champs avec des configurations de base </a></li>
+		<li><a href="../../../demos/fieldflow/advanced-fr.html" hreflang="fr" lang="fr">Déroulement de champs avancé</a></li>
+	</ul>
+</section>
+
+<section>
+	<h2>How to implement</h2>
+	<p>Take also a look of the varieties of working examples.</p>
+	<ol>
+		<li>Create an unordered bullet list where each list item is a link to a page
+			<pre><code>&lt;ul&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+		</li>
+		<li>Insert a paragraph before that list, it will be used to label the drop down (select).
+			<pre><code>&lt;p&gt;Find the plugin for the action you need.&lt;/p&gt;
+
+&lt;ul&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+		</li>
+		<li>Wrap your paragraph and the list with a <code>&lt;div&gt;</code> container to call the plugin
+			<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Find the plugin for the action you need.&lt;/p&gt;
+
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+		</li>
+	</ol>
+
+	<h3>Complex example <small>Content preparation step</small></h3>
+	<p>We recommend to do a content preparation step when your are planning to use the advanced fonctionality of this plugin. Preparation step could look like as the following but not limited to:</p>
+	<ul>
+		<li>Define what is the main result (business goal) you want, like insert content, redirect the user, filtering tables, ...</li>
+		<li>Design a full decission tree that represent all the possible results.</li>
+		<li>For each node (item) combination, define actions that should be taken, like:
+			<ul>
+				<li>Node 3 - Action 1: Insert content XYZ in the page feature container;</li>
+				<li>Node 3 - Action 2: Insert content ABC that have WET component;</li>
+			</ul>
+		</li>
+		<li>Review and get approved the logic of your mapping with a web specialist that know and have experience of using this plugin. He should be able to let you know the feasibility and the complexiness.</li>
+		<li>Develop an early prototype and finalize feasibility test</li>
+		<li>Finalise the content, for the logic and for the content, as per your internal process.</li>
+		<li>Do a high fidelity prototype.</li>
+	</ul>
+
+</section>
+
+<section>
+	<h2>Abstract fieldflow event chain</h2>
+	<ul>
+		<li>Upon plugin initialisation
+			<ul>
+				<li>[wet-boew plugin] <strong>Init</strong>: WET core initiate the creation of a fieldflow component. The fieldflow control is registered in the parent form</li>
+				<li>[extension] <strong>Ready</strong>: Notify the exention that it should init() and get his things ready to execute actions that is support.</li>
+			</ul>
+		</li>
+		<li>When creating a control
+			<ul>
+				<li>[Control] <strong>Draw</strong>: Read the html, standardize the output data</li>
+				<li>[Form component] <strong>Create ctrl</strong>: Create a component on the page (select, radio, checkbox). This component will be register to the field flow control</li>
+			</ul>
+		</li>
+		<li>When a selected option have action
+			<ul>
+				<li>[Control] <strong>Reset</strong>: Reset the initial state of the control, as configure</li>
+				<li>[Action] <strong>Clean</strong>: Cleaning task from the previous executed action</li>
+				<li>[Action] <strong>Action</strong>: An option has been selected, action need to be executed. Action can be postponed upon form submission.</li>
+			</ul>
+		</li>
+		<li>When the form is submited
+			<ul>
+				<li>[Action] <strong>Submit</strong>: When an action is postponed, triggered upon form submission. An action could prevent the form submission.</li>
+				<li>[Action] <strong>Submited</strong>: Triggered after all the submit action has been completed and just before the final form submission happend.</li>
+			</ul>
+		</li>
+	</ul>
+</section>
+<section>
+	<h2>Class delimiter</h2>
+
+	<p>Use those default class to specify thing inside you template</p>
+
+	<dl class="dl-horizontal">
+		<dt><code>[class="wb-fieldflow-label"]</code></dt>
+		<dd>Indicate content to use for labeling the control</dd>
+	</dl>
+</section>
+
+<section>
+	<h2>Configuration options</h2>
+	<p>Document the public configuration options that can be used by implementers or developers.</p>
+
+	<h3>Set on the plugin <code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow=&quot;{...}&quot;&gt;</code></h3>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Option</th>
+				<th>Description</th>
+				<th>How to configure</th>
+				<th>Values</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>noForm</td>
+				<td>Wont generate a form wrapper, it is assumed it already exists and it is surronding the control.</td>
+				<td><code>data-wb-fieldflow='{&quot;noForm&quot;: true}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Create a form container along with the form validator plugin (wb-frmvld) and a submit button</dd>
+						<dt>true:</dt>
+						<dd>A binding will be done with the parent form element.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>srctype</td>
+				<td>Define what content interpreter to use in order to create a field flow control.</td>
+				<td><code>data-wb-fieldflow='{&quot;srctype&quot;: "wb-fieldflow"}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Same as if the value was set to <code>wb-fieldflow</code>, it will use the standard content interpreter.</dd>
+						<dt>Table filter <code>tblfilter</code>:</dt>
+						<dd>It will use a data table informatin to create a field flow control. The additional property <code>fltrseq</code> is requried.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>outputctnrid</td>
+				<td>Indicate what container in the page should be used to output content, like ajax</td>
+				<td><code>data-wb-fieldflow='{&quot;noForm&quot;: true}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Will create a container next to the form to output.</dd>
+						<dt>[ID]:</dt>
+						<dd>Any valid ID that could contain <a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow content</a>.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>source</td>
+				<td>Specify element to use as the source to feed.</td>
+				<td><code>data-wb-fieldflow='{&quot;source&quot;: &quot;<em>[jQuery selector]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Use the current plugin container</dd>
+						<dt>jQuery Selector</dt>
+						<dd>A <a href="http://api.jquery.com/category/selectors/">jQuery selector</a> that contain a understandable structure to proceed. For example when using field flow to dynamicly filter a table, the source property will make the binding to that table.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>renderas</td>
+				<td>Specify what UI to render.</td>
+				<td><code>data-wb-fieldflow='{&quot;renderas&quot;: &quot;<em>[Name of the UI]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Create a drop down for the field flow UI. Same as if the value was set to <code>select</code>.</dd>
+						<dt>checkbox</dt>
+						<dd>Create a list of checkbox.</dd>
+						<dt>radio</dt>
+						<dd>Create a list of checkbox.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>default</td>
+				<td>Specify a action or an array of action to be applied everytime a option is selected.</td>
+				<td><code>data-wb-fieldflow='{&quot;default&quot;: { <em>[action]</em> } }</code> or <code>data-wb-fieldflow='{&quot;default&quot;: [ { <em>[action]</em> }, { <em>[action]</em> } ] }</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Do nothing</dd>
+						<dt>Object</dt>
+						<dd>Execute the action prior actions defined by the options.</dd>
+						<dt>Array</dt>
+						<dd>Execute all those actions prior actions defined by the options.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>reset</td>
+				<td>Specify a action or an array of action to be applied everytime an option is changed or when the control is destroyed.</td>
+				<td><code>data-wb-fieldflow='{&quot;reset&quot;: { <em>[action]</em> } }</code> or <code>data-wb-fieldflow='{&quot;reset&quot;: [ { <em>[action]</em> }, { <em>[action]</em> } ] }</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Do nothing</dd>
+						<dt>Object</dt>
+						<dd>Execute the single action</dd>
+						<dt>Array</dt>
+						<dd>Execute all the action</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>base</td>
+				<td>Establish a baseline on which subsequent action will be extended from</td>
+				<td><code>data-wb-fieldflow='{&quot;base&quot;: { <em>[action configuration to use as a baseline]</em> } }</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Nothing</dd>
+						<dt>Object</dt>
+						<dd>Those configuration would be re-used in all action selected. When specifying the action for your selectable option, it is possible to overwrite a value defined by the base but not to remove it.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>inline</td>
+				<td>Indicate to render a inline interface. Availble only for <code>{&quot;renderas&quot;:&quot;checkbox&quot;}</code> and <code>{&quot;renderas&quot;:&quot;radio&quot;}</code> </td>
+				<td><code>data-wb-fieldflow='{&quot;renderas&quot;: &quot;<em>[radio|checkbox]</em>&quot;, &quot;inline&quot;: <em>true</em>}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Render one checkbox or radio per line</dd>
+						<dt>true</dt>
+						<dd>Checkbox or radio are side by side.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>isoptional</td>
+				<td>Indicate if the field flow control are optional.</td>
+				<td><code>data-wb-fieldflow='{&quot;isoptional&quot;: <em>true</em>}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>The field flow control require an input and get validated by the form validation plugin</dd>
+						<dt>true</dt>
+						<dd>The field flow control are optional.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>fltrseq</td>
+				<td>Array indicating the table filtering sequence to follow. Availble only for and required when <code>{&quot;srctype&quot;:&quot;tblfilter&quot;}</code></td>
+				<td><code>data-wb-fieldflow='{&quot;srctype&quot;: &quot;tblfilter&quot;, &quot;fltrseq&quot;: [<em>{Column filter object}</em>]}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Render one checkbox or radio per line</dd>
+						<dt>true</dt>
+						<dd>Checkbox or radio are side by side.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>Column filter object</td>
+				<td>Object contained in the fltrseq array. Required for adding item in <code>fltrseq</code>.</td>
+				<td><code>&quot;fltrseq&quot;: [<em>{Column filter object}</em>, <em>{Column filter object}</em>, ...]</code></td>
+				<td>
+					<p>Note that all the following property can be used outside the <code>fltrseq</code> context like <code>data-wb-fieldflow='{&quot;srctype&quot;: &quot;tblfilter&quot;, &quot;columng&quot;: 0}</code>. If <code>Column filter object</code> property and the <code>fltrseq</code> property is present, then the "Column filter object" will be know as being the first column being filtered, then followed by the column being filtered in the array.</p>
+					<p>Properties:</p>
+					<ul>
+						<li><code>column</code> <strong>(required)</strong>: Integer representing the column number or a <a href="https://datatables.net/reference/type/column-selector">DataTable column selector</a>.</li>
+
+						<li><code>csvextract</code>: How to extract the value to feed the drop down from the selected column.
+							<dl>
+								<dt>false (default)</dt>
+								<dd>The value of each list item <code>&lt;li&gt;</code> will be extracted.</dd>
+								<dt>true</dt>
+								<dd>The information of each cell of the select column will be extracted as a <a href="https://tools.ietf.org/html/rfc4180">Comma-Separated Values</a>.</dd>
+							</dl>
+						</li>
+						<li><code>regex</code> as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a></li>
+						<li><code>smart</code> as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a></li>
+						<li><code>caseinsen</code> as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a></li>
+						<li><code>defaultselectedlabel</code> as defined by the property of the same name in the <strong>Text and i18n</strong> row group section in this table.</li>
+						<li><code>label</code>: Text label to use or a jQuery selector or text HTML.</li>
+						<li><code>lblselector</code> as defined by the property of the same name in the <strong>Text and i18n</strong> row group section in this table.</li>
+						<li><code>renderas</code> as defined by the property of the same name in this row group section in this table.</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>action</td>
+				<td>Define the default action for unknow item (<code>data-wb-fieldflow="something"</code>). Usually use in conjonction with "prop".</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;<em>[Name of the action]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>ajax</dd>
+						<dt>Name of the action</dt>
+						<dd>A valid action, the action build-in are listed in the following section.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>prop</td>
+				<td>Define the default property for unknow item (<code>data-wb-fieldflow="something"</code>). Usually use in conjonction with "action".</td>
+				<td><code>data-wb-fieldflow='{&quot;prop&quot;: &quot;<em>[Name of the property]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>url</dd>
+						<dt>Name of the property</dt>
+						<dd>A property recongnised by the the action where his value will be the set by the value of the unknow item.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>actionData</td>
+				<td>Define a base object for action created from unknow item. Usually use in conjonction with "action" and "prop".</td>
+				<td><code>data-wb-fieldflow='{&quot;actionData&quot;: { [...] }}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Use an empty object <code>{ }</code></dd>
+						<dt>An object</dt>
+						<dd>Will extend the action item, after his creation.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>attributes</td>
+				<td>Add attributes on the form input elements, like select, during their creation.</td>
+				<td><code>data-wb-fieldflow='{ &quot;attributes&quot;: { "attributeName": "value", [...] } }</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>No custom element is added</dd>
+						<dt>An object with key value pair</dt>
+						<dd>The key represent the name of the attribute and the value is the value that would be set on the attribute.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>ext <span class="label label-warning">Experimental</span></td>
+				<td>Specify the name of an fieldflow extension to allow to run his own initialisation.</td>
+				<td><code>data-wb-fieldflow='{&quot;ext&quot;: &quot;<em>[Extended plugin name]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Do nothing</dd>
+						<dt>Name of the extension</dt>
+						<dd>Will trigger the event <code>[Name of the extension].ready.wb-fieldflow</code> where it let extension know that the field flow plugin is ready to operate and require that extension to be fully functional.</dd>
+					</dl>
+				</td>
+			</tr>
+		</tbody>
+		<tbody>
+			<tr>
+				<th colspan="4" scope="rowgroup">DOM Manipulation <small>on plugin initialisation</small></th>
+			</tr>
+
+			<tr>
+				<td>unhideelm</td>
+				<td>Remove <code>hidden</code> class</td>
+				<td><code>data-wb-fieldflow='{&quot;unhideelm&quot;: &quot;#myJQuerySelector&quot;}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Do nothing</dd>
+						<dt>jQuery Selector</dt>
+						<dd>A <a href="http://api.jquery.com/category/selectors/">jQuery selector</a> that return result for the current document.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>hideelm</td>
+				<td>Add <code>hidden</code> class</td>
+				<td><code>data-wb-fieldflow='{&quot;hideelm&quot;: &quot;#myJQuerySelector&quot;}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Do nothing</dd>
+						<dt>jQuery Selector</dt>
+						<dd>A <a href="http://api.jquery.com/category/selectors/">jQuery selector</a> that return result for the current document.</dd>
+					</dl>
+				</td>
+			</tr>
+		</tbody>
+
+		<tbody>
+			<tr>
+				<th colspan="4" scope="rowgroup">Text and i18n</th>
+			</tr>
+
+			<tr>
+				<td>defaultselectedlabel</td>
+				<td>Text to use for the default selected option.</td>
+				<td><code>data-wb-fieldflow='{ &quot;defaultselectedlabel&quot;: &quot;<em>default selected option text</em>&quot; }'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Use &quot;Make your selection...&quot; in English and &quot;<span lang="fr">Sélectionnez dans la liste...</span>&quot; in French</dd>
+						<dt>Text</dt>
+						<dd>Text only, providing HTML markup may cause unwanted result.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>lblselector</td>
+				<td>Specify how to find the label through a jQuery selector.</td>
+				<td><code>data-wb-fieldflow='{ &quot;lblselector&quot;: &quot;<em>[jQuery selector]</em>&quot; }'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Use the html of the first child element</dd>
+						<dt>jQuery Selector</dt>
+						<dd>A <a href="http://api.jquery.com/category/selectors/">jQuery selector</a> used to select the label.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr class="text-muted">
+				<td>i18n <span class="label label-warning">Deprecated</span></td>
+				<td>Allow to set the internationalisation text to use for this plugin. </td>
+				<td></td>
+				<td>Setting this option could impact default text used for other wb-fieldflow plugin in the same page.</td>
+			</tr>
+			<tr class="text-muted">
+				<td>i18n.btn <span class="label label-warning">Deprecated</span></td>
+				<td>Set the label to use for the submit button when creating the form wrapper</td>
+				<td><code>data-wb-fieldflow='{&quot;i18n&quot;: { &quot;btn&quot;: &quot;Continue&quot; } }'</code></td>
+				<td>
+					<dl>
+						<dt>English default:</dt>
+						<dd>Continue</dd>
+						<dt>French default:</dt>
+						<dd lang="fr">Allez</dd>
+						<dt>Textual value:</dt>
+						<dd>Any text value</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr class="text-muted">
+				<td>i18n.defaultsel <span class="label label-warning">Deprecated</span></td>
+				<td>Set label the default dropdown option to use.</td>
+				<td><code>data-wb-fieldflow='{&quot;i18n&quot;: { &quot;defaultsel&quot;: &quot;Make your selection...&quot; } }'</code></td>
+				<td>
+					<dl>
+						<dt>English default:</dt>
+						<dd>Make your selection...</dd>
+						<dt>French default:</dt>
+						<dd lang="fr">Sélectionnez dans la liste...</dd>
+						<dt>Textual value:</dt>
+						<dd>Any text value</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr class="text-muted">
+				<td>i18n.required <span class="label label-warning">Deprecated</span></td>
+				<td>Set the mendatory text that is added in the select label between parentisis</td>
+				<td><code>data-wb-fieldflow='{&quot;i18n&quot;: { &quot;required&quot;: &quot;required&quot; } }'</code></td>
+				<td>
+					<dl>
+						<dt>English default:</dt>
+						<dd>required</dd>
+						<dt>French default:</dt>
+						<dd lang="fr">obligatoire</dd>
+						<dt>Textual value:</dt>
+						<dd>Any text value</dd>
+					</dl>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+
+
+	<h3>Set on list item <code>&lt;li data-wb-fieldflow=&quot;...&quot;&gt;</code></h3>
+
+	<p>Kind of value supported:</p>
+	<dl class="dl-horizontal">
+		<dt>Text</dt>
+		<dd><code>data-wb-fieldflow=&quot;...&quot;</code> URL Location of a file that will inserted (through ajax) in a container that follow the plugin. The <a href="http://wet-boew.github.io/wet-boew/docs/ref/data-ajax/data-ajax-en.html">data-ajax</a> filter selector  are supported. <code>data-wb-fieldflow=&quot;MyFragment.html&quot;</code> is equivalent to <code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;MyFragment.html&quot;, &quot;type&quot;: &quot;replace&quot;}'</code></dd>
+		<dt>Object</dt>
+		<dd><code>&lt;li data-wb-fieldflow=&quot;{...}&quot;&gt;</code> Define how the action should be performed, see bellow for all the options.</dd>
+		<dt>Array</dt>
+		<dd><code>&lt;li data-wb-fieldflow=&quot;[{...}, {...}, {...}]&quot;&gt;</code> Allow to set multiple action to perform when one specific item is selected. Some action are incompatible like it make no sense to inserting content through ajax and redirecting the user somewhere else.</dd>
+	</dl>
+
+	<h4>The <code>&quot;action&quot;</code> option</h4>
+
+	<p>Define the <strong>action</strong> to take upon selection/form submission. Based on the value, some other option could be required, optional or ignored.</p>
+
+	<ul>
+		<li>Option: <strong>action</strong></li>
+		<li>How to configure: <code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, ...}'</code></li>
+	</ul>
+
+	<table class="table">
+		<colgroup>
+			<col />
+			<col />
+			<col />
+		</colgroup>
+		<colgroup>
+			<col />
+			<col />
+		</colgroup>
+		<thead>
+			<tr>
+				<th rowspan="2" scope="col">Value</th>
+				<th rowspan="2" scope="col">Description</th>
+				<th rowspan="2" scope="col">How to configure</th>
+				<th colspan="2" scope="colgroup">Options</th>
+			</tr>
+			<tr>
+				<th scope="col">Required</th>
+				<th scope="col">Optional</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>ajax (default)</td>
+				<td>Insert live content into the current page. It use the data-ajax plugin.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>url</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>type</li>
+						<li>container</li>
+						<li>clean</li>
+						<li>trigger</li>
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>redir</td>
+				<td>Page redirection. Default when the list item only contain an anchor.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;redir&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>url</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>toggle</td>
+				<td>Toggle (show/hide) an element on the current page. It use the toggle plugin.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>append</td>
+				<td>Append a secondary drop down from an inline template.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;append&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>source</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+						<li>srctype</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>addClass</td>
+				<td>Add a class to the element specified by the source selector.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;addClass&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>source</li>
+						<li>class</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>removeClass</td>
+				<td>Remove a class to the element specified by the source selector.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;addClass&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>source</li>
+						<li>class</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>query</td>
+				<td>Set a custom query parameter for the destination page upon redirection.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>name</li>
+						<li>value</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>tblfilter</td>
+				<td>Apply a filter to a data table created with <code>wb-tables</code> plugin.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>source</li>
+						<li>column</li>
+						<li>value</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+						<li>regex</li>
+						<li>smart</li>
+						<li>caseinsen</li>
+					</ul>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<h4>Note about &quot;Append&quot; required options <code>{&quot;action&quot;: &quot;append&quot;, ...}</code></h4>
+
+	<p>The append action act similar as when you initially configure the field flow. But instead of creating the field flow working environment it will simply add the field flow control next to the current one.</p>
+
+	<p>You can configure a appended control as you will have it setup the configuration option for <code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow=&quot;{...}&quot;&gt;</code>. For example:</p>
+	<pre><code>{
+	"action": "append",
+	"srctype": "tblfilter",
+	"source": "#MyTableID",
+	"csvextract": true,
+	"isoptional": true,
+	"column": 5,
+	"defaultselectedlabel": "View all results",
+	"label": "Choose something:"
+}</code></pre>
+
+	<p>The &quot;append&quot; action will set the <code>srctype</code> to <code>wb-fieldflow</code> by default if not specified and it will throw an error if the source haven't be set.</p>
+
+	<h4>Configuration options for each action.</h4>
+
+	<details>
+		<summary>Source code of how the following table is filtered</summary>
+
+		<pre><code>&lt;form id=&quot;frmActionConfig&quot;&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+		&quot;noForm&quot;: true,
+		&quot;unhideelm&quot;:
+		&quot;#frmActionConfig&quot;,
+		&quot;srctype&quot;:&quot;tblfilter&quot;,
+		&quot;source&quot;:&quot;#actionConfig&quot;,
+		&quot;column&quot;:1,
+		&quot;defaultselectedlabel&quot;: &quot;All the configuration options&quot;,
+		&quot;label&quot;:&quot;Filter by type of action:&quot;,
+		&quot;csvextract&quot;: true
+	}'&gt;&lt;/div&gt;
+&lt;/form&gt;
+
+&lt;table id=&quot;actionConfig&quot; class=&quot;table wb-tables&quot; data-wb-tables='{
+	&quot;ordering&quot; : false,
+	&quot;paging&quot;: false,
+	&quot;columnDefs&quot;: [ { &quot;targets&quot;: [ 1 ], &quot;visible&quot;: false } ] }'&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Option&lt;/th&gt;
+			&lt;th&gt;Available for&lt;/th&gt;
+			&lt;th&gt;Description&lt;/th&gt;
+			&lt;th&gt;How to configure&lt;/th&gt;
+			&lt;th&gt;Values&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody&gt;
+
+	[...]
+
+	&lt;/tbody&gt;
+&lt;/table&gt;</code></pre>
+	</details>
+
+	<form id="frmActionConfig">
+		<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "unhideelm": "#frmActionConfig", "srctype":"tblfilter", "source":"#actionConfig", "column":1, "defaultselectedlabel": "All the configuration options", "label":"Filter by type of action:", "csvextract": true}'></div>
+	</form>
+
+	<table id="actionConfig" class="table wb-tables" data-wb-tables='{ "ordering" : false, "paging": false, "columnDefs": [ { "targets": [ 1 ], "visible": false } ] }'>
+		<thead>
+			<tr>
+				<th>Option</th>
+				<th>Available for</th>
+				<th>Description</th>
+				<th>How to configure</th>
+				<th>Values</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>action</td>
+				<td>ajax,redir,toggle,append,query,tblfilter</td>
+				<td><p>Specify what action to take</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+						<li>redir</li>
+						<li>toggle</li>
+						<li>append</li>
+						<li>query</li>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, ...}'</code></td>
+				<td>
+					<dl>
+						<dt>ajax (default):</dt>
+						<dd>Insert content</dd>
+						<dt>redir:</dt>
+						<dd>Redirection</dd>
+						<dt>toggle:</dt>
+						<dd>Toggle (show/hide) content</dd>
+						<dt>append:</dt>
+						<dd>Append a secondary drop down</dd>
+						<dt>query:</dt>
+						<dd>Add a query parameter for the page to be redirected to.</dd>
+						<dt>tblfilter:</dt>
+						<dd>Apply a filter to a data table created with <code>wb-tables</code> plugin.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>url</td>
+				<td>ajax,redir</td>
+				<td><p>Address of the hyperlink or the location of the HTML fragment.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+						<li>redir</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;url&quot;: &quot;path/to/my/file.html&quot;}'</code></td>
+				<td>URL</td>
+			</tr>
+			<tr>
+				<td>live</td>
+				<td>ajax,toggle</td>
+				<td><p>Perform the action upon selection change instead of form submission.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;live&quot;: true}'</code></td>
+				<td>URL</td>
+			</tr>
+			<tr>
+				<td>type</td>
+				<td>ajax</td>
+				<td><p>Define how content will be inserted from the container perspective.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;path/to/my/file.html&quot;, &quot;type&quot;: &quot;replace&quot;}'</code></td>
+				<td>
+					<ul>
+						<li>replace(default)</li>
+						<li>after</li>
+						<li>append</li>
+						<li>before</li>
+						<li>prepend</li>
+					</ul>
+					<p>This value map how to call the data-ajax plugin</p>
+				</td>
+			</tr>
+			<tr>
+				<td>container</td>
+				<td>ajax</td>
+				<td><p>Specify the container to use to insert the ajax(ed) content</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;path/to/my/file.html&quot;, &quot;container&quot;: &quot;#jQuerySelector&quot;}'</code></td>
+				<td>jQuery selector
+					<p>(By default the container will be a empty container inserted after the form.)</p>
+				</td>
+			</tr>
+			<tr>
+				<td>clean</td>
+				<td>ajax</td>
+				<td><p>Call <code>empty()</code> jQuery function</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;path/to/my/file.html&quot;, &quot;clean&quot;: &quot;#jQuerySelector&quot;}'</code></td>
+				<td>jQuery selector</td>
+			</tr>
+			<tr>
+				<td>trigger</td>
+				<td>ajax</td>
+				<td><p>Initiate WET features of the inserted content.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;path/to/my/file.html&quot;, &quot;clean&quot;: true}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Content is kept as is</dd>
+						<dt>true:</dt>
+						<dd>Will initiate any WET feature that exist in the inserted content</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>target</td>
+				<td>ajax,redir,toggle,append,query,tblfilter</td>
+				<td><p>Specify an action that should be only executed and considered when the targeted "option" is selected, like by a subsequent drop down.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+						<li>redir</li>
+						<li>toggle</li>
+						<li>append</li>
+						<li>addClass</li>
+						<li>removeClass</li>
+						<li>query</li>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;path/to/my/file.html&quot;, &quot;target&quot;: &quot;containerID&quot;}'</code></td>
+				<td>ID of a list item that will be transform into a drop down.
+					<p>(By default the target action is to current item)</p>
+				</td>
+			</tr>
+			<tr>
+				<td>toggle</td>
+				<td>toggle</td>
+				<td><p>Selector or a toggle configuration options</p>
+					<p>Available for:</p>
+					<ul>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#jQuerySelector&quot;}'</code> or
+				<code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: { &quot;selector&quot;: &quot;#jQuerySelector&quot;} }'</code></td>
+				<td>
+					<dl>
+						<dt>jQuery selector:</dt>
+						<dd>Selector of an element to toggle</dd>
+						<dt>toggle configuration:</dt>
+						<dd>Any configuration supported as defined in the <a href="http://wet-boew.github.io/wet-boew/docs/ref/toggle/toggle-en.html">toggle documentation</a></dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>toggle.stateOn</td>
+				<td>toggle</td>
+				<td><p>A toggle configuration options. CSS class that's added to elements when they are toggled on.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: { &quot;selector&quot;:&quot;#jQuerySelector&quot;, &quot;stateOn&quot;:&quot;cssClass&quot; } }'</code> or
+				<code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: { &quot;selector&quot;: &quot;#jQuerySelector&quot;} }'</code></td>
+				<td>
+					<dl>
+						<dt>Default:</dt>
+						<dd>Use the class "visible"</dd>
+						<dt>String</dt>
+						<dd>A CSS class or whatever supported by the same property named defined in the <a href="http://wet-boew.github.io/wet-boew/docs/ref/toggle/toggle-en.html">toggle documentation</a></dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>toggle.stateOff</td>
+				<td>toggle</td>
+				<td><p>A toggle configuration options. CSS class that's added to elements when they are toggled off.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: { &quot;selector&quot;:&quot;#jQuerySelector&quot;, &quot;stateOff&quot;:&quot;cssClass&quot; } }'</code> or
+				<code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: { &quot;selector&quot;: &quot;#jQuerySelector&quot;} }'</code></td>
+				<td>
+					<dl>
+						<dt>Default:</dt>
+						<dd>Use the class "hidden"</dd>
+						<dt>String</dt>
+						<dd>A CSS class or whatever supported by the same property named defined in the <a href="http://wet-boew.github.io/wet-boew/docs/ref/toggle/toggle-en.html">toggle documentation</a></dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>class</td>
+				<td>addClass,removeClass</td>
+				<td><p>CSS Class name.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>addClass</li>
+						<li>removeClass</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;: "#id", &quot;class&quot;: "myclass" }'</code></td>
+				<td>A CSS class</td>
+			</tr>
+			<tr>
+				<td>source</td>
+				<td>append,addClass,removeClass,tblfilter</td>
+				<td><p>jQuery selector of the sub wb-fieldflow template to be inserted. This configuration option is required for table filtering because it is specify on which data table the filter should be applied.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>append</li>
+						<li>addClass</li>
+						<li>removeClass</li>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td>
+					<p><code>data-wb-fieldflow='{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#jQuerySelector&quot;}'</code></p>
+					<p>Or like:</p>
+					<p><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;source&quot;: &quot;#data-table-id&quot;}</code></p>
+				</td>
+				<td>jQuery selector and when the action is set to <code>tblfilter</code> the source should refer to a data table enhanced with <a href="http://wet-boew.github.io/wet-boew/demos/tables/tables-en.html">tables plugin</a>.</td>
+			</tr>
+
+			<tr>
+				<td>name</td>
+				<td>query</td>
+				<td><p>Name of the query parameter that will be insert in the redirection URL. The other option "value"is required.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>query</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;ParameterName&quot;, &quot;value&quot;: &quot;aValue&quot;}'</code></td>
+				<td>Text without containing space that could be a valid name for a hidden field element.</td>
+			</tr>
+			<tr>
+				<td>value</td>
+				<td>query</td>
+				<td><p>Value of the query parameter that will be insert in the redirection URL. The other option "name" is required.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>query</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;ParameterName&quot;, &quot;value&quot;: &quot;aValue&quot;}'</code></td>
+				<td>Value that could be valid as being the value of a hidden field element.</td>
+			</tr>
+
+			<tr>
+				<td>renderas</td>
+				<td>append,tblfilter</td>
+				<td><p>Specify what UI to render.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>append</li>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;append&quot;, &quot;renderas&quot;: &quot;<em>[Name of the UI]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Create a drop down for the field flow UI. Same as if the value was set to <code>select</code>.</dd>
+						<dt>checkbox</dt>
+						<dd>Create a list of checkbox.</dd>
+						<dt>radio</dt>
+						<dd>Create a list of checkbox.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>column</td>
+				<td>tblfilter</td>
+				<td><p>Required for table filtering, this is specify on which column the filter should be applied</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 5}</code></td>
+				<td>
+					<dl>
+						<dt>Number</dt>
+						<dd>Integer representing the column number where the first column of table is the number &quot;0&quot;</dd>
+
+						<dt>Column selector</dt>
+						<dd>A valid <a href="https://datatables.net/reference/type/column-selector">DataTable column selector</a></dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>value</td>
+				<td>tblfilter</td>
+				<td><p>Required for table filtering, this specify on what value the filter should be applied</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;value&quot;: &quot;a value to be filtered about&quot;}</code></td>
+				<td>A value that will be searched agains the specified column in order to filter the rows.</td>
+			</tr>
+			<tr>
+				<td>csvextract</td>
+				<td>tblfilter</td>
+				<td><p>Assume the column value are CSV and then it is use to feed the item of the field flow control from the selected column.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;csvextract&quot;:true}</code></td>
+				<td><dl>
+					<dt>false (default)</dt>
+					<dd>The value will be the content of each list item <code>&lt;li&gt;</code> for the specified column.</dd>
+					<dt>true</dt>
+					<dd>The value will be the <a href="https://tools.ietf.org/html/rfc4180">Comma-Separated Values</a> of each cell for the specified column. It is assumed that column only content CSV data and nothing else.</dd>
+				</dl></td>
+			</tr>
+			<tr>
+				<td>limit</td>
+				<td>tblfilter</td>
+				<td><p>This specify to show a subsequent filter, based on the fltrseq, only if the number of rows displayed is larger than the limit.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;limit&quot;: 5}</code></td>
+				<td>
+					<dl>
+						<dt>false (default)</dt>
+						<dd>The limit is set to 10 items.</dd>
+						<dt>Number</dt>
+						<dd>Integer representing minimum number of rows displayed in order to show the subsequent fltrseq.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>regex</td>
+				<td>tblfilter</td>
+				<td><p>Treat the searched value as a regular expression. Enable regular expressions without desabling smart search, as smart search use regular expressions, both might conflict and cause unexpected results.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;regex&quot;:true, &quot;smart&quot;:false}</code></td>
+				<td>Boolean, default false (as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a>)</td>
+			</tr>
+			<tr>
+				<td>smart</td>
+				<td>tblfilter</td>
+				<td><p>Perform smart search. Note that to perform a smart search, DataTables uses regular expressions, so if enable regular expressions using the regex parameter to this method, you will likely want to disable smart searching as the two regular expressions might otherwise conflict and cause unexpected results.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;smart&quot;:false}</code></td>
+				<td>Boolean, default true (as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a>)</td>
+			</tr>
+			<tr>
+				<td>caseinsen</td>
+				<td>tblfilter</td>
+				<td><p>Do case-insensitive matching.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;caseinsen&quot;:false}</code></td>
+				<td>Boolean, default true (as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a>)</td>
+			</tr>
+			<tr>
+				<td>defaultselectedlabel</td>
+				<td>tblfilter</td>
+				<td><p>Empty label to use where the filtering is not applied</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;defaultselectedlabel&quot;:&quot;[my default options]&quot;}</code></td>
+				<td>String, as defined by the property of the same name in the <strong>Text and i18n</strong> row group section in configuration option set on the plugin table.</td>
+			</tr>
+			<tr>
+				<td>label</td>
+				<td>tblfilter</td>
+				<td><p>Label to use for the field flow control</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;label&quot;:&quot;[my label]&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default)</dt>
+						<dd>The column title will be use as the label</dd>
+						<dt>String</dt>
+						<dd>Text to use as the label</dd>
+						<dt>jQuery Selector</dt>
+						<dd>Select content on the current page to be use as the label.</dd>
+						<dt>HTML text</dt>
+						<dd>Text representing HTML content that will be used as the label.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>lblselector</td>
+				<td>tblfilter</td>
+				<td><p>Select the label to use. this could be useful when the label configuration option contain html in order to insert additional information sounrounding the label itself.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;lblselector&quot;:&quot;[jQuery selector]&quot;}</code></td>
+				<td>jQuery selector, as defined by the property of the same name in the <strong>Text and i18n</strong> row group section in configuration option set on the plugin table.</td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+
+<section>
+	<h2>Events</h2>
+	<p>Document the public events that can be used by implementers or developers.  Event that is specific related to an action is scoped to the field flow control that have initiated the action. By default, field flow control do not conflict with other field flow control or subsequent field flow control.</p>
+
+
+	<details>
+		<summary>Source code of how the following table is filtered</summary>
+
+		<pre><code>&lt;form id=&quot;frmEvents&quot;&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true, &quot;unhideelm&quot;: &quot;#frmEvents&quot;, &quot;srctype&quot;:&quot;tblfilter&quot;, &quot;source&quot;:&quot;#events&quot;, &quot;column&quot;:0, &quot;defaultselectedlabel&quot;: &quot;All the events&quot;, &quot;label&quot;:&quot;Filter by type of action:&quot;}'&gt;&lt;/div&gt;
+&lt;/form&gt;
+
+&lt;table id=&quot;events&quot; class=&quot;table wb-tables&quot; data-wb-tables='{ &quot;ordering&quot; : false, &quot;paging&quot;: false }'&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Event&lt;/th&gt;
+			&lt;th&gt;Trigger&lt;/th&gt;
+			&lt;th&gt;What it does&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody&gt;
+
+	[...]
+
+	&lt;/tbody&gt;
+&lt;/table&gt;</code></pre>
+	</details>
+
+	<form id="frmEvents">
+		<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "unhideelm": "#frmEvents", "srctype":"tblfilter", "source":"#events", "column":0, "defaultselectedlabel": "All the events", "label":"Filter by type of action:"}'></div>
+	</form>
+
+	<table id="events" class="table wb-tables" data-wb-tables='{ "ordering" : false, "paging": false }'>
+		<thead>
+			<tr>
+				<th>Event</th>
+				<th>Trigger</th>
+				<th>What it does</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>redir.action.wb-fieldflow</code>
+					<ul>
+						<li>redir</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>The action is delayed to happend on form submission.</td>
+			</tr>
+			<tr>
+				<td><code>redir.submit.wb-fieldflow</code>
+					<ul>
+						<li>redir</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon form submission.</td>
+				<td>Set the redirection url to the form action attribute.</td>
+			</tr>
+			<tr>
+				<td><code>query.action.wb-fieldflow</code>
+					<ul>
+						<li>query</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Save the information for form upon submission</td>
+			</tr>
+			<tr>
+				<td><code>ajax.action.wb-fieldflow</code>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Execute the ajax instruction if <code>live</code> flag is specified otherwise it will postpone the action upon form submission.</td>
+			</tr>
+			<tr>
+				<td><code>ajax.submit.wb-fieldflow</code>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon form submission.</td>
+				<td>Execute the ajax instruction.</td>
+			</tr>
+			<tr>
+				<td><code>toggle.action.wb-fieldflow</code>
+					<ul>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Execute the toggle instruction if <code>live</code> flag is specified otherwise it will postpone the action upon form submission.</td>
+			</tr>
+			<tr>
+				<td><code>toggle.submit.wb-fieldflow</code>
+					<ul>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon form submission.</td>
+				<td>Execute the toggle instruction.</td>
+			</tr>
+			<tr>
+				<td><code>append.action.wb-fieldflow</code>
+					<ul>
+						<li>append</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Append a field flow control next to current control that have triggered this event.</td>
+			</tr>
+			<tr>
+				<td><code>addClass.action.wb-fieldflow</code>
+					<ul>
+						<li>addClass</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Will add the specified class if <code>live</code> flag is specified otherwise it will postpone the action upon form submission.</td>
+			</tr>
+			<tr>
+				<td><code>addClass.submit.wb-fieldflow</code>
+					<ul>
+						<li>addClass</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon form submission.</td>
+				<td>Add the specified class to the DOM elements retreived with the source jQuery selector.</td>
+			</tr>
+			<tr>
+				<td><code>removeClass.action.wb-fieldflow</code>
+					<ul>
+						<li>removeClass</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Will add the specified class if <code>live</code> flag is specified otherwise it will postpone the action upon form submission.</td>
+			</tr>
+			<tr>
+				<td><code>removeClass.submit.wb-fieldflow</code>
+					<ul>
+						<li>removeClass</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon form submission.</td>
+				<td>Add the specified class to the DOM elements retreived with the source jQuery selector.</td>
+			</tr>
+			<tr>
+				<td><code>tblfilter.action.wb-fieldflow</code>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Filter the data table rows by searching on the specified column.</td>
+			</tr>
+			<tr>
+				<td><code>tblfilter.draw.wb-fieldflow</code>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when the creation of a field flow control is requested.</td>
+				<td>Read the information in the table and standardize the information in order to be processed by the event that create the control (renderas).</td>
+			</tr>
+			<tr>
+				<td><code>wb-fieldflow.draw.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when the creation of a field flow control is requested.</td>
+				<td>Read the information from the standard inline template and standardize the information in order to be processed by the event that create the control (renderas).</td>
+			</tr>
+			<tr>
+				<td><code>select.createctrl.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when a field flow control typed select (drop down) is requested.</td>
+				<td>From a standardized information it generate the html code being the next field flow control.</td>
+			</tr>
+			<tr>
+				<td><code>checkbox.createctrl.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when a field flow control typed checkbox is requested.</td>
+				<td>From a standardized information it generate the html code being the next field flow control.</td>
+			</tr>
+			<tr>
+				<td><code>radio.createctrl.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when a field flow control typed radio is requested.</td>
+				<td>From a standardized information it generate the html code being the next field flow control.</td>
+			</tr>
+			<tr>
+				<td><code>reset.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically on field flow control and sub control when they need to be reseted or destroyed.</td>
+				<td>It apply the reset actions set by the configuration of the control.</td>
+			</tr>
+			<tr>
+				<td><code>clean.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon when a cleaning task for action need to selection change after a toggle action has been completed.</td>
+				<td>When a completed action need to perform some cleaning task upon value change or when the control that initiated the action are destroyed. For example:
+					<dl>
+						<dt>Toggle</dt>
+						<dd>Perform a toogle action. It will trigger the "off" state.</dd>
+						<dt>ajax</dt>
+						<dd>Execute <code>empty()</code> on the specified element.</dd>
+						<dt>tblfilter</dt>
+						<dd>Remove the search instruction that was set.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>[Name of the extension].ready.wb-fieldflow</code> <span class="label label-warning">Experimental</span>
+					<ul class="mrgn-lft-0">
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when wb-fieldflow has finished is initialization.</td>
+				<td>It let the field flow extension know that the field flow plugin is ready to operate and require that extension to be fully functional.</td>
+			</tr>
+			<tr>
+				<td><code>wb-init.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered manually (e.g., <code>$( ".wb-fieldflow" ).trigger( "wb-init.wb-fieldflow" );</code>).</td>
+				<td>Used to manually initialize the wb-fieldflow plugin. <strong>Note:</strong> The wb-fieldflow plugin will be initialized automatically unless the required markup is added after the page has already loaded.</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically after an wb-fieldflow is initialized.</td>
+				<td>Used to identify when an wb-fieldflow has initialized (target of the event)
+					<pre><code>$( document ).on( "wb-ready.wb-fieldflow", ".wb-fieldflow", function( event ) {
+});</code></pre>
+					<pre><code>$( ".wb-fieldflow" ).on( "wb-ready.wb-fieldflow", function( event ) {
+});</code></pre>
+				</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb</code>
+					<ul class="mrgn-lft-0">
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when WET has finished loading and executing.</td>
+				<td>Used to identify when all WET plugins and polyfills have finished loading and executing.
+				<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
+});</code></pre>
+				</td>
+			</tr>
+			<tr>
+				<td><code>draw.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Upon creation of a drop down</td>
+				<td>Used to notice the creation of a dropdown
+					<pre><code>$( document ).on( "draw.wb-fieldflow", ".wb-fieldflow", function( event ) {
+});</code></pre></td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+
+<section>
+	<h2>Source code</h2>
+	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/fieldflow">Field flow source code on GitHub</a></p>
+</section>

--- a/site/pages/docs/ref/fieldflow/fieldflow-fr.hbs
+++ b/site/pages/docs/ref/fieldflow/fieldflow-fr.hbs
@@ -1,0 +1,1547 @@
+---
+{
+	"title": "Déroulement de champs",
+	"language": "fr",
+	"category": "Plugiciels",
+	"categoryfile": "plugins",
+	"description": "Transforme une simple liste en un liste de choix.",
+	"altLangPrefix": "fieldflow",
+	"dateModified": "2016-11-30"
+}
+---
+
+<div class="wb-prettify all-pre"></div>
+
+<div lang="en">
+
+<p><strong>Needs translation</strong></p>
+
+<section>
+	<h2>Purpose</h2>
+	<p>Provide an alternative user interface when a page contain a really long list. This plugin have two action phase, the first phase, initiation, is creating a drop down to let the user to select an option. The second phase, action, will provide result to the user like redirecting him, ajax-in content, toggle content, creating a second drop down.</p>
+
+	<p>This plugin is highly customizable and work in three phases</p>
+	<ol>
+		<li>Generate the user interface</li>
+		<li>Action upon selection</li>
+		<li>Action upon submission</li>
+	</ol>
+
+</section>
+
+<section>
+	<h2>Usage</h2>
+
+	<div class="row wb-eqht mrgn-tp-lg mrgn-bttm-xl">
+		<div class="col-md-6">
+			<h3 class="mrgn-tp-0 text-success h4">Use when <span class="glyphicon glyphicon-ok-circle"></span></h3>
+			<ul>
+				<li>Provide an alternative way to navigate easier in long listing.</li>
+				<li>Steamline complex navigation through multiple option.</li>
+			</ul>
+		</div>
+
+		<div class="col-md-6 brdr-lft">
+			<h3 class="mrgn-tp-0 text-danger h4">Do not use when <span class="glyphicon glyphicon-remove-circle"></span></h3>
+			<ul>
+				<li>For list 3 items or less, take time to reconsider the default rendering interface.</li>
+				<li>Simple navigation mechanism (like: tabs, expand/collapse (details/summary)) is more suitable for your use case.</li>
+			</ul>
+		</div>
+	</div>
+
+	<div class="well">
+		<h3 class="mrgn-tp-0 text-warning h4">Be carreful when <span class="glyphicon glyphicon-exclamation-sign"></span></h3>
+		<ul>
+			<li>Creating complex user interface, you may need to follow additional required for acessibilty (WCAG) or progressive enhancement, like to providing an alternative representation.</li>
+			<li>Amazing thing could be done, depending how you configure it you can make your page failing WCAG.</li>
+		</ul>
+	</div>
+</section>
+
+
+<section>
+	<h2>Working example</h2>
+
+	<p>English:</p>
+	<ul>
+		<li><a href="../../../demos/fieldflow/fieldflow-en.html">Working example</a></li>
+		<li><a href="../../../demos/fieldflow/basic-en.html">Basic configuration</a></li>
+		<li><a href="../../../demos/fieldflow/advanced-en.html">Advanced</a></li>
+	</ul>
+
+	<p>French:</p>
+	<ul>
+		<li><a href="../../../demos/fieldflow/fieldflow-fr.html" hreflang="fr" lang="fr">Example pratique de déroulement de champs</a></li>
+		<li><a href="../../../demos/fieldflow/basic-fr.html" hreflang="fr" lang="fr">Déroulement de champs avec des configurations de base </a></li>
+		<li><a href="../../../demos/fieldflow/advanced-fr.html" hreflang="fr" lang="fr">Déroulement de champs avancé</a></li>
+	</ul>
+</section>
+
+<section>
+	<h2>How to implement</h2>
+	<p>Take also a look of the varieties of working examples.</p>
+	<ol>
+		<li>Create an unordered bullet list where each list item is a link to a page
+			<pre><code>&lt;ul&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+		</li>
+		<li>Insert a paragraph before that list, it will be used to label the drop down (select).
+			<pre><code>&lt;p&gt;Find the plugin for the action you need.&lt;/p&gt;
+
+&lt;ul&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+	&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+		</li>
+		<li>Wrap your paragraph and the list with a <code>&lt;div&gt;</code> container to call the plugin
+			<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Find the plugin for the action you need.&lt;/p&gt;
+
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+		</li>
+	</ol>
+
+	<h3>Complex example <small>Content preparation step</small></h3>
+	<p>We recommend to do a content preparation step when your are planning to use the advanced fonctionality of this plugin. Preparation step could look like as the following but not limited to:</p>
+	<ul>
+		<li>Define what is the main result (business goal) you want, like insert content, redirect the user, filtering tables, ...</li>
+		<li>Design a full decission tree that represent all the possible results.</li>
+		<li>For each node (item) combination, define actions that should be taken, like:
+			<ul>
+				<li>Node 3 - Action 1: Insert content XYZ in the page feature container;</li>
+				<li>Node 3 - Action 2: Insert content ABC that have WET component;</li>
+			</ul>
+		</li>
+		<li>Review and get approved the logic of your mapping with a web specialist that know and have experience of using this plugin. He should be able to let you know the feasibility and the complexiness.</li>
+		<li>Develop an early prototype and finalize feasibility test</li>
+		<li>Finalise the content, for the logic and for the content, as per your internal process.</li>
+		<li>Do a high fidelity prototype.</li>
+	</ul>
+
+</section>
+
+<section>
+	<h2>Abstract fieldflow event chain</h2>
+	<ul>
+		<li>Upon plugin initialisation
+			<ul>
+				<li>[wet-boew plugin] <strong>Init</strong>: WET core initiate the creation of a fieldflow component. The fieldflow control is registered in the parent form</li>
+				<li>[extension] <strong>Ready</strong>: Notify the exention that it should init() and get his things ready to execute actions that is support.</li>
+			</ul>
+		</li>
+		<li>When creating a control
+			<ul>
+				<li>[Control] <strong>Draw</strong>: Read the html, standardize the output data</li>
+				<li>[Form component] <strong>Create ctrl</strong>: Create a component on the page (select, radio, checkbox). This component will be register to the field flow control</li>
+			</ul>
+		</li>
+		<li>When a selected option have action
+			<ul>
+				<li>[Control] <strong>Reset</strong>: Reset the initial state of the control, as configure</li>
+				<li>[Action] <strong>Clean</strong>: Cleaning task from the previous executed action</li>
+				<li>[Action] <strong>Action</strong>: An option has been selected, action need to be executed. Action can be postponed upon form submission.</li>
+			</ul>
+		</li>
+		<li>When the form is submited
+			<ul>
+				<li>[Action] <strong>Submit</strong>: When an action is postponed, triggered upon form submission. An action could prevent the form submission.</li>
+				<li>[Action] <strong>Submited</strong>: Triggered after all the submit action has been completed and just before the final form submission happend.</li>
+			</ul>
+		</li>
+	</ul>
+</section>
+<section>
+	<h2>Class delimiter</h2>
+
+	<p>Use those default class to specify thing inside you template</p>
+
+	<dl class="dl-horizontal">
+		<dt><code>[class="wb-fieldflow-label"]</code></dt>
+		<dd>Indicate content to use for labeling the control</dd>
+	</dl>
+</section>
+
+<section>
+	<h2>Configuration options</h2>
+	<p>Document the public configuration options that can be used by implementers or developers.</p>
+
+	<h3>Set on the plugin <code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow=&quot;{...}&quot;&gt;</code></h3>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Option</th>
+				<th>Description</th>
+				<th>How to configure</th>
+				<th>Values</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>noForm</td>
+				<td>Wont generate a form wrapper, it is assumed it already exists and it is surronding the control.</td>
+				<td><code>data-wb-fieldflow='{&quot;noForm&quot;: true}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Create a form container along with the form validator plugin (wb-frmvld) and a submit button</dd>
+						<dt>true:</dt>
+						<dd>A binding will be done with the parent form element.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>srctype</td>
+				<td>Define what content interpreter to use in order to create a field flow control.</td>
+				<td><code>data-wb-fieldflow='{&quot;srctype&quot;: "wb-fieldflow"}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Same as if the value was set to <code>wb-fieldflow</code>, it will use the standard content interpreter.</dd>
+						<dt>Table filter <code>tblfilter</code>:</dt>
+						<dd>It will use a data table informatin to create a field flow control. The additional property <code>fltrseq</code> is requried.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>outputctnrid</td>
+				<td>Indicate what container in the page should be used to output content, like ajax</td>
+				<td><code>data-wb-fieldflow='{&quot;noForm&quot;: true}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Will create a container next to the form to output.</dd>
+						<dt>[ID]:</dt>
+						<dd>Any valid ID that could contain <a href="https://www.w3.org/TR/html/dom.html#kinds-of-content-flow-content">flow content</a>.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>source</td>
+				<td>Specify element to use as the source to feed.</td>
+				<td><code>data-wb-fieldflow='{&quot;source&quot;: &quot;<em>[jQuery selector]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Use the current plugin container</dd>
+						<dt>jQuery Selector</dt>
+						<dd>A <a href="http://api.jquery.com/category/selectors/">jQuery selector</a> that contain a understandable structure to proceed. For example when using field flow to dynamicly filter a table, the source property will make the binding to that table.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>renderas</td>
+				<td>Specify what UI to render.</td>
+				<td><code>data-wb-fieldflow='{&quot;renderas&quot;: &quot;<em>[Name of the UI]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Create a drop down for the field flow UI. Same as if the value was set to <code>select</code>.</dd>
+						<dt>checkbox</dt>
+						<dd>Create a list of checkbox.</dd>
+						<dt>radio</dt>
+						<dd>Create a list of checkbox.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>default</td>
+				<td>Specify a action or an array of action to be applied everytime a option is selected.</td>
+				<td><code>data-wb-fieldflow='{&quot;default&quot;: { <em>[action]</em> } }</code> or <code>data-wb-fieldflow='{&quot;default&quot;: [ { <em>[action]</em> }, { <em>[action]</em> } ] }</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Do nothing</dd>
+						<dt>Object</dt>
+						<dd>Execute the action prior actions defined by the options.</dd>
+						<dt>Array</dt>
+						<dd>Execute all those actions prior actions defined by the options.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>reset</td>
+				<td>Specify a action or an array of action to be applied everytime an option is changed or when the control is destroyed.</td>
+				<td><code>data-wb-fieldflow='{&quot;reset&quot;: { <em>[action]</em> } }</code> or <code>data-wb-fieldflow='{&quot;reset&quot;: [ { <em>[action]</em> }, { <em>[action]</em> } ] }</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Do nothing</dd>
+						<dt>Object</dt>
+						<dd>Execute the single action</dd>
+						<dt>Array</dt>
+						<dd>Execute all the action</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>base</td>
+				<td>Establish a baseline on which subsequent action will be extended from</td>
+				<td><code>data-wb-fieldflow='{&quot;base&quot;: { <em>[action configuration to use as a baseline]</em> } }</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Nothing</dd>
+						<dt>Object</dt>
+						<dd>Those configuration would be re-used in all action selected. When specifying the action for your selectable option, it is possible to overwrite a value defined by the base but not to remove it.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>inline</td>
+				<td>Indicate to render a inline interface. Availble only for <code>{&quot;renderas&quot;:&quot;checkbox&quot;}</code> and <code>{&quot;renderas&quot;:&quot;radio&quot;}</code> </td>
+				<td><code>data-wb-fieldflow='{&quot;renderas&quot;: &quot;<em>[radio|checkbox]</em>&quot;, &quot;inline&quot;: <em>true</em>}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Render one checkbox or radio per line</dd>
+						<dt>true</dt>
+						<dd>Checkbox or radio are side by side.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>isoptional</td>
+				<td>Indicate if the field flow control are optional.</td>
+				<td><code>data-wb-fieldflow='{&quot;isoptional&quot;: <em>true</em>}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>The field flow control require an input and get validated by the form validation plugin</dd>
+						<dt>true</dt>
+						<dd>The field flow control are optional.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>fltrseq</td>
+				<td>Array indicating the table filtering sequence to follow. Availble only for and required when <code>{&quot;srctype&quot;:&quot;tblfilter&quot;}</code></td>
+				<td><code>data-wb-fieldflow='{&quot;srctype&quot;: &quot;tblfilter&quot;, &quot;fltrseq&quot;: [<em>{Column filter object}</em>]}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Render one checkbox or radio per line</dd>
+						<dt>true</dt>
+						<dd>Checkbox or radio are side by side.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>Column filter object</td>
+				<td>Object contained in the fltrseq array. Required for adding item in <code>fltrseq</code>.</td>
+				<td><code>&quot;fltrseq&quot;: [<em>{Column filter object}</em>, <em>{Column filter object}</em>, ...]</code></td>
+				<td>
+					<p>Note that all the following property can be used outside the <code>fltrseq</code> context like <code>data-wb-fieldflow='{&quot;srctype&quot;: &quot;tblfilter&quot;, &quot;columng&quot;: 0}</code>. If <code>Column filter object</code> property and the <code>fltrseq</code> property is present, then the "Column filter object" will be know as being the first column being filtered, then followed by the column being filtered in the array.</p>
+					<p>Properties:</p>
+					<ul>
+						<li><code>column</code> <strong>(required)</strong>: Integer representing the column number or a <a href="https://datatables.net/reference/type/column-selector">DataTable column selector</a>.</li>
+
+						<li><code>csvextract</code>: How to extract the value to feed the drop down from the selected column.
+							<dl>
+								<dt>false (default)</dt>
+								<dd>The value of each list item <code>&lt;li&gt;</code> will be extracted.</dd>
+								<dt>true</dt>
+								<dd>The information of each cell of the select column will be extracted as a <a href="https://tools.ietf.org/html/rfc4180">Comma-Separated Values</a>.</dd>
+							</dl>
+						</li>
+						<li><code>regex</code> as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a></li>
+						<li><code>smart</code> as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a></li>
+						<li><code>caseinsen</code> as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a></li>
+						<li><code>defaultselectedlabel</code> as defined by the property of the same name in the <strong>Text and i18n</strong> row group section in this table.</li>
+						<li><code>label</code>: Text label to use or a jQuery selector or text HTML.</li>
+						<li><code>lblselector</code> as defined by the property of the same name in the <strong>Text and i18n</strong> row group section in this table.</li>
+						<li><code>renderas</code> as defined by the property of the same name in this row group section in this table.</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>action</td>
+				<td>Define the default action for unknow item (<code>data-wb-fieldflow="something"</code>). Usually use in conjonction with "prop".</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;<em>[Name of the action]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>ajax</dd>
+						<dt>Name of the action</dt>
+						<dd>A valid action, the action build-in are listed in the following section.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>prop</td>
+				<td>Define the default property for unknow item (<code>data-wb-fieldflow="something"</code>). Usually use in conjonction with "action".</td>
+				<td><code>data-wb-fieldflow='{&quot;prop&quot;: &quot;<em>[Name of the property]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>url</dd>
+						<dt>Name of the property</dt>
+						<dd>A property recongnised by the the action where his value will be the set by the value of the unknow item.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>actionData</td>
+				<td>Define a base object for action created from unknow item. Usually use in conjonction with "action" and "prop".</td>
+				<td><code>data-wb-fieldflow='{&quot;actionData&quot;: { [...] }}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Use an empty object <code>{ }</code></dd>
+						<dt>An object</dt>
+						<dd>Will extend the action item, after his creation.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>attributes</td>
+				<td>Add attributes on the form input elements, like select, during their creation.</td>
+				<td><code>data-wb-fieldflow='{ &quot;attributes&quot;: { "attributeName": "value", [...] } }</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>No custom element is added</dd>
+						<dt>An object with key value pair</dt>
+						<dd>The key represent the name of the attribute and the value is the value that would be set on the attribute.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>ext <span class="label label-warning">Experimental</span></td>
+				<td>Specify the name of an fieldflow extension to allow to run his own initialisation.</td>
+				<td><code>data-wb-fieldflow='{&quot;ext&quot;: &quot;<em>[Extended plugin name]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Do nothing</dd>
+						<dt>Name of the extension</dt>
+						<dd>Will trigger the event <code>[Name of the extension].ready.wb-fieldflow</code> where it let extension know that the field flow plugin is ready to operate and require that extension to be fully functional.</dd>
+					</dl>
+				</td>
+			</tr>
+		</tbody>
+		<tbody>
+			<tr>
+				<th colspan="4" scope="rowgroup">DOM Manipulation <small>on plugin initialisation</small></th>
+			</tr>
+
+			<tr>
+				<td>unhideelm</td>
+				<td>Remove <code>hidden</code> class</td>
+				<td><code>data-wb-fieldflow='{&quot;unhideelm&quot;: &quot;#myJQuerySelector&quot;}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Do nothing</dd>
+						<dt>jQuery Selector</dt>
+						<dd>A <a href="http://api.jquery.com/category/selectors/">jQuery selector</a> that return result for the current document.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>hideelm</td>
+				<td>Add <code>hidden</code> class</td>
+				<td><code>data-wb-fieldflow='{&quot;hideelm&quot;: &quot;#myJQuerySelector&quot;}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Do nothing</dd>
+						<dt>jQuery Selector</dt>
+						<dd>A <a href="http://api.jquery.com/category/selectors/">jQuery selector</a> that return result for the current document.</dd>
+					</dl>
+				</td>
+			</tr>
+		</tbody>
+
+		<tbody>
+			<tr>
+				<th colspan="4" scope="rowgroup">Text and i18n</th>
+			</tr>
+
+			<tr>
+				<td>defaultselectedlabel</td>
+				<td>Text to use for the default selected option.</td>
+				<td><code>data-wb-fieldflow='{ &quot;defaultselectedlabel&quot;: &quot;<em>default selected option text</em>&quot; }'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Use &quot;Make your selection...&quot; in English and &quot;<span lang="fr">Sélectionnez dans la liste...</span>&quot; in French</dd>
+						<dt>Text</dt>
+						<dd>Text only, providing HTML markup may cause unwanted result.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>lblselector</td>
+				<td>Specify how to find the label through a jQuery selector.</td>
+				<td><code>data-wb-fieldflow='{ &quot;lblselector&quot;: &quot;<em>[jQuery selector]</em>&quot; }'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Use the html of the first child element</dd>
+						<dt>jQuery Selector</dt>
+						<dd>A <a href="http://api.jquery.com/category/selectors/">jQuery selector</a> used to select the label.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr class="text-muted">
+				<td>i18n <span class="label label-warning">Deprecated</span></td>
+				<td>Allow to set the internationalisation text to use for this plugin. </td>
+				<td></td>
+				<td>Setting this option could impact default text used for other wb-fieldflow plugin in the same page.</td>
+			</tr>
+			<tr class="text-muted">
+				<td>i18n.btn <span class="label label-warning">Deprecated</span></td>
+				<td>Set the label to use for the submit button when creating the form wrapper</td>
+				<td><code>data-wb-fieldflow='{&quot;i18n&quot;: { &quot;btn&quot;: &quot;Continue&quot; } }'</code></td>
+				<td>
+					<dl>
+						<dt>English default:</dt>
+						<dd>Continue</dd>
+						<dt>French default:</dt>
+						<dd lang="fr">Allez</dd>
+						<dt>Textual value:</dt>
+						<dd>Any text value</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr class="text-muted">
+				<td>i18n.defaultsel <span class="label label-warning">Deprecated</span></td>
+				<td>Set label the default dropdown option to use.</td>
+				<td><code>data-wb-fieldflow='{&quot;i18n&quot;: { &quot;defaultsel&quot;: &quot;Make your selection...&quot; } }'</code></td>
+				<td>
+					<dl>
+						<dt>English default:</dt>
+						<dd>Make your selection...</dd>
+						<dt>French default:</dt>
+						<dd lang="fr">Sélectionnez dans la liste...</dd>
+						<dt>Textual value:</dt>
+						<dd>Any text value</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr class="text-muted">
+				<td>i18n.required <span class="label label-warning">Deprecated</span></td>
+				<td>Set the mendatory text that is added in the select label between parentisis</td>
+				<td><code>data-wb-fieldflow='{&quot;i18n&quot;: { &quot;required&quot;: &quot;required&quot; } }'</code></td>
+				<td>
+					<dl>
+						<dt>English default:</dt>
+						<dd>required</dd>
+						<dt>French default:</dt>
+						<dd lang="fr">obligatoire</dd>
+						<dt>Textual value:</dt>
+						<dd>Any text value</dd>
+					</dl>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+
+
+	<h3>Set on list item <code>&lt;li data-wb-fieldflow=&quot;...&quot;&gt;</code></h3>
+
+	<p>Kind of value supported:</p>
+	<dl class="dl-horizontal">
+		<dt>Text</dt>
+		<dd><code>data-wb-fieldflow=&quot;...&quot;</code> URL Location of a file that will inserted (through ajax) in a container that follow the plugin. The <a href="http://wet-boew.github.io/wet-boew/docs/ref/data-ajax/data-ajax-en.html">data-ajax</a> filter selector  are supported. <code>data-wb-fieldflow=&quot;MyFragment.html&quot;</code> is equivalent to <code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;MyFragment.html&quot;, &quot;type&quot;: &quot;replace&quot;}'</code></dd>
+		<dt>Object</dt>
+		<dd><code>&lt;li data-wb-fieldflow=&quot;{...}&quot;&gt;</code> Define how the action should be performed, see bellow for all the options.</dd>
+		<dt>Array</dt>
+		<dd><code>&lt;li data-wb-fieldflow=&quot;[{...}, {...}, {...}]&quot;&gt;</code> Allow to set multiple action to perform when one specific item is selected. Some action are incompatible like it make no sense to inserting content through ajax and redirecting the user somewhere else.</dd>
+	</dl>
+
+	<h4>The <code>&quot;action&quot;</code> option</h4>
+
+	<p>Define the <strong>action</strong> to take upon selection/form submission. Based on the value, some other option could be required, optional or ignored.</p>
+
+	<ul>
+		<li>Option: <strong>action</strong></li>
+		<li>How to configure: <code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, ...}'</code></li>
+	</ul>
+
+	<table class="table">
+		<colgroup>
+			<col />
+			<col />
+			<col />
+		</colgroup>
+		<colgroup>
+			<col />
+			<col />
+		</colgroup>
+		<thead>
+			<tr>
+				<th rowspan="2" scope="col">Value</th>
+				<th rowspan="2" scope="col">Description</th>
+				<th rowspan="2" scope="col">How to configure</th>
+				<th colspan="2" scope="colgroup">Options</th>
+			</tr>
+			<tr>
+				<th scope="col">Required</th>
+				<th scope="col">Optional</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>ajax (default)</td>
+				<td>Insert live content into the current page. It use the data-ajax plugin.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>url</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>type</li>
+						<li>container</li>
+						<li>clean</li>
+						<li>trigger</li>
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>redir</td>
+				<td>Page redirection. Default when the list item only contain an anchor.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;redir&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>url</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>toggle</td>
+				<td>Toggle (show/hide) an element on the current page. It use the toggle plugin.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>append</td>
+				<td>Append a secondary drop down from an inline template.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;append&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>source</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+						<li>srctype</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>addClass</td>
+				<td>Add a class to the element specified by the source selector.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;addClass&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>source</li>
+						<li>class</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>removeClass</td>
+				<td>Remove a class to the element specified by the source selector.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;addClass&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>source</li>
+						<li>class</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>query</td>
+				<td>Set a custom query parameter for the destination page upon redirection.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>name</li>
+						<li>value</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+					</ul>
+				</td>
+			</tr>
+			<tr>
+				<td>tblfilter</td>
+				<td>Apply a filter to a data table created with <code>wb-tables</code> plugin.</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, ...}'</code></td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>source</li>
+						<li>column</li>
+						<li>value</li>
+					</ul>
+				</td>
+				<td>
+					<ul class="mrgn-lft-0">
+						<li>target</li>
+						<li>regex</li>
+						<li>smart</li>
+						<li>caseinsen</li>
+					</ul>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<h4>Note about &quot;Append&quot; required options <code>{&quot;action&quot;: &quot;append&quot;, ...}</code></h4>
+
+	<p>The append action act similar as when you initially configure the field flow. But instead of creating the field flow working environment it will simply add the field flow control next to the current one.</p>
+
+	<p>You can configure a appended control as you will have it setup the configuration option for <code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow=&quot;{...}&quot;&gt;</code>. For example:</p>
+	<pre><code>{
+	"action": "append",
+	"srctype": "tblfilter",
+	"source": "#MyTableID",
+	"csvextract": true,
+	"isoptional": true,
+	"column": 5,
+	"defaultselectedlabel": "View all results",
+	"label": "Choose something:"
+}</code></pre>
+
+	<p>The &quot;append&quot; action will set the <code>srctype</code> to <code>wb-fieldflow</code> by default if not specified and it will throw an error if the source haven't be set.</p>
+
+	<h4>Configuration options for each action.</h4>
+
+	<details>
+		<summary>Source code of how the following table is filtered</summary>
+
+		<pre><code>&lt;form id=&quot;frmActionConfig&quot;&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+		&quot;noForm&quot;: true,
+		&quot;unhideelm&quot;:
+		&quot;#frmActionConfig&quot;,
+		&quot;srctype&quot;:&quot;tblfilter&quot;,
+		&quot;source&quot;:&quot;#actionConfig&quot;,
+		&quot;column&quot;:1,
+		&quot;defaultselectedlabel&quot;: &quot;All the configuration options&quot;,
+		&quot;label&quot;:&quot;Filter by type of action:&quot;,
+		&quot;csvextract&quot;: true
+	}'&gt;&lt;/div&gt;
+&lt;/form&gt;
+
+&lt;table id=&quot;actionConfig&quot; class=&quot;table wb-tables&quot; data-wb-tables='{
+	&quot;ordering&quot; : false,
+	&quot;paging&quot;: false,
+	&quot;columnDefs&quot;: [ { &quot;targets&quot;: [ 1 ], &quot;visible&quot;: false } ] }'&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Option&lt;/th&gt;
+			&lt;th&gt;Available for&lt;/th&gt;
+			&lt;th&gt;Description&lt;/th&gt;
+			&lt;th&gt;How to configure&lt;/th&gt;
+			&lt;th&gt;Values&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody&gt;
+
+	[...]
+
+	&lt;/tbody&gt;
+&lt;/table&gt;</code></pre>
+	</details>
+
+	<form id="frmActionConfig">
+		<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "unhideelm": "#frmActionConfig", "srctype":"tblfilter", "source":"#actionConfig", "column":1, "defaultselectedlabel": "All the configuration options", "label":"Filter by type of action:", "csvextract": true}'></div>
+	</form>
+
+	<table id="actionConfig" class="table wb-tables" data-wb-tables='{ "ordering" : false, "paging": false, "columnDefs": [ { "targets": [ 1 ], "visible": false } ] }'>
+		<thead>
+			<tr>
+				<th>Option</th>
+				<th>Available for</th>
+				<th>Description</th>
+				<th>How to configure</th>
+				<th>Values</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>action</td>
+				<td>ajax,redir,toggle,append,query,tblfilter</td>
+				<td><p>Specify what action to take</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+						<li>redir</li>
+						<li>toggle</li>
+						<li>append</li>
+						<li>query</li>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, ...}'</code></td>
+				<td>
+					<dl>
+						<dt>ajax (default):</dt>
+						<dd>Insert content</dd>
+						<dt>redir:</dt>
+						<dd>Redirection</dd>
+						<dt>toggle:</dt>
+						<dd>Toggle (show/hide) content</dd>
+						<dt>append:</dt>
+						<dd>Append a secondary drop down</dd>
+						<dt>query:</dt>
+						<dd>Add a query parameter for the page to be redirected to.</dd>
+						<dt>tblfilter:</dt>
+						<dd>Apply a filter to a data table created with <code>wb-tables</code> plugin.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>url</td>
+				<td>ajax,redir</td>
+				<td><p>Address of the hyperlink or the location of the HTML fragment.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+						<li>redir</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;url&quot;: &quot;path/to/my/file.html&quot;}'</code></td>
+				<td>URL</td>
+			</tr>
+			<tr>
+				<td>live</td>
+				<td>ajax,toggle</td>
+				<td><p>Perform the action upon selection change instead of form submission.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;live&quot;: true}'</code></td>
+				<td>URL</td>
+			</tr>
+			<tr>
+				<td>type</td>
+				<td>ajax</td>
+				<td><p>Define how content will be inserted from the container perspective.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;path/to/my/file.html&quot;, &quot;type&quot;: &quot;replace&quot;}'</code></td>
+				<td>
+					<ul>
+						<li>replace(default)</li>
+						<li>after</li>
+						<li>append</li>
+						<li>before</li>
+						<li>prepend</li>
+					</ul>
+					<p>This value map how to call the data-ajax plugin</p>
+				</td>
+			</tr>
+			<tr>
+				<td>container</td>
+				<td>ajax</td>
+				<td><p>Specify the container to use to insert the ajax(ed) content</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;path/to/my/file.html&quot;, &quot;container&quot;: &quot;#jQuerySelector&quot;}'</code></td>
+				<td>jQuery selector
+					<p>(By default the container will be a empty container inserted after the form.)</p>
+				</td>
+			</tr>
+			<tr>
+				<td>clean</td>
+				<td>ajax</td>
+				<td><p>Call <code>empty()</code> jQuery function</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;path/to/my/file.html&quot;, &quot;clean&quot;: &quot;#jQuerySelector&quot;}'</code></td>
+				<td>jQuery selector</td>
+			</tr>
+			<tr>
+				<td>trigger</td>
+				<td>ajax</td>
+				<td><p>Initiate WET features of the inserted content.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;path/to/my/file.html&quot;, &quot;clean&quot;: true}'</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Content is kept as is</dd>
+						<dt>true:</dt>
+						<dd>Will initiate any WET feature that exist in the inserted content</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>target</td>
+				<td>ajax,redir,toggle,append,query,tblfilter</td>
+				<td><p>Specify an action that should be only executed and considered when the targeted "option" is selected, like by a subsequent drop down.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>ajax</li>
+						<li>redir</li>
+						<li>toggle</li>
+						<li>append</li>
+						<li>addClass</li>
+						<li>removeClass</li>
+						<li>query</li>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;path/to/my/file.html&quot;, &quot;target&quot;: &quot;containerID&quot;}'</code></td>
+				<td>ID of a list item that will be transform into a drop down.
+					<p>(By default the target action is to current item)</p>
+				</td>
+			</tr>
+			<tr>
+				<td>toggle</td>
+				<td>toggle</td>
+				<td><p>Selector or a toggle configuration options</p>
+					<p>Available for:</p>
+					<ul>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#jQuerySelector&quot;}'</code> or
+				<code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: { &quot;selector&quot;: &quot;#jQuerySelector&quot;} }'</code></td>
+				<td>
+					<dl>
+						<dt>jQuery selector:</dt>
+						<dd>Selector of an element to toggle</dd>
+						<dt>toggle configuration:</dt>
+						<dd>Any configuration supported as defined in the <a href="http://wet-boew.github.io/wet-boew/docs/ref/toggle/toggle-en.html">toggle documentation</a></dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>toggle.stateOn</td>
+				<td>toggle</td>
+				<td><p>A toggle configuration options. CSS class that's added to elements when they are toggled on.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: { &quot;selector&quot;:&quot;#jQuerySelector&quot;, &quot;stateOn&quot;:&quot;cssClass&quot; } }'</code> or
+				<code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: { &quot;selector&quot;: &quot;#jQuerySelector&quot;} }'</code></td>
+				<td>
+					<dl>
+						<dt>Default:</dt>
+						<dd>Use the class "visible"</dd>
+						<dt>String</dt>
+						<dd>A CSS class or whatever supported by the same property named defined in the <a href="http://wet-boew.github.io/wet-boew/docs/ref/toggle/toggle-en.html">toggle documentation</a></dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>toggle.stateOff</td>
+				<td>toggle</td>
+				<td><p>A toggle configuration options. CSS class that's added to elements when they are toggled off.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: { &quot;selector&quot;:&quot;#jQuerySelector&quot;, &quot;stateOff&quot;:&quot;cssClass&quot; } }'</code> or
+				<code>data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: { &quot;selector&quot;: &quot;#jQuerySelector&quot;} }'</code></td>
+				<td>
+					<dl>
+						<dt>Default:</dt>
+						<dd>Use the class "hidden"</dd>
+						<dt>String</dt>
+						<dd>A CSS class or whatever supported by the same property named defined in the <a href="http://wet-boew.github.io/wet-boew/docs/ref/toggle/toggle-en.html">toggle documentation</a></dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>class</td>
+				<td>addClass,removeClass</td>
+				<td><p>CSS Class name.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>addClass</li>
+						<li>removeClass</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;: "#id", &quot;class&quot;: "myclass" }'</code></td>
+				<td>A CSS class</td>
+			</tr>
+			<tr>
+				<td>source</td>
+				<td>append,addClass,removeClass,tblfilter</td>
+				<td><p>jQuery selector of the sub wb-fieldflow template to be inserted. This configuration option is required for table filtering because it is specify on which data table the filter should be applied.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>append</li>
+						<li>addClass</li>
+						<li>removeClass</li>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td>
+					<p><code>data-wb-fieldflow='{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#jQuerySelector&quot;}'</code></p>
+					<p>Or like:</p>
+					<p><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;source&quot;: &quot;#data-table-id&quot;}</code></p>
+				</td>
+				<td>jQuery selector and when the action is set to <code>tblfilter</code> the source should refer to a data table enhanced with <a href="http://wet-boew.github.io/wet-boew/demos/tables/tables-en.html">tables plugin</a>.</td>
+			</tr>
+
+			<tr>
+				<td>name</td>
+				<td>query</td>
+				<td><p>Name of the query parameter that will be insert in the redirection URL. The other option "value"is required.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>query</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;ParameterName&quot;, &quot;value&quot;: &quot;aValue&quot;}'</code></td>
+				<td>Text without containing space that could be a valid name for a hidden field element.</td>
+			</tr>
+			<tr>
+				<td>value</td>
+				<td>query</td>
+				<td><p>Value of the query parameter that will be insert in the redirection URL. The other option "name" is required.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>query</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;: &quot;ParameterName&quot;, &quot;value&quot;: &quot;aValue&quot;}'</code></td>
+				<td>Value that could be valid as being the value of a hidden field element.</td>
+			</tr>
+
+			<tr>
+				<td>renderas</td>
+				<td>append,tblfilter</td>
+				<td><p>Specify what UI to render.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>append</li>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;append&quot;, &quot;renderas&quot;: &quot;<em>[Name of the UI]</em>&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default):</dt>
+						<dd>Create a drop down for the field flow UI. Same as if the value was set to <code>select</code>.</dd>
+						<dt>checkbox</dt>
+						<dd>Create a list of checkbox.</dd>
+						<dt>radio</dt>
+						<dd>Create a list of checkbox.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>column</td>
+				<td>tblfilter</td>
+				<td><p>Required for table filtering, this is specify on which column the filter should be applied</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 5}</code></td>
+				<td>
+					<dl>
+						<dt>Number</dt>
+						<dd>Integer representing the column number where the first column of table is the number &quot;0&quot;</dd>
+
+						<dt>Column selector</dt>
+						<dd>A valid <a href="https://datatables.net/reference/type/column-selector">DataTable column selector</a></dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>value</td>
+				<td>tblfilter</td>
+				<td><p>Required for table filtering, this specify on what value the filter should be applied</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;value&quot;: &quot;a value to be filtered about&quot;}</code></td>
+				<td>A value that will be searched agains the specified column in order to filter the rows.</td>
+			</tr>
+			<tr>
+				<td>csvextract</td>
+				<td>tblfilter</td>
+				<td><p>Assume the column value are CSV and then it is use to feed the item of the field flow control from the selected column.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;csvextract&quot;:true}</code></td>
+				<td><dl>
+					<dt>false (default)</dt>
+					<dd>The value will be the content of each list item <code>&lt;li&gt;</code> for the specified column.</dd>
+					<dt>true</dt>
+					<dd>The value will be the <a href="https://tools.ietf.org/html/rfc4180">Comma-Separated Values</a> of each cell for the specified column. It is assumed that column only content CSV data and nothing else.</dd>
+				</dl></td>
+			</tr>
+			<tr>
+				<td>limit</td>
+				<td>tblfilter</td>
+				<td><p>This specify to show a subsequent filter, based on the fltrseq, only if the number of rows displayed is larger than the limit.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;limit&quot;: 5}</code></td>
+				<td>
+					<dl>
+						<dt>false (default)</dt>
+						<dd>The limit is set to 10 items.</dd>
+						<dt>Number</dt>
+						<dd>Integer representing minimum number of rows displayed in order to show the subsequent fltrseq.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>regex</td>
+				<td>tblfilter</td>
+				<td><p>Treat the searched value as a regular expression. Enable regular expressions without desabling smart search, as smart search use regular expressions, both might conflict and cause unexpected results.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;regex&quot;:true, &quot;smart&quot;:false}</code></td>
+				<td>Boolean, default false (as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a>)</td>
+			</tr>
+			<tr>
+				<td>smart</td>
+				<td>tblfilter</td>
+				<td><p>Perform smart search. Note that to perform a smart search, DataTables uses regular expressions, so if enable regular expressions using the regex parameter to this method, you will likely want to disable smart searching as the two regular expressions might otherwise conflict and cause unexpected results.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;smart&quot;:false}</code></td>
+				<td>Boolean, default true (as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a>)</td>
+			</tr>
+			<tr>
+				<td>caseinsen</td>
+				<td>tblfilter</td>
+				<td><p>Do case-insensitive matching.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;caseinsen&quot;:false}</code></td>
+				<td>Boolean, default true (as defined in <a href="https://datatables.net/reference/api/search()">DataTable search() API</a>)</td>
+			</tr>
+			<tr>
+				<td>defaultselectedlabel</td>
+				<td>tblfilter</td>
+				<td><p>Empty label to use where the filtering is not applied</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;defaultselectedlabel&quot;:&quot;[my default options]&quot;}</code></td>
+				<td>String, as defined by the property of the same name in the <strong>Text and i18n</strong> row group section in configuration option set on the plugin table.</td>
+			</tr>
+			<tr>
+				<td>label</td>
+				<td>tblfilter</td>
+				<td><p>Label to use for the field flow control</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;label&quot;:&quot;[my label]&quot;}</code></td>
+				<td>
+					<dl>
+						<dt>false (default)</dt>
+						<dd>The column title will be use as the label</dd>
+						<dt>String</dt>
+						<dd>Text to use as the label</dd>
+						<dt>jQuery Selector</dt>
+						<dd>Select content on the current page to be use as the label.</dd>
+						<dt>HTML text</dt>
+						<dd>Text representing HTML content that will be used as the label.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td>lblselector</td>
+				<td>tblfilter</td>
+				<td><p>Select the label to use. this could be useful when the label configuration option contain html in order to insert additional information sounrounding the label itself.</p>
+					<p>Available for:</p>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td><code>data-wb-fieldflow='{&quot;action&quot;: &quot;tblfilter&quot;, &quot;column&quot;: 0, &quot;lblselector&quot;:&quot;[jQuery selector]&quot;}</code></td>
+				<td>jQuery selector, as defined by the property of the same name in the <strong>Text and i18n</strong> row group section in configuration option set on the plugin table.</td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+
+<section>
+	<h2>Events</h2>
+	<p>Document the public events that can be used by implementers or developers.  Event that is specific related to an action is scoped to the field flow control that have initiated the action. By default, field flow control do not conflict with other field flow control or subsequent field flow control.</p>
+
+
+	<details>
+		<summary>Source code of how the following table is filtered</summary>
+
+		<pre><code>&lt;form id=&quot;frmEvents&quot;&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true, &quot;unhideelm&quot;: &quot;#frmEvents&quot;, &quot;srctype&quot;:&quot;tblfilter&quot;, &quot;source&quot;:&quot;#events&quot;, &quot;column&quot;:0, &quot;defaultselectedlabel&quot;: &quot;All the events&quot;, &quot;label&quot;:&quot;Filter by type of action:&quot;}'&gt;&lt;/div&gt;
+&lt;/form&gt;
+
+&lt;table id=&quot;events&quot; class=&quot;table wb-tables&quot; data-wb-tables='{ &quot;ordering&quot; : false, &quot;paging&quot;: false }'&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Event&lt;/th&gt;
+			&lt;th&gt;Trigger&lt;/th&gt;
+			&lt;th&gt;What it does&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody&gt;
+
+	[...]
+
+	&lt;/tbody&gt;
+&lt;/table&gt;</code></pre>
+	</details>
+
+	<form id="frmEvents">
+		<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "unhideelm": "#frmEvents", "srctype":"tblfilter", "source":"#events", "column":0, "defaultselectedlabel": "All the events", "label":"Filter by type of action:"}'></div>
+	</form>
+
+	<table id="events" class="table wb-tables" data-wb-tables='{ "ordering" : false, "paging": false }'>
+		<thead>
+			<tr>
+				<th>Event</th>
+				<th>Trigger</th>
+				<th>What it does</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>redir.action.wb-fieldflow</code>
+					<ul>
+						<li>redir</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>The action is delayed to happend on form submission.</td>
+			</tr>
+			<tr>
+				<td><code>redir.submit.wb-fieldflow</code>
+					<ul>
+						<li>redir</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon form submission.</td>
+				<td>Set the redirection url to the form action attribute.</td>
+			</tr>
+			<tr>
+				<td><code>query.action.wb-fieldflow</code>
+					<ul>
+						<li>query</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Save the information for form upon submission</td>
+			</tr>
+			<tr>
+				<td><code>ajax.action.wb-fieldflow</code>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Execute the ajax instruction if <code>live</code> flag is specified otherwise it will postpone the action upon form submission.</td>
+			</tr>
+			<tr>
+				<td><code>ajax.submit.wb-fieldflow</code>
+					<ul>
+						<li>ajax</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon form submission.</td>
+				<td>Execute the ajax instruction.</td>
+			</tr>
+			<tr>
+				<td><code>toggle.action.wb-fieldflow</code>
+					<ul>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Execute the toggle instruction if <code>live</code> flag is specified otherwise it will postpone the action upon form submission.</td>
+			</tr>
+			<tr>
+				<td><code>toggle.submit.wb-fieldflow</code>
+					<ul>
+						<li>toggle</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon form submission.</td>
+				<td>Execute the toggle instruction.</td>
+			</tr>
+			<tr>
+				<td><code>append.action.wb-fieldflow</code>
+					<ul>
+						<li>append</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Append a field flow control next to current control that have triggered this event.</td>
+			</tr>
+			<tr>
+				<td><code>addClass.action.wb-fieldflow</code>
+					<ul>
+						<li>addClass</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Will add the specified class if <code>live</code> flag is specified otherwise it will postpone the action upon form submission.</td>
+			</tr>
+			<tr>
+				<td><code>addClass.submit.wb-fieldflow</code>
+					<ul>
+						<li>addClass</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon form submission.</td>
+				<td>Add the specified class to the DOM elements retreived with the source jQuery selector.</td>
+			</tr>
+			<tr>
+				<td><code>removeClass.action.wb-fieldflow</code>
+					<ul>
+						<li>removeClass</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Will add the specified class if <code>live</code> flag is specified otherwise it will postpone the action upon form submission.</td>
+			</tr>
+			<tr>
+				<td><code>removeClass.submit.wb-fieldflow</code>
+					<ul>
+						<li>removeClass</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon form submission.</td>
+				<td>Add the specified class to the DOM elements retreived with the source jQuery selector.</td>
+			</tr>
+			<tr>
+				<td><code>tblfilter.action.wb-fieldflow</code>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon selection change.</td>
+				<td>Filter the data table rows by searching on the specified column.</td>
+			</tr>
+			<tr>
+				<td><code>tblfilter.draw.wb-fieldflow</code>
+					<ul>
+						<li>tblfilter</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when the creation of a field flow control is requested.</td>
+				<td>Read the information in the table and standardize the information in order to be processed by the event that create the control (renderas).</td>
+			</tr>
+			<tr>
+				<td><code>wb-fieldflow.draw.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when the creation of a field flow control is requested.</td>
+				<td>Read the information from the standard inline template and standardize the information in order to be processed by the event that create the control (renderas).</td>
+			</tr>
+			<tr>
+				<td><code>select.createctrl.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when a field flow control typed select (drop down) is requested.</td>
+				<td>From a standardized information it generate the html code being the next field flow control.</td>
+			</tr>
+			<tr>
+				<td><code>checkbox.createctrl.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when a field flow control typed checkbox is requested.</td>
+				<td>From a standardized information it generate the html code being the next field flow control.</td>
+			</tr>
+			<tr>
+				<td><code>radio.createctrl.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when a field flow control typed radio is requested.</td>
+				<td>From a standardized information it generate the html code being the next field flow control.</td>
+			</tr>
+			<tr>
+				<td><code>reset.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically on field flow control and sub control when they need to be reseted or destroyed.</td>
+				<td>It apply the reset actions set by the configuration of the control.</td>
+			</tr>
+			<tr>
+				<td><code>clean.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically upon when a cleaning task for action need to selection change after a toggle action has been completed.</td>
+				<td>When a completed action need to perform some cleaning task upon value change or when the control that initiated the action are destroyed. For example:
+					<dl>
+						<dt>Toggle</dt>
+						<dd>Perform a toogle action. It will trigger the "off" state.</dd>
+						<dt>ajax</dt>
+						<dd>Execute <code>empty()</code> on the specified element.</dd>
+						<dt>tblfilter</dt>
+						<dd>Remove the search instruction that was set.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>[Name of the extension].ready.wb-fieldflow</code> <span class="label label-warning">Experimental</span>
+					<ul class="mrgn-lft-0">
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when wb-fieldflow has finished is initialization.</td>
+				<td>It let the field flow extension know that the field flow plugin is ready to operate and require that extension to be fully functional.</td>
+			</tr>
+			<tr>
+				<td><code>wb-init.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered manually (e.g., <code>$( ".wb-fieldflow" ).trigger( "wb-init.wb-fieldflow" );</code>).</td>
+				<td>Used to manually initialize the wb-fieldflow plugin. <strong>Note:</strong> The wb-fieldflow plugin will be initialized automatically unless the required markup is added after the page has already loaded.</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically after an wb-fieldflow is initialized.</td>
+				<td>Used to identify when an wb-fieldflow has initialized (target of the event)
+					<pre><code>$( document ).on( "wb-ready.wb-fieldflow", ".wb-fieldflow", function( event ) {
+});</code></pre>
+					<pre><code>$( ".wb-fieldflow" ).on( "wb-ready.wb-fieldflow", function( event ) {
+});</code></pre>
+				</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb</code>
+					<ul class="mrgn-lft-0">
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Triggered automatically when WET has finished loading and executing.</td>
+				<td>Used to identify when all WET plugins and polyfills have finished loading and executing.
+				<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
+});</code></pre>
+				</td>
+			</tr>
+			<tr>
+				<td><code>draw.wb-fieldflow</code>
+					<ul>
+						<li>Plugin core</li>
+					</ul>
+				</td>
+				<td>Upon creation of a drop down</td>
+				<td>Used to notice the creation of a dropdown
+					<pre><code>$( document ).on( "draw.wb-fieldflow", ".wb-fieldflow", function( event ) {
+});</code></pre></td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+
+<section>
+	<h2>Source code</h2>
+	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/fieldflow">Field flow source code on GitHub</a></p>
+</section>
+
+</div>

--- a/site/pages/docs/ref/plugins-en.hbs
+++ b/site/pages/docs/ref/plugins-en.hbs
@@ -21,6 +21,7 @@
 	<li><a href="favicon/favicon-en.html">Favicon</a> - This plugin provides the ability to add and update the favicon's on a web page.</li>
 	<li><a href="feedback/feedback-en.html">Feedback form</a> - Allows users to submit feedback for a specific Web page or Web site.</li>
 	<li><a href="feeds/feeds-en.html">Feeds</a> - Aggregates and displays entries from one or more Web feeds.</li>
+	<li><a href="fieldflow/fieldflow-en.html">Field flow</a> - Transform a basic list into a drop down.</li>
 	<li><a href="footnotes/footnotes-en.html">Footnotes</a> - Provides a consistent, accessible way of handling footnotes across websites.</li>
 	<li><a href="formvalid/formvalid-en.html">Form validation</a> - Provides generic validation and error message handling for Web forms.</li>
 	<li><a href="geomap/geomap-en.html">Geomap</a> - Displays a dynamic map over which information from additional sources can be overlaid.</li>

--- a/site/pages/docs/ref/plugins-fr.hbs
+++ b/site/pages/docs/ref/plugins-fr.hbs
@@ -19,6 +19,7 @@
 	<li><a href="data-inview/data-inview-fr.html">Data Inview</a> - Affiche de contenu superposé quand une section se déplace hors de la clôture.</li>
 	<li><a href="data-json/data-json-fr.html">Data JSON</a> - Insertion de contenu extrait d'un fichier JSON.</li>
 	<li><a href="data-picture/data-picture-fr.html">Data Picture</a> - Conversion de Picturefill guidé par l'événement.</li>
+	<li><a href="fieldflow/fieldflow-fr.html">Déroulement de champs</a> - Transforme une simple liste en un liste de choix.</li>
 	<li><a href="equalheight/equalheight-fr.html">Égalisation des hauteurs</a> - Un plugiel d'égalisation des hauteurs réactif.</li>
 	<li><a href="session-timeout/session-timeout-fr.html">Expiration de la session</a> - Ferme la session de l'utilisateur après un certain délai.</li>
 	<li><a href="favicon/favicon-fr.html">Favoricône</a> - Offre la possibilité d'ajouter et de mettre à jour les favoricônes d'une page.</li>

--- a/src/plugins/fieldflow/advanced-en.hbs
+++ b/src/plugins/fieldflow/advanced-en.hbs
@@ -1,0 +1,1626 @@
+---
+{
+	"title": "Field flow advanced",
+	"language": "en",
+	"category": "Plugins",
+	"description": "How to go beyond with field flow.",
+	"tag": "fieldflow",
+	"parentdir": "fieldflow",
+	"altLangPrefix": "advanced",
+	"dateModified": "2016-11-30"
+}
+---
+<p>How to go beyond with field flow.</p>
+
+
+
+<ul>
+	<li><a href="fieldflow-en.html">Field flow</a></li>
+	<li><a href="basic-en.html">Field flow basic configuration</a></li>
+	<li>Field flow advanced (current)</li>
+</ul>
+
+<hr />
+
+<div class="wb-prettify all-pre"></div>
+
+<p>On this page:</p>
+
+<ul>
+	<li><a href="#customajax">Custom ajax</a></li>
+	<li><a href="#append">Append</a></li>
+	<li><a href="#cssclass">Add and remove CSS class</a></li>
+	<li><a href="#defaultreset">Applying a set of default and reset action</a></li>
+	<li><a href="#baseAction">Define a base action object</a></li>
+	<li><a href="#redefineDefaultBehavior">Redefine defaults behaviour of simple call</a></li>
+	<li><a href="#querying">Querying and form integration</a></li>
+	<li><a href="#toggle">Toggle</a></li>
+	<li><a href="#tblfilter">Table filtering</a></li>
+</ul>
+
+
+<h2 id="customajax">Custom ajax</h2>
+
+
+	<div class="well">
+
+		<p>The content is insert by using the data-ajax plugin. It is possible to target specific container, by using different method (append, prepend, after, before, replace) and to benefit of the ajax filtering fonctionality provided by the ajax fetch plugin.</p>
+
+		<p>A simple use is set the url of the file that need to be ajaxed in the attribute <code>data-wb-fieldflow=&quot;URL/of/the/file&quot;</code>.</p>
+
+		<p>The content set by the attribute <code>data-wb-fieldflow</code> may are not be accessible to search engine and to the user if javascript is disabled. So, it's recommended to provide an alternative representation where the user will be able to get equivalent information.</p>
+
+		<p>Using <code>data-wb-fieldflow=&quot;URL/of/the/file&quot;</code> is the same as:</p>
+		<ul>
+			<li><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;URL/of/the/file&quot;}'</code></li>
+			<li><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;URL/of/the/file&quot;, &quot;type&quot;: &quot;replace&quot;}'</code></li>
+		</ul>
+		<p>The following configuration option are available:</p>
+
+		<dl class="dl-horizontal">
+			<dt><code>type</code></dt>
+			<dd>Define how the content will be inserted. The available options are: after, append, before, prepend, replace. Default value is "replace"</dd>
+
+			<dt><code>container</code></dt>
+			<dd>A jquery selector of where the data ajax will be initialised. If not specified, an empty container will be created after Fieldflow control.</dd>
+
+			<dt><code>clean</code></dt>
+			<dd>A jquery selector of where the jquery <code>empty()</code> will be called.</dd>
+
+			<dt><code>trigger</code></dt>
+			<dd>Allow to initiate WET features included in the content to be inserted through ajax.</dd>
+		</dl>
+	</div>
+
+
+	<section id="ajaxPanel" class="panel panel-primary">
+		<header class="panel-heading">
+			<h3 class="panel-title"><code>id="ajaxPanel"</code> Aside panel, for example</h3>
+		</header>
+		<div class="panel-body">
+			<p>(To illustrate <code>container</code> and <code>clean</code> options)</p>
+		</div>
+	</section>
+
+	<div class="wb-fieldflow">
+		<p>Choose content to be ajaxed?</p>
+		<ul>
+			<li data-wb-fieldflow="ajax/ajax-1.html">Set 1</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-1.html", "live": true}'>Set 1 - Do it live</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-3.html", "live": true}'>Set 3 - Do it live</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-4.html", "live": true}'>Set 4 - Do it live</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-2.html"}'>Set 2 - Alternative call within object defined in data-wb-fieldflow</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-2.html", "type": "replace"}'>Set 2 - Alternative call with specifying how to ajax content</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-3.html", "container": "#ajaxPanel .panel-body"}'>Set 3 - Use container: $("#ajaxPanel .panel-body")</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-4.html", "container": "#ajaxPanel .panel-body"}'>Set 4 - Use container: $("#ajaxPanel .panel-body")</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-4.html", "container": "#ajaxPanel .panel-body", "type": "append"}'>Set 4 - Append content to the container: $("#ajaxPanel .panel-body")</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-3.html", "container": "#ajaxPanel .panel-body", "type": "prepend", "clean": "#ajaxPanel .panel-body"}'>Set 3 - Prepend content to the contenainer $("#ajaxPanel .panel-body") and clean it on change</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-5.html"}'>Set 5</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-5.html", "trigger": true}'>Set 5 - with Trigger WET plugin</li>
+		</ul>
+	</div>
+
+
+<pre><code>&lt;section id=&quot;ajaxPanel&quot; class=&quot;panel panel-primary&quot;&gt;
+	&lt;header class=&quot;panel-heading&quot;&gt;
+		&lt;h3 class=&quot;panel-title&quot;&gt;&lt;code&gt;id=&quot;ajaxPanel&quot;&lt;/code&gt; Aside panel, for example&lt;/h3&gt;
+	&lt;/header&gt;
+	&lt;div class=&quot;panel-body&quot;&gt;
+		&lt;p&gt;(To illustrate &lt;code&gt;container&lt;/code&gt; and &lt;code&gt;clean&lt;/code&gt; options)&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/section&gt;
+
+&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choose content to be ajaxed?&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;Set 1&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-1.html&quot;, &quot;live&quot;: true}'&gt;Set 1 - Do it live&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;, &quot;live&quot;: true}'&gt;Set 3 - Do it live&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;, &quot;live&quot;: true}'&gt;Set 4 - Do it live&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;}'&gt;Set 2 - with action defined&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;, &quot;type&quot;: &quot;replace&quot;}'&gt;Set 2 - with action and type defined&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;, &quot;container&quot;: &quot;#ajaxPanel .panel-body&quot;}'&gt;Set 3 - Use container: $(&quot;#ajaxPanel .panel-body&quot;)&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;, &quot;container&quot;: &quot;#ajaxPanel .panel-body&quot;}'&gt;Set 4 - Use container: $(&quot;#ajaxPanel .panel-body&quot;)&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;, &quot;container&quot;: &quot;#ajaxPanel .panel-body&quot;, &quot;type&quot;: &quot;append&quot;}'&gt;Set 4 - Append content to the container: $(&quot;#ajaxPanel .panel-body&quot;)&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;, &quot;container&quot;: &quot;#ajaxPanel .panel-body&quot;, &quot;type&quot;: &quot;prepend&quot;, &quot;clean&quot;: &quot;#ajaxPanel .panel-body&quot;}'&gt;Set 3 - Prepend content to the contenainer $(&quot;#ajaxPanel .panel-body&quot;) and clean it on change&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;}'&gt;Set 5&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;, &quot;trigger&quot;: true}'&gt;Set 5 - with Trigger WET plugin&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+
+<h2 id="append">Append</h2>
+	<div class="well">
+		<p>The append action required the configuration option <code>source</code> that contain a jQuery selector representing the element to be used as a sub-plugin and be appended to the control. Similar behaviour can be acheived by duplicating the content of the appended element in each list item.</p>
+
+		<p>The configuration option <code>target</code> contain an <code>id</code> of what subsequent selected element that action is targeted to.</p>
+
+		<p>This feature became useful when the same field is re-used again and again by a lot of items.</p>
+	</div>
+
+<div class="wb-fieldflow">
+	<p>Find the plugin for the action you need.</p>
+	<ul>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html"},
+			{"action": "append", "source": "#language-question"}
+		]'>Inserting content</li>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html"},
+			{"action": "append", "source": "#language-question"}
+		]'>Photo galery</li>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html"},
+			{"action": "append", "source": "#language-question"}
+		]'>Draw charts</li>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html"},
+			{"action": "append", "source": "#language-question"}
+		]'>Expand and collapse content</li>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html"},
+			{"action": "append", "source": "#language-question"}
+		]'>Set a consistant height</li>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html"},
+			{"action": "append", "source": "#language-question"}
+		]'>Popup content</li>
+
+	</ul>
+</div>
+
+<div id="language-question" class="hidden">
+	<p>What language?</p>
+	<ul>
+		<li id="append-ex-en">English</li>
+		<li id="append-ex-fr">French</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Find the plugin for the action you need.&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#language-question&quot;}
+		]'&gt;Inserting content&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#language-question&quot;}
+		]'&gt;Photo galery&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#language-question&quot;}
+		]'&gt;Draw charts&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#language-question&quot;}
+		]'&gt;Expand and collapse content&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#language-question&quot;}
+		]'&gt;Set a consistant height&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#language-question&quot;}
+		]'&gt;Popup content&lt;/li&gt;
+
+	&lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;div id=&quot;language-question&quot; class=&quot;hidden&quot;&gt;
+	&lt;p&gt;What language?&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li id=&quot;append-ex-en&quot;&gt;English&lt;/li&gt;
+		&lt;li id=&quot;append-ex-fr&quot;&gt;French&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h3>Are equivalent to:</h3>
+
+<div class="wb-fieldflow">
+	<p>Find the plugin for the action you need.</p>
+	<ul>
+		<li>Inserting content
+			<div class="wb-fieldflow-sub">
+				<p>What language?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html">English</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html">French</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>Photo galery
+			<div class="wb-fieldflow-sub">
+				<p>What language?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html">English</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html">French</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>Draw charts
+			<div class="wb-fieldflow-sub">
+				<p>What language?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">English</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">French</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>Expand and collapse content
+			<div class="wb-fieldflow-sub">
+				<p>What language?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">English</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">French</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>Set a consistant height
+			<div class="wb-fieldflow-sub">
+				<p>What language?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">English</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">French</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>Popup content
+			<div class="wb-fieldflow-sub">
+				<p>What language?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html">English</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">French</a></li>
+				</ul>
+			</div>
+		</li>
+
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Find the plugin for the action you need.&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;Inserting content
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;What language?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;English&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;&gt;French&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Photo galery
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;What language?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;English&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;&gt;French&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Draw charts
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;What language?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;English&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;French&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Expand and collapse content
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;What language?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;English&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;French&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Set a consistant height
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;What language?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;English&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;French&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Popup content
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;What language?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;English&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;French&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h2 id="cssclass">Add and remove CSS class</h2>
+
+<div class="wb-fieldflow" data-wb-fieldflow='{
+		"reset": { "action": "removeClass", "source":"#addremoveCSSexample", "class": "text-muted text-primary text-success text-info text-warning text-danger" }
+	}'>
+	<p>Change the color of the following paragraph:</p>
+	<ul>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-muted" }'>Muted</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-primary" }'>Primary</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-success" }'>Sucess</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-info" }'>Info</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-warning" }'>Warning</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-danger" }'>Danger</li>
+	</ul>
+</div>
+
+<p id="addremoveCSSexample">Example of paragraph where the preceding field flow component could change my color.</p>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+		&quot;reset&quot;: { &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-muted text-primary text-success text-info text-warning text-danger&quot; }
+	}'&gt;
+	&lt;p&gt;Change the color of the following paragraph:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-muted&quot; }'&gt;Muted&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-primary&quot; }'&gt;Primary&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-success&quot; }'&gt;Sucess&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-info&quot; }'&gt;Info&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-warning&quot; }'&gt;Warning&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-danger&quot; }'&gt;Danger&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;p id=&quot;addremoveCSSexample&quot;&gt;Example of paragraph where the preceding field flow component could change my color.&lt;/p&gt;</code></pre>
+
+<h2 id="defaultreset">Applying a set of default and reset action</h2>
+
+
+<div class="wb-fieldflow" data-wb-fieldflow='{
+		"reset": { "action": "removeClass", "source":"#resetdefaultExample-en", "class": "text-muted text-primary text-success text-info text-warning text-danger" },
+		"default": { "action": "ajax", "url":"ajax/paragraph.html#paragraph1-en", "live": true }
+	}'>
+	<p>Change the color of the following paragraph:</p>
+	<ul>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-en", "class": "text-muted" }'>Muted</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-en", "class": "text-primary" }'>Primary</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-en", "class": "text-success" }'>Sucess</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-en", "class": "text-info" }'>Info</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-en", "class": "text-warning" }'>Warning</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-en", "class": "text-danger" }'>Danger</li>
+	</ul>
+</div>
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+		&quot;reset&quot;: { &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-en&quot;, &quot;class&quot;: &quot;text-muted text-primary text-success text-info text-warning text-danger&quot; },
+		&quot;default&quot;: { &quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;:&quot;<a href="ajax/paragraph.html">ajax/paragraph.html</a>#paragraph1-en&quot;, &quot;live&quot;: true }
+	}'&gt;
+	&lt;p&gt;Change the color of the following paragraph:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-en&quot;, &quot;class&quot;: &quot;text-muted&quot; }'&gt;Muted&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-en&quot;, &quot;class&quot;: &quot;text-primary&quot; }'&gt;Primary&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-en&quot;, &quot;class&quot;: &quot;text-success&quot; }'&gt;Sucess&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-en&quot;, &quot;class&quot;: &quot;text-info&quot; }'&gt;Info&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-en&quot;, &quot;class&quot;: &quot;text-warning&quot; }'&gt;Warning&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-en&quot;, &quot;class&quot;: &quot;text-danger&quot; }'&gt;Danger&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h3>File <code>ajax/paragraph.html</code></h3>
+<pre><code>&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;!-- DataAjaxFragmentStart --&gt;
+
+&lt;div lang=&quot;en&quot;&gt;
+	&lt;div id=&quot;paragraph1-en&quot;&gt;
+		&lt;p id=&quot;resetdefaultExample-en&quot;&gt;Example of paragraph where the preceding field flow component could change my color.&lt;/p&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;paragraph2-en&quot;&gt;
+		&lt;p id=&quot;definebaseExample-en&quot;&gt;Example of paragraph where the preceding field flow component could change my color.&lt;/p&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;paragraph3-en&quot;&gt;
+		&lt;p id=&quot;defineDefaultExample-en&quot;&gt;Example of paragraph where the preceding field flow component could change my color.&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;div lang=&quot;fr&quot;&gt;
+	&lt;div id=&quot;paragraph1-fr&quot;&gt;
+		&lt;p id=&quot;resetdefaultExample-fr&quot;&gt;Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.&lt;/p&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;paragraph2-fr&quot;&gt;
+		&lt;p id=&quot;definebaseExample-fr&quot;&gt;Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.&lt;/p&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;paragraph3-fr&quot;&gt;
+		&lt;p id=&quot;defineDefaultExample-fr&quot;&gt;Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- DataAjaxFragmentEnd --&gt;
+&lt;/html&gt;</code></pre>
+
+
+
+<h2 id="baseAction">Define a base action object</h2>
+
+<p>This example is the same as applying a set of default, reset action but it set a base action object and executed action inherit from the base action.</p>
+
+<div class="wb-fieldflow" data-wb-fieldflow='{
+		"reset": { "action": "removeClass", "source":"#definebaseExample-en", "class": "text-muted text-primary text-success text-info text-warning text-danger" },
+		"default": { "action": "ajax", "url":"ajax/paragraph.html#paragraph2-en", "live": true },
+		"base" : { "action": "addClass", "source":"#definebaseExample-en" }
+	}'>
+	<p>Change the color of the following paragraph:</p>
+	<ul>
+		<li data-wb-fieldflow='{ "class": "text-muted" }'>Muted</li>
+		<li data-wb-fieldflow='{ "class": "text-primary" }'>Primary</li>
+		<li data-wb-fieldflow='{ "class": "text-success" }'>Sucess</li>
+		<li data-wb-fieldflow='{ "class": "text-info" }'>Info</li>
+		<li data-wb-fieldflow='{ "class": "text-warning" }'>Warning</li>
+		<li data-wb-fieldflow='{ "class": "text-danger" }'>Danger</li>
+	</ul>
+</div>
+
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+		&quot;reset&quot;: { &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;:&quot;#definebaseExample-en&quot;, &quot;class&quot;: &quot;text-muted text-primary text-success text-info text-warning text-danger&quot; },
+		&quot;default&quot;: { &quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;:&quot;<a href="ajax/paragraph.html">ajax/paragraph.html</a>#paragraph2-en&quot;, &quot;live&quot;: true },
+		&quot;base&quot; : { &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#definebaseExample-en&quot; }
+	}'&gt;
+	&lt;p&gt;Change the color of the following paragraph:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-muted&quot; }'&gt;Muted&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-primary&quot; }'&gt;Primary&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-success&quot; }'&gt;Sucess&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-info&quot; }'&gt;Info&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-warning&quot; }'&gt;Warning&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-danger&quot; }'&gt;Danger&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h2 id="redefineDefaultBehavior">Redefine defaults behaviour of simple call</h2>
+
+<p>Change the default behaviour when each items are configured.</p>
+
+<div class="wb-fieldflow" data-wb-fieldflow='{
+		"reset": { "action": "removeClass", "source":"#definebaseExample-en", "class": "text-muted text-primary text-success text-info text-warning text-danger" },
+		"default": { "action": "ajax", "url":"ajax/paragraph.html#paragraph3-en", "live": true },
+		"actionData" : { "source":"#defineDefaultExample-en" },
+		"action": "addClass",
+		"prop": "class"
+	}'>
+	<p>Change the color of the following paragran</p>
+	<ul>
+		<li data-wb-fieldflow="text-muted">Muted</li>
+		<li data-wb-fieldflow="text-primary">Primary</li>
+		<li data-wb-fieldflow="text-success">Sucess</li>
+		<li data-wb-fieldflow="text-info">Info</li>
+		<li data-wb-fieldflow="text-warning">Warning</li>
+		<li data-wb-fieldflow="text-danger">Danger</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+		&quot;reset&quot;: { &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;:&quot;#definebaseExample-en&quot;, &quot;class&quot;: &quot;text-muted text-primary text-success text-info text-warning text-danger&quot; },
+		&quot;default&quot;: { &quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;:&quot;<a href="ajax/paragraph.html">ajax/paragraph.html</a>#paragraph3-en&quot;, &quot;live&quot;: true },
+		&quot;actionData&quot; : { &quot;source&quot;:&quot;#defineDefaultExample-en&quot; },
+		&quot;action&quot;: &quot;addClass&quot;,
+		&quot;prop&quot;: &quot;class&quot;
+	}'&gt;
+	&lt;p&gt;Change the color of the following paragran&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;text-muted&quot;&gt;Muted&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;text-primary&quot;&gt;Primary&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;text-success&quot;&gt;Sucess&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;text-info&quot;&gt;Info&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;text-warning&quot;&gt;Warning&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;text-danger&quot;&gt;Danger&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h2 id="querying">Querying and form integration</h2>
+
+<div class="well">
+	<p>Allow to set a name and value to the URL on which the user will be usually redirected to.</p>
+
+	<p>This show how to use the <code>query</code> action. The following configuration option must be present:</p>
+
+	<dl class="dl-horizontal">
+		<dt><code>name</code></dt>
+		<dd>Define the query parameter name to use.</dd>
+		<dt><code>value</code></dt>
+		<dd>Define the query value to set for the specified parameter name.</dd>
+	</dl>
+
+	<p>The configuration option <code>noForm</code> set on the <code>&lt;div class=&quot;wb-fieldflow&quot;&gt;&lt;/div&gt;</code> tell the plugin to not create a form wrapper but instead to bind with the existing one. The submit button need to be supplied in that mode. It is assumed the form is also wrapped with <code>wb-frmvld</code></p>
+
+</div>
+
+<section class="panel panel-info">
+  <header class="panel-heading">
+   <h3 class="panel-title">A few remark regarding the following example</h3>
+  </header>
+  <div class="panel-body">
+	<ul>
+		<li>It is itself submiting. Once submited, the additional query parameter, <code>animal</code> that will be present in the result page URL.</li>
+		<li>As is, that form are unusable if javascript are disabled, so:
+			<ul>
+				<li>That is why a static alternative example follow the form.</li>
+				<li>It is hidden by default</li>
+				<li>It get unhide by the field flow plugin initialization, as specified by the configuration option <code>unhideelm</code> (containing a jQuery selector value).</li>
+			</ul>
+		</li>
+	</ul>
+  </div>
+</section>
+
+<div id="myformid" class="wb-frmvld hidden">
+<form action="advanced-en.html" class="col-md-12">
+
+	<fieldset>
+		<legend><span class="field-name">Favourite pets</span></legend>
+		<div class="checkbox">
+			<label for="animal5"><input type="checkbox" name="animal" value="Dog" id="animal5" /> Dog</label>
+		</div>
+		<div class="checkbox">
+			<label for="animal6"><input type="checkbox" name="animal" value="Cat" id="animal6" /> Cat</label>
+		</div>
+		<div class="checkbox">
+			<label for="animal7"><input type="checkbox" name="animal" value="Fish" id="animal7" /> Fish</label>
+		</div>
+		<div class="checkbox">
+			<label for="animal8"><input type="checkbox" name="animal" value="Snake" id="animal8" /> Snake</label>
+		</div>
+	</fieldset>
+
+
+	<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "unhideelm": "#myformid"}'>
+		<p>You want to get more information about?</p>
+		<ul>
+			<li>Habitation
+				<div class="wb-fieldflow-sub">
+					<p>What kind of habitation are looking for?</p>
+					<ul>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"wild"}'>Wild</li>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"recomhab"}'>Recommended</li>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"inside"}'>Inside</li>
+						<li data-wb-fieldflow='[
+							{"action": "query", "name":"moreinfo", "value":"outside"},
+							{"action": "redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html"}
+						]'>Outside</li>
+					</ul>
+				</div>
+			</li>
+			<li>Food
+				<div class="wb-fieldflow-sub">
+					<p>What kind of nutrition your are seeking?</p>
+					<ul>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"healty"}'>Healty</li>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"nutrition"}'>Recommended</li>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"avoid"}'>To avoid</li>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"trending"}'>Trending</li>
+					</ul>
+				</div>
+			</li>
+
+		</ul>
+	</div>
+
+
+	<input class="mrgn-bttm-lg" type="submit" value="Submit and look at the resulting URL" />
+</form></div>
+
+<details id="myformidAlternate">
+	<summary>Alternative representation alloweing to get equivalent information.</summary>
+
+	<p>Dog:</p>
+	<ul>
+		<li><a href="advanced-en.html?animal=Dog&amp;moreinfo=wild">Wild habitation</a></li>
+		<li><a href="advanced-en.html?animal=Dog&amp;moreinfo=recomhab">Recommended habitation</a></li>
+		<li><a href="advanced-en.html?animal=Dog&amp;moreinfo=inside">Inside leaving</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html?animal=Dog&amp;moreinfo=outside">Outside leaving</a></li>
+		<li><a href="advanced-en.html?animal=Dog&amp;moreinfo=healty">Healty food</a></li>
+		<li><a href="advanced-en.html?animal=Dog&amp;moreinfo=nutrition">Recommended nutrition</a></li>
+		<li><a href="advanced-en.html?animal=Dog&amp;moreinfo=avoid">Meat toavoid</a></li>
+		<li><a href="advanced-en.html?animal=Dog&amp;moreinfo=trending">Trending meal</a></li>
+	</ul>
+	<p>Cat:</p>
+	<ul>
+		<li><a href="advanced-en.html?animal=Cat&amp;moreinfo=wild">Wild habitation</a></li>
+		<li><a href="advanced-en.html?animal=Cat&amp;moreinfo=recomhab">Recommended habitation</a></li>
+		<li><a href="advanced-en.html?animal=Cat&amp;moreinfo=inside">Inside leaving</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html?animal=Cat&amp;moreinfo=outside">Outside leaving</a></li>
+		<li><a href="advanced-en.html?animal=Cat&amp;moreinfo=healty">Healty food</a></li>
+		<li><a href="advanced-en.html?animal=Cat&amp;moreinfo=nutrition">Recommended nutrition</a></li>
+		<li><a href="advanced-en.html?animal=Cat&amp;moreinfo=avoid">Meat toavoid</a></li>
+		<li><a href="advanced-en.html?animal=Cat&amp;moreinfo=trending">Trending meal</a></li>
+	</ul>
+	<p>Fish:</p>
+	<ul>
+		<li><a href="advanced-en.html?animal=Fish&amp;moreinfo=wild">Wild habitation</a></li>
+		<li><a href="advanced-en.html?animal=Fish&amp;moreinfo=recomhab">Recommended habitation</a></li>
+		<li><a href="advanced-en.html?animal=Fish&amp;moreinfo=inside">Inside leaving</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html?animal=Fish&amp;moreinfo=outside">Outside leaving</a></li>
+		<li><a href="advanced-en.html?animal=Fish&amp;moreinfo=healty">Healty food</a></li>
+		<li><a href="advanced-en.html?animal=Fish&amp;moreinfo=nutrition">Recommended nutrition</a></li>
+		<li><a href="advanced-en.html?animal=Fish&amp;moreinfo=avoid">Meat toavoid</a></li>
+		<li><a href="advanced-en.html?animal=Fish&amp;moreinfo=trending">Trending meal</a></li>
+	</ul>
+	<p>Snake:</p>
+	<ul>
+		<li><a href="advanced-en.html?animal=Snake&amp;moreinfo=wild">Wild habitation</a></li>
+		<li><a href="advanced-en.html?animal=Snake&amp;moreinfo=recomhab">Recommended habitation</a></li>
+		<li><a href="advanced-en.html?animal=Snake&amp;moreinfo=inside">Inside leaving</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html?animal=Snake&amp;moreinfo=outside">Outside leaving</a></li>
+		<li><a href="advanced-en.html?animal=Snake&amp;moreinfo=healty">Healty food</a></li>
+		<li><a href="advanced-en.html?animal=Snake&amp;moreinfo=nutrition">Recommended nutrition</a></li>
+		<li><a href="advanced-en.html?animal=Snake&amp;moreinfo=avoid">Meat toavoid</a></li>
+		<li><a href="advanced-en.html?animal=Snake&amp;moreinfo=trending">Trending meal</a></li>
+	</ul>
+</details>
+
+
+
+<pre><code>&lt;div id=&quot;myformid&quot; class=&quot;wb-frmvld hidden&quot;&gt;
+&lt;form action=&quot;advanced-en.html&quot; class=&quot;col-md-12&quot;&gt;
+
+	&lt;fieldset&gt;
+		&lt;legend&gt;&lt;span class=&quot;field-name&quot;&gt;Favourite pets&lt;/span&gt;&lt;/legend&gt;
+		&lt;div class=&quot;checkbox&quot;&gt;
+			&lt;label for=&quot;animal5&quot;&gt;&lt;input type=&quot;checkbox&quot; name=&quot;animal&quot; value=&quot;Dog&quot; id=&quot;animal5&quot; /&gt; Dog&lt;/label&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;checkbox&quot;&gt;
+			&lt;label for=&quot;animal6&quot;&gt;&lt;input type=&quot;checkbox&quot; name=&quot;animal&quot; value=&quot;Cat&quot; id=&quot;animal6&quot; /&gt; Cat&lt;/label&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;checkbox&quot;&gt;
+			&lt;label for=&quot;animal7&quot;&gt;&lt;input type=&quot;checkbox&quot; name=&quot;animal&quot; value=&quot;Fish&quot; id=&quot;animal7&quot; /&gt; Fish&lt;/label&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;checkbox&quot;&gt;
+			&lt;label for=&quot;animal8&quot;&gt;&lt;input type=&quot;checkbox&quot; name=&quot;animal&quot; value=&quot;Snake&quot; id=&quot;animal8&quot; /&gt; Snake&lt;/label&gt;
+		&lt;/div&gt;
+	&lt;/fieldset&gt;
+
+
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true, &quot;unhideelm&quot;: &quot;#myformid&quot;}'&gt;
+		&lt;p&gt;You want to get more information about?&lt;/p&gt;
+		&lt;ul&gt;
+			&lt;li&gt;Habitation
+				&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+					&lt;p&gt;What kind of habitation are looking for?&lt;/p&gt;
+					&lt;ul&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;wild&quot;}'&gt;Wild&lt;/li&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;recomhab&quot;}'&gt;Recommended&lt;/li&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;inside&quot;}'&gt;Inside&lt;/li&gt;
+						&lt;li data-wb-fieldflow='[
+							{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;outside&quot;},
+							{&quot;action&quot;: &quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;}
+						]'&gt;Outside&lt;/li&gt;
+					&lt;/ul&gt;
+				&lt;/div&gt;
+			&lt;/li&gt;
+			&lt;li&gt;Food
+				&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+					&lt;p&gt;What kind of nutrition your are seeking?&lt;/p&gt;
+					&lt;ul&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;healty&quot;}'&gt;Healty&lt;/li&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;nutrition&quot;}'&gt;Recommended&lt;/li&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;avoid&quot;}'&gt;To avoid&lt;/li&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;trending&quot;}'&gt;Trending&lt;/li&gt;
+					&lt;/ul&gt;
+				&lt;/div&gt;
+			&lt;/li&gt;
+
+		&lt;/ul&gt;
+	&lt;/div&gt;
+
+
+	&lt;input class=&quot;mrgn-bttm-lg&quot; type=&quot;submit&quot; value=&quot;Submit and look at the resulting URL&quot; /&gt;
+&lt;/form&gt;&lt;/div&gt;
+
+&lt;details id=&quot;myformidAlternate&quot;&gt;
+	&lt;summary&gt;Alternative representation alloweing to get equivalent information.&lt;/summary&gt;
+
+	&lt;p&gt;Dog:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Dog&amp;amp;moreinfo=wild&quot;&gt;Wild habitation&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Dog&amp;amp;moreinfo=recomhab&quot;&gt;Recommended habitation&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Dog&amp;amp;moreinfo=inside&quot;&gt;Inside leaving&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html?animal=Dog&amp;amp;moreinfo=outside&quot;&gt;Outside leaving&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Dog&amp;amp;moreinfo=healty&quot;&gt;Healty food&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Dog&amp;amp;moreinfo=nutrition&quot;&gt;Recommended nutrition&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Dog&amp;amp;moreinfo=avoid&quot;&gt;Meat toavoid&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Dog&amp;amp;moreinfo=trending&quot;&gt;Trending meal&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;p&gt;Cat:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Cat&amp;amp;moreinfo=wild&quot;&gt;Wild habitation&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Cat&amp;amp;moreinfo=recomhab&quot;&gt;Recommended habitation&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Cat&amp;amp;moreinfo=inside&quot;&gt;Inside leaving&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html?animal=Cat&amp;amp;moreinfo=outside&quot;&gt;Outside leaving&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Cat&amp;amp;moreinfo=healty&quot;&gt;Healty food&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Cat&amp;amp;moreinfo=nutrition&quot;&gt;Recommended nutrition&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Cat&amp;amp;moreinfo=avoid&quot;&gt;Meat toavoid&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Cat&amp;amp;moreinfo=trending&quot;&gt;Trending meal&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;p&gt;Fish:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Fish&amp;amp;moreinfo=wild&quot;&gt;Wild habitation&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Fish&amp;amp;moreinfo=recomhab&quot;&gt;Recommended habitation&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Fish&amp;amp;moreinfo=inside&quot;&gt;Inside leaving&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html?animal=Fish&amp;amp;moreinfo=outside&quot;&gt;Outside leaving&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Fish&amp;amp;moreinfo=healty&quot;&gt;Healty food&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Fish&amp;amp;moreinfo=nutrition&quot;&gt;Recommended nutrition&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Fish&amp;amp;moreinfo=avoid&quot;&gt;Meat toavoid&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Fish&amp;amp;moreinfo=trending&quot;&gt;Trending meal&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;p&gt;Snake:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Snake&amp;amp;moreinfo=wild&quot;&gt;Wild habitation&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Snake&amp;amp;moreinfo=recomhab&quot;&gt;Recommended habitation&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Snake&amp;amp;moreinfo=inside&quot;&gt;Inside leaving&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html?animal=Snake&amp;amp;moreinfo=outside&quot;&gt;Outside leaving&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Snake&amp;amp;moreinfo=healty&quot;&gt;Healty food&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Snake&amp;amp;moreinfo=nutrition&quot;&gt;Recommended nutrition&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Snake&amp;amp;moreinfo=avoid&quot;&gt;Meat toavoid&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-en.html?animal=Snake&amp;amp;moreinfo=trending&quot;&gt;Trending meal&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/details&gt;</code></pre>
+
+
+
+<h2 id="toggle">Toggle</h2>
+
+
+
+	<div class="well">
+		<p>All the option defined for the <a href="http://wet-boew.github.io/wet-boew/demos/toggle/toggle-en.html">toggle plugin</a> can be set in the <code>toggle</code> parameter in the <code>data-wb-fieldflow</code>.</p>
+
+		<p>The following are equivalent
+		<ul>
+			<li><code>&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#myblockid&quot;}'&gt;My block of content&lt;/li&gt;</code></li>
+			<li><code>&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: {&quot;selector&quot;:&quot;#myblockid&quot;}}'&gt;My block of content&lt;/li&gt;</code></li>
+		</ul>
+
+		<p>If no option specified for the toggle plugin, the following options will be set</p>
+
+<pre><code>toggle: {
+	stateOn: "visible",
+	stateOff: "hidden"
+}</code></pre>
+	</div>
+
+
+	<div class="wb-fieldflow">
+		<p>Choose content to be toggle?</p>
+		<ul>
+			<li data-wb-fieldflow='{"action": "toggle", "toggle": "#toggle-first"}'>Toggle first</li>
+			<li data-wb-fieldflow='{"action": "toggle", "toggle": "#toggle-second"}'>Toggle second</li>
+			<li data-wb-fieldflow='{"action": "toggle", "toggle": "#toggle-first, #toggle-second"}'>Toggle both</li>
+		</ul>
+	</div>
+
+	<div id="toggle-first" class="well hidden">
+		<p>This is first <code>@id=toggle-first</code></p>
+	</div>
+
+	<div id="toggle-second" class="jumbotron hidden">
+		<p>This is second <code>@id=toggle-second</code></p>
+	</div>
+
+	<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choose content to be toggle?&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#toggle-first&quot;}'&gt;Toggle first&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#toggle-second&quot;}'&gt;Toggle second&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#toggle-first, #toggle-second&quot;}'&gt;Toggle both&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;div id=&quot;toggle-first&quot; class=&quot;well hidden&quot;&gt;
+	&lt;p&gt;This is first &lt;code&gt;@id=toggle-first&lt;/code&gt;&lt;/p&gt;
+&lt;/div&gt;
+
+&lt;div id=&quot;toggle-second&quot; class=&quot;jumbotron hidden&quot;&gt;
+	&lt;p&gt;This is second &lt;code&gt;@id=toggle-second&lt;/code&gt;&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+
+
+	<h3>Without a submit button</h3>
+
+<div class="wb-frmvld"><form method="get">
+	<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true}'>
+		<p>Choose content to be toggle?</p>
+		<ul>
+			<li data-wb-fieldflow='{"action": "toggle", "toggle": "#toggle-third", "live": true}' data-wb-toggle='{"stateOn": "visible", "stateOff":"hidden"}'>Toggle third</li>
+			<li data-wb-fieldflow='{"action": "toggle", "toggle": "#toggle-forth", "live": true}'>Toggle forth</li>
+			<li data-wb-fieldflow='{"action": "toggle", "toggle": "#toggle-third, #toggle-forth", "live": true}'>Toggle both</li>
+		</ul>
+	</div>
+
+	<div id="toggle-third" class="well hidden">
+		<p>This is third <code>@id=toggle-third</code></p>
+	</div>
+
+	<div id="toggle-forth" class="jumbotron hidden">
+		<p>This is forth <code>@id=toggle-forth</code></p>
+	</div>
+
+</form></div>
+
+<pre><code>&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form method=&quot;get&quot;&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true}'&gt;
+		&lt;p&gt;Choose content to be toggle?&lt;/p&gt;
+		&lt;ul&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#toggle-third&quot;, &quot;live&quot;: true}'&gt;Toggle third&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#toggle-forth&quot;, &quot;live&quot;: true}'&gt;Toggle forth&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#toggle-third, #toggle-forth&quot;, &quot;live&quot;: true}'&gt;Toggle both&lt;/li&gt;
+		&lt;/ul&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;toggle-third&quot; class=&quot;well hidden&quot;&gt;
+		&lt;p&gt;This is third &lt;code&gt;@id=toggle-third&lt;/code&gt;&lt;/p&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;toggle-forth&quot; class=&quot;jumbotron hidden&quot;&gt;
+		&lt;p&gt;This is forth &lt;code&gt;@id=toggle-forth&lt;/code&gt;&lt;/p&gt;
+	&lt;/div&gt;
+
+&lt;/form&gt;&lt;/div&gt;</code></pre>
+
+
+
+<h2 id="tblfilter">Table filtering</h2>
+
+
+<div class="wb-frmvld"><form method="get">
+<div class="wb-fieldflow" data-wb-fieldflow='
+		{
+			"srctype": "tblfilter",
+			"noForm": true,
+			"source": "#table-filtering-example",
+			"fltrseq": [
+				{"column": 2},
+				{"column": 3}
+			],
+			"limit": 3
+		}'></div>
+</form></div>
+
+
+<table id="table-filtering-example" class="wb-tables table table-striped table-hover">
+	<thead>
+		<tr>
+			<th>Title</th>
+			<th>Publication date</th>
+			<th>Summary</th>
+			<th>Subject</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Biomass Program Continues to Support Transition to Renewable Energy in Manitoba</a></th>
+			<td>2016-07-29 12:07:00</td>
+			<td>
+				<p>The governments of Canada and Manitoba are supporting a greener, more sustainable economy through the $1 million Biomass Energy Support Program, Federal Agriculture Minister Lawrence MacAulay and Manitoba Agriculture Minister Ralph Eichler announced today.</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>Farmers</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Agriculture</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">MP Rodger Cuzner to make announcement in Broad Cove</a></th>
+			<td>2016-07-29 12:07:00</td>
+			<td>
+				<p>Rodger Cuzner, Member of Parliament for Cape Breton – Canso, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency, will make a funding announcement at the Broad Cove Scottish Concert..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>Rural Community</li>
+					<li>Travellers</li>
+					<li>Visitors</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Society and Culture</li>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">An Exhibition Dedicated to the Caribou and Other Animals Like It</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>The Government of Canada supports the Musée du Fjord.</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Backgrounder: Government of Canada delivers $109 million to Alberta for community infrastructure projects</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>The Government of Canada delivered the first of two federal Gas Tax Fund installments for 2016-17 to all the provinces and territories benefitting 364 municipalities in Alberta..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Transport</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Government of Canada delivers $109 million to Alberta for community infrastructure projects</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>Modern and up-to-date community infrastructure helps ensure that Canadians live the quality of life that they want and expect. Community infrastructure helps connect people to jobs and provides access to better community services, attracts new businesses and creates economic growth opportunities..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Transport</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Minister Carr to Make an Announcement About the Winnipeg Art Gallery</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>WINNIPEG – The Honourable Jim Carr, Minister of Natural Resources....</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a></th>
+			<td>2016-07-29 10:07:00</td>
+			<td>
+				<p>What an honour to be at the University of Toronto-my alma mater-for this tremendous announcement..</p>
+				<p>For:</p>
+				<ul>
+					<li>Business</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Economics and Industry</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a></th>
+			<td>2016-07-29 10:07:00</td>
+			<td>
+				<p>Thank you, Meric [Meric S. Gertler, President, University of Toronto]. And thank you to the University of Toronto for being such great hosts today. I'm delighted to be here with my friend and colleague Kirsty Duncan, Minister of Science..</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Economics and Industry</li>
+				</ul>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<pre><code>&lt;div class=&quot;wb-frmvld&quot;&gt;
+	&lt;form method=&quot;get&quot;&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='
+			{
+				&quot;srctype&quot;: &quot;tblfilter&quot;,
+				&quot;noForm&quot;: true,
+				&quot;source&quot;: &quot;#table-filtering-example&quot;,
+				&quot;fltrseq&quot;: [
+					{&quot;column&quot;: 2},
+					{&quot;column&quot;: 3}
+				],
+				&quot;limit&quot;: 3
+			}'&gt;&lt;/div&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+
+&lt;table id=&quot;table-filtering-example&quot; class=&quot;wb-tables table table-striped table-hover&quot;&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Title&lt;/th&gt;
+			&lt;th&gt;Publication date&lt;/th&gt;
+			&lt;th&gt;Summary&lt;/th&gt;
+			&lt;th&gt;Subject&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody&gt;
+		&lt;tr&gt;
+			&lt;th&gt;&lt;a href=&quot;http://news.gc.ca/web/index-en.do&quot;&gt;Biomass Program Continues to Support Transition to Renewable Energy in Manitoba&lt;/a&gt;&lt;/th&gt;
+			&lt;td&gt;2016-07-29 12:07:00&lt;/td&gt;
+			&lt;td&gt;
+				&lt;p&gt;The governments of Canada and Manitoba are supporting a greener, more sustainable economy through the $1 million Biomass Energy Support Program, Federal Agriculture Minister Lawrence MacAulay and Manitoba Agriculture Minister Ralph Eichler announced today.&lt;/p&gt;
+				&lt;p&gt;For:&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;Media&lt;/li&gt;
+					&lt;li&gt;Farmers&lt;/li&gt;
+					&lt;li&gt;General Public&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/td&gt;
+			&lt;td&gt;
+				&lt;ul&gt;
+					&lt;li&gt;Agriculture&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/td&gt;
+		&lt;/tr&gt;
+
+		[...]
+
+	&lt;/tbody&gt;
+&lt;/table&gt;</code></pre>
+
+
+
+
+<h3>Custom filtering interface <small>Table filtering</small></h3>
+
+<div id="table-filtering-example2-form" class="wb-frmvld hidden">
+	<form>
+		<div class="wb-fieldflow" data-wb-fieldflow='{ "noForm": true, "isoptional": true, "unhideelm": "#table-filtering-example2-form" }'>
+			<p>Filter by subject:</p>
+			<ul>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Agriculture"
+				}'>Agriculture</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Society"
+				}'>Society and Culture</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "table#-filtering-example2",
+					"column": 3,
+					"value": "Arts"
+				}'>Arts</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Music"
+				}'>Music</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Literature"
+				}'>Literature</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Transport"
+				}'>Transport</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Economics"
+				}'>Economics and Industry</li>
+			</ul>
+		</div>
+		<div class="wb-fieldflow" data-wb-fieldflow='{ "noForm": true, "isoptional": true }'>
+			<p>Filter by audience:</p>
+			<ul>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Business"
+				}'>Business</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Farmers"
+				}'>Farmers</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Public"
+				}'>General Public</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Media"
+				}'>Media</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2
+					"value": "Rural"
+				}'>Rural Community</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Travellers"
+				}'>Travellers</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Visitors"
+				}'>Visitors</li>
+			</ul>
+		</div>
+	</form>
+</div>
+
+<table id="table-filtering-example2" class="wb-tables table table-striped table-hover">
+	<thead>
+		<tr>
+			<th>Title</th>
+			<th>Publication date</th>
+			<th>Summary</th>
+			<th>Subject</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Biomass Program Continues to Support Transition to Renewable Energy in Manitoba</a></th>
+			<td>2016-07-29 12:07:00</td>
+			<td>
+				<p>The governments of Canada and Manitoba are supporting a greener, more sustainable economy through the $1 million Biomass Energy Support Program, Federal Agriculture Minister Lawrence MacAulay and Manitoba Agriculture Minister Ralph Eichler announced today.</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>Farmers</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Agriculture</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">MP Rodger Cuzner to make announcement in Broad Cove</a></th>
+			<td>2016-07-29 12:07:00</td>
+			<td>
+				<p>Rodger Cuzner, Member of Parliament for Cape Breton – Canso, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency, will make a funding announcement at the Broad Cove Scottish Concert..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>Rural Community</li>
+					<li>Travellers</li>
+					<li>Visitors</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Society and Culture</li>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">An Exhibition Dedicated to the Caribou and Other Animals Like It</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>The Government of Canada supports the Musée du Fjord.</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Backgrounder: Government of Canada delivers $109 million to Alberta for community infrastructure projects</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>The Government of Canada delivered the first of two federal Gas Tax Fund installments for 2016-17 to all the provinces and territories benefitting 364 municipalities in Alberta..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Transport</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Government of Canada delivers $109 million to Alberta for community infrastructure projects</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>Modern and up-to-date community infrastructure helps ensure that Canadians live the quality of life that they want and expect. Community infrastructure helps connect people to jobs and provides access to better community services, attracts new businesses and creates economic growth opportunities..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Transport</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Minister Carr to Make an Announcement About the Winnipeg Art Gallery</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>WINNIPEG – The Honourable Jim Carr, Minister of Natural Resources....</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a></th>
+			<td>2016-07-29 10:07:00</td>
+			<td>
+				<p>What an honour to be at the University of Toronto-my alma mater-for this tremendous announcement..</p>
+				<p>For:</p>
+				<ul>
+					<li>Business</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Economics and Industry</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a></th>
+			<td>2016-07-29 10:07:00</td>
+			<td>
+				<p>Thank you, Meric [Meric S. Gertler, President, University of Toronto]. And thank you to the University of Toronto for being such great hosts today. I'm delighted to be here with my friend and colleague Kirsty Duncan, Minister of Science..</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Economics and Industry</li>
+				</ul>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+
+<pre><code>&lt;div id=&quot;table-filtering-example2-form&quot; class=&quot;wb-frmvld hidden&quot;&gt;
+	&lt;form&gt;
+		&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{ &quot;noForm&quot;: true, &quot;isoptional&quot;: true, &quot;unhideelm&quot;: &quot;#table-filtering-example2-form&quot; }'&gt;
+			&lt;p&gt;Filter by subject:&lt;/p&gt;
+			&lt;ul&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Agriculture&quot;
+				}'&gt;Agriculture&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Society&quot;
+				}'&gt;Society and Culture&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Arts&quot;
+				}'&gt;Arts&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Music&quot;
+				}'&gt;Music&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Literature&quot;
+				}'&gt;Literature&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Transport&quot;
+				}'&gt;Transport&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Economics&quot;
+				}'&gt;Economics and Industry&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{ &quot;noForm&quot;: true, &quot;isoptional&quot;: true }'&gt;
+			&lt;p&gt;Filter by audience:&lt;/p&gt;
+			&lt;ul&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Business&quot;
+				}'&gt;Business&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Farmers&quot;
+				}'&gt;Farmers&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Public&quot;
+				}'&gt;General Public&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Media&quot;
+				}'&gt;Media&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2
+					&quot;value&quot;: &quot;Rural&quot;
+				}'&gt;Rural Community&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Travellers&quot;
+				}'&gt;Travellers&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Visitors&quot;
+				}'&gt;Visitors&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/div&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+
+&lt;table id=&quot;table-filtering-example2&quot; class=&quot;wb-tables table table-striped table-hover&quot;&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Title&lt;/th&gt;
+			&lt;th&gt;Publication date&lt;/th&gt;
+			&lt;th&gt;Summary&lt;/th&gt;
+			&lt;th&gt;Subject&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody&gt;
+		&lt;tr&gt;
+			&lt;th&gt;&lt;a href=&quot;http://news.gc.ca/web/index-en.do&quot;&gt;Biomass Program Continues to Support Transition to Renewable Energy in Manitoba&lt;/a&gt;&lt;/th&gt;
+			&lt;td&gt;2016-07-29 12:07:00&lt;/td&gt;
+			&lt;td&gt;
+				&lt;p&gt;The governments of Canada and Manitoba are supporting a greener, more sustainable economy through the $1 million Biomass Energy Support Program, Federal Agriculture Minister Lawrence MacAulay and Manitoba Agriculture Minister Ralph Eichler announced today.&lt;/p&gt;
+				&lt;p&gt;For:&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;Media&lt;/li&gt;
+					&lt;li&gt;Farmers&lt;/li&gt;
+					&lt;li&gt;General Public&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/td&gt;
+			&lt;td&gt;
+				&lt;ul&gt;
+					&lt;li&gt;Agriculture&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/td&gt;
+		&lt;/tr&gt;
+
+		[...]
+
+	&lt;/tbody&gt;
+&lt;/table&gt;</code></pre>
+
+
+<h3>Another table filtering example</h3>
+
+
+
+<div class="row">
+	<div class="col-md-3">
+		<section>
+			<h4 class="wb-inv">Filtering Options</h4>
+			<div class="wb-frmvld"><form>
+					<div class="wb-fieldflow" data-wb-fieldflow='
+							{
+								"srctype": "tblfilter",
+								"noForm": true,
+								"source": "#dataset-filter",
+								"fltrseq": [
+									{"column": 3, "csvextract": true, "defaultselectedlabel": "All news types", "label":"Data Type"},
+									{"column": 2, "csvextract": true, "defaultselectedlabel": "From any department", "label":"Department"},
+									{"column": 8, "csvextract": true, "defaultselectedlabel": "Related to any minister", "label":"Minister"},
+									{"column": 6, "csvextract": true, "defaultselectedlabel": "Everyone", "label":"For"},
+									{"column": 5, "csvextract": true, "defaultselectedlabel": "Anywhere", "label":"Location"}
+								]
+							}'></div>
+			</form></div>
+		</section>
+	</div>
+	<div class="col-md-9">
+		<table class="wb-tables table table-striped table-hover" id="dataset-filter" aria-live="polite" data-wb-tables='{
+					"bDeferRender": true,
+					"ajaxSource": "http://wet-boew.github.io/wet-boew/demos/tables/ajax/datasource.json",
+					"order": [5, "desc"],
+					 "columns": [
+						{ "data": "TITLE", "className": "nws-tbl-ttl h4" },
+						{ "data": "PUBDATE", "className": "nws-tbl-date" },
+						{ "data": "DEPT", "className": "nws-tbl-dept" },
+						{ "data": "TYPE", "className": "nws-tbl-type" },
+						{ "data": "TEASER",  "className": "nws-tbl-desc" },
+						{ "data": "LOCATION",  "visible": false },
+						{ "data": "AUDIENCE",  "visible": false },
+						{ "data": "SUBJECT", "visible": false },
+						{ "data": "MINISTER", "visible": false }
+					  ]}'>
+			<thead>
+				<tr>
+					<th>Title</th>
+					<th>Publication date</th>
+					<th>Department</th>
+					<th>News Type</th>
+					<th>Summary</th>
+					<th>Location</th>
+					<th>For</th>
+					<th>Subject</th>
+					<th>Minister</th>
+				</tr>
+			</thead>
+		</table>
+	</div>
+</div>
+
+
+<pre><code>&lt;div class=&quot;row&quot;&gt;
+	&lt;div class=&quot;col-md-3&quot;&gt;
+		&lt;section&gt;
+			&lt;h4 class=&quot;wb-inv&quot;&gt;Filtering Options&lt;/h4&gt;
+			&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form&gt;
+					&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='
+							{
+								&quot;srctype&quot;: &quot;tblfilter&quot;,
+								&quot;noForm&quot;: true,
+								&quot;source&quot;: &quot;#dataset-filter&quot;,
+								&quot;fltrseq&quot;: [
+									{&quot;column&quot;: 3, &quot;csvextract&quot;: true, &quot;defaultselectedlabel&quot;: &quot;All news types&quot;, &quot;label&quot;:&quot;Data Type&quot;},
+									{&quot;column&quot;: 2, &quot;csvextract&quot;: true, &quot;defaultselectedlabel&quot;: &quot;From any department&quot;, &quot;label&quot;:&quot;Department&quot;},
+									{&quot;column&quot;: 8, &quot;csvextract&quot;: true, &quot;defaultselectedlabel&quot;: &quot;Related to any minister&quot;, &quot;label&quot;:&quot;Minister&quot;},
+									{&quot;column&quot;: 6, &quot;csvextract&quot;: true, &quot;defaultselectedlabel&quot;: &quot;Everyone&quot;, &quot;label&quot;:&quot;For&quot;},
+									{&quot;column&quot;: 5, &quot;csvextract&quot;: true, &quot;defaultselectedlabel&quot;: &quot;Anywhere&quot;, &quot;label&quot;:&quot;Location&quot;}
+								]
+							}'&gt;&lt;/div&gt;
+			&lt;/form&gt;&lt;/div&gt;
+		&lt;/section&gt;
+	&lt;/div&gt;
+	&lt;div class=&quot;col-md-9&quot;&gt;
+		&lt;table class=&quot;wb-tables table table-striped table-hover&quot; id=&quot;dataset-filter&quot; aria-live=&quot;polite&quot; data-wb-tables='{
+					&quot;bDeferRender&quot;: true,
+					&quot;ajaxSource&quot;: &quot;http://wet-boew.github.io/wet-boew/demos/tables/ajax/datasource.json&quot;,
+					&quot;order&quot;: [5, &quot;desc&quot;],
+					 &quot;columns&quot;: [
+						{ &quot;data&quot;: &quot;TITLE&quot;, &quot;className&quot;: &quot;nws-tbl-ttl h4&quot; },
+						{ &quot;data&quot;: &quot;PUBDATE&quot;, &quot;className&quot;: &quot;nws-tbl-date&quot; },
+						{ &quot;data&quot;: &quot;DEPT&quot;, &quot;className&quot;: &quot;nws-tbl-dept&quot; },
+						{ &quot;data&quot;: &quot;TYPE&quot;, &quot;className&quot;: &quot;nws-tbl-type&quot; },
+						{ &quot;data&quot;: &quot;TEASER&quot;,  &quot;className&quot;: &quot;nws-tbl-desc&quot; },
+						{ &quot;data&quot;: &quot;LOCATION&quot;,  &quot;visible&quot;: false },
+						{ &quot;data&quot;: &quot;AUDIENCE&quot;,  &quot;visible&quot;: false },
+						{ &quot;data&quot;: &quot;SUBJECT&quot;, &quot;visible&quot;: false },
+						{ &quot;data&quot;: &quot;MINISTER&quot;, &quot;visible&quot;: false }
+					  ]}'&gt;
+			&lt;thead&gt;
+				&lt;tr&gt;
+					&lt;th&gt;Title&lt;/th&gt;
+					&lt;th&gt;Publication date&lt;/th&gt;
+					&lt;th&gt;Department&lt;/th&gt;
+					&lt;th&gt;News Type&lt;/th&gt;
+					&lt;th&gt;Summary&lt;/th&gt;
+					&lt;th&gt;Location&lt;/th&gt;
+					&lt;th&gt;For&lt;/th&gt;
+					&lt;th&gt;Subject&lt;/th&gt;
+					&lt;th&gt;Minister&lt;/th&gt;
+				&lt;/tr&gt;
+			&lt;/thead&gt;
+		&lt;/table&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>

--- a/src/plugins/fieldflow/advanced-fr.hbs
+++ b/src/plugins/fieldflow/advanced-fr.hbs
@@ -1,0 +1,1617 @@
+---
+{
+	"title": "Déroulement de champs avancé",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Comment aller au-delà avec le déroulement de champs.",
+	"tag": "fieldflow",
+	"parentdir": "fieldflow",
+	"altLangPrefix": "advanced",
+	"dateModified": "2016-11-30"
+}
+---
+<p>Comment aller au-delà avec le déroulement de champs.</p>
+
+<ul>
+	<li><a href="fieldflow-fr.html">Déroulement de champs</a></li>
+	<li><a href="basic-fr.html">Déroulement de champs avec des configurations de base</a></li>
+	<li>Déroulement de champs avancé (actuelle)</li>
+</ul>
+
+<hr />
+
+<div class="wb-prettify all-pre"></div>
+
+<p>Sur cette page:</p>
+
+<ul>
+	<li><a href="#ajax">Requête ajax personalisé</a></li>
+	<li><a href="#ajouter">Ajouter un control fieldflow</a></li>
+	<li><a href="#css">Ajout ou retirer des classes CSS</a></li>
+	<li><a href="#defaultreinit">Appliquer des actions par défaut et pour la réinitialisation</a></li>
+	<li><a href="#actionBase">Définir une action de base</a></li>
+	<li><a href="#redefinirdefautcomportement">Redéfinir les comportement par défault lors d'une configuration simple</a></li>
+	<li><a href="#interrogation">Interrogation et intégration aux formulaires</a></li>
+	<li><a href="#basculer">Basculer</a></li>
+	<li><a href="#tblfiltrage">Filtrage de tableaux</a></li>
+</ul>
+
+
+<h2 id="ajax">Requête ajax personalisé</h2>
+
+
+	<div class="well">
+
+		<p>Le contenu est insérer en utilisant le plugiciel data-ajax. Il est possible de cibler des récipent spécifique, il est possible d'utiliser différente méthode (tel que: <span lang="en">append, prepend, after, before, replace</span>) et de bénifier des fonctionalité de filtrage fait par le ajax fetch.</p>
+
+		<p>Un usage simplet c'est de définir le chemin du fichier (URL) à insérer à l'aide de l'attribut <code>data-wb-fieldflow=&quot;Chemin/du/fichier&quot;</code>.</p>
+
+		<p>Le contenu définie par l'attribut <code>data-wb-fieldflow</code> peut ne pas être accessible lorsque le javascript est déactivé et par les moteurs de recherche à des fins d'indexation et de référencement. Donc, il est recommendé de fournir une solution alternative duquel l'utilisateur pourra obtenir de l'information équivalente.</p>
+
+		<p>Utilisé l'attribut <code>data-wb-fieldflow=&quot;Chemin/du/fichier&quot;</code> est la même instruction que:</p>
+		<ul>
+			<li><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;Chemin/du/fichier&quot;}'</code></li>
+			<li><code>data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;Chemin/du/fichier&quot;, &quot;type&quot;: &quot;replace&quot;}'</code></li>
+		</ul>
+		<p>Les paramètres suivante sont disponible:</p>
+
+		<dl class="dl-horizontal">
+			<dt><code>type</code></dt>
+			<dd>Défini comment le contenu sera inséré. Les options disponible sont: insérer du contenu après l'élément (<span lang="en">after</span>), ajouter du contenu à la fin de l'élément (<span lang="en">append</span>), insérer le contenu avant l'élément (<span lang="en">before</span>), ajouter le contenu au début de l'élément (<span lang="en">prepend</span>), remplace le contenu de l'élément (<span lang="en">replace</span>). La valeur par défaut c'est "replace"</dd>
+
+			<dt><code>container</code></dt>
+			<dd>Un sélecteur jquery qui sera l'hôte pour l'éxécution du plugiciel data-ajax. S'il n'est pas spécifier, un conteneur vide sera créer et insérer après les controle de déroulement de champs.</dd>
+
+			<dt><code>clean</code></dt>
+			<dd>Un sélecteur jquery dont l'instruction jquery <code>empty()</code> sera exécuté.</dd>
+
+			<dt><code>trigger</code></dt>
+			<dd>Permet d'initier les plugiciels de la WET sur le contenu inséré.</dd>
+		</dl>
+	</div>
+
+
+	<section id="ajaxPanel" class="panel panel-primary">
+		<header class="panel-heading">
+			<h3 class="panel-title"><code>id="ajaxPanel"</code> Paneau a des fins d'example pratique</h3>
+		</header>
+		<div class="panel-body">
+			<p>(Pour illustrer le comportement de la configuration <code>container</code> et de la configuration <code>clean</code>)</p>
+		</div>
+	</section>
+
+	<div class="wb-fieldflow">
+		<p>Choisissez du contenu à insérer:</p>
+		<ul>
+			<li data-wb-fieldflow="ajax/ajax-1.html">Ensemble 1</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-1.html", "live": true}'>Ensemble 1 - Effectuer immédiatement</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-3.html", "live": true}'>Ensemble 3 - Effectuer immédiatement</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-4.html", "live": true}'>Ensemble 4 - Effectuer immédiatement</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-2.html"}'>Ensemble 2 - Appel équivalente avec une configuration différente dans data-wb-fieldflow</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-2.html", "type": "replace"}'>Ensemble 2 - Appel équivalent avec une configuration différentes qui définie le type de requête ajax</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-3.html", "container": "#ajaxPanel .panel-body"}'>Ensemble 3 - Utilise le récipient: $("#ajaxPanel .panel-body")</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-4.html", "container": "#ajaxPanel .panel-body"}'>Ensemble 4 - Utilise le récipient: $("#ajaxPanel .panel-body")</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-4.html", "container": "#ajaxPanel .panel-body", "type": "append"}'>Ensemble 4 - Ajoute le contenu au récipient: $("#ajaxPanel .panel-body")</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-3.html", "container": "#ajaxPanel .panel-body", "type": "prepend", "clean": "#ajaxPanel .panel-body"}'>Set 3 - Insert le contenu au début du récipent $("#ajaxPanel .panel-body") et le vide (clean) lors du changement de sélection</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-5.html"}'>Ensemble 5</li>
+			<li data-wb-fieldflow='{"action": "ajax", "url": "ajax/ajax-5.html", "trigger": true}'>Ensemble 5 - avec initialisation de plugiciel</li>
+		</ul>
+	</div>
+
+
+<pre><code>&lt;section id=&quot;ajaxPanel&quot; class=&quot;panel panel-primary&quot;&gt;
+	&lt;header class=&quot;panel-heading&quot;&gt;
+		&lt;h3 class=&quot;panel-title&quot;&gt;&lt;code&gt;id=&quot;ajaxPanel&quot;&lt;/code&gt; Paneau a des fins d'example pratique&lt;/h3&gt;
+	&lt;/header&gt;
+	&lt;div class=&quot;panel-body&quot;&gt;
+		&lt;p&gt;(Pour illustrer le comportement de la configuration &lt;code&gt;container&lt;/code&gt; et de la configuration &lt;code&gt;clean&lt;/code&gt;)&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/section&gt;
+
+&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choisissez du contenu à insérer:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;Ensemble 1&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-1.html&quot;, &quot;live&quot;: true}'&gt;Ensemble 1 - Effectuer immédiatement&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;, &quot;live&quot;: true}'&gt;Ensemble 3 - Effectuer immédiatement&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;, &quot;live&quot;: true}'&gt;Ensemble 4 - Effectuer immédiatement&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;}'&gt;Ensemble 2 - Appel équivalente avec une configuration différente dans data-wb-fieldflow&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;, &quot;type&quot;: &quot;replace&quot;}'&gt;Ensemble 2 - Appel équivalent avec une configuration différentes qui définie le type de requête ajax&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;, &quot;container&quot;: &quot;#ajaxPanel .panel-body&quot;}'&gt;Ensemble 3 - Utilise le récipient: $(&quot;#ajaxPanel .panel-body&quot;)&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;, &quot;container&quot;: &quot;#ajaxPanel .panel-body&quot;}'&gt;Ensemble 4 - Utilise le récipient: $(&quot;#ajaxPanel .panel-body&quot;)&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;, &quot;container&quot;: &quot;#ajaxPanel .panel-body&quot;, &quot;type&quot;: &quot;append&quot;}'&gt;Ensemble 4 - Ajoute le contenu au récipient: $(&quot;#ajaxPanel .panel-body&quot;)&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;, &quot;container&quot;: &quot;#ajaxPanel .panel-body&quot;, &quot;type&quot;: &quot;prepend&quot;, &quot;clean&quot;: &quot;#ajaxPanel .panel-body&quot;}'&gt;Set 3 - Insert le contenu au début du récipent $(&quot;#ajaxPanel .panel-body&quot;) et le vide (clean) lors du changement de sélection&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;}'&gt;Ensemble 5&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;, &quot;trigger&quot;: true}'&gt;Ensemble 5 - avec initialisation de plugiciel&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+
+<h2 id="ajouter">Ajouter un control fieldflow</h2>
+
+	<div class="well">
+		<p>L'action ajout (<span lang="en">append</span>) nécessite la configuration <code>source</code> représentant un sélecteur jQuery pointant vers le block d'un élément qui peut être utilisé en tant que sous plugin. Ce sous contrôle sera inséré à la suite du contrôle initiateur de l'action. Un comportement similar peut être fait en dupliquant le contenu du sous-controle dans chacune des items de la listes, voir l'exemple subséquent.</p>
+
+		<p>La configuration <code>target</code> contient un <code>id</code> qui définie que cet action sera exécuté lors que l'item identifier par l'id sera sélectioné par un contrôle de déroulement de contenu.</p>
+
+		<p>Cette fonctionalité est utile pour évité la duplication de contenu.</p>
+	</div>
+
+<div class="wb-fieldflow">
+	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
+	<ul>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html"},
+			{"action": "append", "source": "#question-langue"}
+		]'>Insertion de contenu</li>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html"},
+			{"action": "append", "source": "#question-langue"}
+		]'>Galerie photos</li>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html"},
+			{"action": "append", "source": "#question-langue"}
+		]'>Dessiner des graphiques</li>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html"},
+			{"action": "append", "source": "#question-langue"}
+		]'>Contenu affichable/masquable</li>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html"},
+			{"action": "append", "source": "#question-langue"}
+		]'>Uniformisation de la hauteur</li>
+		<li data-wb-fieldflow='[
+			{"action": "redir", "target": "append-ex-en", "url": "http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html"},
+			{"action": "redir", "target": "append-ex-fr", "url": "http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html"},
+			{"action": "append", "source": "#question-langue"}
+		]'>Afficher un contenu superposé</li>
+
+	</ul>
+</div>
+
+<div id="question-langue" class="hidden">
+	<p>Quel langue?</p>
+	<ul>
+		<li id="append-ex-fr">Français</li>
+		<li id="append-ex-en">Anglais</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#question-langue&quot;}
+		]'&gt;Insertion de contenu&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#question-langue&quot;}
+		]'&gt;Galerie photos&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#question-langue&quot;}
+		]'&gt;Dessiner des graphiques&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#question-langue&quot;}
+		]'&gt;Contenu affichable/masquable&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#question-langue&quot;}
+		]'&gt;Uniformisation de la hauteur&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-en&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;},
+			{&quot;action&quot;: &quot;redir&quot;, &quot;target&quot;: &quot;append-ex-fr&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;},
+			{&quot;action&quot;: &quot;append&quot;, &quot;source&quot;: &quot;#question-langue&quot;}
+		]'&gt;Afficher un contenu superposé&lt;/li&gt;
+
+	&lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;div id=&quot;question-langue&quot; class=&quot;hidden&quot;&gt;
+	&lt;p&gt;Quel langue?&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li id=&quot;append-ex-fr&quot;&gt;Français&lt;/li&gt;
+		&lt;li id=&quot;append-ex-en&quot;&gt;Anglais&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h3>Cela est équivale à:</h3>
+
+<div class="wb-fieldflow">
+	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
+	<ul>
+		<li>Insertion de contenu
+			<div class="wb-fieldflow-sub">
+				<p>Quel langue?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html">Français</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html">Anglais</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>Galerie photos
+			<div class="wb-fieldflow-sub">
+				<p>Quel langue?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html">Français</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html">Anglais</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>Dessiner des graphiques
+			<div class="wb-fieldflow-sub">
+				<p>Quel langue?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">Français</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">Anglais</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>Contenu affichable/masquable
+			<div class="wb-fieldflow-sub">
+				<p>Quel langue?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">Français</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">Anglais</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>Uniformisation de la hauteur
+			<div class="wb-fieldflow-sub">
+				<p>Quel langue?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">Français</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">Anglais</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>Afficher un contenu superposé
+			<div class="wb-fieldflow-sub">
+				<p>Quel langue?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">Français</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html">Anglais</a></li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;Insertion de contenu
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;Quel langue?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;&gt;Français&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Anglais&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Galerie photos
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;Quel langue?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;&gt;Français&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Anglais&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Dessiner des graphiques
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;Quel langue?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;Français&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Anglais&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Contenu affichable/masquable
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;Quel langue?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;Français&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Anglais&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Uniformisation de la hauteur
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;Quel langue?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;Français&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Anglais&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Afficher un contenu superposé
+			&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+				&lt;p&gt;Quel langue?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Français&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Anglais&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/div&gt;
+		&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h2 id="css">Ajout ou retirer des classes CSS</h2>
+
+<div class="wb-fieldflow" data-wb-fieldflow='{
+		"reset": { "action": "removeClass", "source":"#addremoveCSSexample", "class": "text-muted text-primary text-success text-info text-warning text-danger" }
+	}'>
+	<p>Changer la couleur du paragraphe suivant:</p>
+	<ul>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-muted" }'>Sourde</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-primary" }'>Primaire</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-success" }'>Succès</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-info" }'>Renseignement</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-warning" }'>Avertissement</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#addremoveCSSexample", "class": "text-danger" }'>Danger</li>
+	</ul>
+</div>
+
+<p id="addremoveCSSexample">Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.</p>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+		&quot;reset&quot;: { &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-muted text-primary text-success text-info text-warning text-danger&quot; }
+	}'&gt;
+	&lt;p&gt;Changer la couleur du paragraphe suivant:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-muted&quot; }'&gt;Sourde&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-primary&quot; }'&gt;Primaire&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-success&quot; }'&gt;Succès&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-info&quot; }'&gt;Renseignement&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-warning&quot; }'&gt;Avertissement&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#addremoveCSSexample&quot;, &quot;class&quot;: &quot;text-danger&quot; }'&gt;Danger&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;p id=&quot;addremoveCSSexample&quot;&gt;Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.&lt;/p&gt;</code></pre>
+
+<h2 id="defaultreinit">Appliquer des actions par défaut et pour la réinitialisation</h2>
+
+<div class="wb-fieldflow" data-wb-fieldflow='{
+		"reset": { "action": "removeClass", "source":"#resetdefaultExample-fr", "class": "text-muted text-primary text-success text-info text-warning text-danger" },
+		"default": { "action": "ajax", "url":"ajax/paragraph.html#paragraph1-fr", "live": true }
+	}'>
+	<p>Changer la couleur du paragraphe suivant:</p>
+	<ul>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-fr", "class": "text-muted" }'>Sourde</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-fr", "class": "text-primary" }'>Primaire</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-fr", "class": "text-success" }'>Succès</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-fr", "class": "text-info" }'>Renseignement</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-fr", "class": "text-warning" }'>Avertissement</li>
+		<li data-wb-fieldflow='{ "action": "addClass", "source":"#resetdefaultExample-fr", "class": "text-danger" }'>Danger</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+		&quot;reset&quot;: { &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-fr&quot;, &quot;class&quot;: &quot;text-muted text-primary text-success text-info text-warning text-danger&quot; },
+		&quot;default&quot;: { &quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;:&quot;<a href="ajax/paragraph.html">ajax/paragraph.html</a>#paragraph1-fr&quot;, &quot;live&quot;: true }
+	}'&gt;
+	&lt;p&gt;Changer la couleur du paragraphe suivant:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-fr&quot;, &quot;class&quot;: &quot;text-muted&quot; }'&gt;Sourde&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-fr&quot;, &quot;class&quot;: &quot;text-primary&quot; }'&gt;Primaire&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-fr&quot;, &quot;class&quot;: &quot;text-success&quot; }'&gt;Succès&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-fr&quot;, &quot;class&quot;: &quot;text-info&quot; }'&gt;Renseignement&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-fr&quot;, &quot;class&quot;: &quot;text-warning&quot; }'&gt;Avertissement&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#resetdefaultExample-fr&quot;, &quot;class&quot;: &quot;text-danger&quot; }'&gt;Danger&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h3>Fichier <code>ajax/paragraph.html</code></h3>
+<pre><code>&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;!-- DataAjaxFragmentStart --&gt;
+
+&lt;div lang=&quot;en&quot;&gt;
+	&lt;div id=&quot;paragraph1-en&quot;&gt;
+		&lt;p id=&quot;resetdefaultExample-en&quot;&gt;Example of paragraph where the preceding field flow component could change my color.&lt;/p&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;paragraph2-en&quot;&gt;
+		&lt;p id=&quot;definebaseExample-en&quot;&gt;Example of paragraph where the preceding field flow component could change my color.&lt;/p&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;paragraph3-en&quot;&gt;
+		&lt;p id=&quot;defineDefaultExample-en&quot;&gt;Example of paragraph where the preceding field flow component could change my color.&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;div lang=&quot;fr&quot;&gt;
+	&lt;div id=&quot;paragraph1-fr&quot;&gt;
+		&lt;p id=&quot;resetdefaultExample-fr&quot;&gt;Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.&lt;/p&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;paragraph2-fr&quot;&gt;
+		&lt;p id=&quot;definebaseExample-fr&quot;&gt;Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.&lt;/p&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;paragraph3-fr&quot;&gt;
+		&lt;p id=&quot;defineDefaultExample-fr&quot;&gt;Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- DataAjaxFragmentEnd --&gt;
+&lt;/html&gt;</code></pre>
+
+<h2 id="actionBase">Définir une action de base</h2>
+
+<p>Cet exemple applique la même action pour n'importe lequel des items sélectionné, exécute les actions défini dans "reset" lors de la réinitialisation du contrôle et chaque action hérite de l'action de base.</p>
+
+<div class="wb-fieldflow" data-wb-fieldflow='{
+		"reset": { "action": "removeClass", "source":"#definebaseExample-fr", "class": "text-muted text-primary text-success text-info text-warning text-danger" },
+		"default": { "action": "ajax", "url":"ajax/paragraph.html#paragraph2-fr", "live": true },
+		"base" : { "action": "addClass", "source":"#definebaseExample-fr" }
+	}'>
+	<p>Changer la couleur du paragraphe suivant:</p>
+	<ul>
+		<li data-wb-fieldflow='{ "class": "text-muted" }'>Sourde</li>
+		<li data-wb-fieldflow='{ "class": "text-primary" }'>Primaire</li>
+		<li data-wb-fieldflow='{ "class": "text-success" }'>Succès</li>
+		<li data-wb-fieldflow='{ "class": "text-info" }'>Renseignement</li>
+		<li data-wb-fieldflow='{ "class": "text-warning" }'>Avertissement</li>
+		<li data-wb-fieldflow='{ "class": "text-danger" }'>Danger</li>
+	</ul>
+</div>
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+		&quot;reset&quot;: { &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;:&quot;#definebaseExample-fr&quot;, &quot;class&quot;: &quot;text-muted text-primary text-success text-info text-warning text-danger&quot; },
+		&quot;default&quot;: { &quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;:&quot;<a href="ajax/paragraph.html">ajax/paragraph.html</a>#paragraph2-fr&quot;, &quot;live&quot;: true },
+		&quot;base&quot; : { &quot;action&quot;: &quot;addClass&quot;, &quot;source&quot;:&quot;#definebaseExample-fr&quot; }
+	}'&gt;
+	&lt;p&gt;Changer la couleur du paragraphe suivant:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-muted&quot; }'&gt;Sourde&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-primary&quot; }'&gt;Primaire&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-success&quot; }'&gt;Succès&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-info&quot; }'&gt;Renseignement&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-warning&quot; }'&gt;Avertissement&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{ &quot;class&quot;: &quot;text-danger&quot; }'&gt;Danger&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+
+<h2 id="redefinirdefautcomportement">Redéfinir les comportement par défault lors d'une configuration simple</h2>
+
+<p>Change le comportement par défaut lors de la configuration de la liste des items.</p>
+
+<div class="wb-fieldflow" data-wb-fieldflow='{
+		"reset": { "action": "removeClass", "source":"#definebaseExample-fr", "class": "text-muted text-primary text-success text-info text-warning text-danger" },
+		"default": { "action": "ajax", "url":"ajax/paragraph.html#paragraph3-fr", "live": true },
+		"actionData" : { "source":"#defineDefaultExample-fr" },
+		"action": "addClass",
+		"prop": "class"
+	}'>
+	<p>Changer la couleur du paragraphe suivant:</p>
+	<ul>
+		<li data-wb-fieldflow="text-muted">Sourde</li>
+		<li data-wb-fieldflow="text-primary">Primaire</li>
+		<li data-wb-fieldflow="text-success">Succès</li>
+		<li data-wb-fieldflow="text-info">Renseignement</li>
+		<li data-wb-fieldflow="text-warning">Avertissement</li>
+		<li data-wb-fieldflow="text-danger">Danger</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+		&quot;reset&quot;: { &quot;action&quot;: &quot;removeClass&quot;, &quot;source&quot;:&quot;#definebaseExample-fr&quot;, &quot;class&quot;: &quot;text-muted text-primary text-success text-info text-warning text-danger&quot; },
+		&quot;default&quot;: { &quot;action&quot;: &quot;ajax&quot;, &quot;url&quot;:&quot;<a href="ajax/paragraph.html">ajax/paragraph.html</a>#paragraph3-fr&quot;, &quot;live&quot;: true },
+		&quot;actionData&quot; : { &quot;source&quot;:&quot;#defineDefaultExample-fr&quot; },
+		&quot;action&quot;: &quot;addClass&quot;,
+		&quot;prop&quot;: &quot;class&quot;
+	}'&gt;
+	&lt;p&gt;Changer la couleur du paragraphe suivant:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;text-muted&quot;&gt;Sourde&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;text-primary&quot;&gt;Primaire&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;text-success&quot;&gt;Succès&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;text-info&quot;&gt;Renseignement&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;text-warning&quot;&gt;Avertissement&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;text-danger&quot;&gt;Danger&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h2 id="interrogation">Interrogation et intégration aux formulaires</h2>
+
+<div class="well">
+	<p>Permet de définir le nom et la value d'un champs lorsque le formulaire doit être soumis et évaluer par le serveur.</p>
+
+	<p>Ceci montre comment utiliser l'action <code>query</code>. Les configurations suivante doivent être présent également:</p>
+
+	<dl class="dl-horizontal">
+		<dt><code>name</code></dt>
+		<dd>Défini le nom du contrôle à utiliser.</dd>
+		<dt><code>value</code></dt>
+		<dd>Définie la valeur du contrôle.</dd>
+	</dl>
+
+	<p>La configuration <code>noForm</code> lorsque définie pour la configuration de <code>&lt;div class=&quot;wb-fieldflow&quot;&gt;&lt;/div&gt;</code> indique que le plugiciel ne doit pas envelopper le contrôle d'un formulaire mais à la place d'utiliser celui qui existe déjà. Dans ce mode, le bouton de soumission dois être codé manuellement. Il est aussi assumé que le formulaire est utilise le plugiciel <code>wb-frmvld</code>.</p>
+
+</div>
+
+
+<section class="panel panel-info">
+  <header class="panel-heading">
+   <h3 class="panel-title">Quelques remarque concernant l'exemple suivant</h3>
+  </header>
+  <div class="panel-body">
+	<ul>
+		<li>Il se soumet à lui-même, donc après la soumission du formulaire, le paramètre <code>animal</code> sera présent dans l'URL de la page courante.</li>
+		<li>Tel quel, ce formulaire n'est pas utilisable si le javascript est déactivé, donc:
+			<ul>
+				<li>C'est pourquoi une version alternative statique a été ajouter après le formulaire.</li>
+				<li>Le formulaire est caché par défaut.</li>
+				<li>Le formulaire est affiché après l'initialistion du plugiciel car l'option de configuration <code>unhideelm</code> contient un sélecteur qui identifie ledit formulaire.</li>
+			</ul>
+		</li>
+	</ul>
+  </div>
+</section>
+
+<div id="myformid" class="wb-frmvld hidden">
+<form action="advanced-fr.html" class="col-md-12">
+
+	<fieldset>
+		<legend><span class="field-name">Mes animeaux favories</span></legend>
+		<div class="checkbox">
+			<label for="animal5"><input type="checkbox" name="animal" value="Chien" id="animal5" /> Chien</label>
+		</div>
+		<div class="checkbox">
+			<label for="animal6"><input type="checkbox" name="animal" value="Chat" id="animal6" /> Chat</label>
+		</div>
+		<div class="checkbox">
+			<label for="animal7"><input type="checkbox" name="animal" value="Poisson" id="animal7" /> Poisson</label>
+		</div>
+		<div class="checkbox">
+			<label for="animal8"><input type="checkbox" name="animal" value="Serpent" id="animal8" /> Serpent</label>
+		</div>
+	</fieldset>
+
+
+	<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true, "unhideelm": "#myformid"}'>
+		<p>Vous désirez plus de renseignement à propos?</p>
+		<ul>
+			<li>L'habitat
+				<div class="wb-fieldflow-sub">
+					<p>Quel type d'habitat vous vous intéresser?</p>
+					<ul>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"sauvage"}'>Sauvage</li>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"HabRecommendé"}'>Recommendé</li>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"intérieur"}'>À l'intérieur</li>
+						<li data-wb-fieldflow='[
+							{"action": "query", "name":"moreinfo", "value":"extérieur"},
+							{"action": "redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html"}
+						]'>à l'éxtérieur</li>
+					</ul>
+				</div>
+			</li>
+			<li>La nouriture
+				<div class="wb-fieldflow-sub">
+					<p>Quel type de nourriture vous vous intéresser?</p>
+					<ul>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"santé"}'>Santé</li>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"nouRecommendé"}'>Recommandé</li>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"éviter"}'>à éviter</li>
+						<li data-wb-fieldflow='{"action": "query", "name":"moreinfo", "value":"tendance"}'>Tendance</li>
+					</ul>
+				</div>
+			</li>
+
+		</ul>
+	</div>
+
+
+	<input class="mrgn-bttm-lg" type="submit" value="Soummetez et regardé l'URL de la page" />
+</form></div>
+
+<details id="myformidAlternate">
+	<summary>Version alternative permettant d'obtenir la même information que le formulaire précédent.</summary>
+
+	<p>Chien:</p>
+	<ul>
+		<li><a href="advanced-fr.html?animal=Chien&amp;moreinfo=sauvage">Habitation sauvage</a></li>
+		<li><a href="advanced-fr.html?animal=Chien&amp;moreinfo=HabRecommendé">Habitation recommendé</a></li>
+		<li><a href="advanced-fr.html?animal=Chien&amp;moreinfo=intérieur">Habitation à l'intérieur</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html?animal=Chien&amp;moreinfo=extérieur">Habitation à l'extérieur</a></li>
+		<li><a href="advanced-fr.html?animal=Chien&amp;moreinfo=santé">Nouriture santé</a></li>
+		<li><a href="advanced-fr.html?animal=Chien&amp;moreinfo=nouRecommendé">Nouriture recommendé</a></li>
+		<li><a href="advanced-fr.html?animal=Chien&amp;moreinfo=éviter">Nouriture à éviter</a></li>
+		<li><a href="advanced-fr.html?animal=Chien&amp;moreinfo=tendance">Nouriture tendance</a></li>
+	</ul>
+	<p>Chat:</p>
+	<ul>
+		<li><a href="advanced-fr.html?animal=Chat&amp;moreinfo=sauvage">Habitation sauvage</a></li>
+		<li><a href="advanced-fr.html?animal=Chat&amp;moreinfo=HabRecommendé">Habitation recommendé</a></li>
+		<li><a href="advanced-fr.html?animal=Chat&amp;moreinfo=intérieur">Habitation à l'intérieur</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html?animal=Chat&amp;moreinfo=extérieur">Habitation à l'extérieur</a></li>
+		<li><a href="advanced-fr.html?animal=Chat&amp;moreinfo=santé">Nouriture santé</a></li>
+		<li><a href="advanced-fr.html?animal=Chat&amp;moreinfo=nouRecommendé">Nouriture recommendé</a></li>
+		<li><a href="advanced-fr.html?animal=Chat&amp;moreinfo=éviter">Nouriture à éviter</a></li>
+		<li><a href="advanced-fr.html?animal=Chat&amp;moreinfo=tendance">Nouriture tendance</a></li>
+	</ul>
+	<p>Poisson:</p>
+	<ul>
+		<li><a href="advanced-fr.html?animal=Poisson&amp;moreinfo=sauvage">Habitation sauvage</a></li>
+		<li><a href="advanced-fr.html?animal=Poisson&amp;moreinfo=HabRecommendé">Habitation recommendé</a></li>
+		<li><a href="advanced-fr.html?animal=Poisson&amp;moreinfo=intérieur">Habitation à l'intérieur</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html?animal=Poisson&amp;moreinfo=extérieur">Habitation à l'extérieur</a></li>
+		<li><a href="advanced-fr.html?animal=Poisson&amp;moreinfo=santé">Nouriture santé</a></li>
+		<li><a href="advanced-fr.html?animal=Poisson&amp;moreinfo=nouRecommendé">Nouriture recommendé</a></li>
+		<li><a href="advanced-fr.html?animal=Poisson&amp;moreinfo=éviter">Nouriture à éviter</a></li>
+		<li><a href="advanced-fr.html?animal=Poisson&amp;moreinfo=tendance">Nouriture tendance</a></li>
+	</ul>
+	<p>Serpent:</p>
+	<ul>
+		<li><a href="advanced-fr.html?animal=Serpent&amp;moreinfo=sauvage">Habitation sauvage</a></li>
+		<li><a href="advanced-fr.html?animal=Serpent&amp;moreinfo=HabRecommendé">Habitation recommendé</a></li>
+		<li><a href="advanced-fr.html?animal=Serpent&amp;moreinfo=intérieur">Habitation à l'intérieur</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html?animal=Serpent&amp;moreinfo=extérieur">Habitation à l'extérieur</a></li>
+		<li><a href="advanced-fr.html?animal=Serpent&amp;moreinfo=santé">Nouriture santé</a></li>
+		<li><a href="advanced-fr.html?animal=Serpent&amp;moreinfo=nouRecommendé">Nouriture recommendé</a></li>
+		<li><a href="advanced-fr.html?animal=Serpent&amp;moreinfo=éviter">Nouriture à éviter</a></li>
+		<li><a href="advanced-fr.html?animal=Serpent&amp;moreinfo=tendance">Nouriture tendance</a></li>
+	</ul>
+</details>
+
+
+
+<pre><code>&lt;div id=&quot;myformid&quot; class=&quot;wb-frmvld hidden&quot;&gt;
+&lt;form action=&quot;advanced-fr.html&quot; class=&quot;col-md-12&quot;&gt;
+
+	&lt;fieldset&gt;
+		&lt;legend&gt;&lt;span class=&quot;field-name&quot;&gt;Mes animeaux favories&lt;/span&gt;&lt;/legend&gt;
+		&lt;div class=&quot;checkbox&quot;&gt;
+			&lt;label for=&quot;animal5&quot;&gt;&lt;input type=&quot;checkbox&quot; name=&quot;animal&quot; value=&quot;Chien&quot; id=&quot;animal5&quot; /&gt; Chien&lt;/label&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;checkbox&quot;&gt;
+			&lt;label for=&quot;animal6&quot;&gt;&lt;input type=&quot;checkbox&quot; name=&quot;animal&quot; value=&quot;Chat&quot; id=&quot;animal6&quot; /&gt; Chat&lt;/label&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;checkbox&quot;&gt;
+			&lt;label for=&quot;animal7&quot;&gt;&lt;input type=&quot;checkbox&quot; name=&quot;animal&quot; value=&quot;Poisson&quot; id=&quot;animal7&quot; /&gt; Poisson&lt;/label&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;checkbox&quot;&gt;
+			&lt;label for=&quot;animal8&quot;&gt;&lt;input type=&quot;checkbox&quot; name=&quot;animal&quot; value=&quot;Serpent&quot; id=&quot;animal8&quot; /&gt; Serpent&lt;/label&gt;
+		&lt;/div&gt;
+	&lt;/fieldset&gt;
+
+
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true, &quot;unhideelm&quot;: &quot;#myformid&quot;}'&gt;
+		&lt;p&gt;Vous désirez plus de renseignement à propos?&lt;/p&gt;
+		&lt;ul&gt;
+			&lt;li&gt;L'habitat
+				&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+					&lt;p&gt;Quel type d'habitat vous vous intéresser?&lt;/p&gt;
+					&lt;ul&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;sauvage&quot;}'&gt;Sauvage&lt;/li&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;HabRecommendé&quot;}'&gt;Recommendé&lt;/li&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;intérieur&quot;}'&gt;À l'intérieur&lt;/li&gt;
+						&lt;li data-wb-fieldflow='[
+							{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;extérieur&quot;},
+							{&quot;action&quot;: &quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;}
+						]'&gt;à l'éxtérieur&lt;/li&gt;
+					&lt;/ul&gt;
+				&lt;/div&gt;
+			&lt;/li&gt;
+			&lt;li&gt;La nouriture
+				&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;
+					&lt;p&gt;Quel type de nourriture vous vous intéresser?&lt;/p&gt;
+					&lt;ul&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;santé&quot;}'&gt;Santé&lt;/li&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;nouRecommendé&quot;}'&gt;Recommandé&lt;/li&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;éviter&quot;}'&gt;à éviter&lt;/li&gt;
+						&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;query&quot;, &quot;name&quot;:&quot;moreinfo&quot;, &quot;value&quot;:&quot;tendance&quot;}'&gt;Tendance&lt;/li&gt;
+					&lt;/ul&gt;
+				&lt;/div&gt;
+			&lt;/li&gt;
+
+		&lt;/ul&gt;
+	&lt;/div&gt;
+
+
+	&lt;input class=&quot;mrgn-bttm-lg&quot; type=&quot;submit&quot; value=&quot;Soummetez et regardé l'URL de la page de résultat&quot; /&gt;
+&lt;/form&gt;&lt;/div&gt;
+
+&lt;details id=&quot;myformidAlternate&quot;&gt;
+	&lt;summary&gt;Version alternative permettant d'obtenir la même informatio que le formulaire précédent.&lt;/summary&gt;
+
+	&lt;p&gt;Chien:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chien&amp;amp;moreinfo=sauvage&quot;&gt;Habitation sauvage&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chien&amp;amp;moreinfo=HabRecommendé&quot;&gt;Habitation recommendé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chien&amp;amp;moreinfo=intérieur&quot;&gt;Habitation à l'intérieur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html?animal=Chien&amp;amp;moreinfo=extérieur&quot;&gt;Habitation à l'extérieur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chien&amp;amp;moreinfo=santé&quot;&gt;Nouriture santé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chien&amp;amp;moreinfo=nouRecommendé&quot;&gt;Nouriture recommendé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chien&amp;amp;moreinfo=éviter&quot;&gt;Nouriture à éviter&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chien&amp;amp;moreinfo=tendance&quot;&gt;Nouriture tendance&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;p&gt;Chat:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chat&amp;amp;moreinfo=sauvage&quot;&gt;Habitation sauvage&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chat&amp;amp;moreinfo=HabRecommendé&quot;&gt;Habitation recommendé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chat&amp;amp;moreinfo=intérieur&quot;&gt;Habitation à l'intérieur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html?animal=Chat&amp;amp;moreinfo=extérieur&quot;&gt;Habitation à l'extérieur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chat&amp;amp;moreinfo=santé&quot;&gt;Nouriture santé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chat&amp;amp;moreinfo=nouRecommendé&quot;&gt;Nouriture recommendé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chat&amp;amp;moreinfo=éviter&quot;&gt;Nouriture à éviter&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Chat&amp;amp;moreinfo=tendance&quot;&gt;Nouriture tendance&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;p&gt;Poisson:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Poisson&amp;amp;moreinfo=sauvage&quot;&gt;Habitation sauvage&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Poisson&amp;amp;moreinfo=HabRecommendé&quot;&gt;Habitation recommendé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Poisson&amp;amp;moreinfo=intérieur&quot;&gt;Habitation à l'intérieur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html?animal=Poisson&amp;amp;moreinfo=extérieur&quot;&gt;Habitation à l'extérieur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Poisson&amp;amp;moreinfo=santé&quot;&gt;Nouriture santé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Poisson&amp;amp;moreinfo=nouRecommendé&quot;&gt;Nouriture recommendé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Poisson&amp;amp;moreinfo=éviter&quot;&gt;Nouriture à éviter&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Poisson&amp;amp;moreinfo=tendance&quot;&gt;Nouriture tendance&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+	&lt;p&gt;Serpent:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Serpent&amp;amp;moreinfo=sauvage&quot;&gt;Habitation sauvage&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Serpent&amp;amp;moreinfo=HabRecommendé&quot;&gt;Habitation recommendé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Serpent&amp;amp;moreinfo=intérieur&quot;&gt;Habitation à l'intérieur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html?animal=Serpent&amp;amp;moreinfo=extérieur&quot;&gt;Habitation à l'extérieur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Serpent&amp;amp;moreinfo=santé&quot;&gt;Nouriture santé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Serpent&amp;amp;moreinfo=nouRecommendé&quot;&gt;Nouriture recommendé&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Serpent&amp;amp;moreinfo=éviter&quot;&gt;Nouriture à éviter&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;advanced-fr.html?animal=Serpent&amp;amp;moreinfo=tendance&quot;&gt;Nouriture tendance&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/details&gt;</code></pre>
+
+
+
+<h2 id="basculer">Basculer</h2>
+
+	<div class="well">
+		<p>Toute les options tel que définie par le <a href="http://wet-boew.github.io/wet-boew/demos/toggle/toggle-fr.html">plugiciel basculer</a> peuvent être utilisé par l'entremise du paramètre <code>toggle</code> lors de la configuration de l'item <code>data-wb-fieldflow</code>.</p>
+
+		<p>Ces configurations sont équivalentes:
+		<ul>
+			<li><code>&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#myblockid&quot;}'&gt;Mon block de contenu&lt;/li&gt;</code></li>
+			<li><code>&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: {&quot;selector&quot;:&quot;#myblockid&quot;}}'&gt;Mon block de contenu&lt;/li&gt;</code></li>
+		</ul>
+
+		<p>Si aucune options n'est spécifier, le plugiciel de bascule sera configuré avec les options suivantes:</p>
+<pre><code>toggle: {
+	stateOn: "visible",
+	stateOff: "hidden"
+}</code></pre>
+	</div>
+
+
+<div class="wb-fieldflow">
+	<p>Choisissez un contenu à basculer?</p>
+	<ul>
+		<li data-wb-fieldflow='{"action": "toggle", "toggle": "#basculer-premier"}'>Basculer le premier</li>
+		<li data-wb-fieldflow='{"action": "toggle", "toggle": "#basculer-second"}'>Basculer le second</li>
+		<li data-wb-fieldflow='{"action": "toggle", "toggle": "#basculer-premier, #basculer-second"}'>Basculer les deux</li>
+	</ul>
+</div>
+
+<div id="basculer-premier" class="well hidden">
+	<p>Ceci est le premier <code>@id=basculer-premier</code></p>
+</div>
+
+<div id="basculer-second" class="jumbotron hidden">
+	<p>Ceci est le second <code>@id=basculer-second</code></p>
+</div>
+
+	<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choisissez un contenu à basculer?&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#basculer-premier&quot;}'&gt;Basculer le premier&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#basculer-second&quot;}'&gt;Basculer le second&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#basculer-premier, #basculer-second&quot;}'&gt;Basculer les deux&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;div id=&quot;basculer-premier&quot; class=&quot;well hidden&quot;&gt;
+	&lt;p&gt;Ceci est le premier &lt;code&gt;@id=basculer-premier&lt;/code&gt;&lt;/p&gt;
+&lt;/div&gt;
+
+&lt;div id=&quot;basculer-second&quot; class=&quot;jumbotron hidden&quot;&gt;
+	&lt;p&gt;Ceci est le second &lt;code&gt;@id=basculer-second&lt;/code&gt;&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+
+
+	<h3>Sans bouton de soumission</h3>
+
+<div class="wb-frmvld"><form method="get">
+	<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true}'>
+		<p>Choisissez un contenu à basculer?</p>
+		<ul>
+			<li data-wb-fieldflow='{"action": "toggle", "toggle": "#basculer-troisieme", "live": true}' data-wb-toggle='{"stateOn": "visible", "stateOff":"hidden"}'>Basculer le troisième</li>
+			<li data-wb-fieldflow='{"action": "toggle", "toggle": "#basculer-quatrieme", "live": true}'>Basculer le quatrième</li>
+			<li data-wb-fieldflow='{"action": "toggle", "toggle": "#basculer-troisieme, #basculer-quatrieme", "live": true}'>Basculer les deux</li>
+		</ul>
+	</div>
+
+	<div id="basculer-troisieme" class="well hidden">
+		<p>Ceci est le troisième <code>@id=basculer-troisieme</code></p>
+	</div>
+
+	<div id="basculer-quatrieme" class="jumbotron hidden">
+		<p>Ceci est le quatrième <code>@id=basculer-quatrieme</code></p>
+	</div>
+
+</form></div>
+
+<pre><code>&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form method=&quot;get&quot;&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true}'&gt;
+		&lt;p&gt;Choisissez un contenu à basculer?&lt;/p&gt;
+		&lt;ul&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#basculer-troisieme&quot;, &quot;live&quot;: true}' data-wb-toggle='{&quot;stateOn&quot;: &quot;visible&quot;, &quot;stateOff&quot;:&quot;hidden&quot;}'&gt;Basculer le troisième&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#basculer-quatrieme&quot;, &quot;live&quot;: true}'&gt;Basculer le quatrième&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;: &quot;toggle&quot;, &quot;toggle&quot;: &quot;#basculer-troisieme, #basculer-quatrieme&quot;, &quot;live&quot;: true}'&gt;Basculer les deux&lt;/li&gt;
+		&lt;/ul&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;basculer-troisieme&quot; class=&quot;well hidden&quot;&gt;
+		&lt;p&gt;Ceci est le troisième &lt;code&gt;@id=basculer-troisieme&lt;/code&gt;&lt;/p&gt;
+	&lt;/div&gt;
+
+	&lt;div id=&quot;basculer-quatrieme&quot; class=&quot;jumbotron hidden&quot;&gt;
+		&lt;p&gt;Ceci est le quatrième &lt;code&gt;@id=basculer-quatrieme&lt;/code&gt;&lt;/p&gt;
+	&lt;/div&gt;
+
+&lt;/form&gt;&lt;/div&gt;</code></pre>
+
+
+
+<h2 id="tblfiltrage">Filtrage de tableaux</h2>
+<div class="alert alert-info">
+<p>Le contenu pour l'example de filtrage de tableaux suivant a été tiré de l'exemple pratique du plugiciel des tableaux Considerant que celui n'a pas été traduit entièrement en français, c'est pour cette raison que le contenu des examples suivants sont traduit que partiellement en français.</p>
+</div>
+
+<div class="wb-frmvld"><form method="get">
+<div class="wb-fieldflow" data-wb-fieldflow='
+		{
+			"srctype": "tblfilter",
+			"noForm": true,
+			"source": "#table-filtering-example",
+			"fltrseq": [
+				{"column": 2},
+				{"column": 3}
+			],
+			"limit": 3
+		}'></div>
+</form></div>
+
+
+<table id="table-filtering-example" class="wb-tables table table-striped table-hover">
+	<thead>
+		<tr>
+			<th>Titre</th>
+			<th>Date de publication</th>
+			<th>Résumé</th>
+			<th>Sujets</th>
+		</tr>
+	</thead>
+	<tbody lang="en">
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Biomass Program Continues to Support Transition to Renewable Energy in Manitoba</a></th>
+			<td>2016-07-29 12:07:00</td>
+			<td>
+				<p>The governments of Canada and Manitoba are supporting a greener, more sustainable economy through the $1 million Biomass Energy Support Program, Federal Agriculture Minister Lawrence MacAulay and Manitoba Agriculture Minister Ralph Eichler announced today.</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>Farmers</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Agriculture</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">MP Rodger Cuzner to make announcement in Broad Cove</a></th>
+			<td>2016-07-29 12:07:00</td>
+			<td>
+				<p>Rodger Cuzner, Member of Parliament for Cape Breton – Canso, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency, will make a funding announcement at the Broad Cove Scottish Concert..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>Rural Community</li>
+					<li>Travellers</li>
+					<li>Visitors</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Society and Culture</li>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">An Exhibition Dedicated to the Caribou and Other Animals Like It</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>The Government of Canada supports the Musée du Fjord.</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Backgrounder: Government of Canada delivers $109 million to Alberta for community infrastructure projects</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>The Government of Canada delivered the first of two federal Gas Tax Fund installments for 2016-17 to all the provinces and territories benefitting 364 municipalities in Alberta..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Transport</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Government of Canada delivers $109 million to Alberta for community infrastructure projects</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>Modern and up-to-date community infrastructure helps ensure that Canadians live the quality of life that they want and expect. Community infrastructure helps connect people to jobs and provides access to better community services, attracts new businesses and creates economic growth opportunities..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Transport</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Minister Carr to Make an Announcement About the Winnipeg Art Gallery</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>WINNIPEG – The Honourable Jim Carr, Minister of Natural Resources....</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a></th>
+			<td>2016-07-29 10:07:00</td>
+			<td>
+				<p>What an honour to be at the University of Toronto-my alma mater-for this tremendous announcement..</p>
+				<p>For:</p>
+				<ul>
+					<li>Business</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Economics and Industry</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a></th>
+			<td>2016-07-29 10:07:00</td>
+			<td>
+				<p>Thank you, Meric [Meric S. Gertler, President, University of Toronto]. And thank you to the University of Toronto for being such great hosts today. I'm delighted to be here with my friend and colleague Kirsty Duncan, Minister of Science..</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Economics and Industry</li>
+				</ul>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<pre><code>&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form method=&quot;get&quot;&gt;
+&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='
+		{
+			&quot;srctype&quot;: &quot;tblfilter&quot;,
+			&quot;noForm&quot;: true,
+			&quot;source&quot;: &quot;#table-filtering-example&quot;,
+			&quot;fltrseq&quot;: [
+				{&quot;column&quot;: 2},
+				{&quot;column&quot;: 3}
+			],
+			&quot;limit&quot;: 3
+		}'&gt;&lt;/div&gt;
+&lt;/form&gt;&lt;/div&gt;
+
+&lt;table id=&quot;table-filtering-example&quot; class=&quot;wb-tables table table-striped table-hover&quot;&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Titre&lt;/th&gt;
+			&lt;th&gt;Date de publication&lt;/th&gt;
+			&lt;th&gt;Résumé&lt;/th&gt;
+			&lt;th&gt;Sujets&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody lang=&quot;en&quot;&gt;
+		&lt;tr&gt;
+			&lt;th&gt;&lt;a href=&quot;http://news.gc.ca/web/index-en.do&quot;&gt;Biomass Program Continues to Support Transition to Renewable Energy in Manitoba&lt;/a&gt;&lt;/th&gt;
+			&lt;td&gt;2016-07-29 12:07:00&lt;/td&gt;
+			&lt;td&gt;
+				&lt;p&gt;The governments of Canada and Manitoba are supporting a greener, more sustainable economy through the $1 million Biomass Energy Support Program, Federal Agriculture Minister Lawrence MacAulay and Manitoba Agriculture Minister Ralph Eichler announced today.&lt;/p&gt;
+				&lt;p&gt;For:&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;Media&lt;/li&gt;
+					&lt;li&gt;Farmers&lt;/li&gt;
+					&lt;li&gt;General Public&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/td&gt;
+			&lt;td&gt;
+				&lt;ul&gt;
+					&lt;li&gt;Agriculture&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/td&gt;
+		&lt;/tr&gt;
+
+		[...]
+
+	&lt;/tbody&gt;
+&lt;/table&gt;</code></pre>
+
+
+
+
+<h3>Filtrage avec une interface personalisé <small>Filtrage de tableaux</small></h3>
+
+<div id="table-filtering-example2-form" class="wb-frmvld hidden">
+	<form>
+		<div class="wb-fieldflow" data-wb-fieldflow='{ "noForm": true, "isoptional": true, "unhideelm": "#table-filtering-example2-form" }'>
+			<p>Filter par sujet:</p>
+			<ul>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Agriculture"
+				}'>Agriculture</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Society"
+				}'>Society and Culture</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "table#-filtering-example2",
+					"column": 3,
+					"value": "Arts"
+				}'>Arts</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Music"
+				}'>Music</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Literature"
+				}'>Literature</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Transport"
+				}'>Transport</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 3,
+					"value": "Economics"
+				}'>Economics and Industry</li>
+			</ul>
+		</div>
+		<div class="wb-fieldflow" data-wb-fieldflow='{ "noForm": true, "isoptional": true }'>
+			<p>Filter par audience:</p>
+			<ul>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Business"
+				}'>Business</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Farmers"
+				}'>Farmers</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Public"
+				}'>General Public</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Media"
+				}'>Media</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2
+					"value": "Rural"
+				}'>Rural Community</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Travellers"
+				}'>Travellers</li>
+				<li data-wb-fieldflow='{
+					"action": "tblfilter",
+					"source": "#table-filtering-example2",
+					"column": 2,
+					"value": "Visitors"
+				}'>Visitors</li>
+			</ul>
+		</div>
+	</form>
+</div>
+
+<table id="table-filtering-example2" class="wb-tables table table-striped table-hover">
+	<thead>
+		<tr>
+			<th>Titre</th>
+			<th>Date de publication</th>
+			<th>Résumé</th>
+			<th>Sujets</th>
+		</tr>
+	</thead>
+	<tbody lang="en">
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Biomass Program Continues to Support Transition to Renewable Energy in Manitoba</a></th>
+			<td>2016-07-29 12:07:00</td>
+			<td>
+				<p>The governments of Canada and Manitoba are supporting a greener, more sustainable economy through the $1 million Biomass Energy Support Program, Federal Agriculture Minister Lawrence MacAulay and Manitoba Agriculture Minister Ralph Eichler announced today.</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>Farmers</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Agriculture</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">MP Rodger Cuzner to make announcement in Broad Cove</a></th>
+			<td>2016-07-29 12:07:00</td>
+			<td>
+				<p>Rodger Cuzner, Member of Parliament for Cape Breton – Canso, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency, will make a funding announcement at the Broad Cove Scottish Concert..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>Rural Community</li>
+					<li>Travellers</li>
+					<li>Visitors</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Society and Culture</li>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">An Exhibition Dedicated to the Caribou and Other Animals Like It</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>The Government of Canada supports the Musée du Fjord.</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Backgrounder: Government of Canada delivers $109 million to Alberta for community infrastructure projects</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>The Government of Canada delivered the first of two federal Gas Tax Fund installments for 2016-17 to all the provinces and territories benefitting 364 municipalities in Alberta..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Transport</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Government of Canada delivers $109 million to Alberta for community infrastructure projects</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>Modern and up-to-date community infrastructure helps ensure that Canadians live the quality of life that they want and expect. Community infrastructure helps connect people to jobs and provides access to better community services, attracts new businesses and creates economic growth opportunities..</p>
+				<p>For:</p>
+				<ul>
+					<li>Media</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Transport</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Minister Carr to Make an Announcement About the Winnipeg Art Gallery</a></th>
+			<td>2016-07-29 11:07:00</td>
+			<td>
+				<p>WINNIPEG – The Honourable Jim Carr, Minister of Natural Resources....</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Arts</li>
+					<li>Music</li>
+					<li>Literature</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a></th>
+			<td>2016-07-29 10:07:00</td>
+			<td>
+				<p>What an honour to be at the University of Toronto-my alma mater-for this tremendous announcement..</p>
+				<p>For:</p>
+				<ul>
+					<li>Business</li>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Economics and Industry</li>
+				</ul>
+			</td>
+		</tr>
+		<tr>
+			<th><a href="http://news.gc.ca/web/index-en.do">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a></th>
+			<td>2016-07-29 10:07:00</td>
+			<td>
+				<p>Thank you, Meric [Meric S. Gertler, President, University of Toronto]. And thank you to the University of Toronto for being such great hosts today. I'm delighted to be here with my friend and colleague Kirsty Duncan, Minister of Science..</p>
+				<p>For:</p>
+				<ul>
+					<li>General Public</li>
+				</ul>
+			</td>
+			<td>
+				<ul>
+					<li>Economics and Industry</li>
+				</ul>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+
+<pre><code>&lt;div id=&quot;table-filtering-example2-form&quot; class=&quot;wb-frmvld hidden&quot;&gt;
+	&lt;form&gt;
+		&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{ &quot;noForm&quot;: true, &quot;isoptional&quot;: true, &quot;unhideelm&quot;: &quot;#table-filtering-example2-form&quot; }'&gt;
+			&lt;p&gt;Filter par sujet:&lt;/p&gt;
+			&lt;ul&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Agriculture&quot;
+				}'&gt;Agriculture&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Society&quot;
+				}'&gt;Society and Culture&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;table#-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Arts&quot;
+				}'&gt;Arts&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Music&quot;
+				}'&gt;Music&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Literature&quot;
+				}'&gt;Literature&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Transport&quot;
+				}'&gt;Transport&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 3,
+					&quot;value&quot;: &quot;Economics&quot;
+				}'&gt;Economics and Industry&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{ &quot;noForm&quot;: true, &quot;isoptional&quot;: true }'&gt;
+			&lt;p&gt;Filter par audience:&lt;/p&gt;
+			&lt;ul&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Business&quot;
+				}'&gt;Business&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Farmers&quot;
+				}'&gt;Farmers&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Public&quot;
+				}'&gt;General Public&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Media&quot;
+				}'&gt;Media&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2
+					&quot;value&quot;: &quot;Rural&quot;
+				}'&gt;Rural Community&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Travellers&quot;
+				}'&gt;Travellers&lt;/li&gt;
+				&lt;li data-wb-fieldflow='{
+					&quot;action&quot;: &quot;tblfilter&quot;,
+					&quot;source&quot;: &quot;#table-filtering-example2&quot;,
+					&quot;column&quot;: 2,
+					&quot;value&quot;: &quot;Visitors&quot;
+				}'&gt;Visitors&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/div&gt;
+	&lt;/form&gt;
+&lt;/div&gt;
+
+&lt;table id=&quot;table-filtering-example2&quot; class=&quot;wb-tables table table-striped table-hover&quot;&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Titre&lt;/th&gt;
+			&lt;th&gt;Date de publication&lt;/th&gt;
+			&lt;th&gt;Résumé&lt;/th&gt;
+			&lt;th&gt;Sujets&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody lang=&quot;en&quot;&gt;
+		&lt;tr&gt;
+			&lt;th&gt;&lt;a href=&quot;http://news.gc.ca/web/index-en.do&quot;&gt;Biomass Program Continues to Support Transition to Renewable Energy in Manitoba&lt;/a&gt;&lt;/th&gt;
+			&lt;td&gt;2016-07-29 12:07:00&lt;/td&gt;
+			&lt;td&gt;
+				&lt;p&gt;The governments of Canada and Manitoba are supporting a greener, more sustainable economy through the $1 million Biomass Energy Support Program, Federal Agriculture Minister Lawrence MacAulay and Manitoba Agriculture Minister Ralph Eichler announced today.&lt;/p&gt;
+				&lt;p&gt;For:&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;Media&lt;/li&gt;
+					&lt;li&gt;Farmers&lt;/li&gt;
+					&lt;li&gt;General Public&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/td&gt;
+			&lt;td&gt;
+				&lt;ul&gt;
+					&lt;li&gt;Agriculture&lt;/li&gt;
+				&lt;/ul&gt;
+			&lt;/td&gt;
+		&lt;/tr&gt;
+
+		[...]
+
+	&lt;/tbody&gt;
+&lt;/table&gt;</code></pre>
+
+
+<h3>Un autre example de filtrage de tableau</h3>
+
+
+
+<div class="row">
+	<div class="col-md-3">
+		<section>
+			<h4 class="wb-inv">Options de filtrage</h4>
+			<div class="wb-frmvld"><form>
+					<div class="wb-fieldflow" data-wb-fieldflow='
+							{
+								"srctype": "tblfilter",
+								"noForm": true,
+								"source": "#dataset-filter",
+								"fltrseq": [
+									{"column": 3, "csvextract": true, "defaultselectedlabel": "Toutes les type de nouvelle", "label":"Type de nouvelle"},
+									{"column": 2, "csvextract": true, "defaultselectedlabel": "De tous les département", "label":"Département"},
+									{"column": 8, "csvextract": true, "defaultselectedlabel": "Relative à tous les ministère", "label":"Ministère"},
+									{"column": 6, "csvextract": true, "defaultselectedlabel": "Tous le mondes", "label":"Pour"},
+									{"column": 5, "csvextract": true, "defaultselectedlabel": "Partout", "label":"Endroit"}
+								]
+							}'></div>
+			</form></div>
+		</section>
+	</div>
+	<div class="col-md-9">
+		<table class="wb-tables table table-striped table-hover" id="dataset-filter" aria-live="polite" data-wb-tables='{
+					"bDeferRender": true,
+					"ajaxSource": "http://wet-boew.github.io/wet-boew/demos/tables/ajax/datasource.json",
+					"order": [5, "desc"],
+					 "columns": [
+						{ "data": "TITLE", "className": "nws-tbl-ttl h4" },
+						{ "data": "PUBDATE", "className": "nws-tbl-date" },
+						{ "data": "DEPT", "className": "nws-tbl-dept" },
+						{ "data": "TYPE", "className": "nws-tbl-type" },
+						{ "data": "TEASER",  "className": "nws-tbl-desc" },
+						{ "data": "LOCATION",  "visible": false },
+						{ "data": "AUDIENCE",  "visible": false },
+						{ "data": "SUBJECT", "visible": false },
+						{ "data": "MINISTER", "visible": false }
+					  ]}'>
+			<thead>
+				<tr>
+					<th>Titre</th>
+					<th>Date de publication</th>
+					<th>Département</th>
+					<th>Type de nouvelle</th>
+					<th>Résumé</th>
+					<th>Endroit</th>
+					<th>Pour</th>
+					<th>Sujets</th>
+					<th>Ministère</th>
+				</tr>
+			</thead>
+		</table>
+	</div>
+</div>
+
+
+<pre><code>&lt;div class=&quot;row&quot;&gt;
+	&lt;div class=&quot;col-md-3&quot;&gt;
+		&lt;section&gt;
+			&lt;h4 class=&quot;wb-inv&quot;&gt;Options de filtrage&lt;/h4&gt;
+			&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form&gt;
+					&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='
+							{
+								&quot;srctype&quot;: &quot;tblfilter&quot;,
+								&quot;noForm&quot;: true,
+								&quot;source&quot;: &quot;#dataset-filter&quot;,
+								&quot;fltrseq&quot;: [
+									{&quot;column&quot;: 3, &quot;csvextract&quot;: true, &quot;defaultselectedlabel&quot;: &quot;Toutes les type de nouvelle&quot;, &quot;label&quot;:&quot;Type de nouvelle&quot;},
+									{&quot;column&quot;: 2, &quot;csvextract&quot;: true, &quot;defaultselectedlabel&quot;: &quot;De tous les département&quot;, &quot;label&quot;:&quot;Département&quot;},
+									{&quot;column&quot;: 8, &quot;csvextract&quot;: true, &quot;defaultselectedlabel&quot;: &quot;Relative à tous les ministère&quot;, &quot;label&quot;:&quot;Ministère&quot;},
+									{&quot;column&quot;: 6, &quot;csvextract&quot;: true, &quot;defaultselectedlabel&quot;: &quot;Tous le mondes&quot;, &quot;label&quot;:&quot;Pour&quot;},
+									{&quot;column&quot;: 5, &quot;csvextract&quot;: true, &quot;defaultselectedlabel&quot;: &quot;Partout&quot;, &quot;label&quot;:&quot;Endroit&quot;}
+								]
+							}'&gt;&lt;/div&gt;
+			&lt;/form&gt;&lt;/div&gt;
+		&lt;/section&gt;
+	&lt;/div&gt;
+	&lt;div class=&quot;col-md-9&quot;&gt;
+		&lt;table class=&quot;wb-tables table table-striped table-hover&quot; id=&quot;dataset-filter&quot; aria-live=&quot;polite&quot; data-wb-tables='{
+					&quot;bDeferRender&quot;: true,
+					&quot;ajaxSource&quot;: &quot;http://wet-boew.github.io/wet-boew/demos/tables/ajax/datasource.json&quot;,
+					&quot;order&quot;: [5, &quot;desc&quot;],
+					 &quot;columns&quot;: [
+						{ &quot;data&quot;: &quot;TITLE&quot;, &quot;className&quot;: &quot;nws-tbl-ttl h4&quot; },
+						{ &quot;data&quot;: &quot;PUBDATE&quot;, &quot;className&quot;: &quot;nws-tbl-date&quot; },
+						{ &quot;data&quot;: &quot;DEPT&quot;, &quot;className&quot;: &quot;nws-tbl-dept&quot; },
+						{ &quot;data&quot;: &quot;TYPE&quot;, &quot;className&quot;: &quot;nws-tbl-type&quot; },
+						{ &quot;data&quot;: &quot;TEASER&quot;,  &quot;className&quot;: &quot;nws-tbl-desc&quot; },
+						{ &quot;data&quot;: &quot;LOCATION&quot;,  &quot;visible&quot;: false },
+						{ &quot;data&quot;: &quot;AUDIENCE&quot;,  &quot;visible&quot;: false },
+						{ &quot;data&quot;: &quot;SUBJECT&quot;, &quot;visible&quot;: false },
+						{ &quot;data&quot;: &quot;MINISTER&quot;, &quot;visible&quot;: false }
+					  ]}'&gt;
+			&lt;thead&gt;
+				&lt;tr&gt;
+					&lt;th&gt;Titre&lt;/th&gt;
+					&lt;th&gt;Date de publication&lt;/th&gt;
+					&lt;th&gt;Département&lt;/th&gt;
+					&lt;th&gt;Type de nouvelle&lt;/th&gt;
+					&lt;th&gt;Résumé&lt;/th&gt;
+					&lt;th&gt;Endroit&lt;/th&gt;
+					&lt;th&gt;Pour&lt;/th&gt;
+					&lt;th&gt;Sujets&lt;/th&gt;
+					&lt;th&gt;Ministère&lt;/th&gt;
+				&lt;/tr&gt;
+			&lt;/thead&gt;
+		&lt;/table&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>

--- a/src/plugins/fieldflow/ajax/ajax-1.html
+++ b/src/plugins/fieldflow/ajax/ajax-1.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- DataAjaxFragmentStart -->
+
+<section>
+	<h3>AJAX content Set 1 <span lang="fr">(Ensemble 1)</span></h3>
+		
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc hendrerit turpis nec urna pulvinar, sit amet iaculis est ultrices. Nullam erat elit, pellentesque ac arcu sit amet, pretium scelerisque dui. Ut id porta sapien. Quisque imperdiet turpis quis urna mollis mollis. Vivamus eget laoreet lorem, ac commodo mauris. Vivamus et blandit odio. Donec nec mauris et mauris aliquet viverra vel id nisl. Etiam dui sem, fringilla ac est quis, sollicitudin scelerisque velit. Nulla ac semper erat. Integer lorem nisl, placerat eget facilisis sit amet, molestie at libero. Nam cursus mollis odio, vel viverra sem mollis id.
+
+	<div class="well">
+		<ul>
+			<li>quam</li>
+		</ul>
+	</div>
+
+	<p>Fusce a finibus diam, sed tristique metus. Aliquam auctor tellus cursus, ultrices magna ac, lobortis erat. Praesent ac eros venenatis, fringilla sapien non, cursus mi. Morbi ultrices id sem nec vestibulum. Sed vehicula lacus turpis, ac vestibulum orci feugiat sed. Aliquam quam diam, hendrerit at mi vitae, ornare dictum urna. Proin vehicula mi quam, ac venenatis urna scelerisque nec. Sed aliquet quis dui commodo aliquet. Integer commodo quam sed ultricies laoreet. Fusce ut rutrum enim. Ut erat massa, sollicitudin sit amet auctor a, tincidunt sed nibh. Nulla pulvinar tellus urna, sed tristique tellus lobortis non. Vestibulum at accumsan massa. Proin et diam vitae nisi placerat fermentum sit amet et est. Nunc non est vulputate, aliquet ante ultrices, aliquet est.
+
+	<p>Quisque imperdiet, purus sit amet dapibus venenatis, ligula nulla blandit libero, in tincidunt lorem lorem luctus ligula. Quisque ornare nibh et risus tincidunt, ac pellentesque urna hendrerit. Suspendisse feugiat efficitur cursus. Suspendisse sodales mauris eget diam porttitor, eu scelerisque est condimentum. Nam ultricies pharetra metus eu lobortis. Phasellus urna erat, semper vel mauris congue, convallis varius mi. Sed vestibulum, dolor id blandit aliquam, erat orci dictum tellus, vel malesuada mauris eros fringilla risus.
+
+	<p>Ut sed tempor metus. Mauris sed nisi eu purus consectetur mattis luctus ornare mauris. Vestibulum blandit ullamcorper elit ac tempus. Etiam sed porta tortor. Phasellus congue a mauris lobortis egestas. Praesent porta ligula sapien, ut feugiat magna feugiat in. Proin non bibendum dui, faucibus iaculis nunc. Donec tempus ullamcorper finibus. Integer velit arcu, facilisis eu tincidunt a, faucibus sit amet massa.
+</section>
+
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/src/plugins/fieldflow/ajax/ajax-2.html
+++ b/src/plugins/fieldflow/ajax/ajax-2.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- DataAjaxFragmentStart -->
+
+<section>
+	<h3>AJAX content Set 2 <span lang="fr">(Ensemble 2)</span></h3>
+		
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc hendrerit turpis nec urna pulvinar, sit amet iaculis est ultrices. Nullam erat elit, pellentesque ac arcu sit amet, pretium scelerisque dui. Ut id porta sapien. Quisque imperdiet turpis quis urna mollis mollis. Vivamus eget laoreet lorem, ac commodo mauris. Vivamus et blandit odio. Donec nec mauris et mauris aliquet viverra vel id nisl. Etiam dui sem, fringilla ac est quis, sollicitudin scelerisque velit. Nulla ac semper erat. Integer lorem nisl, placerat eget facilisis sit amet, molestie at libero. Nam cursus mollis odio, vel viverra sem mollis id.
+
+	<div class="well">
+		<ul>
+			<li>quam</li>
+			<li>id porta sapien</li>
+		</ul>
+	</div>
+
+	<p>Fusce a finibus diam, sed tristique metus. Aliquam auctor tellus cursus, ultrices magna ac, lobortis erat. Praesent ac eros venenatis, fringilla sapien non, cursus mi. Morbi ultrices id sem nec vestibulum. Sed vehicula lacus turpis, ac vestibulum orci feugiat sed. Aliquam quam diam, hendrerit at mi vitae, ornare dictum urna. Proin vehicula mi quam, ac venenatis urna scelerisque nec. Sed aliquet quis dui commodo aliquet. Integer commodo quam sed ultricies laoreet. Fusce ut rutrum enim. Ut erat massa, sollicitudin sit amet auctor a, tincidunt sed nibh. Nulla pulvinar tellus urna, sed tristique tellus lobortis non. Vestibulum at accumsan massa. Proin et diam vitae nisi placerat fermentum sit amet et est. Nunc non est vulputate, aliquet ante ultrices, aliquet est.
+
+	<p>Quisque imperdiet, purus sit amet dapibus venenatis, ligula nulla blandit libero, in tincidunt lorem lorem luctus ligula. Quisque ornare nibh et risus tincidunt, ac pellentesque urna hendrerit. Suspendisse feugiat efficitur cursus. Suspendisse sodales mauris eget diam porttitor, eu scelerisque est condimentum. Nam ultricies pharetra metus eu lobortis. Phasellus urna erat, semper vel mauris congue, convallis varius mi. Sed vestibulum, dolor id blandit aliquam, erat orci dictum tellus, vel malesuada mauris eros fringilla risus.
+
+	<p>Ut sed tempor metus. Mauris sed nisi eu purus consectetur mattis luctus ornare mauris. Vestibulum blandit ullamcorper elit ac tempus. Etiam sed porta tortor. Phasellus congue a mauris lobortis egestas. Praesent porta ligula sapien, ut feugiat magna feugiat in. Proin non bibendum dui, faucibus iaculis nunc. Donec tempus ullamcorper finibus. Integer velit arcu, facilisis eu tincidunt a, faucibus sit amet massa.
+</section>
+
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/src/plugins/fieldflow/ajax/ajax-3.html
+++ b/src/plugins/fieldflow/ajax/ajax-3.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- DataAjaxFragmentStart -->
+
+<section>
+	<h3>AJAX content Set 3 <span lang="fr">(Ensemble 3)</span></h3>
+		
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc hendrerit turpis nec urna pulvinar, sit amet iaculis est ultrices. Nullam erat elit, pellentesque ac arcu sit amet, pretium scelerisque dui. Ut id porta sapien. Quisque imperdiet turpis quis urna mollis mollis. Vivamus eget laoreet lorem, ac commodo mauris. Vivamus et blandit odio. Donec nec mauris et mauris aliquet viverra vel id nisl. Etiam dui sem, fringilla ac est quis, sollicitudin scelerisque velit. Nulla ac semper erat. Integer lorem nisl, placerat eget facilisis sit amet, molestie at libero. Nam cursus mollis odio, vel viverra sem mollis id.
+
+	<div class="well">
+		<ul>
+			<li>quam</li>
+			<li>id porta sapien</li>
+			<li>Vestibulum at accumsan massa</li>
+		</ul>
+	</div>
+
+	<p>Fusce a finibus diam, sed tristique metus. Aliquam auctor tellus cursus, ultrices magna ac, lobortis erat. Praesent ac eros venenatis, fringilla sapien non, cursus mi. Morbi ultrices id sem nec vestibulum. Sed vehicula lacus turpis, ac vestibulum orci feugiat sed. Aliquam quam diam, hendrerit at mi vitae, ornare dictum urna. Proin vehicula mi quam, ac venenatis urna scelerisque nec. Sed aliquet quis dui commodo aliquet. Integer commodo quam sed ultricies laoreet. Fusce ut rutrum enim. Ut erat massa, sollicitudin sit amet auctor a, tincidunt sed nibh. Nulla pulvinar tellus urna, sed tristique tellus lobortis non. Vestibulum at accumsan massa. Proin et diam vitae nisi placerat fermentum sit amet et est. Nunc non est vulputate, aliquet ante ultrices, aliquet est.
+
+	<p>Quisque imperdiet, purus sit amet dapibus venenatis, ligula nulla blandit libero, in tincidunt lorem lorem luctus ligula. Quisque ornare nibh et risus tincidunt, ac pellentesque urna hendrerit. Suspendisse feugiat efficitur cursus. Suspendisse sodales mauris eget diam porttitor, eu scelerisque est condimentum. Nam ultricies pharetra metus eu lobortis. Phasellus urna erat, semper vel mauris congue, convallis varius mi. Sed vestibulum, dolor id blandit aliquam, erat orci dictum tellus, vel malesuada mauris eros fringilla risus.
+
+	<p>Ut sed tempor metus. Mauris sed nisi eu purus consectetur mattis luctus ornare mauris. Vestibulum blandit ullamcorper elit ac tempus. Etiam sed porta tortor. Phasellus congue a mauris lobortis egestas. Praesent porta ligula sapien, ut feugiat magna feugiat in. Proin non bibendum dui, faucibus iaculis nunc. Donec tempus ullamcorper finibus. Integer velit arcu, facilisis eu tincidunt a, faucibus sit amet massa.
+</section>
+
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/src/plugins/fieldflow/ajax/ajax-4.html
+++ b/src/plugins/fieldflow/ajax/ajax-4.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- DataAjaxFragmentStart -->
+
+<section>
+	<h3>AJAX content Set 4 <span lang="fr">(Ensemble 4)</span></h3>
+		
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc hendrerit turpis nec urna pulvinar, sit amet iaculis est ultrices. Nullam erat elit, pellentesque ac arcu sit amet, pretium scelerisque dui. Ut id porta sapien. Quisque imperdiet turpis quis urna mollis mollis. Vivamus eget laoreet lorem, ac commodo mauris. Vivamus et blandit odio. Donec nec mauris et mauris aliquet viverra vel id nisl. Etiam dui sem, fringilla ac est quis, sollicitudin scelerisque velit. Nulla ac semper erat. Integer lorem nisl, placerat eget facilisis sit amet, molestie at libero. Nam cursus mollis odio, vel viverra sem mollis id.
+
+	<div class="well">
+		<ul>
+			<li>quam</li>
+			<li>id porta sapien</li>
+			<li>Vestibulum at accumsan massa</li>
+			<li>lorem lorem luctus ligula</li>
+		</ul>
+	</div>
+
+	<p>Fusce a finibus diam, sed tristique metus. Aliquam auctor tellus cursus, ultrices magna ac, lobortis erat. Praesent ac eros venenatis, fringilla sapien non, cursus mi. Morbi ultrices id sem nec vestibulum. Sed vehicula lacus turpis, ac vestibulum orci feugiat sed. Aliquam quam diam, hendrerit at mi vitae, ornare dictum urna. Proin vehicula mi quam, ac venenatis urna scelerisque nec. Sed aliquet quis dui commodo aliquet. Integer commodo quam sed ultricies laoreet. Fusce ut rutrum enim. Ut erat massa, sollicitudin sit amet auctor a, tincidunt sed nibh. Nulla pulvinar tellus urna, sed tristique tellus lobortis non. Vestibulum at accumsan massa. Proin et diam vitae nisi placerat fermentum sit amet et est. Nunc non est vulputate, aliquet ante ultrices, aliquet est.
+
+	<p>Quisque imperdiet, purus sit amet dapibus venenatis, ligula nulla blandit libero, in tincidunt lorem lorem luctus ligula. Quisque ornare nibh et risus tincidunt, ac pellentesque urna hendrerit. Suspendisse feugiat efficitur cursus. Suspendisse sodales mauris eget diam porttitor, eu scelerisque est condimentum. Nam ultricies pharetra metus eu lobortis. Phasellus urna erat, semper vel mauris congue, convallis varius mi. Sed vestibulum, dolor id blandit aliquam, erat orci dictum tellus, vel malesuada mauris eros fringilla risus.
+
+	<p>Ut sed tempor metus. Mauris sed nisi eu purus consectetur mattis luctus ornare mauris. Vestibulum blandit ullamcorper elit ac tempus. Etiam sed porta tortor. Phasellus congue a mauris lobortis egestas. Praesent porta ligula sapien, ut feugiat magna feugiat in. Proin non bibendum dui, faucibus iaculis nunc. Donec tempus ullamcorper finibus. Integer velit arcu, facilisis eu tincidunt a, faucibus sit amet massa.
+</section>
+
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/src/plugins/fieldflow/ajax/ajax-5.html
+++ b/src/plugins/fieldflow/ajax/ajax-5.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- DataAjaxFragmentStart -->
+
+<section>
+	<h3>AJAX content Set 5 <span lang="fr">(Ensemble 5)</span></h3>
+		
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc hendrerit turpis nec urna pulvinar, sit amet iaculis est ultrices. Nullam erat elit, pellentesque ac arcu sit amet, pretium scelerisque dui. Ut id porta sapien. Quisque imperdiet turpis quis urna mollis mollis. Vivamus eget laoreet lorem, ac commodo mauris. Vivamus et blandit odio. Donec nec mauris et mauris aliquet viverra vel id nisl. Etiam dui sem, fringilla ac est quis, sollicitudin scelerisque velit. Nulla ac semper erat. Integer lorem nisl, placerat eget facilisis sit amet, molestie at libero. Nam cursus mollis odio, vel viverra sem mollis id.
+
+	<div class="well">
+		<ul>
+			<li>quam</li>
+			<li>id porta sapien</li>
+			<li>Vestibulum at accumsan massa</li>
+			<li>lorem lorem luctus ligula</li>
+			<li>Suspendisse sodales mauris eget</li>
+		</ul>
+	</div>
+	
+	<details>
+		<summary>This is a Summary Element</summary>
+		<p>This is a paragraph inside a details element
+	</details>
+	<p>The previous block have the following source code:
+	<pre><code>&lt;details&gt;
+	&lt;summary&gt;This is a Summary Element&lt;/summary&gt;
+	&lt;p&gt;This is a paragraph inside a details element
+&lt;/details&gt;</code></pre>
+
+	<p>Fusce a finibus diam, sed tristique metus. Aliquam auctor tellus cursus, ultrices magna ac, lobortis erat. Praesent ac eros venenatis, fringilla sapien non, cursus mi. Morbi ultrices id sem nec vestibulum. Sed vehicula lacus turpis, ac vestibulum orci feugiat sed. Aliquam quam diam, hendrerit at mi vitae, ornare dictum urna. Proin vehicula mi quam, ac venenatis urna scelerisque nec. Sed aliquet quis dui commodo aliquet. Integer commodo quam sed ultricies laoreet. Fusce ut rutrum enim. Ut erat massa, sollicitudin sit amet auctor a, tincidunt sed nibh. Nulla pulvinar tellus urna, sed tristique tellus lobortis non. Vestibulum at accumsan massa. Proin et diam vitae nisi placerat fermentum sit amet et est. Nunc non est vulputate, aliquet ante ultrices, aliquet est.
+
+	<p>Following this paragraph we have this code <code>&lt;div data-ajax-append=&quot;ajax/ajax-5a.html&quot;&gt;&lt;/div&gt;</code>
+	<div data-ajax-append="ajax/ajax-5a.html"></div>
+	
+	<p>Quisque imperdiet, purus sit amet dapibus venenatis, ligula nulla blandit libero, in tincidunt lorem lorem luctus ligula. Quisque ornare nibh et risus tincidunt, ac pellentesque urna hendrerit. Suspendisse feugiat efficitur cursus. Suspendisse sodales mauris eget diam porttitor, eu scelerisque est condimentum. Nam ultricies pharetra metus eu lobortis. Phasellus urna erat, semper vel mauris congue, convallis varius mi. Sed vestibulum, dolor id blandit aliquam, erat orci dictum tellus, vel malesuada mauris eros fringilla risus.
+
+	<p>Ut sed tempor metus. Mauris sed nisi eu purus consectetur mattis luctus ornare mauris. Vestibulum blandit ullamcorper elit ac tempus. Etiam sed porta tortor. Phasellus congue a mauris lobortis egestas. Praesent porta ligula sapien, ut feugiat magna feugiat in. Proin non bibendum dui, faucibus iaculis nunc. Donec tempus ullamcorper finibus. Integer velit arcu, facilisis eu tincidunt a, faucibus sit amet massa.
+</section>
+
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/src/plugins/fieldflow/ajax/ajax-5a.html
+++ b/src/plugins/fieldflow/ajax/ajax-5a.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- DataAjaxFragmentStart -->
+
+<section class="mrgn-lft-lg">
+	<h4>AJAX sub-content Set 5a <span lang="fr">(Ensemble de sous-contenu 5a)</span></h4>
+		
+	<p>Paragraph 1 <strong>Blabla A</strong></p>
+
+	<details>
+		<summary>This is a Summary Element</summary>
+		<p>This is a paragraph inside a details element
+	</details>
+	
+	<p>The previous block have the following source code:
+	<pre><code>&lt;details&gt;
+	&lt;summary&gt;This is a Summary Element&lt;/summary&gt;
+	&lt;p&gt;This is a paragraph inside a details element
+&lt;/details&gt;</code></pre>
+
+	<p>Quisque imperdiet, purus sit amet dapibus venenatis, ligula nulla blandit libero, in tincidunt lorem lorem luctus ligula. Quisque ornare nibh et risus tincidunt, ac pellentesque urna hendrerit. Suspendisse feugiat efficitur cursus. Suspendisse sodales mauris eget diam porttitor, eu scelerisque est condimentum. Nam ultricies pharetra metus eu lobortis. Phasellus urna erat, semper vel mauris congue, convallis varius mi. Sed vestibulum, dolor id blandit aliquam, erat orci dictum tellus, vel malesuada mauris eros fringilla risus.
+
+	<p>Ut sed tempor metus. Mauris sed nisi eu purus consectetur mattis luctus ornare mauris. Vestibulum blandit ullamcorper elit ac tempus. Etiam sed porta tortor. Phasellus congue a mauris lobortis egestas. Praesent porta ligula sapien, ut feugiat magna feugiat in. Proin non bibendum dui, faucibus iaculis nunc. Donec tempus ullamcorper finibus. Integer velit arcu, facilisis eu tincidunt a, faucibus sit amet massa.
+
+	<p><strong>End of Set 5a <span lang="fr">(Fin de l'ensemble 5a)</span></strong></p>
+	<hr />
+
+</section>
+
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/src/plugins/fieldflow/ajax/filtering-hash.html
+++ b/src/plugins/fieldflow/ajax/filtering-hash.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="en">
+<!-- CIC Drop down prototype -->
+<!-- DataAjaxFragmentStart -->
+
+<section id="part1" class="section1">
+	<h2>Part 1 <span lang="fr">(Section 1)</span></h2>
+
+	<p class="filter-selector">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ultricies feugiat pulvinar. Maecenas eu lacus vel elit ultrices ornare. Donec molestie feugiat tincidunt. Cras sagittis eget quam at congue. Suspendisse et cursus justo, vel molestie dolor. Nunc vestibulum enim in nisl aliquet congue. Duis ac nulla cursus, scelerisque magna nec, commodo felis. Mauris tempus leo id hendrerit pharetra.</p>
+</section>
+
+<section id="part2" class="section2">
+	<h2 class="filter-selector">Part 2 <span lang="fr">(Section 2)</span></h2>
+
+	<ul>
+		<li>Lorem ipsum dolor sit amet</li>
+		<li>Consectetur adipiscing elit</li>
+		<li>Vivamus ultricies feugiat pulvinar</li>
+		<li>Maecenas eu lacus vel elit ultrices ornare</li>
+		<li>Donec molestie feugiat tincidunt</li>
+	</ul>
+</section>
+
+<section id="part3" class="section3">
+	<h2>Part 3 <span lang="fr">(Section 3)</span></h2>
+
+	<div class="well">
+		<p class="filter-selector">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ultricies feugiat pulvinar. Maecenas eu lacus vel elit ultrices ornare. Donec molestie feugiat tincidunt. Cras sagittis eget quam at congue. Suspendisse et cursus justo, vel molestie dolor. Nunc vestibulum enim in nisl aliquet congue. Duis ac nulla cursus, scelerisque magna nec, commodo felis. Mauris tempus leo id hendrerit pharetra.</p>
+		
+		<ul>
+			<li>First <span lang="fr">(Premier)</span></li>
+			<li>Second <span lang="fr">(Second)</span></li>
+			<li>Third <span lang="fr">(Troisième)</span></li>
+		</ul>
+	</div>
+</section>
+
+<section id="part4" class="filter-selector section4">
+	<h2>Part 4 <span lang="fr">(Section 4)</span></h2>
+	<div class="jumbotron">
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ultricies feugiat pulvinar. Maecenas eu lacus vel elit ultrices ornare. Donec molestie feugiat tincidunt. Cras sagittis eget quam at congue. Suspendisse et cursus justo, vel molestie dolor. Nunc vestibulum enim in nisl aliquet congue. Duis ac nulla cursus, scelerisque magna nec, commodo felis. Mauris tempus leo id hendrerit pharetra.</p>
+	</div>
+</section>
+
+<section id="part5" class="section5">
+	<h2>Part 5 <span lang="fr">(Section 5)</span></h2>
+
+	<blockquote>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ultricies feugiat pulvinar. Maecenas eu lacus vel elit ultrices ornare. Donec molestie feugiat tincidunt. Cras sagittis eget quam at congue. Suspendisse et cursus justo, vel molestie dolor. Nunc vestibulum enim in nisl aliquet congue. Duis ac nulla cursus, scelerisque magna nec, commodo felis. Mauris tempus leo id hendrerit pharetra.</p>
+	</blockquote>
+</section>
+
+
+
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/src/plugins/fieldflow/ajax/paragraph.html
+++ b/src/plugins/fieldflow/ajax/paragraph.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<!-- DataAjaxFragmentStart -->
+
+<div lang="en">
+	<div id="paragraph1-en">
+		<p id="resetdefaultExample-en">Example of paragraph where the preceding field flow component could change my color.</p>
+	</div>
+
+	<div id="paragraph2-en">
+		<p id="definebaseExample-en">Example of paragraph where the preceding field flow component could change my color.</p>
+	</div>
+
+	<div id="paragraph3-en">
+		<p id="defineDefaultExample-en">Example of paragraph where the preceding field flow component could change my color.</p>
+	</div>
+</div>
+
+<div lang="fr">
+	<div id="paragraph1-fr">
+		<p id="resetdefaultExample-fr">Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.</p>
+	</div>
+
+	<div id="paragraph2-fr">
+		<p id="definebaseExample-fr">Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.</p>
+	</div>
+
+	<div id="paragraph3-fr">
+		<p id="defineDefaultExample-fr">Example d'un paragraphe qui change de couleur dépendant du choix du composant de déroulement de contenu précédent.</p>
+	</div>
+</div>
+
+<!-- DataAjaxFragmentEnd -->
+</html>

--- a/src/plugins/fieldflow/basic-en.hbs
+++ b/src/plugins/fieldflow/basic-en.hbs
@@ -1,0 +1,581 @@
+---
+{
+	"title": "Field flow basic configuration",
+	"language": "en",
+	"category": "Plugins",
+	"description": "How to use field flow to create small scale user interaction.",
+	"tag": "fieldflow",
+	"parentdir": "fieldflow",
+	"altLangPrefix": "basic",
+	"dateModified": "2016-11-30"
+}
+---
+<p>How to use field flow to create small scale user interaction.</p>
+
+
+<ul>
+	<li><a href="fieldflow-en.html">Field flow</a></li>
+	<li>Field flow basic configuration (current)</li>
+	<li><a href="advanced-en.html">Field flow advanced</a></li>
+</ul>
+
+<hr />
+
+<div class="wb-prettify all-pre"></div>
+
+<p>On this page:</p>
+
+<ul>
+	<li><a href="#filetering">Ajax filtering</a></li>
+	<li><a href="#renderas">Specifying what UI to render</a></li>
+	<li><a href="#setaction">Specifying the action</a></li>
+	<li><a href="#immediate">Make immediate action upon selection</a></li>
+	<li><a href="#multiple">Make multiple actions</a></li>
+	<li><a href="#optional">Making the field optional</a></li>
+	<li><a href="#labeling">Custom labeling</a></li>
+</ul>
+
+
+
+<h2 id="filetering">Ajax filtering</h2>
+
+<div class="well">
+	<p>This functionality is provided by the <a href="http://wet-boew.github.io/wet-boew/demos/data-ajax/data-ajax-en.html">data ajax plugin</a></p>
+</div>
+
+<p>It load the following file: <a href="ajax/filtering-hash.html">../ajax/filtering-hash.html</a></p>
+
+<div class="wb-fieldflow">
+	<p>Choose content to be ajaxed?</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/filtering-hash.html#part1">Part 1 (hash)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html#part2">Part 2 (hash)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html#part3">Part 3 (hash)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html#part4">Part 4 (hash)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html#part5">Part 5 (hash)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html ul">ul (selector)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html .filter-selector">.filter-selector (selector)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html .section1,.section2,.section3">Multi hash [.section1,.section2,.section3] (selector)</li>
+	</ul>
+</div>
+
+<pre><code>&lt;p&gt;It load the following file: &lt;a href=&quot;ajax/filtering-hash.html&quot;&gt;../ajax/filtering-hash.html&lt;/a&gt;&lt;/p&gt;
+
+&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choose content to be ajaxed?&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html#part1&quot;&gt;Part 1 (hash)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html#part2&quot;&gt;Part 2 (hash)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html#part3&quot;&gt;Part 3 (hash)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html#part4&quot;&gt;Part 4 (hash)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html#part5&quot;&gt;Part 5 (hash)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html ul&quot;&gt;ul (selector)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html .filter-selector&quot;&gt;.filter-selector (selector)&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h2 id="renderas">Specifying what UI to render</h2>
+
+<dl class="dl-horizontal">
+	<dt><code>select</code></dt>
+	<dd>Default, single selection from a dropdown (<code>select</code>,<code>option</code>,<code>optgroup</code> elements)</dd>
+
+	<dt><code>checkbox</code>
+	<dd>List of checkboxes (<code>input[type=checkbox]</code> elements).</dd>
+
+	<dt><code>radio</code>
+	<dd>List of options (<code>input[type=radio]</code> elements).</dd>
+
+</dl>
+
+<p>When using the render as "checkbox" or "radio", you could use the additional configuration option <code>inline</code> that could be set to true in order to indicate to render an inline interface.</p>
+
+<p><strong>Note</strong>: Using an interface that allow multiple choice is like executing multiple action.</p>
+
+
+<div class="wb-fieldflow" data-wb-fieldflow='{"renderas":"checkbox"}'>
+	<p>Choose content to be ajaxed:</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;renderas&quot;:&quot;checkbox&quot;}'&gt;
+	&lt;p&gt;Choose content to be ajaxed:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-1.html">ajax/ajax-1.html</a>&quot;&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-2.html">ajax/ajax-2.html</a>&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-3.html">ajax/ajax-3.html</a>&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-4.html">ajax/ajax-4.html</a>&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-5.html">ajax/ajax-5.html</a>&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h2 id="setaction">Specifying the action</h2>
+
+<p>List of built-in action.</p>
+<dl class="dl-horizontal">
+	<dt><code>redir</code></dt>
+	<dd>Perform a redirection</dd>
+	<dt><code>ajax</code></dt>
+	<dd>Ajax-in content</dd>
+	<dt><code>query</code></dt>
+	<dd>Set a value and a name for an input element. Could be useful when used with subsequent dropdown.</dd>
+	<dt><code>append</code></dt>
+	<dd>Append a second field, like a second dropdown</dd>
+	<dt><code>addClass</code></dt>
+	<dd>Add CSS class to an element</dd>
+	<dt><code>removeClass</code></dt>
+	<dd>Remove CSS class to an element</dd>
+	<dt><code>toggle</code></dt>
+	<dd>Toggle an element on the page</dd>
+	<dt><code>tblfilter</code></dt>
+	<dd>Apply filter to a data table (<code>wb-tables</code>).</dd>
+</dl>
+
+<h3>Redirection example</h3>
+
+<div class="wb-fieldflow">
+	<p>Find the plugin for the action you need:</p>
+
+	<ul>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html"}'>Inserting content</li>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html"}'>Photo galery</li>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html"}'>Draw charts</li>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html"}'>Expand and collapse content</li>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html"}'>Set a consistant height</li>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html"}'>Popup content</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Find the plugin for the action you need:&lt;/p&gt;
+
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;}'&gt;Inserting content&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;}'&gt;Photo galery&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;}'&gt;Draw charts&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;}'&gt;Expand and collapse content&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;}'&gt;Set a consistant height&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;}'&gt;Popup content&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h3>Ajax example</h3>
+
+<div class="wb-fieldflow">
+	<p>Choose content to be ajaxed:</p>
+	<ul>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-1.html"}'>(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-2.html"}'>(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-3.html"}'>(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-4.html"}'>(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html"}'>(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/filtering-hash.html ul"}'>Ajax filtering, ul (selector)</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choose content to be ajaxed:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-1.html&quot;}'&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;}'&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;}'&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;}'&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;}'&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html ul&quot;}'&gt;Ajax filtering, ul (selector)&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h2 id="immediate">Make immediate action upon selection</h2>
+
+<p>First you need to deactivate the form creation and create manually that form environment. Then you can specify <code>"live":true</code> in the configuration of the list item.</p>
+
+<div class="wb-frmvld"><form>
+	<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true}'>
+		<p>Choose content to be ajaxed:</p>
+		<ul>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-1.html", "live":true}'>(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-2.html", "live":true}'>(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-3.html", "live":true}'>(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-4.html", "live":true}'>(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html", "live":true}'>(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		</ul>
+	</div>
+</form></div>
+
+<pre><code>&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true}'&gt;
+		&lt;p&gt;Choose content to be ajaxed:&lt;/p&gt;
+		&lt;ul&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-1.html&quot;, &quot;live&quot;:true}'&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;, &quot;live&quot;:true}'&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;, &quot;live&quot;:true}'&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;, &quot;live&quot;:true}'&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;, &quot;live&quot;:true}'&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;/ul&gt;
+	&lt;/div&gt;
+&lt;/form&gt;&lt;/div&gt;</code></pre>
+
+<h2 id="multiple">Make multiple actions</h2>
+
+<p>Multiple action can be set by providing an JSON array for the item configuration. Althrough the plugin will not check for potential incompatibility between any action being set. It's the responsability of the interaction designer too choose wisely compatible action. Like making a redirection within an ajax are incompatible action.</p>
+
+<p>In the following example it use the option <code>container</code> to specify where to insert the content, where it doen't clean automatically and his value is an valid jquery selector.</p>
+
+<div class="wb-fieldflow">
+	<p>Choose content to be ajaxed?</p>
+	<ul>
+		<li data-wb-fieldflow='[
+				{"action":"ajax", "container":"#ajaxOutA", "url": "ajax/ajax-1.html"},
+				{"action":"ajax", "container":"#ajaxOutB", "url": "ajax/filtering-hash.html#part1"}
+			]'>Set 1 [A] - Part 1 [B]</li>
+		<li data-wb-fieldflow='[
+				{"action":"ajax", "container":"#ajaxOutA", "url": "ajax/ajax-2.html"},
+				{"action":"ajax", "container":"#ajaxOutB", "url": "ajax/filtering-hash.html#part2"}
+			]'>Set 2 [A] - Part 2 [B]</li>
+		<li data-wb-fieldflow='[
+				{"action":"ajax", "container":"#ajaxOutA", "url": "ajax/ajax-3.html"},
+				{"action":"ajax", "container":"#ajaxOutB", "url": "ajax/filtering-hash.html#part3"}
+			]'>Set 3 [A] - Part 3 [B]</li>
+		<li data-wb-fieldflow='[
+				{"action":"ajax", "container":"#ajaxOutA", "url": "ajax/ajax-4.html"},
+				{"action":"ajax", "container":"#ajaxOutB", "url": "ajax/filtering-hash.html#part4"}
+			]'>Set 4 [A] - Part 4 [B]</li>
+		<li data-wb-fieldflow='[
+				{"action":"ajax", "container":"#ajaxOutA", "url": "ajax/ajax-5.html"},
+				{"action":"ajax", "container":"#ajaxOutB", "url": "ajax/filtering-hash.html#part5"}
+			]'>Set 5 [A] - Part 5 [B]</li>
+	</ul>
+</div>
+
+<div class="row">
+	<div class="col-md-6">
+		<section class="panel panel-default">
+			<header class="panel-heading">
+				<h5 class="panel-title">Ajax Output A (<code>id="ajaxOutA"</code>)</h5>
+			</header>
+		<div id="ajaxOutA" class="panel-body">
+		</div>
+		</section>
+	</div>
+	<div class="col-md-6">
+		<section class="panel panel-default">
+			<header class="panel-heading">
+				<h5 class="panel-title">Ajax Output B (<code>id="ajaxOutB"</code>)</h5>
+			</header>
+		<div id="ajaxOutB" class="panel-body">
+		</div>
+		</section>
+	</div>
+</div>
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choose content to be ajaxed?&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='[
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutA&quot;, &quot;url&quot;: &quot;ajax/ajax-1.html&quot;},
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutB&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html#part1&quot;}
+			]'&gt;Set 1 [A] - Part 1 [B]&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutA&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;},
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutB&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html#part2&quot;}
+			]'&gt;Set 2 [A] - Part 2 [B]&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutA&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;},
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutB&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html#part3&quot;}
+			]'&gt;Set 3 [A] - Part 3 [B]&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutA&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;},
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutB&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html#part4&quot;}
+			]'&gt;Set 4 [A] - Part 4 [B]&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutA&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;},
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutB&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html#part5&quot;}
+			]'&gt;Set 5 [A] - Part 5 [B]&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;row&quot;&gt;
+	&lt;div class=&quot;col-md-6&quot;&gt;
+		&lt;section class=&quot;panel panel-default&quot;&gt;
+			&lt;header class=&quot;panel-heading&quot;&gt;
+				&lt;h5 class=&quot;panel-title&quot;&gt;Ajax Output A (&lt;code&gt;id=&quot;ajaxOutA&quot;&lt;/code&gt;)&lt;/h5&gt;
+			&lt;/header&gt;
+		&lt;div id=&quot;ajaxOutA&quot; class=&quot;panel-body&quot;&gt;
+		&lt;/div&gt;
+		&lt;/section&gt;
+	&lt;/div&gt;
+	&lt;div class=&quot;col-md-6&quot;&gt;
+		&lt;section class=&quot;panel panel-default&quot;&gt;
+			&lt;header class=&quot;panel-heading&quot;&gt;
+				&lt;h5 class=&quot;panel-title&quot;&gt;Ajax Output B (&lt;code&gt;id=&quot;ajaxOutB&quot;&lt;/code&gt;)&lt;/h5&gt;
+			&lt;/header&gt;
+		&lt;div id=&quot;ajaxOutB&quot; class=&quot;panel-body&quot;&gt;
+		&lt;/div&gt;
+		&lt;/section&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
+<h2 id="optional">Making the field optional</h2>
+
+<p>By default, all field flow control are required and they are validated by the form validator plugin, exception of the table filtering action. When needed, like when you are doing live action only, it could be useful to make the field control optional.</p>
+
+<div class="wb-frmvld"><form method="get">
+	<div class="wb-fieldflow" data-wb-fieldflow='{ "noForm": true, "base": { "live": true }, "isoptional": true }'>
+		<p>Choose content to be ajaxed:</p>
+		<ul>
+			<li data-wb-fieldflow="ajax/ajax-1.html">(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+			<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+			<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+			<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		</ul>
+	</div>
+</form></div>
+
+<pre><code>&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form method=&quot;get&quot;&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{ &quot;noForm&quot;: true, &quot;base&quot;: { &quot;live&quot;: true }, <strong>&quot;isoptional&quot;: true</strong> }'&gt;
+		&lt;p&gt;Choose content to be ajaxed:&lt;/p&gt;
+		&lt;ul&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;/ul&gt;
+	&lt;/div&gt;
+&lt;/form&gt;&lt;/div&gt;</code></pre>
+
+<h2 id="labeling">Custom labeling</h2>
+
+<p>Field flow plugin allow you several way to customize and specify how you want setup label of the generated control.</p>
+
+<h3>Specify a quick label</h3>
+
+<p>By default Field flow will take all the content of the first element, usually a paragraph, but you can specify what text to use by wrapping content with <code>&lt;span class=&quot;wb-fieldflow-label&quot;&gt;...&lt;/span&gt;</code>. This should allow a better progressive enhencement integration by the interaction designer.</p>
+
+
+<div class="wb-fieldflow">
+	<p><span class="wb-fieldflow-label">Choose content</span> to be ajaxed:</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;<strong>&lt;span class=&quot;wb-fieldflow-label&quot;&gt;</strong>Choose content<strong>&lt;/span&gt;</strong> to be ajaxed:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h3>Sophisticated labeling</h3>
+
+<p>Field flow allow you to have content before and after the label. Doing that allow the interaction designer to insert precision and/or instruction regarding of the content of the list item. To do so, the first child must have the class <code>wb-fieldflow-header</code>. If there is no sub-element that contain the class <code>wb-fieldflow-label</code>, the first paragraph will be used as the label.</p>
+
+<div class="wb-fieldflow" >
+	<div class="wb-fieldflow-header">
+		<p>Some text before the label.</p>
+		<p class="wb-fieldflow-label">The label</p>
+		<p>Some text after the label.</p>
+	</div>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; &gt;
+	&lt;div class=&quot;wb-fieldflow-header&quot;&gt;
+		&lt;p&gt;Some text before the label.&lt;/p&gt;
+		&lt;p class=&quot;wb-fieldflow-label&quot;&gt;The label&lt;/p&gt;
+		&lt;p&gt;Some text after the label.&lt;/p&gt;
+	&lt;/div&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h3>Specifying what to use as being the label</h3>
+
+<p>It possible to overwrite the default label class selector by setting the option <code>lblselector</code> to Field flow.</p>
+
+
+<div class="wb-fieldflow" data-wb-fieldflow='{"lblselector":"#myHiddenLabel"}'>
+	<p>Choose content to be ajaxed: <span id="myHiddenLabel" class="hidden">My hidden label.</span></p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;lblselector&quot;:&quot;#myHiddenLabel&quot;}'&gt;
+	&lt;p&gt;Choose content to be ajaxed: &lt;span id=&quot;myHiddenLabel&quot; class=&quot;hidden&quot;&gt;My hidden label.&lt;/span&gt;&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h3>Customize the default selected label</h3>
+
+
+<p>It possible to overwrite the default selected label by setting the option <code>defaultselectedlabel</code> to Field flow.</p>
+
+
+<div class="wb-fieldflow" data-wb-fieldflow='{"defaultselectedlabel":"I am an default selected label (default)"}'>
+	<p>Choose content to be ajaxed:</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;defaultselectedlabel&quot;:&quot;I am an empty option (default)&quot;}'&gt;
+	&lt;p&gt;Choose content to be ajaxed:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h3>Customize the submit button</h3>
+
+<p>The best way to customize the submit button is by coding the form wrapper and letting Field flow know that he should not render the form contained by setting the option <code>noForm</code> to <code>true</code></p>
+
+<div class="wb-frmvld"><form>
+	<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true}'>
+		<p>Choose content to be ajaxed:</p>
+		<ul>
+			<li data-wb-fieldflow="ajax/ajax-1.html">(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+			<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+			<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+			<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		</ul>
+	</div>
+	<input class="btn btn-default btn-lg mrgn-bttm-md" type="submit" value="My custom submit button" />
+</form></div>
+
+<pre><code>&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true}'&gt;
+		&lt;p&gt;Choose content to be ajaxed:&lt;/p&gt;
+		&lt;ul&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;/ul&gt;
+	&lt;/div&gt;
+	&lt;input class=&quot;btn btn-default btn-lg mrgn-bttm-md&quot; type=&quot;submit&quot; value=&quot;My custom submit button&quot; /&gt;
+&lt;/form&gt;&lt;/div&gt;</code></pre>
+
+<h3>The <code>i18n</code> configuration option <small>Deprecated</small></h3>
+
+<div class="well">
+		<p><strong>Deprecated</strong>: That options is a work around until the text used in the plugin get translated all every languages supported by WET and be integrated in the i18n cvs file. This is provided as informational purpose and work well when there is only one field flow feature, but it could be not working as specified when interacting with multiple field flow plugin on the same page. This configuration options are planned to be removed once the text will use the i18n WET core component.</p>
+
+		<p><code>i18n</code>:</p>
+		<dl class="dl-horizontal">
+
+			<dt><code>btn</code></dt>
+			<dd>Text for the submit button
+				<ul>
+					<li>English default: "Continue"</li>
+					<li>French default: "<span lang="fr">Allez</span>"</li>
+				</ul>
+			</dd>
+
+			<dt><code>defaultsel</code></dt>
+			<dd>Text for the first default drop down option
+				<ul>
+					<li>English default: "Make your selection..."</li>
+					<li>French default: "<span lang="fr">Sélectionnez dans la liste...</span>"</li>
+				</ul>
+			</dd>
+
+			<dt><code>required</code></dt>
+			<dd>Text for the required label
+				<ul>
+					<li>English default: "required"</li>
+					<li>French default: "<span lang="fr">obligatoire</span>"</li>
+				</ul>
+			</dd>
+		</dl>
+
+		<p>Setting those options could impact all the other dropdown.</p>
+	</div>
+
+
+<div class="wb-fieldflow" data-wb-fieldflow='{
+	"i18n": {
+		"btn": "Do the action",
+		"defaultsel": "Humm, pick an item you like",
+		"required": "You need to choose something"
+	}
+}'>
+	<p>Choose content to be ajaxed:</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+	&quot;i18n&quot;: {
+		&quot;btn&quot;: &quot;Do the action&quot;,
+		&quot;defaultsel&quot;: &quot;Humm, pick an item you like&quot;,
+		&quot;required&quot;: &quot;You need to choose something&quot;
+	}
+}'&gt;
+	&lt;p&gt;Choose content to be ajaxed:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>

--- a/src/plugins/fieldflow/basic-fr.hbs
+++ b/src/plugins/fieldflow/basic-fr.hbs
@@ -1,0 +1,577 @@
+---
+{
+	"title": "Déroulement de champs avec des configurations de base",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Comment utiliser le déroulement de champs afin de créer des interaction utilisateur à petite échèle.",
+	"tag": "fieldflow",
+	"parentdir": "fieldflow",
+	"altLangPrefix": "basic",
+	"dateModified": "2016-11-30"
+}
+---
+<p>Comment utiliser le déroulement de champs afin de créer des interaction utilisateur à petite échèle.</p>
+
+<ul>
+	<li><a href="fieldflow-fr.html">Déroulement de champs</a></li>
+	<li>Déroulement de champs avec des configurations de base (actuelle)</li>
+	<li><a href="advanced-fr.html">Déroulement de champs avancé</a></li>
+</ul>
+
+<hr />
+
+<div class="wb-prettify all-pre"></div>
+
+<p>Sur cette page:</p>
+
+<ul>
+	<li><a href="#filtrage">Filtrage de contenu inséré (Ajax)</a></li>
+	<li><a href="#iugenerer">Définir l'interface utilisateur à générer</a></li>
+	<li><a href="#defaction">Définir l'action</a></li>
+	<li><a href="#immediatement">Faire une action immédiatement lors de la sélection</a></li>
+	<li><a href="#plusieurs">Faire plusieurs actions</a></li>
+	<li><a href="#optionel">Definir le champs optionelle</a></li>
+	<li><a href="#etiquetage">Étiquetage personalisé</a></li>
+</ul>
+
+<h2 id="filtrage">Filtrage de contenu inséré (Ajax)</h2>
+
+<div class="well">
+	<p>Cette fonctionalité dépend du <a href="http://wet-boew.github.io/wet-boew/demos/data-ajax/data-ajax-en.html">plugiciels data ajax</a>.</p>
+</div>
+
+<p>Cet example télécharge ce fichier: <a href="ajax/filtering-hash.html">../ajax/filtering-hash.html</a></p>
+
+<div class="wb-fieldflow">
+	<p>Choisissez du contenu à insérer?</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/filtering-hash.html#part1">Section 1 (hash)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html#part2">Section 2 (hash)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html#part3">Section 3 (hash)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html#part4">Section 4 (hash)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html#part5">Section 5 (hash)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html ul">ul (sélecteur)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html .filter-selector">.filter-selector (sélecteur)</li>
+		<li data-wb-fieldflow="ajax/filtering-hash.html .section1,.section2,.section3">Multi hash [.section1,.section2,.section3] (sélecteur)</li>
+	</ul>
+</div>
+
+<pre><code>&lt;p&gt;Cet example télécharge ce fichier: &lt;a href=&quot;ajax/filtering-hash.html&quot;&gt;../ajax/filtering-hash.html&lt;/a&gt;&lt;/p&gt;
+
+&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choisissez du contenu à insérer?&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html#part1&quot;&gt;Section 1 (hash)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html#part2&quot;&gt;Section 2 (hash)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html#part3&quot;&gt;Section 3 (hash)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html#part4&quot;&gt;Section 4 (hash)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html#part5&quot;&gt;Section 5 (hash)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html ul&quot;&gt;ul (sélecteur)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html .filter-selector&quot;&gt;.filter-selector (sélecteur)&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/filtering-hash.html .section1,.section2,.section3&quot;&gt;Multi hash [.section1,.section2,.section3] (sélecteur)&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h2 id="iugenerer">Définir l'interface utilisateur à générer</h2>
+
+<dl class="dl-horizontal">
+	<dt><code>select</code></dt>
+	<dd>Valeur par défault, selection d'un item parmis d'une liste de choix (Les élements <code>select</code>,<code>option</code>,<code>optgroup</code>).</dd>
+
+	<dt><code>checkbox</code>
+	<dd>Liste de boîte à cocher (Élément <code>input[type=checkbox]</code>).</dd>
+
+	<dt><code>radio</code>
+	<dd>Liste de bouton radio (Élément <code>input[type=radio]</code>).</dd>
+
+</dl>
+
+<p>Lorsque l'interface utilisateur à générer est soit une liste de boîte à cocher ou une liste de bouton radio, vous pouvez utiliser la configuration <code>inline</code> avec une valeur vrai (true) ce qui permetera d'indiquer de créer une interface linéraire.</p>
+
+<p><strong>Notez</strong>: L'utilisation d'une interface qui permet plusieurs choix est comme l'execution de plusieurs action en simultané.</p>
+
+
+<div class="wb-fieldflow" data-wb-fieldflow='{"renderas":"checkbox"}'>
+	<p>Choisissez du contenu à insérer:</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;renderas&quot;:&quot;checkbox&quot;}'&gt;
+	&lt;p&gt;Choisissez du contenu à insérer:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-1.html">ajax/ajax-1.html</a>&quot;&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-2.html">ajax/ajax-2.html</a>&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-3.html">ajax/ajax-3.html</a>&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-4.html">ajax/ajax-4.html</a>&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-5.html">ajax/ajax-5.html</a>&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h2 id="defaction">Définir l'action</h2>
+
+<p>Liste des actions pré-définie.</p>
+<dl class="dl-horizontal">
+	<dt><code>redir</code></dt>
+	<dd>Effectue une redirection</dd>
+	<dt><code>ajax</code></dt>
+	<dd>Insert du contenu dans la page (Ajax)</dd>
+	<dt><code>query</code></dt>
+	<dd>Définie une valeur et un nom de champs l'élément du formulaire. Ceci peut-être utile lorsqu'il est utilisé avec d'autre controle de déroulement de champs.</dd>
+	<dt><code>append</code></dt>
+	<dd>Ajoute un second champ, comme un autre controle de déroulement de champs.</dd>
+	<dt><code>addClass</code></dt>
+	<dd>Ajoute une classe CSS à un éléments spécifier</dd>
+	<dt><code>removeClass</code></dt>
+	<dd>Enlève une classe CSS à un éléments spécifier</dd>
+	<dt><code>toggle</code></dt>
+	<dd>Bascule des éléments entre les états activé et désactivé.</dd>
+	<dt><code>tblfilter</code></dt>
+	<dd>Applique un filter à un tableau de donnée (<code>wb-tables</code>).</dd>
+</dl>
+
+<h3>Example de redirection</h3>
+
+<div class="wb-fieldflow">
+	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
+
+	<ul>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html"}'>Insertion de contenu</li>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html"}'>Galerie photos</li>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html"}'>Dessiner des graphiques</li>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html"}'>Contenu affichable/masquable</li>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html"}'>Uniformisation de la hauteur</li>
+		<li data-wb-fieldflow='{"action":"redir", "url": "http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html"}'>Afficher un contenu superposé</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
+
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;}'&gt;Insertion de contenu&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;}'&gt;Galerie photos&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;}'&gt;Dessiner des graphiques&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;}'&gt;Contenu affichable/masquable&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;}'&gt;Uniformisation de la hauteur&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;redir&quot;, &quot;url&quot;: &quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;}'&gt;Afficher un contenu superposé&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h3>Example avec Ajax</h3>
+
+<div class="wb-fieldflow">
+	<p>Choisissez du contenu à insérer:</p>
+	<ul>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-1.html"}'>(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-2.html"}'>(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-3.html"}'>(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-4.html"}'>(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html"}'>(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choisissez du contenu à insérer:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-1.html&quot;}'&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;}'&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;}'&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;}'&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;}'&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h2 id="immediatement">Faire une action immédiatement lors de la sélection</h2>
+
+<p>En premier vous devez déactiver la création automatique du formulaire conteneur et de créer cet environnement manuellement. Par la suite vous pouvez utilisé l'option <code>"live":true</code> pour les éléments qui doit être executé lors de la sélection.</p>
+
+<div class="wb-frmvld"><form>
+	<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true}'>
+		<p>Choisissez du contenu à insérer:</p>
+		<ul>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-1.html", "live":true}'>(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-2.html", "live":true}'>(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-3.html", "live":true}'>(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-4.html", "live":true}'>(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+			<li data-wb-fieldflow='{"action":"ajax", "url": "ajax/ajax-5.html", "live":true}'>(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		</ul>
+	</div>
+</form></div>
+
+
+<pre><code>&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true}'&gt;
+		&lt;p&gt;Choisissez du contenu à insérer:&lt;/p&gt;
+		&lt;ul&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-1.html&quot;, &quot;live&quot;:true}'&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;, &quot;live&quot;:true}'&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;, &quot;live&quot;:true}'&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;, &quot;live&quot;:true}'&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+			&lt;li data-wb-fieldflow='{&quot;action&quot;:&quot;ajax&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;, &quot;live&quot;:true}'&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;/ul&gt;
+	&lt;/div&gt;
+&lt;/form&gt;&lt;/div&gt;</code></pre>
+
+<h2 id="plusieurs">Faire plusieurs actions</h2>
+
+<p>Multiple action can be set by providing an JSON array for the item configuration. Althrough the plugin will not check for potential incompatibility between any action being set. It's the responsability of the interaction designer too choose wisely compatible action. Like making a redirection within an ajax are incompatible action.</p>
+
+<p>In the following example it use the option <code>container</code> to specify where to insert the content, where it doen't clean automatically and his value is an valid jquery selector.</p>
+
+<div class="wb-fieldflow">
+	<p>Choisissez du contenu à insérer?</p>
+	<ul>
+		<li data-wb-fieldflow='[
+				{"action":"ajax", "container":"#ajaxOutA", "url": "ajax/ajax-1.html"},
+				{"action":"ajax", "container":"#ajaxOutB", "url": "ajax/filtering-hash.html#part1"}
+			]'>Ensemble 1 [A] - Section 1 [B]</li>
+		<li data-wb-fieldflow='[
+				{"action":"ajax", "container":"#ajaxOutA", "url": "ajax/ajax-2.html"},
+				{"action":"ajax", "container":"#ajaxOutB", "url": "ajax/filtering-hash.html#part2"}
+			]'>Ensemble 2 [A] - Section 2 [B]</li>
+		<li data-wb-fieldflow='[
+				{"action":"ajax", "container":"#ajaxOutA", "url": "ajax/ajax-3.html"},
+				{"action":"ajax", "container":"#ajaxOutB", "url": "ajax/filtering-hash.html#part3"}
+			]'>Ensemble 3 [A] - Section 3 [B]</li>
+		<li data-wb-fieldflow='[
+				{"action":"ajax", "container":"#ajaxOutA", "url": "ajax/ajax-4.html"},
+				{"action":"ajax", "container":"#ajaxOutB", "url": "ajax/filtering-hash.html#part4"}
+			]'>Ensemble 4 [A] - Section 4 [B]</li>
+		<li data-wb-fieldflow='[
+				{"action":"ajax", "container":"#ajaxOutA", "url": "ajax/ajax-5.html"},
+				{"action":"ajax", "container":"#ajaxOutB", "url": "ajax/filtering-hash.html#part5"}
+			]'>Ensemble 5 [A] - Section 5 [B]</li>
+	</ul>
+</div>
+
+<div class="row">
+	<div class="col-md-6">
+		<section class="panel panel-default">
+			<header class="panel-heading">
+				<h5 class="panel-title">Sortie de contenu A (<code>id="ajaxOutA"</code>)</h5>
+			</header>
+		<div id="ajaxOutA" class="panel-body">
+		</div>
+		</section>
+	</div>
+	<div class="col-md-6">
+		<section class="panel panel-default">
+			<header class="panel-heading">
+				<h5 class="panel-title">Sortie de contenu B (<code>id="ajaxOutB"</code>)</h5>
+			</header>
+		<div id="ajaxOutB" class="panel-body">
+		</div>
+		</section>
+	</div>
+</div>
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choisissez du contenu à insérer?&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow='[
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutA&quot;, &quot;url&quot;: &quot;ajax/ajax-1.html&quot;},
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutB&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html#part1&quot;}
+			]'&gt;Ensemble 1 [A] - Section 1 [B]&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutA&quot;, &quot;url&quot;: &quot;ajax/ajax-2.html&quot;},
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutB&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html#part2&quot;}
+			]'&gt;Ensemble 2 [A] - Section 2 [B]&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutA&quot;, &quot;url&quot;: &quot;ajax/ajax-3.html&quot;},
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutB&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html#part3&quot;}
+			]'&gt;Ensemble 3 [A] - Section 3 [B]&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutA&quot;, &quot;url&quot;: &quot;ajax/ajax-4.html&quot;},
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutB&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html#part4&quot;}
+			]'&gt;Ensemble 4 [A] - Section 4 [B]&lt;/li&gt;
+		&lt;li data-wb-fieldflow='[
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutA&quot;, &quot;url&quot;: &quot;ajax/ajax-5.html&quot;},
+				{&quot;action&quot;:&quot;ajax&quot;, &quot;container&quot;:&quot;#ajaxOutB&quot;, &quot;url&quot;: &quot;ajax/filtering-hash.html#part5&quot;}
+			]'&gt;Ensemble 5 [A] - Section 5 [B]&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;row&quot;&gt;
+	&lt;div class=&quot;col-md-6&quot;&gt;
+		&lt;section class=&quot;panel panel-default&quot;&gt;
+			&lt;header class=&quot;panel-heading&quot;&gt;
+				&lt;h5 class=&quot;panel-title&quot;&gt;Sortie de contenu A (&lt;code&gt;id=&quot;ajaxOutA&quot;&lt;/code&gt;)&lt;/h5&gt;
+			&lt;/header&gt;
+		&lt;div id=&quot;ajaxOutA&quot; class=&quot;panel-body&quot;&gt;
+		&lt;/div&gt;
+		&lt;/section&gt;
+	&lt;/div&gt;
+	&lt;div class=&quot;col-md-6&quot;&gt;
+		&lt;section class=&quot;panel panel-default&quot;&gt;
+			&lt;header class=&quot;panel-heading&quot;&gt;
+				&lt;h5 class=&quot;panel-title&quot;&gt;Sortie de contenu B (&lt;code&gt;id=&quot;ajaxOutB&quot;&lt;/code&gt;)&lt;/h5&gt;
+			&lt;/header&gt;
+		&lt;div id=&quot;ajaxOutB&quot; class=&quot;panel-body&quot;&gt;
+		&lt;/div&gt;
+		&lt;/section&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
+<h2 id="optionel">Definir le champs optionelle</h2>
+
+<p>Par défaut, tous les champs du déroulement de champs sont requis et sont validé par le plugiciel du validateur de formulaire, à l'exception de l'action pour le filtrage de tableau. Lorsque nécessaire, comme lorsque vous voulez faire une action à la volé, it peut être intéressant que le champ soit marqué optionelle.</p>
+
+<div class="wb-frmvld"><form method="get">
+	<div class="wb-fieldflow" data-wb-fieldflow='{ "noForm": true, "base": { "live": true }, "isoptional": true }'>
+		<p>Choisissez du contenu à insérer:</p>
+		<ul>
+			<li data-wb-fieldflow="ajax/ajax-1.html">(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+			<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+			<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+			<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		</ul>
+	</div>
+</form></div>
+
+<pre><code>&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form method=&quot;get&quot;&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{ &quot;noForm&quot;: true, &quot;base&quot;: { &quot;live&quot;: true }, <strong>&quot;isoptional&quot;: true</strong> }'&gt;
+		&lt;p&gt;Choisissez du contenu à insérer:&lt;/p&gt;
+		&lt;ul&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;/ul&gt;
+	&lt;/div&gt;
+&lt;/form&gt;&lt;/div&gt;</code></pre>
+
+<h2 id="etiquetage">Étiquetage personalisé</h2>
+
+<p>Le déroulement de champs permet de personalisé les étiquettes de plusieurs façons.</p>
+
+<h3>Définir un étiquette</h3>
+
+<p>Par défaut tous le contenu du premier éléments, habituellement un paragraph, est utilisé. Par contre, vous pouvez spécifier le texte à utiliser en enveloppant une partie du contenu avec <code>&lt;span class=&quot;wb-fieldflow-label&quot;&gt;...&lt;/span&gt;</code>. Cela devrait vous permetre d'adopter une approche simpliste pour l'améliorartion progressive de votre contenu.</p>
+
+
+<div class="wb-fieldflow">
+	<p><span class="wb-fieldflow-label">Choisissez du contenu</span> à insérer:</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;&lt;span class=&quot;wb-fieldflow-label&quot;&gt;Choisissez du contenu&lt;/span&gt; à insérer:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h3>Block d'étiquette </h3>
+
+<p>Il est possible de spécifier du contenu qui sera inséré avant et après l'étiquette. Ceci permet, lors de la conception, d'ajouter des précision à l'utilisateur lorsqu'il utilise le contrôle. Pour ce faire, le premier élément enfant doit avoir la classe <code>wb-fieldflow-header</code>. S'il n'y a pas de sous-éléments avec la classe <code>wb-fieldflow-label</code>, le premier paragraph sera utilisé en tant qu'étiquette.</p>
+
+<div class="wb-fieldflow">
+	<div class="wb-fieldflow-header">
+		<p>Du texte avant l'étiquette.</p>
+		<p class="wb-fieldflow-label">L'étiquette</p>
+		<p>Du texte après l'étiquette.</p>
+	</div>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;div class=&quot;wb-fieldflow-header&quot;&gt;
+		&lt;p&gt;Du texte avant l'étiquette.&lt;/p&gt;
+		&lt;p class=&quot;wb-fieldflow-label&quot;&gt;L'étiquette&lt;/p&gt;
+		&lt;p&gt;Du texte après l'étiquette.&lt;/p&gt;
+	&lt;/div&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+<h3>Définir le sélecteur d'étiquette à utiliser</h3>
+
+<p>Il est possible redéfinir le sélecteur d'étiquette par défaut en utilisant l'option <code>lblselector</code>.</p>
+
+
+<div class="wb-fieldflow" data-wb-fieldflow='{"lblselector":"#myHiddenLabel"}'>
+	<p>Choisissez du contenu à insérer: <span id="myHiddenLabel" class="hidden">Mon étiquette caché.</span></p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;lblselector&quot;:&quot;#myHiddenLabel&quot;}'&gt;
+	&lt;p&gt;Choisissez du contenu à insérer: &lt;span id=&quot;myHiddenLabel&quot; class=&quot;hidden&quot;&gt;Mon étiquette caché.&lt;/span&gt;&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h3>Personalisé l'étiquette de sélection.</h3>
+
+
+<p>Il est possible de définir l'étiquette de sélection par l'option <code>defaultselectedlabel</code>.</p>
+
+
+<div class="wb-fieldflow" data-wb-fieldflow='{"defaultselectedlabel":"Je suis une étiquette de choix (valeur par défaut)"}'>
+	<p>Choisissez du contenu à insérer:</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;defaultselectedlabel&quot;:&quot;Je suis une étiquette écrassante&quot;}'&gt;
+	&lt;p&gt;Choisissez du contenu à insérer:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+<h3>Personalisation du bouton de soumission</h3>
+
+<p>La meilleur façon de personaliser le bouton de soumission c'est en le codant à même le formulaire et d'indiqué au contrôle de déroulement de champ de ne pas créer l'enveloppe de formulaire, option <code>"noForm": true</code></p>
+
+<div class="wb-frmvld"><form>
+	<div class="wb-fieldflow" data-wb-fieldflow='{"noForm": true}'>
+		<p>Choisissez du contenu à insérer:</p>
+		<ul>
+			<li data-wb-fieldflow="ajax/ajax-1.html">(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+			<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+			<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+			<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+			<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+		</ul>
+	</div>
+	<input class="btn btn-default btn-lg mrgn-bttm-md" type="submit" value="Mon bouton soumettre personalisé" />
+</form></div>
+
+<pre><code>&lt;div class=&quot;wb-frmvld&quot;&gt;&lt;form&gt;
+	&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{&quot;noForm&quot;: true}'&gt;
+		&lt;p&gt;Choisissez du contenu à insérer:&lt;/p&gt;
+		&lt;ul&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+			&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+		&lt;/ul&gt;
+	&lt;/div&gt;
+	&lt;input class=&quot;btn btn-default btn-lg mrgn-bttm-md&quot; type=&quot;submit&quot; value=&quot;Mon bouton soumettre personalisé&quot; /&gt;
+&lt;/form&gt;&lt;/div&gt;</code></pre>
+
+<h3>La configuration <code>i18n</code> <small>Déconseillé</small></h3>
+
+<div class="well">
+		<p><strong>Déconseillé</strong>: Cette option est un mécanisme de contournement jusqu'à le texte soit traduit dans toutes les langues supporté par la boîte à outils d'expérience web. Ceci est fourni à titre informative seulement et il est possible que ces réglage créer une interférance avec les autres composant de déroulement de champs dans la page. Il est planifier de retirer cette options lorsque l'intégration du texte traduit soit complété.</p>
+
+		<p><code>i18n</code>:</p>
+		<dl class="dl-horizontal">
+
+			<dt><code>btn</code></dt>
+			<dd>Texte du bouton soumettre
+				<ul>
+					<li>Français: "Allez" (valeur par défaut)</li>
+					<li>Anglais: "<span lang="en">Continue</span>" (valeur par défaut)</li>
+				</ul>
+			</dd>
+
+			<dt><code>defaultsel</code></dt>
+			<dd>Texte de l'option par défaut dans une liste de choix
+				<ul>
+					<li>Français: "Sélectionnez dans la liste..." (valeur par défaut)</li>
+					<li>Anglais: "<span lang="en">Make your selection...</span>" (valeur par défaut)</li>
+				</ul>
+			</dd>
+
+			<dt><code>required</code></dt>
+			<dd>Texte pour l'étiquette de champs requis
+				<ul>
+					<li>Français: "obligatoire" (valeur par défaut)</li>
+					<li>Anglais: "<span lang="en">required</span>" (valeur par défaut)</li>
+				</ul>
+			</dd>
+		</dl>
+
+		<p>Définir ces options peux avoir une influence sur les autres contrôle de déroulement de champs.</p>
+	</div>
+
+
+<div class="wb-fieldflow" data-wb-fieldflow='{
+	"i18n": {
+		"btn": "Faites ce qui est demandé",
+		"defaultsel": "Humm, choisez une options que vous aimer",
+		"required": "Vous devez absolument choisir quelques chose"
+	}
+}'>
+	<p>Choisissez du contenu à insérer:</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot; data-wb-fieldflow='{
+	&quot;i18n&quot;: {
+		&quot;btn&quot;: &quot;Faites ce qui est demandé&quot;,
+		&quot;defaultsel&quot;: &quot;Humm, choisez une options que vous aimer&quot;,
+		&quot;required&quot;: &quot;Vous devez absolument choisir quelques chose&quot;
+	}
+}'&gt;
+	&lt;p&gt;Choisissez du contenu à insérer:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>

--- a/src/plugins/fieldflow/fieldflow-en.hbs
+++ b/src/plugins/fieldflow/fieldflow-en.hbs
@@ -1,0 +1,220 @@
+---
+{
+	"title": "Field flow",
+	"language": "en",
+	"category": "Plugins",
+	"description": "Transform a basic list into a selectable list.",
+	"tag": "fieldflow",
+	"parentdir": "fieldflow",
+	"altLangPrefix": "fieldflow",
+	"dateModified": "2016-11-30"
+}
+---
+<p>Transform a basic list into a selectable list.</p>
+
+
+<ul>
+	<li>Field flow (current)</li>
+	<li><a href="basic-en.html">Field flow basic configuration</a></li>
+	<li><a href="advanced-en.html">Field flow advanced</a></li>
+</ul>
+
+<hr />
+
+<div class="wb-prettify all-pre"></div>
+
+<p>On this page:</p>
+<ul>
+	<li><a href="#redirect">Redirection</a></li>
+	<li><a href="#ajax">Ajax</a></li>
+	<li><a href="#grouping">Grouping</a></li>
+	<li><a href="#nesting">Nesting</a></li>
+</ul>
+
+
+<h2 id="redirect" class="page-header">Redirection</h2>
+
+<div class="wb-fieldflow">
+	<p>Find the plugin for the action you need:</p>
+
+	<ul>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html">Inserting content</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html">Photo galery</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">Draw charts</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">Expand and collapse content</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">Set a consistant height</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html">Popup content</a></li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Find the plugin for the action you need:&lt;/p&gt;
+
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+
+
+<h2 id="ajax" class="page-header">Ajax</h2>
+
+<div class="well">
+	<p>This functionality depends on the <a href="http://wet-boew.github.io/wet-boew/docs/ref/data-ajax/data-ajax-en.html">Data ajax plugin</a>.</p>
+</div>
+
+<div class="wb-fieldflow">
+	<p>Choose content to be ajaxed:</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Set 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Set 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Set 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Set 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<!-- Providing an alternative/multiple way could be required for WCAG conformance and/or design conform to progressive enhancement -->
+<p><em><a rel="alternate" href="#">Consult one page with the full list of all options</a> (Link not working)</em></p>
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choose content to be ajaxed:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-1.html">ajax/ajax-1.html</a>&quot;&gt;(Set 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-2.html">ajax/ajax-2.html</a>&quot;&gt;(Set 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-3.html">ajax/ajax-3.html</a>&quot;&gt;(Set 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-4.html">ajax/ajax-4.html</a>&quot;&gt;(Set 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;<a href="ajax/ajax-5.html">ajax/ajax-5.html</a>&quot;&gt;(Set 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;!-- Providing an alternative/multiple way could be required for WCAG conformance and/or design conform to progressive enhancement --&gt;
+&lt;p&gt;&lt;em&gt;&lt;a rel=&quot;alternate&quot; href=&quot;#&quot;&gt;Consult one page with the full list of all options&lt;/a&gt; (Link not working)&lt;/em&gt;&lt;/p&gt;</code></pre>
+
+
+
+
+
+<h2 id="grouping">Grouping</h2>
+
+<div class="wb-fieldflow">
+	<p>Find the plugin for the action you need.</p>
+	<ul>
+		<li>Layout and rendering
+			<ul>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html">Inserting content</a></li>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">Draw charts</a></li>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">Set a consistant height</a></li>
+			</ul>
+		</li>
+		<li>Interactive
+			<ul>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">Expand and collapse content</a></li>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html">Photo galery</a></li>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html">Popup content</a></li>
+			</ul>
+		</li>
+	</ul>
+</div>
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Find the plugin for the action you need.&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;Layout and rendering
+			&lt;ul&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Interactive
+			&lt;ul&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+
+<h2 id="nesting" class="page-header">Nesting <small>Adding subsequent control</small></h2>
+
+<div class="well">
+	<p>Consider to insert a textual clue into an item that will open up a subsequent drop down. Like, by adding a plus sign "+" at the beginning of the label. Remark that the subsequent drop down is identified by: <code>&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;</code>.</p>
+</div>
+
+<div class="wb-fieldflow">
+	<p>Find the plugin for the action you need.</p>
+	<ul>
+		<li>+ Layout and rendering
+			<div class="wb-fieldflow-sub">
+				<p>It is for?..</p>
+				<ul>
+					<li>+ Esthetic
+						<div class="wb-fieldflow-sub">
+							<p>What kind of transformation</p>
+							<ul>
+								<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html">Set a consistant height</a></li>
+							</ul>
+						</div>
+					</li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html">Inserting content</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html">Draw charts</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>+ Interactive
+			<div class="wb-fieldflow-sub">
+				<p class="wb-fieldflow-label">What kind of interaction?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html">Expand and collapse content</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html">Photo galery</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html">Popup content</a></li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Find the plugin for the action you need.&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;+ Layout and rendering
+			<strong>&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;</strong>
+				&lt;p&gt;It is for?..&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;+ Esthetic
+						<strong>&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;</strong>
+							&lt;p&gt;What kind of transformation&lt;/p&gt;
+							&lt;ul&gt;
+								&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-en.html&quot;&gt;Set a consistant height&lt;/a&gt;&lt;/li&gt;
+							&lt;/ul&gt;
+						<strong>&lt;/div&gt;</strong>
+					&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-en.html&quot;&gt;Inserting content&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-en.html&quot;&gt;Draw charts&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			<strong>&lt;/div&gt;</strong>
+		&lt;/li&gt;
+		&lt;li&gt;+ Interactive
+			<strong>&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;</strong>
+				&lt;p class=&quot;wb-fieldflow-label&quot;&gt;What kind of interaction?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-en.html&quot;&gt;Expand and collapse content&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-en.html&quot;&gt;Photo galery&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-en.html&quot;&gt;Popup content&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			<strong>&lt;/div&gt;</strong>
+		&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>

--- a/src/plugins/fieldflow/fieldflow-fr.hbs
+++ b/src/plugins/fieldflow/fieldflow-fr.hbs
@@ -1,0 +1,222 @@
+---
+{
+	"title": "Déroulement de champs",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Transforme une simple liste en un liste de choix.",
+	"tag": "fieldflow",
+	"parentdir": "fieldflow",
+	"altLangPrefix": "fieldflow",
+	"dateModified": "2016-11-30"
+}
+---
+<p>Transforme une simple liste en un liste de choix.</p>
+
+<ul>
+	<li>Déroulement de champs (actuelle)</li>
+	<li><a href="basic-fr.html">Déroulement de champs avec des configurations de base</a></li>
+	<li><a href="advanced-fr.html">Déroulement de champs avancé</a></li>
+</ul>
+
+<hr />
+
+<div class="wb-prettify all-pre"></div>
+
+<p>Sur cette page:</p>
+
+<ul>
+	<li><a href="#redirect">Redirection</a></li>
+	<li><a href="#ajax">Ajax</a></li>
+	<li><a href="#regroupement">Regroupement</a></li>
+	<li><a href="#imbrication">Imbrication</a></li>
+</ul>
+
+
+<h2 id="redirect" class="page-header">Redirection</h2>
+
+<div class="wb-fieldflow">
+	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
+
+	<ul>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html">Insertion de contenu</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html">Galerie photos</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">Dessiner des graphiques</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">Contenu affichable/masquable</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">Uniformisation de la hauteur</a></li>
+		<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">Afficher un contenu superposé</a></li>
+	</ul>
+</div>
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
+
+	&lt;ul&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;&gt;Insertion de contenu&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;&gt;Galerie photos&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;Dessiner des graphiques&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;Contenu affichable/masquable&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;Uniformisation de la hauteur&lt;/a&gt;&lt;/li&gt;
+		&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Afficher un contenu superposé&lt;/a&gt;&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+
+
+<h2 id="ajax" class="page-header">Ajax</h2>
+
+<div class="well">
+	<p>Cette fonctionalité dépend du <a href="http://wet-boew.github.io/wet-boew/docs/ref/data-ajax/data-ajax-fr.html">plugiciel Data ajax</a>.</p>
+</div>
+
+<div class="wb-fieldflow">
+	<p>Choisissez du contenu à insérer:</p>
+	<ul>
+		<li data-wb-fieldflow="ajax/ajax-1.html">(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.</li>
+		<li data-wb-fieldflow="ajax/ajax-2.html">(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.</li>
+		<li data-wb-fieldflow="ajax/ajax-3.html">(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.</li>
+		<li data-wb-fieldflow="ajax/ajax-4.html">(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.</li>
+		<li data-wb-fieldflow="ajax/ajax-5.html">(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.</li>
+	</ul>
+</div>
+
+<!-- Fournir des alternative et/ou des façons multiple à accéder au contenu pourrait être requis afin d'être conforme à la norme WCAG et/ou afin de respecter l'approche de l'amélioration progressive -->
+<p><em><a rel="alternate" href="#">Consulter la liste entière des options disponible</a> (Lien bidon)</em></p>
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Choisissez du contenu à insérer:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-1.html&quot;&gt;(Ensemble 1) Nunc sed mauris id nisi molestie porta at quis erat.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-2.html&quot;&gt;(Ensemble 2) Vestibulum pretium tortor vel facilisis sodales.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-3.html&quot;&gt;(Ensemble 3) Nunc sit amet dui ut justo efficitur dapibus.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-4.html&quot;&gt;(Ensemble 4) Praesent at purus ut turpis sollicitudin aliquam.&lt;/li&gt;
+		&lt;li data-wb-fieldflow=&quot;ajax/ajax-5.html&quot;&gt;(Ensemble 5) Sed eget dui ac nunc mattis consequat in a ex.&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;!-- Fournir des alternative et/ou des façons multiple à accéder au contenu pourrait être requis afin d'être conforme à la norme WCAG et/ou afin de respecter l'approche de l'amélioration progressive --&gt;
+&lt;p&gt;&lt;em&gt;&lt;a rel=&quot;alternate&quot; href=&quot;#&quot;&gt;Consulter la liste entière des options disponible&lt;/a&gt; (Lien bidon)&lt;/em&gt;&lt;/p&gt;</code></pre>
+
+
+
+
+<h2 id="regroupement">Regroupement</h2>
+
+<div class="wb-fieldflow">
+	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
+
+	<ul>
+		<li>Mise en page et présentation
+			<ul>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html">Insertion de contenu</a></li>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">Dessiner des graphiques</a></li>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">Uniformisation de la hauteur</a></li>
+			</ul>
+		</li>
+		<li>Intéraction
+			<ul>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">Contenu affichable/masquable</a></li>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html">Galerie photos</a></li>
+				<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">Afficher un contenu superposé</a></li>
+			</ul>
+		</li>
+	</ul>
+</div>
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
+
+	&lt;ul&gt;
+		&lt;li&gt;Mise en page et présentation
+			&lt;ul&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;&gt;Insertion de contenu&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;Dessiner des graphiques&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;Uniformisation de la hauteur&lt;/a&gt;&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/li&gt;
+		&lt;li&gt;Intéraction
+			&lt;ul&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;Contenu affichable/masquable&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;&gt;Galerie photos&lt;/a&gt;&lt;/li&gt;
+				&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Afficher un contenu superposé&lt;/a&gt;&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+
+
+
+<h2 id="imbrication" class="page-header">Imbrication <small>Ajout d'un contrôle subséquant</small></h2>
+
+<div class="well">
+	<p>Considerez d'inclure un indice textuel dans chaque items qui affichera une second liste déroulante. Par example, ceci peut ce faire en ajoutant le signe "+" au début de l'étiquette. Veuillez remarquer que les liste déroulante sont identifié par la présence de: <code>&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;</code>.</p>
+</div>
+
+<div class="wb-fieldflow">
+	<p>Trouvez le plugiciel qui répond à vos besoin:</p>
+	<ul>
+		<li>+ Mise en page et présentation
+			<div class="wb-fieldflow-sub">
+				<p>Et c'est pour?</p>
+				<ul>
+					<li>+ L'apparance
+						<div class="wb-fieldflow-sub">
+							<p>Quel sorte de transformation?</p>
+							<ul>
+								<li><a href="http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html">Uniformisation de la hauteur</a></li>
+							</ul>
+						</div>
+					</li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html">Insertion de contenu</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html">Dessiner des graphiques</a></li>
+				</ul>
+			</div>
+		</li>
+		<li>+ Intéraction
+			<div class="wb-fieldflow-sub">
+				<p class="wb-fieldflow-label">Quel type d'intéraction?</p>
+				<ul>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html">Contenu affichable/masquable</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html">Galerie photos</a></li>
+					<li><a href="http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html">Afficher un contenu superposé</a></li>
+				</ul>
+			</div>
+		</li>
+	</ul>
+</div>
+
+
+<pre><code>&lt;div class=&quot;wb-fieldflow&quot;&gt;
+	&lt;p&gt;Trouvez le plugiciel qui répond à vos besoin:&lt;/p&gt;
+	&lt;ul&gt;
+		&lt;li&gt;+ Mise en page et présentation
+			<strong>&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;</strong>
+				&lt;p&gt;Et c'est pour?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;+ L'apparance
+						<strong>&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;</strong>
+							&lt;p&gt;Quel sorte de transformation?&lt;/p&gt;
+							&lt;ul&gt;
+								&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/equalheight/equalheight-fr.html&quot;&gt;Uniformisation de la hauteur&lt;/a&gt;&lt;/li&gt;
+							&lt;/ul&gt;
+						<strong>&lt;/div&gt;</strong>
+					&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/data-ajax/data-ajax-fr.html&quot;&gt;Insertion de contenu&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/charts/charts-fr.html&quot;&gt;Dessiner des graphiques&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			<strong>&lt;/div&gt;</strong>
+		&lt;/li&gt;
+		&lt;li&gt;+ Intéraction
+			<strong>&lt;div class=&quot;wb-fieldflow-sub&quot;&gt;</strong>
+				&lt;p class=&quot;wb-fieldflow-label&quot;&gt;Quel type d'intéraction?&lt;/p&gt;
+				&lt;ul&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/details/details-fr.html&quot;&gt;Contenu affichable/masquable&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/lightbox/lightbox-fr.html&quot;&gt;Galerie photos&lt;/a&gt;&lt;/li&gt;
+					&lt;li&gt;&lt;a href=&quot;http://wet-boew.github.io/v4.0-ci/demos/overlay/overlay-fr.html&quot;&gt;Afficher un contenu superposé&lt;/a&gt;&lt;/li&gt;
+				&lt;/ul&gt;
+			<strong>&lt;/div&gt;</strong>
+		&lt;/li&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>

--- a/src/plugins/fieldflow/fieldflow.js
+++ b/src/plugins/fieldflow/fieldflow.js
@@ -1,0 +1,1282 @@
+/**
+ * @title WET-BOEW Field Flow
+ * @overview Transform a basic list into a selectable list.
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @duboisp
+ */
+( function( $, document, wb ) {
+"use strict";
+
+var componentName = "wb-fieldflow",
+	selector = "." + componentName,
+	formComponent = componentName + "-form",
+	subComponentName = componentName + "-sub",
+	crtlSelectClass = componentName + "-init",
+	crtlSelectSelector = "." + crtlSelectClass,
+	basenameInput = componentName + wb.getId(),
+	basenameInputSelector = "[name^=" + basenameInput + "]",
+	labelClass = componentName + "-label",
+	headerClass = componentName + "-header",
+	selectorForm = "." + formComponent,
+	initEvent = "wb-init" + selector,
+	drawEvent = "draw" + selector,
+	actionEvent = "action" + selector,
+	submitEvent = "submit" + selector,
+	submitedEvent = "submited" + selector,
+	readyEvent = "ready" + selector,
+	cleanEvent = "clean" + selector,
+	resetActionEvent = "reset" + selector,
+	createCtrlEvent = "createctrl" + selector,
+	registerJQData = componentName + "-register", // Data that contain all the component registered (to the form element and component), used for executing action upon submit
+	registerHdnFld = componentName + "-hdnfld",
+	configData = componentName + "-config",
+	pushJQData =  componentName + "-push",
+	submitJQData =  componentName + "-submit", // List of action to perform upon form submission
+	actionData =  componentName + "-action", // temp for code transition
+	originData =  componentName + "-origin", // To carry the plugin origin ID, any implementation of "createCtrlEvent" must set that option.
+	sourceDataAttr =  "data-" + componentName + "-source",
+	flagOptValueData =  componentName + "-flagoptvalue",
+	$document = wb.doc,
+	defaults = {
+		toggle: {
+			stateOn: "visible", // For toggle plugin
+			stateOff: "hidden"  // For toggle plugin
+		},
+		i18n:
+		{
+			"en": {
+				btn: "Continue", // Action button
+				defaultsel: "Make your selection...", // text use for the first empty select
+				required: "required"// text for the required label
+			},
+			"fr": {
+				btn: "Allez",
+				defaultsel: "Sélectionnez dans la liste...", // text use for the first empty select
+				required: "obligatoire" // text for the required label
+			}
+		},
+		action: "ajax",
+		prop: "url"
+	},
+	fieldflowActionsEvents = [
+		[
+			"redir",
+			"query",
+			"ajax",
+			"addClass",
+			"removeClass",
+			"removeClass",
+			"append",
+			"tblfilter",
+			"toggle"
+		].join( "." + actionEvent + " " ) + "." + actionEvent,
+		[
+			"ajax",
+			"toggle",
+			"redir",
+			"addClass",
+			"removeClass"
+		].join( "." + submitEvent + " " ) + "." + submitEvent,
+		[
+			"tblfilter",
+			componentName
+		].join( "." + drawEvent + " " ) + "." + drawEvent,
+		[
+			"select",
+			"checkbox",
+			"radio"
+		].join( "." + createCtrlEvent + " " ) + "." + createCtrlEvent
+	].join( " " ),
+
+	/**
+	* @method init
+	* @param {jQuery Event} event Event that triggered the function call
+	*/
+	init = function( event ) {
+		var elm = wb.init( event, componentName, selector ),
+			$elm, elmId,
+			wbDataElm,
+			config,
+			i18n;
+
+		if ( elm ) {
+			$elm = $( elm );
+			elmId = elm.id;
+
+			// Set default i18n information
+			if ( defaults.i18n[ wb.lang ] ) {
+				defaults.i18n = defaults.i18n[ wb.lang ];
+			}
+
+			// Extend this data with the contextual default
+			wbDataElm = wb.getData( $elm, componentName );
+			if ( wbDataElm && wbDataElm.i18n ) {
+				wbDataElm.i18n = $.extend( {}, defaults.i18n, wbDataElm.i18n );
+			}
+			config = $.extend( {}, defaults, wbDataElm );
+
+			// Set the data to the component, if other event need to have access to it.
+			$elm.data( configData, config );
+			i18n = config.i18n;
+
+			// Add startWith function (ref: https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/String/startsWith)
+			if ( !String.prototype.startsWith ) {
+				String.prototype.startsWith = function( searchString, position ) {
+					position = position || 0;
+					return this.substr( position, searchString.length ) === searchString;
+				};
+			}
+
+			// Transform the list into a select, use the first paragrap content for the label, and extract for i18n the name of the button action.
+			var bodyID = wb.getId(),
+				stdOut,
+				formElm, $form;
+
+			if ( config.noForm ) {
+				stdOut = "<div class='mrgn-tp-md'><div id='" + bodyID + "'></div></div>";
+
+				// Need to add the class="formComponent" to the div that wrap the form element.
+				formElm = elm.parentElement;
+				while ( formElm.nodeName !== "FORM" ) {
+					formElm = formElm.parentElement;
+				}
+				$( formElm.parentElement ).addClass( formComponent );
+			} else {
+				stdOut = "<div class='wb-frmvld " + formComponent + "'><form><div id='" + bodyID + "'>";
+				stdOut = stdOut + "</div><input type=\"submit\" value=\"" + i18n.btn + "\" class=\"btn btn-primary mrgn-bttm-md\" /> </form></div>";
+			}
+			$elm.addClass( "hidden" );
+			stdOut = $( stdOut );
+			$elm.after( stdOut );
+
+			if ( !config.noForm ) {
+				formElm = stdOut.find( "form" );
+				stdOut.trigger( "wb-init.wb-frmvld" );
+			}
+
+			$form = $( formElm );
+
+			// Register this plugin within the form, this is to manage form submission
+			pushData( $form, registerJQData, elmId );
+
+			if ( !config.outputctnrid ) { // Output container ID
+				config.outputctnrid = bodyID;
+			}
+
+			if ( !config.source ) {
+				config.source = elm; // We assume th container have the source
+			}
+
+			if ( !config.srctype ) {
+				config.srctype = componentName;
+			}
+
+			config.inline = !!config.inline;
+
+			// Trigger the drop down loading
+			$elm.trigger( config.srctype + "." + drawEvent, config );
+
+			// Do requested DOM manipulation
+			if ( config.unhideelm ) {
+				$( config.unhideelm ).removeClass( "hidden" );
+			}
+			if ( config.hideelm ) {
+				$( config.hideelm ).addClass( "hidden" );
+			}
+
+			// Identify that initialization has completed
+			wb.ready( $elm, componentName );
+
+			if ( config.ext ) {
+				config.form = $form.get( 0 );
+				$elm.trigger( config.ext + "." + readyEvent, config );
+			}
+		}
+	},
+	pushData = function( $elm, prop, data, reset ) {
+		var dtCache = $elm.data( prop );
+		if ( !dtCache || reset ) {
+			dtCache = [];
+		}
+		dtCache.push( data );
+		return $elm.data( prop, dtCache );
+	},
+	subRedir = function( event, data ) {
+
+		var form = data.form,
+			url = data.url;
+
+		if ( url ) {
+			form.setAttribute( "action", url );
+		}
+	},
+	actQuery = function( event, data ) {
+		var $selectElm = data.$selElm,
+			fieldName = data.name,
+			fieldValue = data.value;
+
+		if ( fieldName ) {
+			data.provEvt.setAttribute( "name", fieldName );
+		}
+		if ( fieldValue ) {
+			$selectElm.val( fieldValue );
+		}
+
+		// Add a flag to know the option value was inserted
+		$selectElm.attr( "data-" + flagOptValueData, flagOptValueData );
+	},
+	actAjax = function( event, data ) {
+		var provEvt = data.provEvt,
+			$container;
+
+		if ( !data.live ) {
+			data.preventSubmit = true;
+			pushData( $( provEvt ), submitJQData, data );
+		} else {
+			if ( !data.container ) {
+
+				// Create the container next to component
+				$container = $( "<div></div>" );
+				$( provEvt.parentNode ).append( $container );
+				data.container = $container.get( 0 );
+			}
+			$( event.target ).trigger( "ajax." + submitEvent, data );
+		}
+	},
+	subAjax = function( event, data ) {
+		var $container, containerID, ajxType,
+			cleanSelector = data.clean;
+
+		if ( !data.container ) {
+			containerID = wb.getId();
+			$container = $( "<div id='" + containerID + "'></div>" );
+			$( data.form ).append( $container );
+			cleanSelector = "#" + containerID;
+		} else {
+			$container = $( data.container );
+		}
+
+		if ( cleanSelector ) {
+			$( data.origin ).one( cleanEvent, function( ) {
+				$( cleanSelector ).empty();
+			} );
+		}
+
+		if ( data.trigger ) {
+			$container.attr( "data-trigger-wet", "true" );
+		}
+
+		ajxType = data.type ? data.type : "replace";
+		$container.attr( "data-ajax-" + ajxType, data.url );
+
+		$container.one( "wb-contentupdated", function( event, data ) {
+			var updtElm = event.currentTarget,
+				trigger = updtElm.getAttribute( "data-trigger-wet" );
+
+			updtElm.removeAttribute( "data-ajax-" + data[ "ajax-type" ] );
+			if ( trigger ) {
+				$( updtElm )
+					.find( wb.allSelectors )
+						.addClass( "wb-init" )
+						.filter( ":not(#" + updtElm.id + " .wb-init .wb-init)" )
+							.trigger( "timerpoke.wb" );
+				updtElm.removeAttribute( "data-trigger-wet" );
+			}
+		} );
+		$container.trigger( "wb-update.wb-data-ajax" );
+	},
+	subToggle = function( event, data ) {
+		var $origin = $( data.origin ),
+			config = $( event.target ).data( configData ),
+			toggleOpts = data.toggle;
+
+
+		// For simple toggle call syntax
+		if ( toggleOpts && typeof toggleOpts === "string" ) {
+			toggleOpts = { selector: toggleOpts };
+		}
+		toggleOpts = $.extend( {}, toggleOpts, config.toggle );
+
+		// Doing an add and remove "wb-toggle" class in order to avoid the click event added by toggle plugin
+		$origin.addClass( "wb-toggle" );
+		$origin.trigger( "toggle.wb-toggle", toggleOpts );
+
+		// Set the cleaning task
+		toggleOpts.type = "off";
+		$origin.one( cleanEvent, function( ) {
+			$origin.addClass( "wb-toggle" );
+			$origin.trigger( "toggle.wb-toggle", toggleOpts );
+			$origin.removeClass( "wb-toggle" );
+		} );
+	},
+	actAppend = function( event, data ) {
+		if ( event.namespace === actionEvent ) {
+			var srctype = data.srctype ? data.srctype : componentName;
+			data.container = data.provEvt.parentNode.id;
+			if ( !data.source ) {
+				throw "A source is required to append a field flow control.";
+			}
+			$( event.currentTarget ).trigger( srctype + "." + drawEvent, data );
+		}
+	},
+	actTblFilter = function( event, data ) {
+		if ( event.namespace === actionEvent ) {
+			var sourceSelector = data.source,
+				$datatable = $( sourceSelector ).dataTable( { "retrieve": true } ).api(),
+				$dtSelectedColumn,
+				column = data.column,
+				colInt = parseInt( column, 10 ),
+				regex = !!data.regex,
+				smart = ( !data.smart ) ? true : !!data.smart,
+				caseinsen = ( !data.caseinsen ) ? true : !!data.caseinsen;
+
+			column = ( colInt === true ) ? colInt : column;
+
+			$dtSelectedColumn = $datatable.column( column );
+
+			$dtSelectedColumn.search( data.value, regex, smart, caseinsen ).draw();
+
+			// Add a clean up task
+			$( data.provEvt ).one( cleanEvent, function( ) {
+				$dtSelectedColumn.search( "" ).draw();
+			} );
+
+		}
+	},
+	drwTblFilter = function( event, data ) {
+		if ( event.namespace === drawEvent ) {
+			var selColumn = data.column, // (integer/datatable column selector)
+				csvExtract = data.csvextract, // (true|false) assume items are in CSV format instead of being inside "li" elements
+				$column,
+				sourceSelector = data.source,
+				$source = $( sourceSelector ),
+				$datatable,
+				arrData, $listItem,
+				i, i_len,
+				j, j_len,
+				items = [ ],
+				cur_itm,
+				prefLabel = data.label,
+				defaultSelectedLabel = data.defaultselectedlabel,
+				lblselector = data.lblselector,
+				filterSequence = data.fltrseq ? data.fltrseq : [ ],
+				limit = data.limit ? data.limit : 10,
+				firstFilterSeq,
+				actionItm, filterItm,
+				renderas;
+
+			// Check if the datatable has been loaded, if not we will wait until it is.
+			if ( !$source.hasClass( "wb-tables-inited" ) ) {
+				$source.one( "wb-ready.wb-tables", function() {
+					$( event.target ).trigger( "tblfilter." + drawEvent, data );
+				} );
+				return false;
+			}
+			$datatable = $source.dataTable( { "retrieve": true } ).api();
+
+			if ( $datatable.rows( { "search": "applied" } ).data().length <= limit  ) {
+				return true;
+			}
+
+			renderas = data.renderas ? data.renderas : "select"; // Default it will render as select
+
+			if ( !selColumn && filterSequence.length ) {
+				cur_itm = filterSequence.shift();
+				if ( !cur_itm.column ) {
+					throw "Column is undefined in the filter sequence";
+				}
+				selColumn = cur_itm.column;
+				csvExtract = cur_itm.csvextract;
+				defaultSelectedLabel = cur_itm.defaultselectedlabel;
+				prefLabel = cur_itm.label;
+				lblselector = cur_itm.lblselector;
+			}
+
+			$column = $datatable.column( selColumn, { "search": "applied" } );
+
+			// Get the items
+			if ( csvExtract ) {
+				arrData = $column.data();
+				for ( i = 0, i_len = arrData.length; i !== i_len; i += 1 ) {
+					items = items.concat( arrData[ i ].split( "," ) );
+				}
+			} else {
+				arrData = $column.nodes();
+				for ( i = 0, i_len = arrData.length; i !== i_len; i += 1 ) {
+					$listItem = $( arrData[ i ] ).find( "li" );
+					for ( j = 0, j_len = $listItem.length; j !== j_len; j += 1 ) {
+						items.push( $( $listItem[ j ] ).text() );
+					}
+				}
+			}
+
+			items = items.sort().filter( function( item, pos, ary ) {
+				return !pos || item !== ary[ pos - 1 ];
+			} );
+
+			var elm = event.target,
+				$elm = $( elm ),
+				itemsToCreate = [ ],
+				pushAction = data.actions ? data.actions : [ ];
+
+			if ( filterSequence.length ) {
+				firstFilterSeq = filterSequence[ 0 ];
+				filterItm = {
+					action: "append",
+					srctype: "tblfilter",
+					source: sourceSelector,
+					renderas: firstFilterSeq.renderas ? firstFilterSeq.renderas : renderas,
+					fltrseq: filterSequence,
+					limit: limit
+				};
+			}
+			for ( i = 0, i_len = items.length; i !== i_len; i += 1 ) {
+				cur_itm = items[ i ];
+				actionItm = {
+					label: cur_itm,
+					actions: [
+						{ // Set an action upon item selection
+							action: "tblfilter",
+							source: sourceSelector,
+							column: selColumn,
+							value: cur_itm
+						}
+					]
+				};
+				if ( filterItm ) {
+					actionItm.actions.push( filterItm );
+				}
+				itemsToCreate.push( actionItm );
+			}
+
+			if ( !prefLabel ) {
+				prefLabel = $column.header().textContent;
+			}
+
+			if ( !data.outputctnrid ) {
+				data.outputctnrid = data.provEvt.parentElement.id;
+			}
+
+			$elm.trigger( renderas + "." + createCtrlEvent, {
+				actions: pushAction,
+				source: $source.get( 0 ),
+				outputctnrid: data.outputctnrid,
+				label: prefLabel,
+				defaultselectedlabel: defaultSelectedLabel,
+				lblselector: lblselector,
+				items: itemsToCreate,
+				inline: data.inline
+			} );
+
+		}
+	},
+	drwFieldflow = function( event, data ) {
+		if ( event.namespace === drawEvent ) {
+			var elm = event.target,
+				$elm = $( elm ),
+				wbDataElm,
+				$source = $( data.source ),
+				source = $source.get( 0 ),
+				$labelExplicit, $firstChild,
+				labelSelector = data.lblselector || "." + labelClass,
+				labelTxt,
+				$items = getItemsData( $source.find( "ul:first() > li" ) ),
+				actions,
+				renderas;
+
+			// Extend if it is a sub-component
+			if ( $source.hasClass( subComponentName ) ) {
+				wbDataElm = wb.getData( $source, componentName );
+				$source.data( configData, wbDataElm );
+				data = $.extend( {}, data, wbDataElm );
+			}
+
+			actions = data.actions || [ ];
+			renderas = data.renderas ? data.renderas : "select"; // Default it will render as select
+
+			// Check if the first node is a div and contain the label.
+			if ( !source.id ) {
+				source.id = wb.getId();
+			}
+			$firstChild = $source.children().first();
+
+			if ( !$firstChild.hasClass( headerClass ) ) {
+
+				// Only use what defined as the label, nothing else
+				$labelExplicit = $firstChild.find( labelSelector );
+				if ( $labelExplicit.length ) {
+					labelTxt = $labelExplicit.html();
+				} else {
+					labelTxt = $source.find( "> p" ).html();
+				}
+				labelSelector = null; // unset the label selector because it not needed for the control creation
+			} else {
+				labelTxt = $firstChild.html();
+			}
+
+			if ( !data.outputctnrid ) {
+				data.outputctnrid = data.provEvt.parentElement.id;
+			}
+
+			$elm.trigger( renderas + "." + createCtrlEvent, {
+				actions: actions,
+				source: source,
+				attributes: data.attributes,
+				outputctnrid: data.outputctnrid,
+				label: labelTxt,
+				lblselector: labelSelector,
+				defaultselectedlabel: data.defaultselectedlabel,
+				required: !!!data.isoptional,
+				items: $items,
+				inline: data.inline
+			} );
+		}
+	},
+	ctrlSelect = function( event, data ) {
+		var bodyId = data.outputctnrid,
+			$body = $( "#" + bodyId ),
+			actions = data.actions,
+			lblselector = data.lblselector,
+			isReq = !!data.required,
+			items = data.items,
+			elm = event.target,
+			$elm = $( elm ),
+			source = data.source,
+			attributes = data.attributes,
+			i18n = $elm.data( configData ).i18n,
+			autoID = wb.getId(),
+			labelPrefix = "<label for='" + autoID + "'",
+			labelSuffix = "</span>",
+			$out, $tmpLabel,
+			selectOut, $selectOut,
+			defaultSelectedLabel = data.defaultselectedlabel ? data.defaultselectedlabel : i18n.defaultsel,
+			i, i_len, j, j_len, cur_itm;
+
+		// Create the label
+		if ( isReq ) {
+			labelPrefix += " class='required'";
+			labelSuffix += " <strong class='required'>(" + i18n.required + ")</strong>";
+		}
+		labelPrefix += "><span class='field-name'>";
+		labelSuffix += "</label>";
+
+		if ( !lblselector ) {
+			$out = $( labelPrefix + data.label + labelSuffix );
+		} else {
+			$out = $( "<div>" + data.label + "</div>" );
+			$tmpLabel = $out.find( lblselector );
+			$tmpLabel.html( labelPrefix + $tmpLabel.html() + labelSuffix );
+		}
+
+		// Create the select
+		selectOut = "<select id='" + autoID + "' name='" + basenameInput + autoID + "' class='full-width form-control mrgn-bttm-md " + crtlSelectClass + "' data-" + originData + "='" + elm.id + "' " + sourceDataAttr + "='" + source.id + "'";
+		if ( isReq ) {
+			selectOut += " required";
+		}
+		if ( attributes && typeof attributes === "object" ) {
+			for ( i in attributes ) {
+				if ( attributes.hasOwnProperty( i ) ) {
+					selectOut += " " + i + "='" + attributes[ i ] + "'";
+				}
+			}
+		}
+		selectOut += "><option value=''>" + defaultSelectedLabel + "</option>";
+		for ( i = 0, i_len = items.length; i !== i_len; i += 1 ) {
+			cur_itm = items[ i ];
+
+			if ( !cur_itm.group ) {
+				selectOut += buildSelectOption( cur_itm );
+			} else {
+
+				// We have a group of sub-items, the cur_itm are a group
+				selectOut += "<optgroup label='" + cur_itm.label + "'>";
+				j_len = cur_itm.group.length;
+				for ( j = 0; j !== j_len; j += 1 ) {
+					selectOut += buildSelectOption( cur_itm.group[ j ] );
+				}
+				selectOut += "</optgroup>";
+			}
+		}
+		selectOut += "</select>";
+		$selectOut = $( selectOut );
+
+		$body.append( $out ).append( $selectOut );
+
+		// Set post action if any
+		if ( actions && actions.length > 0 ) {
+			$selectOut.data( pushJQData, actions );
+		}
+
+		// Register this control
+		pushData( $elm, registerJQData, autoID );
+	},
+	ctrlChkbxRad = function( event, data ) {
+		var bodyId = data.outputctnrid,
+			actions = data.actions,
+			lblselector = data.lblselector,
+			isReq = !!data.required,
+			items = data.items,
+			elm = event.target,
+			$elm = $( elm ),
+			source = data.source,
+			i18n = $elm.data( configData ).i18n,
+			attributes = data.attributes,
+			ctrlID = wb.getId(),
+			fieldsetPrefix = "<legend class='h5 ",
+			fieldsetSuffix = "</span>",
+			fieldsetHTML = "<fieldset id='" + ctrlID + "' data-" + originData + "='" + elm.id + "' " + sourceDataAttr + "='" + source.id + "' class='" + crtlSelectClass + " mrgn-bttm-md'",
+			$out,
+			$tmpLabel, $cloneLbl, $prevContent,
+			radCheckOut = "",
+			typeRadCheck = data.typeRadCheck,
+			isInline = data.inline,
+			fieldName = basenameInput + ctrlID,
+			i, i_len, j, j_len, cur_itm;
+
+		if ( attributes && typeof attributes === "object" ) {
+			for ( i in attributes ) {
+				if ( attributes.hasOwnProperty( i ) ) {
+					fieldsetHTML += " " + i + "='" + attributes[ i ] + "'";
+				}
+			}
+		}
+		$out = $( fieldsetHTML + "></fieldset>" );
+
+		// Create the legend
+		if ( isReq ) {
+			fieldsetPrefix += " required";
+			fieldsetSuffix += " <strong class='required'>(" + i18n.required + ")</strong>";
+		}
+		fieldsetPrefix += "'>";
+		fieldsetSuffix += "</legend>";
+		if ( !lblselector ) {
+			$out.append( $( fieldsetPrefix + data.label + fieldsetSuffix ) );
+		} else {
+			$cloneLbl = $( "<div>" + data.label + "</div>" );
+			$tmpLabel = $cloneLbl.find( lblselector );
+			$out.append( ( fieldsetPrefix + $tmpLabel.html() + fieldsetSuffix ) )
+				.append( $tmpLabel.nextAll() );
+			$prevContent = $tmpLabel.prevAll();
+		}
+
+		// Create radio
+		for ( i = 0, i_len = items.length; i !== i_len; i += 1 ) {
+			cur_itm = items[ i ];
+
+			if ( !cur_itm.group ) {
+				radCheckOut += buildCheckboxRadio( cur_itm, fieldName, typeRadCheck, isInline, isReq );
+			} else {
+
+				// We have a group of sub-items, the cur_itm are a group
+				radCheckOut += "<p>" + cur_itm.label + "</p>";
+				j_len = cur_itm.group.length;
+				for ( j = 0; j !== j_len; j += 1 ) {
+					radCheckOut += buildCheckboxRadio( cur_itm.group[ j ], fieldName, typeRadCheck, isInline, isReq );
+				}
+			}
+		}
+		$out.append( radCheckOut );
+		$( "#" + bodyId ).append( $out );
+		if ( $prevContent ) {
+			$out.before( $prevContent );
+		}
+
+		// Set post action if any
+		if ( actions && actions.length > 0 ) {
+			$out.data( pushJQData, actions );
+		}
+
+		// Register this control
+		pushData( $elm, registerJQData, ctrlID );
+	},
+	getItemsData = function( $items, preventRecusive ) {
+		var arrItems = $items.get(),
+			i, i_len = arrItems.length, itmCached,
+			itmLabel, itmValue, grpItem,
+			j, j_len, childNodes, firstNode, childNode, $childNode, childNodeID,
+			parsedItms = [],
+			actions;
+
+		for ( i = 0; i !== i_len; i += 1 ) {
+			itmCached = arrItems[ i ];
+
+			itmValue = "";
+			grpItem = null;
+			itmLabel = "";
+
+			firstNode = itmCached.firstChild;
+			childNodes = itmCached.childNodes;
+			j_len = childNodes.length;
+
+			if ( !firstNode ) {
+				throw "You have a markup error, There may be an empyt <li> elements in your list.";
+			}
+
+			actions = [];
+
+			// Is firstNode an anchor?
+			if ( firstNode.nodeName === "A" ) {
+				itmValue = firstNode.getAttribute( "href" );
+				itmLabel = $( firstNode ).html();
+				j_len = 1; // Force following elements to be ignored
+
+				actions.push( {
+					action: "redir",
+					url: itmValue
+				} );
+			}
+
+			// Iterate until we have found the labelClass or <ul> or element with subSelector or end of the array
+			for ( j = 1; j !== j_len; j += 1 ) {
+				childNode = childNodes[ j ];
+				$childNode = $( childNode );
+
+				// Sub plugin
+				if ( $childNode.hasClass( subComponentName ) ) {
+					childNodeID = childNode.id || wb.getId();
+					childNode.id = childNodeID;
+					itmValue = componentName + "-" + childNodeID;
+
+					actions.push( {
+						action: "append",
+						srctype: componentName,
+						source: "#" + childNodeID
+					} );
+					break;
+				}
+
+				// Grouping
+				if ( childNode.nodeName === "UL" ) {
+					if ( preventRecusive ) {
+						throw "Recursive error, please check your code";
+					}
+					grpItem = getItemsData( $childNode.children(), true );
+				}
+
+				// Explicit label to use
+				if ( $childNode.hasClass( labelClass ) ) {
+					itmLabel = $childNode.html();
+				}
+			}
+
+			if ( !itmLabel ) {
+				itmLabel = firstNode.nodeValue;
+			}
+
+			// Set an id on the element
+			if ( !itmCached.id ) {
+				itmCached.id = wb.getId();
+			}
+
+			// Return the item parsed
+			parsedItms.push( {
+				"bind": itmCached.id,
+				"label": itmLabel,
+				"actions": actions,
+				"group": grpItem
+			} );
+		}
+		return parsedItms;
+	},
+	buildSelectOption = function( data ) {
+		var label = data.label,
+			out = "<option value='" + label + "'";
+
+		out += buildDataAttribute( data );
+
+		out += ">" + label + "</option>";
+
+		return out;
+	},
+	buildDataAttribute = function( data ) {
+		var out = "",
+			dataFieldflow = {};
+
+		dataFieldflow.bind = data.bind || "";
+		dataFieldflow.actions = data.actions || [ ];
+
+		out += " data-" + componentName + "='" + JSON.stringify( dataFieldflow ) + "'";
+
+		return out;
+	},
+	buildCheckboxRadio = function( data, fieldName, inputType, isInline, isReq ) {
+		var label = data.label,
+			fieldID = wb.getId(),
+			inline = isInline ? "-inline" : "",
+			out = " for='" + fieldID + "'><input id='" + fieldID + "' type='" + inputType + "' name='" + fieldName + "' value='" + label + "'";
+
+		if ( isInline ) {
+			out = "<label class='" + inputType + inline + "'" + out;
+		} else {
+			out = "<div class='" + inputType + "'><label" + out;
+		}
+
+		out += buildDataAttribute( data );
+
+		if ( isReq ) {
+			out += " required='required'";
+		}
+		out += " /> " + label + "</label>";
+
+		if ( !isInline ) {
+			out += "</div>";
+		}
+
+		return out;
+	};
+
+$document.on( resetActionEvent, selector + ", ." + subComponentName, function( event ) {
+	var elm = event.target,
+		$elm,
+		settings,
+		settingsReset,
+		resetAction = [],
+		i, i_len, i_cache, action, isLive;
+
+	if ( elm === event.currentTarget ) {
+		$elm = $( elm );
+		settings = $elm.data( configData );
+
+		if ( settings && settings.reset ) {
+			settingsReset = settings.reset;
+
+			if ( $.isArray( settingsReset ) ) {
+				resetAction = settingsReset;
+			} else {
+				resetAction.push( settingsReset );
+			}
+
+			i_len = resetAction.length;
+			for ( i = 0; i !== i_len; i += 1 ) {
+				i_cache = resetAction[ i ];
+				action = i_cache.action;
+				if ( action ) {
+					isLive = i_cache.live;
+					if ( isLive !== false ) {
+						i_cache.live = true;
+					}
+					$elm.trigger( action + "." + actionEvent, i_cache );
+				}
+			}
+		}
+	}
+} );
+
+// Load content after the user have choosen an option
+$document.on( "change", selectorForm + " " + crtlSelectSelector, function( event ) {
+
+	var elm = event.currentTarget,
+		$elm = $( elm ),
+		selCurrentElm, cacheAction,
+		i, i_len, dtCached, dtCachedTarget,
+		itmToClean = $elm.nextAll(), itm, idxItem,
+		$orgin = $( "#" + elm.getAttribute( "data-" + originData ) ),
+		$source = $( "#" + elm.getAttribute( sourceDataAttr ) ),
+		lstIdRegistered = $orgin.data( registerJQData ),
+		$optSel = $elm.find( ":checked", $elm ),
+		form = $elm.get( 0 ).form;
+
+	//
+	// 1. Cleaning
+	//
+	i_len = itmToClean.length;
+	if ( i_len ) {
+		for ( i = i_len; i !== 0; i -= 1 ) {
+			itm = itmToClean[ i ];
+			if ( itm ) {
+				idxItem = lstIdRegistered.indexOf( itm.id );
+				if ( idxItem > -1 ) {
+					lstIdRegistered.splice( idxItem, 1 );
+				}
+				$( "#" + itm.getAttribute( sourceDataAttr ) ).trigger( resetActionEvent ).trigger( cleanEvent );
+				$( itm ).trigger( cleanEvent );
+			}
+		}
+		$orgin.data( registerJQData, lstIdRegistered );
+		itmToClean.remove();
+	}
+	$source.trigger( resetActionEvent ).trigger( cleanEvent );
+	$elm.trigger( cleanEvent );
+
+	// Remove any action that is pending for form submission
+	$elm.data( submitJQData, [] );
+
+	//
+	// 2. Get defined actions
+	//
+
+	var actions = [],
+		settings, settingsSrc, selFieldFlowData,
+		actionAttr,
+		defaultAction,
+		defaultProp,
+		baseAction,
+		nowActions = [],
+		postActions = [], postAction_len,
+		bindTo,
+		bindToElm;
+
+	// From the component, default action
+	settings = $orgin.data( configData );
+	settingsSrc = $source.data( configData );
+	if ( settingsSrc && settings ) {
+		settings = $.extend( {}, settings, settingsSrc );
+	}
+	if ( $optSel.length && $optSel.val() && settings && settings.default ) {
+		cacheAction = settings.default;
+		if ( $.isArray( cacheAction ) ) {
+			actions = cacheAction;
+		} else {
+			actions.push( cacheAction );
+		}
+	}
+
+	defaultAction = settings.action;
+	defaultProp = settings.prop;
+	actionData = settings.actionData || {};
+
+	// From the component, action pushed for later
+	cacheAction = $elm.data( pushJQData );
+	if ( cacheAction ) {
+		actions = actions.concat( cacheAction );
+	}
+
+	// For each the binded elements that are selected
+	for ( i = 0, i_len = $optSel.length; i !== i_len; i += 1 ) {
+		selCurrentElm = $optSel.get( i );
+		selFieldFlowData = wb.getData( selCurrentElm, componentName );
+		if ( selFieldFlowData ) {
+			bindTo = selFieldFlowData.bind;
+			actions = actions.concat( selFieldFlowData.actions );
+
+			if ( bindTo ) {
+
+				// Retreive action set on the binded element
+				bindToElm = document.getElementById( bindTo );
+				actionAttr = bindToElm.getAttribute( "data-" + componentName );
+				if ( actionAttr ) {
+					if ( actionAttr.startsWith( "{" ) || actionAttr.startsWith( "[" ) ) {
+						try {
+							cacheAction = JSON.parse( actionAttr );
+						} catch ( error ) {
+							$.error( "Bad JSON object " + actionAttr );
+						}
+						if ( !$.isArray( cacheAction ) ) {
+							cacheAction = [ cacheAction ];
+						}
+					} else {
+						cacheAction = {};
+						cacheAction.action = defaultAction;
+						cacheAction[ defaultProp ] = actionAttr;
+						cacheAction = $.extend( true, {}, actionData, cacheAction );
+						cacheAction = [ cacheAction ];
+					}
+					actions = actions.concat( cacheAction );
+				}
+			}
+		}
+	}
+
+	// If there is no action, do nothing
+	if ( !actions.length ) {
+		return true;
+	}
+
+	//
+	// 3. Sort action
+	// 			array1 = Action to be executed now
+	//			array2 = Action to be postponed for later use
+	for ( i = 0, i_len = actions.length; i !== i_len; i += 1 ) {
+		dtCached = actions[ i ];
+		dtCachedTarget = dtCached.target;
+		if ( !dtCachedTarget || dtCachedTarget === bindTo ) {
+			nowActions.push( dtCached );
+		} else {
+			postActions.push( dtCached );
+		}
+	}
+
+	//
+	// 4. Execute action for the current item
+	//
+	baseAction = settings.base || {};
+	postAction_len = postActions.length;
+	for ( i = 0, i_len = nowActions.length; i !== i_len; i += 1 ) {
+		dtCached = $.extend( {}, baseAction, nowActions[ i ] );
+		dtCached.origin = $source.get( 0 );
+		dtCached.provEvt = elm;
+		dtCached.$selElm = $optSel;
+		dtCached.form = form;
+		if ( postAction_len ) {
+			dtCached.actions = postActions;
+		}
+		$orgin.trigger( dtCached.action + "." + actionEvent, dtCached );
+	}
+	return true;
+} );
+
+
+// Load content after the user have choosen an option
+$document.on( "submit", selectorForm + " form", function( event ) {
+
+	var elm = event.currentTarget,
+		$elm = $( elm ),
+		wbFieldFlowRegistered = $elm.data( registerJQData ),
+		wbRegisteredHidden = $elm.data( registerHdnFld ) || [],
+		$hdnField,
+		i, i_len = wbFieldFlowRegistered ? wbFieldFlowRegistered.length : 0,
+		$wbFieldFlow, fieldOrigin,
+		lstFieldFlowPostEvent = [],
+		componentRegistered, $componentRegistered, $origin, lstOrigin = [],
+		settings,
+		j, j_len,
+		m, m_len, m_cache,
+		actions,
+		preventSubmit = false, lastProvEvt;
+
+	// Run the cleaning on the current items
+	if ( i_len ) {
+		$wbFieldFlow = $( "#" + wbFieldFlowRegistered[ i_len - 1 ] );
+		fieldOrigin = $wbFieldFlow.data( registerJQData );
+		$( "#" + fieldOrigin[ fieldOrigin.length - 1 ] ).trigger( cleanEvent );
+		$wbFieldFlow.trigger( cleanEvent );
+	}
+
+	// For each wb-fieldflow component, execute submiting task.
+	for ( i = 0; i !== i_len; i += 1 ) {
+		$wbFieldFlow = $( "#" + wbFieldFlowRegistered[ i ] );
+		componentRegistered = $wbFieldFlow.data( registerJQData );
+		j_len = componentRegistered.length;
+		for ( j = 0; j !== j_len; j += 1 ) {
+			$componentRegistered = $( "#" + componentRegistered[ j ] );
+			$origin = $( "#" + $componentRegistered.data( originData ) );
+			lstOrigin.push( $origin );
+			actions = $componentRegistered.data( submitJQData );
+			if ( actions ) {
+				for ( m = 0, m_len = actions.length; m !== m_len; m += 1 ) {
+					m_cache = actions[ m ];
+					m_cache.form = elm;
+					$wbFieldFlow.trigger( m_cache.action + "." + submitEvent, m_cache );
+					lstFieldFlowPostEvent.push( {
+						$elm: $wbFieldFlow,
+						data: m_cache
+					} );
+					preventSubmit = preventSubmit || m_cache.preventSubmit;
+					lastProvEvt = m_cache.provEvt;
+				}
+			}
+		}
+	}
+
+	// Before to submit, remove jj-down accessesory control
+	if ( !preventSubmit ) {
+		$elm.find( basenameInputSelector ).removeAttr( "name" );
+
+		// Fix an issue when clicking back with the mouse
+		i_len = wbRegisteredHidden.length;
+		for ( i = 0; i !== i_len; i += 1 ) {
+			$( wbRegisteredHidden[ i ] ).remove();
+		}
+		wbRegisteredHidden = [];
+
+		// Check the form action, if there is query string, do split it and create hidden field for submission
+		// The following is may be simply caused by a cross-server security issue generated by the browser itself
+		var frmAction, idxQueryDelimiter,
+			queryString, cacheParam, cacheName,
+			items, params;
+
+		frmAction = $elm.attr( "action" );
+		if ( frmAction ) {
+			idxQueryDelimiter = frmAction.indexOf( "?" );
+			if ( idxQueryDelimiter > 0 ) {
+
+				// Split the query string and create hidden input.
+				queryString = frmAction.substring( idxQueryDelimiter + 1 );
+				params = queryString.split( "&" );
+
+				i_len = params.length;
+				for ( i = 0; i !== i_len; i += 1 ) {
+					cacheParam = params[ i ];
+					cacheName = cacheParam;
+					if ( cacheParam.indexOf( "=" ) > 0 ) {
+						items = cacheParam.split( "=", 2 );
+						cacheName = items[ 0 ];
+						cacheParam = items[ 1 ];
+					}
+					$hdnField = $( "<input type='hidden' name='" + cacheName + "' value='" + cacheParam + "' />" );
+					$elm.append( $hdnField );
+					wbRegisteredHidden.push( $hdnField.get( 0 ) );
+				}
+				$elm.data( registerHdnFld, wbRegisteredHidden );
+			}
+		}
+	}
+
+	// Add global action
+	i_len = lstOrigin.length;
+	for ( i = 0; i !== i_len; i += 1 ) {
+		$origin = lstOrigin[ i ];
+		settings = $origin.data( configData );
+		if ( settings.action ) {
+			lstFieldFlowPostEvent.push( {
+				$elm: $origin,
+				data: settings
+			} );
+		}
+	}
+
+	i_len = lstFieldFlowPostEvent.length;
+	for ( i = 0; i !== i_len; i += 1 ) {
+		m_cache = lstFieldFlowPostEvent[ i ];
+		m_cache.data.lastProvEvt = lastProvEvt;
+		m_cache.$elm.trigger( m_cache.data.action + "." + submitedEvent, m_cache.data );
+	}
+	if ( preventSubmit ) {
+		event.preventDefault();
+		if ( event.stopPropagation ) {
+			event.stopImmediatePropagation();
+		} else {
+			event.cancelBubble = true;
+		}
+		return false;
+	}
+} );
+
+$document.on( "keyup", selectorForm + " select", function( Ev ) {
+
+	// Add the fix for the on change event - https://bugzilla.mozilla.org/show_bug.cgi?id=126379
+	if ( navigator.userAgent.indexOf( "Gecko" ) !== -1 ) {
+
+		// prevent tab, alt, ctrl keys from fireing the event
+		if ( Ev.keyCode && ( Ev.keyCode === 1 || Ev.keyCode === 9 || Ev.keyCode === 16 || Ev.altKey || Ev.ctrlKey ) ) {
+			return true;
+		}
+		$( Ev.target ).trigger( "change" );
+		return true;
+	}
+} );
+
+$document.on( fieldflowActionsEvents, selector, function( event, data ) {
+
+	var eventType = event.type;
+
+	switch ( event.namespace ) {
+	case drawEvent:
+		switch ( eventType ) {
+		case componentName:
+			drwFieldflow( event, data );
+			break;
+		case "tblfilter":
+			drwTblFilter( event, data );
+			break;
+		}
+		break;
+
+	case createCtrlEvent:
+		switch ( eventType ) {
+		case "select":
+			ctrlSelect( event, data );
+			break;
+		case "checkbox":
+			data.typeRadCheck = "checkbox";
+			ctrlChkbxRad( event, data );
+			break;
+		case "radio":
+			data.typeRadCheck = "radio";
+			ctrlChkbxRad( event, data );
+			break;
+		}
+		break;
+
+	case actionEvent:
+		switch ( eventType ) {
+		case "append":
+			actAppend( event, data );
+			break;
+		case "redir":
+			pushData( $( data.provEvt ), submitJQData, data, true );
+			break;
+		case "ajax":
+			actAjax( event, data );
+			break;
+		case "tblfilter":
+			actTblFilter( event, data );
+			break;
+		case "toggle":
+			if ( data.live ) {
+				subToggle( event, data );
+			} else {
+				data.preventSubmit = true;
+				pushData( $( data.provEvt ), submitJQData, data );
+			}
+			break;
+		case "addClass":
+			if ( !data.source || !data.class ) {
+				return;
+			}
+			if ( data.live ) {
+				$( data.source ).addClass( data.class );
+			} else {
+				data.preventSubmit = true;
+				pushData( $( data.provEvt ), submitJQData, data );
+			}
+			break;
+		case "removeClass":
+			if ( !data.source || !data.class ) {
+				return;
+			}
+			if ( data.live ) {
+				$( data.source ).removeClass( data.class );
+			} else {
+				data.preventSubmit = true;
+				pushData( $( data.provEvt ), submitJQData, data );
+			}
+			break;
+		case "query":
+			actQuery( event, data );
+			break;
+		}
+		break;
+
+	case submitEvent:
+		switch ( eventType ) {
+		case "redir":
+			subRedir( event, data );
+			break;
+		case "ajax":
+			subAjax( event, data );
+			break;
+		case "toggle":
+			subToggle( event, data );
+			break;
+		case "addClass":
+			$( data.source ).addClass( data.class );
+			break;
+		case "removeClass":
+			$( data.source ).removeClass( data.class );
+			break;
+		}
+		break;
+	}
+} );
+
+// Bind the init event of the plugin
+$document.on( "timerpoke.wb " + initEvent, selector, function( event ) {
+	switch ( event.type ) {
+	case "timerpoke":
+	case "wb-init":
+		init( event );
+		break;
+	}
+
+	/*
+	* Since we are working with events we want to ensure that we are being passive about our control,
+	* so returning true allows for events to always continue
+	*/
+	return true;
+} );
+
+// Add the timer poke to initialize the plugin
+wb.add( selector );
+
+} )( jQuery, document, wb );


### PR DESCRIPTION

Note, the following working example link are based on build 4154900

## English working example:
* [Field flow](http://universallabs.org/wet/labs/wb-fieldflow/dist-0.3/demos/fieldflow/fieldflow-en.html)
* [Field flow basic configuration](http://universallabs.org/wet/labs/wb-fieldflow/dist-0.3/demos/fieldflow/basic-en.html)
* [Field flow advanced](http://universallabs.org/wet/labs/wb-fieldflow/dist-0.3/demos/fieldflow/advanced-en.html)

## French working example:
* [Déroulement de champs](http://universallabs.org/wet/labs/wb-fieldflow/dist-0.3/demos/fieldflow/fieldflow-fr.html)
* [Déroulement de champs, configuration](http://universallabs.org/wet/labs/wb-fieldflow/dist-0.3/demos/fieldflow/basic-fr.html)
* [Déroulement de champs, avancé](http://universallabs.org/wet/labs/wb-fieldflow/dist-0.3/demos/fieldflow/advanced-fr.html)

## Documentation:
* [Field flow Documentation](http://universallabs.org/wet/labs/wb-fieldflow/dist-0.3/docs/ref/fieldflow/fieldflow-en.html)

## i18n temporary workaround
Currently the plugin only support English and French and use a work-around for i18n.

The following text will need to be translated in all language supported by WET, then added to the cvs, then I will be able to update the plugin to fully support the i18n of WET.

* **Button**
  * Continue
  * Allez
* **Default selected item**
  * Make your selection...
  * Sélectionnez dans la liste...
* **Required**
  * required
  * obligatoire

----
cc/ @TouficS