### PR TITLE
Bootstrap overrides: Removed abbreviation titles from print SCSS.

### DIFF
--- a/src/base/_bootstrap.scss
+++ b/src/base/_bootstrap.scss
@@ -14,3 +14,8 @@ $icon-font-path: "#{$wb-core-path}/fonts/";
  */
 @import "../../lib/bootstrap-sass-official/assets/stylesheets/bootstrap";
 @import "bootstrap-overrides/base";
+
+/* Print view */
+@media print {
+	@import "bootstrap-overrides/print";
+}

--- a/src/base/bootstrap-overrides/_print.scss
+++ b/src/base/bootstrap-overrides/_print.scss
@@ -1,0 +1,12 @@
+/*
+  WET-BOEW
+  @title: Bootstrap print overrides for WET-BOEW
+ */
+
+abbr {
+	&[title] {
+		&:after {
+			content: none;
+		}
+	}
+}


### PR DESCRIPTION
Same idea as #7476, but for abbreviation titles.

**Reasons:**
* Printing all abbreviation titles risks bloating printouts of pages that use titles extensively (such as on every single abbr element).
* Showing abbreviation titles in printouts risks presenting meaningful information in that context that isn't available in other contexts. For example, mobile users and keyboard-only desktop users have no means of accessing abbreviation titles.
* Most content isn't written in a manner that lends itself to printing abbreviation titles.