### PR TITLE
Multimedia player: Fixed video cut off/overflow issues.

### DIFF
--- a/src/plugins/multimedia/_base.scss
+++ b/src/plugins/multimedia/_base.scss
@@ -61,7 +61,7 @@ $mm-volume-thumb-width: 10px;
 }
 
 %controls-offset {
-	margin-bottom: -7px;
+	display: block;
 	width: 100%;
 }
 


### PR DESCRIPTION
In Firefox/Blink browsers, the multimedia player's CSS was previously causing the bottom of every video to be cut off by 1px. It also caused video placeholder images to overflow on top of figcaptions when printing (which made the top borders of some of #7815's figcaptions disappear).

**Comparison screenshots of the [multimedia player demo page](http://wet-boew.github.io/v4.0-ci/demos/multimedia/multimedia-en.html)'s placeholder image (note: the grey lines are part of the image itself)...**

**Before (bottom line is missing):**
![multimedia_player_before](https://cloud.githubusercontent.com/assets/1907279/21357599/c5a56da2-c6a3-11e6-96e1-f33a66409bd8.png)

**After (bottom line is present):**
![multimedia_player_after](https://cloud.githubusercontent.com/assets/1907279/21357606/cd4308f8-c6a3-11e6-9225-9a94360028a5.png)