### PR TITLE
Multimedia player: Updated demo explanations/plugin comments.

### DIFF
--- a/src/plugins/multimedia/multimedia-audio-en.hbs
+++ b/src/plugins/multimedia/multimedia-audio-en.hbs
@@ -15,9 +15,9 @@
 <div class="row">
 	<section class="col-md-12">
 		<h2>Overview</h2>
-		<p>For audio-only, the multimedia player leverages the native HTML5 <code>audio</code> tag and relies on Flash as a fallback mechanism when the HTML5 <code>audio</code> tag is not implemented.</p>
+		<p>For audio-only, the multimedia player leverages the native HTML5 <code>audio</code> tag.</p>
 		<p>The multimedia player's timeline relies on the HTML5 <code>progress</code> element and uses a polyfill when the element is not supported.</p>
-		<p>The MP3 format (H264 codec) is the minimum requirement for the player because the Flash fallback relies on it and MP3 is a widely supported format on many mobile devices. An optional but highly recommended format, OGG Vorbis, should be added as well to allow some browsers such as Firefox that do not include native support for MP3 to leverage the HTML5 native performance gains.</p>
+		<p>The MP3 format is the minimum requirement for the player because it is a widely supported format on many browsers. An optional but highly recommended format, OGG Vorbis, should be added as well to allow some browsers such as Firefox that do not include native support for MP3 to leverage the HTML5 native performance gains.</p>
 	</section>
 </div>
 

--- a/src/plugins/multimedia/multimedia-audio-fr.hbs
+++ b/src/plugins/multimedia/multimedia-audio-fr.hbs
@@ -15,9 +15,9 @@
 <div class="row">
 	<section class="col-md-12">
 		<h2>Vue d'ensemble</h2>
-		<p>Pour l'audio seulement, le lecteur multimédia s'appuie sur la balise «&#160;<code>audio</code>&#160;» HTML5 natif et s'appuie sur Flash comme un mécanisme de secours lorsque la balise «&#160;<code>audio</code>&#160;» HTML5 n'est pas implémentée.</p>
+		<p>Pour l'audio seulement, le lecteur multimédia s'appuie sur la balise «&#160;<code>audio</code>&#160;» HTML5 natif.</p>
 		<p>Le scénario du lecteur multimédia repose sur l'élément «&#160;<code>progress</code>&#160;» HTML5 et utilise un polyfill lorsque l'élément n'est pas pris en charge.</p>
-		<p lang="en">The MP3 format (H264 codec) is the minimum requirement for the player because the Flash fallback relies on it and MP3 is a widely supported format on many mobile devices. An optional but highly recommended format, OGG Vorbis, should be added as well to allow some browsers such as Firefox that do not include native support for MP3 to leverage the HTML5 native performance gains.</p>
+		<p>Le format MP3 est le minimum requis pour la vidéo parce que c'est le format vidéo standard sur de nombreux navigateurs. Un OGG Vorbis facultative mais fortement recommandée devrait être ajouté aussi bien pour permettre à certains navigateurs tels que Firefox qui ne comprennent pas un support natif pour MP3 de tirer parti des gains de performance de leur implémentations d'HTML5.</p>
 	</section>
 </div>
 

--- a/src/plugins/multimedia/multimedia-en.hbs
+++ b/src/plugins/multimedia/multimedia-en.hbs
@@ -15,7 +15,7 @@
 <div class="row">
 	<section class="col-md-12">
 		<h2>Overview</h2>
-		<p>For video, the multimedia player leverages the native HTML5 <code>video</code> tag and relies on Flash as a fallback mechanism when the HTML5 <code>video</code> tag is not implemented. The MPEG 4 format (H264 codec) is the minimum requirement for video because the Flash fallback relies on it and H264 is the standard video format on many mobile devices. An optional but highly recommended Webm (VP8 codec) should be added as well to allow some browsers such as Firefox that do not include native support for H264 to leverage the native HTML5 performance gains.</p>
+		<p>For video, the multimedia player leverages the native HTML5 <code>video</code> tag. The MPEG 4 format (H264 codec) is the minimum requirement for video because it is the standard video format on many browsers. An optional but highly recommended format, Webm (VP8 codec), should be added as well to allow some browsers such as Firefox that do not include native support for H264 to leverage the native HTML5 performance gains.</p>
 		<p>The multimedia player's timeline relies on the HTML5 <code>progress</code> element and uses a polyfill when the element is not supported.</p>
 	</section>
 </div>
@@ -24,7 +24,7 @@
 	<div class="row">
 		<div class="col-md-12">
 			<h2>Examples</h2>
-			<p>The first two video examples use native HTML5 video on most modern browsers including Firefox 6+, Google Chrome 3+ and IE9. The third video example works natively in some browsers but relies on the Flash fallback for Firefox. For all examples, the Flash fallback is used for IE8 as well as older versions of Firefox.</p>
+			<p>All video examples use native HTML5 video on most modern browsers including Firefox 6+, Google Chrome 3+ and IE9.</p>
 		</div>
 	</div>
 

--- a/src/plugins/multimedia/multimedia-fr.hbs
+++ b/src/plugins/multimedia/multimedia-fr.hbs
@@ -15,7 +15,7 @@
 <div class="row">
 	<section class="col-md-12">
 		<h2>Vue d'ensemble</h2>
