### PR TITLE
Details: Fixed remaining summary arrow issues.

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -23,6 +23,7 @@ rules:
         - border-top
         - border-bottom
         - cursor
+        - list-style-type
   no-empty-rulesets: 2
   no-ids: 0
   no-important: 0

--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -514,7 +514,7 @@ $tab-margin-width: 10px;
 				&[open] {
 					> {
 						summary {
-							@extend %global-display-block-important;
+							display: list-item !important;
 						}
 					}
 				}
@@ -528,7 +528,7 @@ $tab-margin-width: 10px;
 						&[open] {
 							> {
 								summary {
-									@extend %global-display-block-important;
+									display: list-item !important;
 								}
 							}
 						}

--- a/src/plugins/tabs/_noscript.scss
+++ b/src/plugins/tabs/_noscript.scss
@@ -15,7 +15,7 @@
 			&[open] {
 				> {
 					summary {
-						display: block !important;
+						display: list-item !important;
 					}
 				}
 			}

--- a/src/plugins/tabs/_print.scss
+++ b/src/plugins/tabs/_print.scss
@@ -27,7 +27,7 @@
 		}
 
 		summary {
-			display: block !important;
+			display: list-item !important;
 		}
 	}
 

--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -6,6 +6,8 @@
 summary {
 	// Make sure summary remains visible
 	display: list-item !important;
+	list-style-type: none; // Prevent list bullets from appearing in browsers that lack native details/summary support (e.g. IE/Edge)
+	list-style-type: disclosure-closed; // Show summary arrows in Firefox 49.0+ and future versions of Blink/Webkit
 	visibility: visible !important;
 }
 
@@ -44,6 +46,7 @@ details {
 				border-bottom: 1px solid #ddd;
 				border-bottom-left-radius: 0;
 				border-bottom-right-radius: 0;
+				list-style-type: disclosure-open;
 				margin-bottom: .25em;
 			}
 		}
@@ -90,7 +93,7 @@ details {
 		visibility: visible !important;
 
 		> {
-			* {
+			*:not(summary) {
 				display: block !important;
 			}
 		}

--- a/src/polyfills/details/details.scss
+++ b/src/polyfills/details/details.scss
@@ -36,7 +36,7 @@
 		}
 
 		summary {
-			display: block !important;
+			display: list-item !important;
 		}
 	}
 


### PR DESCRIPTION
Details: Fixed remaining summary arrow issues.

* Firefox:
  * Prevents summary arrows from disappearing in standard details/summary implementations in wbdisable mode.
  * Prevents summary arrows from disappearing in opened tabbed interface tabs in noscript scenarios.
  * Prevents summary arrows from disappearing in all tabbed interface tabs in wbdisable/print scenarios.
* IE11/Edge:
  * Prevents disc bullets from appearing beside summaries in noscript scenarios.
  * Prevents disc bullets from "flashing" beside summaries when loading pages in JavaScript/wbdisable scenarios.