### PR TITLE
Tabbed interface: Made active tab summary inherit content area's background colour by default.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -238,7 +238,7 @@ $tabpanel-border-width: 1px !default;
 
 $tablist-bg-color: #ebf2fc !default;
 $tablist-hover-bg-color: $clrMedium !default;
-$tablist-active-bg-color: #fff !default;
+$tablist-active-bg-color: null !default;
 
 $tablist-active-link-border-color: #666 !default;
 $tablist-active-link-border-style: solid !default;

--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -233,7 +233,13 @@ $tab-margin-width: 10px;
 				}
 
 				&.active {
-					background: $tablist-active-bg-color;
+					@if $tablist-active-bg-color {
+						background: $tablist-active-bg-color;
+					} @else if $main-bg {
+						background: $main-bg
+					} @else {
+						background: $body-bg;
+					}
 					border-bottom: 0;
 					cursor: default;
 					padding-bottom: 1px;


### PR DESCRIPTION
Depends on #7857.

In standard tabbed interface implementations, the active tab's summary used to be set to white. This looked fine in themes that use a white background colour in their content areas (like WET). But in themes that use other background colours, it caused a mismatch between the summary's white background and the transparent background of its associated details element.

This commit resolves the mismatch by:
* Changing the $tablist-active-bg-color variable's default value to null.
* Adding if/else logic to ensure the active tab's summary uses the content area's background colour (unless a theme has specified a value for $tablist-active-bg-color).

**GCWeb screenshots...**

**Before** (active tab summary's background colour is white whereas details' background is light grey):
![v4 0-tabs-active-summary-bg-before](https://cloud.githubusercontent.com/assets/1907279/22224730/aa850faa-e18d-11e6-9479-a2a2b5ad59de.png)

**After** (active tab summary and details' backgrounds are both light grey):
Assumes #7857, wet-boew/GCWeb#1220 and this PR are in place.
![v4 0-tabs-active-summary-bg-after](https://cloud.githubusercontent.com/assets/1907279/22224749/bce68494-e18d-11e6-9368-6339655bdbd7.png)
