### PR TITLE
Multimedia player: Added support for youtu.be URLs.

### DIFF
--- a/site/pages/docs/ref/multimedia/multimedia-en.hbs
+++ b/site/pages/docs/ref/multimedia/multimedia-en.hbs
@@ -131,8 +131,11 @@
 			<h4>Video (YouTube)</h4>
 			<ol>
 				<li>Add a <code>title</code> attribute to the <code>video</code> element with the value being the title of the video.</li>
-				<li>Add a <code>source</code> element to the <code>video</code> element with <code>type="video/youtube"</code> and the <code>src</code> attribute being the URL of the video.
+				<li>
+					<p>Add a <code>source</code> element to the <code>video</code> element with <code>type="video/youtube"</code> and the <code>src</code> attribute being the URL of the video.</p>
 					<pre><code>&lt;source type="video/youtube" src="http://www.youtube.com/watch?v=9znKJqnFuuY" /&gt;</code></pre>
+					<p>or</p>
+					<pre><code>&lt;source type="video/youtube" src="https://youtu.be/9znKJqnFuuY" /&gt;</code></pre>
 				</li>
 				<li>If captions are not already included for the video, add the captions using the tools provided by YouTube.</li>
 			</ol>
@@ -234,7 +237,7 @@
 			<tr>
 				<td><code>wb-ready.wb</code> (v4.0.5+)</td>
 				<td>Triggered automatically when WET has finished loading and executing.</td>
-				<td>Used to identify when all WET plugins and polyfills have finished loading and executing. 
+				<td>Used to identify when all WET plugins and polyfills have finished loading and executing.
 					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
 });</code></pre>
 				</td>

--- a/site/pages/docs/ref/multimedia/multimedia-fr.hbs
+++ b/site/pages/docs/ref/multimedia/multimedia-fr.hbs
@@ -8,7 +8,7 @@
 	"altLangPrefix": "multimedia",
 	"dateModified": "2014-08-04"
 }
----	
+---
 <span class="wb-prettify all-pre hide"></span>
 
 <div lang="fr">
@@ -133,8 +133,10 @@
 			<h4>Vidéo (YouTube)</h4>
 			<ol>
 				<li>Ajoutez l'attribut <code>title</code> à l'élément <code>video</code> avec la valeur étant le titre de la vidéo.</li>
-				<li>Ajoutez un élément <code>source</code> à l'élément <code>video</code> avec l'attribut <code>type="video/youtube"</code> et l'attribut <code>src</code> étant l'URL de la vidéo.
+				<li><p>Ajoutez un élément <code>source</code> à l'élément <code>video</code> avec l'attribut <code>type="video/youtube"</code> et l'attribut <code>src</code> étant l'URL de la vidéo.</p>
 					<pre><code>&lt;source type="video/youtube" src="http://www.youtube.com/watch?v=9znKJqnFuuY" /&gt;</code></pre>
+					<p>Ou</p>
+					<pre><code>&lt;source type="video/youtube" src="https://youtu.be/9znKJqnFuuY" /&gt;</code></pre>
 				</li>
 				<li>Si le sous-titrage n'est pas déjà inclut pour la vidéo, l'ajouter avec les outils fournis par YouTube.</li>
 			</ol>
@@ -236,7 +238,7 @@
 			<tr>
 				<td><code>wb-ready.wb</code> (v4.0.5+)</td>
 				<td>Déclenché automatiquement quant BOEW a fini son chargement et son exécution.</td>
-				<td>Utilisé pour identifier quand tous les plugiciels BOEW et les polyfills ont terminé leur chargement et leur exécution. 
+				<td>Utilisé pour identifier quand tous les plugiciels BOEW et les polyfills ont terminé leur chargement et leur exécution.
 					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
 });</code></pre>
 				</td>

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -591,7 +591,7 @@ $document.on( initializedEvent, selector, function( event ) {
 			url = wb.getUrlParts( $this.find( "[type='video/youtube']" ).attr( "src" ) );
 
 			// lets set the flag for the call back
-			data.youTubeId = url.params.v;
+			data.youTubeId = url.params.v ? url.params.v : url.pathname.substr( 1 );
 
 			if ( youTube.ready === false ) {
 				$document.one( youtubeReadyEvent, function() {


### PR DESCRIPTION
The multimedia player's YouTube variant used to only extract video IDs by checking the v parameter in the video URL's query string. But that didn't lend itself to shortened YouTube URLs (e.g. https://youtu.be/9znKJqnFuuY).

With this change, if a video URL doesn't contain a v parameter, the player will strip the first forward slash from the URL's pathname and treat the result as the video's ID.