### PR TITLE
Overlay Print - Only print the active dialog. Alternate solution of #7791

### DIFF
--- a/src/base/_wet-boew.scss
+++ b/src/base/_wet-boew.scss
@@ -246,6 +246,7 @@
 	@import "../plugins/geomap/print";
 	@import "../plugins/lightbox/print";
 	@import "../plugins/multimedia/print";
+	@import "../plugins/overlay/print";
 	@import "../plugins/prettify/print";
 	@import "../plugins/tabs/print";
 }

--- a/src/plugins/lightbox/_base.scss
+++ b/src/plugins/lightbox/_base.scss
@@ -15,6 +15,10 @@
 	visibility: hidden !important;
 }
 
+%lightbox-modal-visible {
+	visibility: visible !important;
+}
+
 .lbx-hide-gal {
 	li {
 		display: none;
@@ -44,9 +48,14 @@ body {
 
 		.modal-dialog {
 			summary {
-				visibility: visible !important;
+				@extend %lightbox-modal-visible;
 			}
 		}
+
+		.wb-lbx-container {
+			@extend %lightbox-modal-visible;
+		}
+
 	}
 }
 

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -17,9 +17,11 @@ var componentName = "wb-lbx",
 	selector = "." + componentName,
 	initEvent = "wb-init" + selector,
 	setFocusEvent = "setfocus.wb",
+	globalOverlay = "wb-overlay-open",
 	dependenciesLoadedEvent = "deps-loaded" + selector,
 	modalHideSelector = "#wb-tphp, body > header, body > main, body > footer",
 	$document = wb.doc,
+	$html = wb.html,
 	callbacks, i18n, i18nText,
 
 	/**
@@ -42,7 +44,8 @@ var componentName = "wb-lbx",
 				var elm = document.getElementById( elmId ),
 					$elm = $( elm ),
 					settings = {},
-					firstLink;
+					firstLink,
+					pageHeading1 = document.getElementsByTagName( "H1" )[ 0 ];
 
 				if ( !elm ) {
 					return;
@@ -88,6 +91,12 @@ var componentName = "wb-lbx",
 					}
 					if ( elm.className.indexOf( "lbx-inline" ) !== -1 ) {
 						settings.type = "inline";
+					}
+
+					// Prepend the popup in a container after the h1
+					if ( pageHeading1 ) {
+						$( pageHeading1 ).after( "<div class='wb-popup'></div>" );
+						settings.prependTo = pageHeading1.nextSibling;
 					}
 
 					// Extend the settings with window[ "wb-lbx" ] then data-wb-lbx
@@ -163,6 +172,10 @@ var componentName = "wb-lbx",
                         .find( ".activate-open" )
                         .trigger( "wb-activate" );
 
+					$html.addClass( globalOverlay );
+				},
+				close: function() {
+					$html.removeClass( globalOverlay );
 				},
 				close: function() {
 					$document.find( "body" ).removeClass( "wb-modal" );

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -17,11 +17,9 @@ var componentName = "wb-lbx",
 	selector = "." + componentName,
 	initEvent = "wb-init" + selector,
 	setFocusEvent = "setfocus.wb",
-	globalOverlay = "wb-overlay-open",
 	dependenciesLoadedEvent = "deps-loaded" + selector,
 	modalHideSelector = "#wb-tphp, body > header, body > main, body > footer",
 	$document = wb.doc,
-	$html = wb.html,
 	callbacks, i18n, i18nText,
 
 	/**
@@ -93,9 +91,9 @@ var componentName = "wb-lbx",
 						settings.type = "inline";
 					}
 
-					// Prepend the popup in a container after the h1
+					// Insert the lbx in a container after the h1
 					if ( pageHeading1 ) {
-						$( pageHeading1 ).after( "<div class='wb-popup'></div>" );
+						$( pageHeading1 ).after( "<div class='wb-lbx-container'></div>" );
 						settings.prependTo = pageHeading1.nextSibling;
 					}
 
@@ -172,10 +170,6 @@ var componentName = "wb-lbx",
                         .find( ".activate-open" )
                         .trigger( "wb-activate" );
 
-					$html.addClass( globalOverlay );
-				},
-				close: function() {
-					$html.removeClass( globalOverlay );
 				},
 				close: function() {
 					$document.find( "body" ).removeClass( "wb-modal" );

--- a/src/plugins/overlay/_print.scss
+++ b/src/plugins/overlay/_print.scss
@@ -19,19 +19,29 @@
 	}
 }
 
-.wb-overlay-open {
-
-	main {
-
-		* {
-			display:none;
+body {
+	&.wb-modal,
+	&.wb-overlay-dialog {
+		> {
+			header,
+			main h1:first-child
+			{
+				visibility: visible !important;
+			}
 		}
 
-		h1, .wb-popup, .wb-popup *, .wb-overlay.open * {
-			display:block;
-		}
+		main {
 
+			// This remove blank space when printing
+			* {
+				display:none;
+			}
+
+			// Show only the dialog
+			h1, .wb-overlay.open *, .wb-lbx-container, .wb-lbx-container * {
+				display:block;
+			}
+
+		}
 	}
 }
-
-

--- a/src/plugins/overlay/_print.scss
+++ b/src/plugins/overlay/_print.scss
@@ -7,6 +7,18 @@
  * Print styles
  */
 
+.wb-overlay {
+
+	&.open {
+		display: block;
+		position: static;
+
+		&.no-print {
+			display: none;
+		}
+	}
+}
+
 .wb-overlay-open {
 
 	main {
@@ -19,8 +31,7 @@
 			display:block;
 		}
 
-		.wb-overlay.open {
-			position: static;
-		}
 	}
 }