-		<p>Pour la vidéo, le lecteur multimédia s'appuie sur la balise «&#160;<code>video</code>&#160;» HTML5 natif et s'appuie sur Flash comme un mécanisme de secours lorsque la balise «&#160;<code>video</code>&#160;» HTML5 n'est pas implémentée. Le format MPEG-4 (codec H264) est le minimum requis pour la vidéo parce que le repli flash s'appuie sur elle et H264 est le format vidéo standard sur de nombreux appareils mobiles. Un WebM facultative mais fortement recommandée (VP8 codec) devrait être ajouté aussi bien pour permettre à certains navigateurs tels que Firefox qui ne comprennent pas un support natif pour H264 de tirer parti des gains de performance HTML5 indigènes.</p>
+		<p>Pour la vidéo, le lecteur multimédia s'appuie sur la balise «&#160;<code>video</code>&#160;» HTML5 natif. Le format MPEG-4 (codec H264) est le minimum requis pour la vidéo parce que c'est le format vidéo standard sur de nombreux navigateurs. Un WebM facultative mais fortement recommandée (codec VP8) devrait être ajouté aussi bien pour permettre à certains navigateurs tels que Firefox qui ne comprennent pas un support natif pour H264 de tirer parti des gains de performance de leur implémentations d'HTML5.</p>
 		<p>Le scénario du lecteur multimédia repose sur l'élément «&#160;<code>progress</code>&#160;» HTML5 et utilise un polyfill lorsque l'élément n'est pas pris en charge.</p>
 	</section>
 </div>
@@ -24,7 +24,7 @@
 	<div class="row">
 		<div class="col-md-12">
 			<h2>Exemples</h2>
-			<p>Les deux premiers exemples vidéo utilisent la vidéo HTML5 natif sur la plupart des navigateurs modernes, y compris Firefox 6 +, Google Chrome 3 + et IE9. Le troisième exemple de vidéo fonctionne nativement dans certains navigateurs, mais s'appuie sur le repli Flash pour Firefox. Pour tous les exemples, le repli flash est utilisé pour IE8, ainsi que les anciennes versions de Firefox.</p>
+			<p>Tous les exemples vidéo utilisent la vidéo HTML5 natif sur la plupart des navigateurs modernes, y compris Firefox 6 +, Google Chrome 3 + et IE9.</p>
 		</div>
 	</div>
 

--- a/src/plugins/multimedia/multimedia-youtube-en.hbs
+++ b/src/plugins/multimedia/multimedia-youtube-en.hbs
@@ -15,7 +15,7 @@
 <div class="row">
 	<section class="col-md-12">
 		<h2>Overview</h2>
-		<p>For YouTube videos, the multimedia player integrates the YouTube chromeless player which leverages the native HTML5 <code>video</code> tag and relies on Flash as a fallback mechanism when the HTML5 <code>video</code> tag is not implemented.</p>
+		<p>For YouTube videos, the multimedia player integrates the YouTube chromeless player which leverages the native HTML5 <code>video</code> tag.</p>
 		<p>The multimedia player's timeline relies on the HTML5 <code>progress</code> element and uses a polyfill when the element is not supported.</p>
 	</section>
 </div>

--- a/src/plugins/multimedia/multimedia-youtube-fr.hbs
+++ b/src/plugins/multimedia/multimedia-youtube-fr.hbs
@@ -14,7 +14,7 @@
 
 <div class="row">
 	<div class="col-md-12">
-		<p>Pour les vidéos YouTube, le lecteur multimédia s'appuie le lecteur sans interface de YouTube qui s'appuie sur la balise «&#160;<code>video</code>&#160;» HTML5 natif et s'appuie sur Flash comme un mécanisme de secours lorsque la balise «&#160;<code>video</code>&#160;» HTML5 n'est pas implémentée.</p>
+		<p>Pour les vidéos YouTube, le lecteur multimédia s'appuie le lecteur sans interface de YouTube qui s'appuie sur la balise «&#160;<code>video</code>&#160;» HTML5 natif.</p>
 		<p>Le scénario du lecteur multimédia repose sur l'élément «&#160;<code>progress</code>&#160;» HTML5 et utilise un polyfill lorsque l'élément n'est pas pris en charge.</p>
 	</div>
 </div>

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -1,6 +1,6 @@
 /**
  * @title WET-BOEW Multimedia PLayer
- * @overview An accessible multimedia player for <audio> and <video> tags, including a Flash fallback
+ * @overview An accessible multimedia player for <audio> and <video> tags
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author WET Community
  */
@@ -348,7 +348,7 @@ var componentName = "wb-mltmd",
 
 	/**
 	 * @method playerApi
-	 * @description Normalizes the calls to the HTML5 media API and Flash Fallback
+	 * @description Normalizes the calls to the HTML5 media API
 	 * @param {String} fn The function to call
 	 * @param {object} args The arguments to send to the function call
 	 */


### PR DESCRIPTION
* Removed all remaining mentions of Flash fallbacks (the fallbacks themselves were removed in #7509).
* Removed mention of MP3 being a container format for the H264 codec in audio-only demo pages.
* Clarified that minimum required formats (MP3/MP4) are now generally supported by many browsers (not just on mobile devices).
* Added missing French translation (based on updated English content) into its audio-only demo page.
* Changed "VP8 codec" to "codec VP8" in French video demo page.
* Removed "indigènes" and adjusted nearby wording in French demo pages (thanks @duboisp!).

@MaximMartel @LaurentGoderre @duboisp Could one of you double-check my French content revisions? They're probably fine, but it never hurts to have a second set of eyes :).