### PR TITLE
Removed invalid tfoot according to HTML spec

### DIFF
--- a/site/pages/docs/ref/geomap/geomap-en.hbs
+++ b/site/pages/docs/ref/geomap/geomap-en.hbs
@@ -391,9 +391,6 @@
 		&lt;/tr&gt;
 		...
 	&lt;/tbody&gt;
-	&lt;tfoot&gt;
-		...
-	&lt;/tfoot&gt;
 &lt;/table&gt;</code></pre>
 			</section>
 			<p>Note that attribute names for features rendered from an inline HTML table are taken from the table header. In the preceding example the table header would result in attributes named "Rank", "Census subdivision", and "Population 2011".</p>

--- a/site/pages/docs/ref/geomap/geomap-fr.hbs
+++ b/site/pages/docs/ref/geomap/geomap-fr.hbs
@@ -392,9 +392,6 @@
 		&lt;/tr&gt;
 		...
 	&lt;/tbody&gt;
-	&lt;tfoot&gt;
-		...
-	&lt;/tfoot&gt;
 &lt;/table&gt;</code></pre>
 			</section>
 			<p>Note that attribute names for features rendered from an inline HTML table are taken from the table header. In the preceding example the table header would result in attributes named "Rank", "Census subdivision", and "Population 2011".</p>

--- a/src/plugins/tables/tables-en.hbs
+++ b/src/plugins/tables/tables-en.hbs
@@ -1018,19 +1018,6 @@
                     <th>Minister</th>
                 </tr>
                 </thead>
-                <tfoot>
-                <tr>
-                    <th>Title</th>
-                    <th>Publication date</th>
-                    <th>Department</th>
-                    <th>News Type</th>
-                    <th>Summary</th>
-                    <th>Location</th>
-                    <th>For</th>
-                    <th>Subject</th>
-                    <th>Minister</th>
-                </tr>
-                </tfoot>
             </table>
         </div>
     </div>

--- a/src/plugins/tables/tables-fr.hbs
+++ b/src/plugins/tables/tables-fr.hbs
@@ -1023,19 +1023,6 @@
                     <th>Ministre</th>
                 </tr>
                 </thead>
-                <tfoot>
-                <tr>
-                    <th>Titre</th>
-                    <th>Date de publication</th>
-                    <th>Département</th>
-                    <th>Type de nouvelles</th>
-                    <th>Résumé</th>
-                    <th>Emplacement</th>
-                    <th>Public</th>
-                    <th>Suject</th>
-                    <th>Ministre</th>
-                </tr>
-                </tfoot>
             </table>
         </div>
     </div>


### PR DESCRIPTION
According to [HTML spec](https://www.w3.org/TR/html52/tabular-data.html#the-tfoot-element) ```tfoot``` should contains columns summaries.

In the datatable example, it was used to repeat the column header, not for columns summaries

In the geomap documentation, the use of the ```tfoot``` in the code source sample is unclear. 

For reference in the geomap documentation. I perceived the ```tfoot``` was providing a clue to the web editor of that could be the place to insert table note, but in fact it shouldn't. If that was the purpose, the [HTML5.2 spec, Example16 in the Footnotes section](https://www.w3.org/TR/html52/common-idioms-without-dedicated-elements.html#example-7cf40577) have an example of how it should be coded in HTML. And the way it presented, it do not provide the perception that the ```tfoot``` was for columns summaries.