### PR TITLE
Carousel: Fixed various noscript, wb-disable and print CSS issues.

### DIFF
--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -373,15 +373,6 @@ $tab-margin-width: 10px;
 		@extend %carousel-tabpanel-video;
 		background: $carousel-s2-tablist-controls-bg-color;
 
-		// Only need to show controls when JS is active and plugin working
-		&.wb-init {
-			padding-bottom: 4.375em;
-		}
-
-		&.exclude-controls {
-			padding-bottom: 0;
-		}
-
 		[role="tablist"] {
 			bottom: 0;
 			position: absolute;
@@ -494,7 +485,7 @@ $tab-margin-width: 10px;
 }
 
 .wb-disable {
-	.csstransitions {
+	&.csstransitions {
 		.wb-tabs {
 			[role="tabpanel"] {
 				&.out {
@@ -506,6 +497,10 @@ $tab-margin-width: 10px;
 	}
 
 	.wb-tabs {
+		&.carousel-s2 {
+			background: transparent;
+		}
+
 		// Only for backwards compatibility. Should be removed in v4.1.
 		> {
 			details {
@@ -537,13 +532,20 @@ $tab-margin-width: 10px;
 			}
 		}
 
+		.out {
+			visibility: visible;
+		}
+
 		[role="tablist"] {
 			display: none;
 		}
 
 		[role="tabpanel"] {
+			animation: none;
 			display: block;
+			margin-bottom: .5em;
 			opacity: 1;
+			transform: none;
 		}
 	}
 }

--- a/src/plugins/tabs/_noscript.scss
+++ b/src/plugins/tabs/_noscript.scss
@@ -26,10 +26,18 @@
 .wb-tabs {
 	@extend %tabs-noscript-details-summary-display-block-important; /* Only for backwards compatibility. Should be removed in v4.1. */
 
+	&.carousel-s2 {
+		background: transparent;
+	}
+
 	> {
 		.tabpanels {
 			@extend %tabs-noscript-details-summary-display-block-important;
 		}
+	}
+
+	.out {
+		visibility: visible;
 	}
 
 	[role="tablist"] {
@@ -37,7 +45,10 @@
 	}
 
 	[role="tabpanel"] {
-		display: block;
+		animation: none;
+		display: block !important;
+		margin-bottom: .5em;
 		opacity: 1;
+		transform: none;
 	}
 }

--- a/src/plugins/tabs/_print.scss
+++ b/src/plugins/tabs/_print.scss
@@ -11,7 +11,29 @@
 	display: none !important;
 }
 
+%carousel-print-panel {
+	[role="tabpanel"] {
+		margin-bottom: .5em;
+	}
+
+	figure {
+		page-break-inside: avoid;
+	}
+
+	figcaption {
+		border: 1px solid #000;
+	}
+}
+
 .wb-tabs {
+	&.carousel-s1 {
+		@extend %carousel-print-panel;
+	}
+
+	&.carousel-s2 {
+		@extend %carousel-print-panel;
+	}
+
 	[role="tablist"] {
 		@extend %tabs-print-display-none-important;
 	}
@@ -20,6 +42,7 @@
 		display: block !important;
 		opacity: 1 !important;
 		position: static !important;
+		transform: none;
 		visibility: visible !important;
 
 		figcaption {

--- a/src/plugins/tabs/_screen-md-min.scss
+++ b/src/plugins/tabs/_screen-md-min.scss
@@ -36,6 +36,15 @@
 	}
 
 	&.carousel-s2 {
+		// Only need to show controls when JS is active and plugin working
+		&.wb-init {
+			padding-bottom: 4.375em;
+		}
+
+		&.exclude-controls {
+			padding-bottom: 0;
+		}
+
 		&.show-thumbs {
 			[role="tablist"] {
 				li {


### PR DESCRIPTION
* Now displaying all carousel panels in noscript, wb-disable and print scenarios.
* Disabled CSS transitions in noscript, wb-disable and print scenarios to prevent rendering issues.
* Prevented space for carousel style 2's controls from appearing when printing (since the controls aren't used in that scenario).
* Added borders around carousel panel link text when printing.
* Prevented carousel panel images and link text from getting split across separate pages when printing.
* Fixes #7445 and resolves wet-boew/GCWeb#1081.