+
+

--- a/src/plugins/overlay/_print.scss
+++ b/src/plugins/overlay/_print.scss
@@ -1,0 +1,26 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+
+/**
+ * Print styles
+ */
+
+.wb-overlay-open {
+
+	main {
+
+		* {
+			display:none;
+		}
+
+		h1, .wb-popup, .wb-popup *, .wb-overlay.open * {
+			display:block;
+		}
+
+		.wb-overlay.open {
+			position: static;
+		}
+	}
+}

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -19,10 +19,12 @@ var componentName = "wb-overlay",
 	closeClass = "overlay-close",
 	linkClass = "overlay-lnk",
 	ignoreOutsideClass = "outside-off",
+	globalOverlay = "wb-overlay-open",
 	initialized = false,
 	sourceLinks = {},
 	setFocusEvent = "setfocus.wb",
 	$document = wb.doc,
+	$html = wb.html,
 	i18n, i18nText,
 
 	/**
@@ -81,6 +83,10 @@ var componentName = "wb-overlay",
 			.addClass( "open" )
 			.attr( "aria-hidden", "false" );
 
+		if ( $overlay.hasClass( "wb-popup-full" ) || $overlay.hasClass( "wb-popup-mid" ) ) {
+			$html.addClass( globalOverlay );
+		}
+
 		if ( !noFocus ) {
 			$overlay
 				.scrollTop( 0 )
@@ -103,6 +109,10 @@ var componentName = "wb-overlay",
 		$overlay
 			.removeClass( "open" )
 			.attr( "aria-hidden", "true" );
+
+		if ( $overlay.hasClass( "wb-popup-full" ) || $overlay.hasClass( "wb-popup-mid" ) ) {
+			$html.removeClass( globalOverlay );
+		}
 
 		if ( userClosed ) {
 			$overlay.addClass( "user-closed" );

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -19,12 +19,11 @@ var componentName = "wb-overlay",
 	closeClass = "overlay-close",
 	linkClass = "overlay-lnk",
 	ignoreOutsideClass = "outside-off",
-	globalOverlay = "wb-overlay-open",
+	globalOverlay = "wb-overlay-dialog",
 	initialized = false,
 	sourceLinks = {},
 	setFocusEvent = "setfocus.wb",
 	$document = wb.doc,
-	$html = wb.html,
 	i18n, i18nText,
 
 	/**
@@ -84,7 +83,7 @@ var componentName = "wb-overlay",
 			.attr( "aria-hidden", "false" );
 
 		if ( $overlay.hasClass( "wb-popup-full" ) || $overlay.hasClass( "wb-popup-mid" ) ) {
-			$html.addClass( globalOverlay );
+			$document.find( "body" ).addClass( globalOverlay );
 		}
 
 		if ( !noFocus ) {
@@ -111,7 +110,7 @@ var componentName = "wb-overlay",
 			.attr( "aria-hidden", "true" );
 
 		if ( $overlay.hasClass( "wb-popup-full" ) || $overlay.hasClass( "wb-popup-mid" ) ) {
-			$html.removeClass( globalOverlay );
+			$document.find( "body" ).removeClass( globalOverlay );
 		}
 
 		if ( userClosed ) {


### PR DESCRIPTION
This should fix #7615

See the conversation on #7791 for more info.

Here PDF showing what it would look like when printed.
* [Centered popup](http://universallabs.org/wet/labs/temporary/center-popup.pdf)
* [Middle screen overlay](http://universallabs.org/wet/labs/temporary/middle-screen.pdf)
* [Full screen overvay](http://universallabs.org/wet/labs/temporary/full-screen.pdf)

It was tested on FF dev, Chrome and Edge