### PR TITLE
Data-json template and alternative data-ajax syntax

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -908,6 +908,18 @@ module.exports = (grunt) ->
 					"dist/unmin/demos/**/ajax/**/*.html"
 					"dist/unmin/assets/*.html"
 				]
+			templates:
+				options:
+					ignore: [
+						"The “details” element is not supported properly by browsers yet. It would probably be better to wait for implementations."
+						"Element “dl” is missing a required instance of child element “dd”."
+						"Element “dl” is missing a required instance of child element “dt”."
+						"Empty heading."
+					]
+				src: [
+					"dist/unmin/demos/data-json/template-en.html"
+					"dist/unmin/demos/data-json/template-fr.html"
+				]
 			all:
 				options:
 					ignore: [
@@ -922,6 +934,8 @@ module.exports = (grunt) ->
 					"!dist/unmin/assets/**/*.html"
 					"!dist/unmin/demos/menu/demo/*.html"
 					"!dist/unmin/test/**/*.html"
+					"!dist/unmin/demos/data-json/template-en.html"
+					"!dist/unmin/demos/data-json/template-fr.html"
 				]
 
 		bootlint:

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :default => [:test]
 
 task :test do
 	HTML::Proofer.new("dist/", {
-		:href_ignore => [
+		:url_ignore => [
 			"#",
 			# The additional anchor link is picked up from the Geomap JSON, but shouldn't be flagged
 			"\\\"#\\\"",
@@ -19,6 +19,14 @@ task :test do
 			# The texthighlight plug-in has some non-escaped characters in the query string
 			"texthighlight/texthighlight-fr.html?txthl=influenza%20aviaire+monde+suffis+symptômes%20semblables%20à%20ceux%20de%20l'influenza+À%20titre%20de%20rappel...+À%20de%20rares%20occasions,%20des%20humains%20ont%20été%20infectés%20par%20ce%20virus.",
 			"../../../demos/texthighlight/texthighlight-en.html?txthl=influenza%20aviaire+monde+suffis+sympt%C3%B4mes%20semblables%20%C3%A0%20ceux%20de%20l'influenza+%C3%80%20titre%20de%20rappel...+%C3%80%20de%20rares%20occasions,%20des%20humains%20ont%20%C3%A9t%C3%A9%20infect%C3%A9s%20par%20ce%20virus.#exemple"
+		],
+		:file_ignore => [
+			# Ignore empty href error. Content and inner code inside <template> element should be ignored.
+			"dist/demos/data-json/template-en.html",
+			"dist/demos/data-json/template-fr.html",
+			"dist/unmin/demos/data-json/template-en.html",
+			"dist/unmin/demos/data-json/template-fr.html"
+
 		],
 		:disable_external => true,
 		:empty_alt_ignore => true,

--- a/site/pages/docs/ref/data-ajax/data-ajax-en.hbs
+++ b/site/pages/docs/ref/data-ajax/data-ajax-en.hbs
@@ -117,7 +117,11 @@
 		<li><strong>Optional (v4.0.12+):</strong> Filter the content using the URL hash (<code>ajax/data-ajax-filter-en.html#filter-id</code>) or a selector (<code>ajax/data-ajax-filter-en.html .filter-selector</code>).</li>
 	</ol>
 </section>
-
+<section>
+	<h2>Cache busting</h2>
+	<p>Before to use the cache busting mechanism with your data json instance, it's highly recommended to configure your server properly instead.</p>
+	<p>Various strategy can be set on the server side and those are communicated to the browser through an http header as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>.</p>
+</section>
 <section>
 	<h2>Configuration options</h2>
 	<table class="table">
@@ -146,6 +150,59 @@
 						<dd>Insert the content at the start of the element.</dd>
 						<dt><code>data-ajax-replace</code>:</dt>
 						<dd>Replace the element with the content.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>url</code></td>
+				<td>Configure the origin of the content to AJAX in.</td>
+				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace" }'</code></td>
+				<td>The value being the URL of the content to AJAX in.</td>
+			</tr>
+			<tr>
+				<td><code>type</code></td>
+				<td>Configure how the destination of the content will be inserted.</td>
+				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace" }'</code></td>
+				<td>Be one of the valid value listed.
+					<dl>
+						<dt><code>after</code></dt>
+						<dd>Insert content after the element</dd>
+						<dt><code>append</code></dt>
+						<dd>Insert content at the end of the element</dd>
+						<dt><code>before</code></dt>
+						<dd>Insert content before the element</dd>
+						<dt><code>replace</code></dt>
+						<dd>Replace content inside the element</dd>
+						<dt><code>prepend</code></dt>
+						<dd>Insert content at the start of the element</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>nocache</code></td>
+				<td>Prevent caching. Prior using the functionality, use the various caching strategies that can be set and communicated through http header from your server, as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>. Also, please note that some server may not like to have an query appended to his url and you may get an HTTP error like "400 Bad Request" or "404 Not Found". Like a page served by a domino server will return 404 error if the query string do not start with "<code>?open</code>", "<code>?openDocument</code>" or "<code>?readForm</code>".</td>
+				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace", "nocache": true }'</code> or <code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace", "nocache": "nocache" }'</code>
+				<td>
+					<dl>
+						<dt>Default</dt>
+						<dd>The browser will manage the cache based on how the server has sent the file.</dd>
+						<dt><code>true</code></dt>
+						<dd>Boolean, Use the same cache buster id for the user session. Clossing and opening the tab should generate a new cache busting id.</dd>
+						<dt><code>nocache</code></dt>
+						<dd>String, A new id is generated everytime the file is fetched</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>nocachekey</code></td>
+				<td>Prevent caching. Optional, it defined what query parameter name to use for the cache busting.</td>
+				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace", "nocache": true, "nocachekey": "wbCacheBust" }'</code></td>
+				<td>
+					<dl>
+						<dt>Default</dt>
+						<dd>Will use "<code>wbCacheBust</code>" for the parameter name.</dd>
+						<dt>String</dt>
+						<dd>URL pre-encoded string</dd>
 					</dl>
 				</td>
 			</tr>

--- a/site/pages/docs/ref/data-ajax/data-ajax-fr.hbs
+++ b/site/pages/docs/ref/data-ajax/data-ajax-fr.hbs
@@ -152,6 +152,59 @@
 					</dl>
 				</td>
 			</tr>
+			<tr>
+				<td><code>url</code></td>
+				<td>Configure the origin of the content to AJAX in.</td>
+				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace" }'</code></td>
+				<td>The value being the URL of the content to AJAX in.</td>
+			</tr>
+			<tr>
+				<td><code>type</code></td>
+				<td>Configure how the destination of the content will be inserted.</td>
+				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace" }'</code></td>
+				<td>Be one of the valid value listed.
+					<dl>
+						<dt><code>after</code></dt>
+						<dd>Insert content after the element</dd>
+						<dt><code>append</code></dt>
+						<dd>Insert content at the end of the element</dd>
+						<dt><code>before</code></dt>
+						<dd>Insert content before the element</dd>
+						<dt><code>replace</code></dt>
+						<dd>Replace content inside the element</dd>
+						<dt><code>prepend</code></dt>
+						<dd>Insert content at the start of the element</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>nocache</code></td>
+				<td>Prevent caching. Prior using the functionality, use the various caching strategies that can be set and communicated through http header from your server, as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>. Also, please note that some server may not like to have an query appended to his url and you may get an HTTP error like "400 Bad Request" or "404 Not Found". Like a page served by a domino server will return 404 error if the query string do not start with "<code>?open</code>", "<code>?openDocument</code>" or "<code>?readForm</code>".</td>
+				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace", "nocache": true }'</code> or <code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace", "nocache": "nocache" }'</code>
+				<td>
+					<dl>
+						<dt>Default</dt>
+						<dd>The browser will manage the cache based on how the server has sent the file.</dd>
+						<dt><code>true</code></dt>
+						<dd>Boolean, Use the same cache buster id for the user session. Clossing and opening the tab should generate a new cache busting id.</dd>
+						<dt><code>nocache</code></dt>
+						<dd>String, A new id is generated everytime the file is fetched</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>nocachekey</code></td>
+				<td>Prevent caching. Optional, it defined what query parameter name to use for the cache busting.</td>
+				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace", "nocache": true, "nocachekey": "wbCacheBust" }'</code></td>
+				<td>
+					<dl>
+						<dt>Default</dt>
+						<dd>Will use "<code>wbCacheBust</code>" for the parameter name.</dd>
+						<dt>String</dt>
+						<dd>URL pre-encoded string</dd>
+					</dl>
+				</td>
+			</tr>
 		</tbody>
 	</table>
 </section>

--- a/site/pages/docs/ref/data-json/data-json-en.hbs
+++ b/site/pages/docs/ref/data-json/data-json-en.hbs
@@ -4,33 +4,41 @@
 	"language": "en",
 	"category": "Plugins",
 	"categoryfile": "plugins",
-	"description": "Insert content extracted from a JSON file.",
+	"description": "Insert content extracted from a JSON file and leverage HTML 5 template element.",
 	"altLangPrefix": "data-json",
-	"dateModified": "2016-11-07"
+	"dateModified": "2017-01-31"
 }
 ---
 <div class="wb-prettify all-pre"></div>
 
 <section>
 	<h2>Purpose</h2>
-	<p>Insert content extracted from a JSON file.</p>
+	<p>Insert content extracted from a JSON file or provided by a dataset.</p>
+	<p>The role of this plugin is to display selected data into HTML elements, if you need to manipulate the data prior it get displayed or you need to interact with, then use this plugin in conjonction with the JSON-manager plugin that support dataset.</p>
 </section>
 <section>
 	<h2>Use when</h2>
 	<p>When you need to display the same atomic information on multiple pages. Like a fee for a services that is re-use across multiple pages.</p>
+	<p>To insert repeatitive content by using HTML5 template element.</p>
 </section>
 <section>
 	<h2>Do not use when</h2>
 	<ul>
-		<li>To insert HTML content, use <a href="../data-ajax/data-ajax-en.html">data-ajax</a> instead.</li>
-		<li>For inserting data that only apply for one unique page.</li>
+		<li>To insert block of HTML content, instead use <a href="../data-ajax/data-ajax-en.html">data-ajax</a> with the filtering option if neccessary.</li>
+		<li>For inserting data that only apply to an unique page.</li>
 	</ul>
 </section>
 <section>
 	<h2>Working example</h2>
+	<p>English:</p>
 	<ul>
-		<li><a href="../../../demos/data-json/data-json-en.html">English example</a></li>
-		<li><a href="../../../demos/data-json/data-json-fr.html">French example</a></li>
+		<li><a href="../../../demos/data-json/data-json-en.html">Data JSON</a></li>
+		<li><a href="../../../demos/data-json/template-en.html">HTML 5 template</a></li>
+	</ul>
+	<p>French:</p>
+	<ul>
+		<li><a href="../../../demos/data-json/data-json-fr.html" hreflang="fr">Data JSON</a></li>
+		<li><a href="../../../demos/data-json/template-fr.html" hreflang="fr" lang="fr">Gabarit HTML 5</a></li>
 	</ul>
 </section>
 <section>
@@ -38,44 +46,87 @@
 
 	<ol>
 		<li>Create a <a href="https://www.google.ca/search?q=validate+JSON#q=validate+JSON">valid JSON file</a></li>
-		<li>
-			<p>Add one of the following data-json attributes to an element, with the attribute value being the URL of the JSON file followed by a <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a> URL hash:</p>
+		<li>The one of the following:
 			<ul>
 				<li>
-				<p><code>data-json-after</code>: Insert content after the element</p>
-				<pre><code>&lt;span data-json-after=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
+					<p>Add one of the following data-json attributes to an element, with the attribute value being the URL of the JSON file followed by a <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a> URL hash:</p>
+					<ul>
+						<li>
+						<p><code>data-json-after</code>: Insert content after the element</p>
+						<pre><code>&lt;span data-json-after=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+						<li>
+						<p><code>data-json-append</code>: Insert content at the end of the element</p>
+						<pre><code>&lt;span data-json-append=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+						<li>
+						<p><code>data-json-before</code>: Insert content before the element</p>
+						<pre><code>&lt;span data-json-before=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+						<li>
+						<p><code>data-json-prepend</code>: Insert content at the start of the element</p>
+						<pre><code>&lt;span data-json-prepend=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+						<li>
+						<p><code>data-json-replace</code>: Replace content inside the element</p>
+						<pre><code>&lt;span data-json-replace=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+						<li>
+						<p><code>data-json-replacewith</code>: Replace the element by the content</p>
+						<pre><code>&lt;span data-json-replacewith=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+					</ul>
 				</li>
 				<li>
-				<p><code>data-json-append</code>: Insert content at the end of the element</p>
-				<pre><code>&lt;span data-json-append=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
+					<p>For HTML5 templating, add the attribute <code>data-wb-json</code> on the elements you wanted to append items. The following populate a list:</p>
+					<pre><code>&lt;ul data-wb-json='{
+		&quot;url&quot;: &quot;data-en.json#/anArray&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/name&quot;
+		]
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;</code></pre>
+					<p>Where:</p>
+					<dl class="dl-horizontal">
+						<dt><code>url</code></dt>
+						<dd>JSON file location or dataset name followed by an optional JSON pointer</dd>
+						<dt><code>queryall</code></dt>
+						<dd>Contain a valid <a href="https://www.w3.org/TR/selectors/">CSS selector</a>.</dd>
+						<dt><code>mapping</code></dt>
+						<dd>Array of JSON pointer, as many as the return result of <code>queryall</code> applied on the <code>&lt;template&gt;</code> element.</dd>
+					</dl>
+					<p>Note: When using the template for filling a table, wrap your rows template into a <code>table</code> element in order to avoid a bug in Internet Explorer.</p>
 				</li>
 				<li>
-				<p><code>data-json-before</code>: Insert content before the element</p>
-				<pre><code>&lt;span data-json-before=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
-				</li>
-				<li>
-				<p><code>data-json-prepend</code>: Insert content at the start of the element</p>
-				<pre><code>&lt;span data-json-prepend=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
-				</li>
-				<li>
-				<p><code>data-json-replace</code>: Replace content inside the element</p>
-				<pre><code>&lt;span data-json-replace=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
-				</li>
-				<li>
-				<p><code>data-json-replacewith</code>: Replace the element by the content</p>
-				<pre><code>&lt;span data-json-replacewith=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
+					<p>Use the data for shapping multiple area of an HTML element</p>
+					<pre><code>&lt;a href=&quot;generic/location.html&quot; data-wb-json='[
+		{
+			&quot;url&quot;: &quot;mydata.json#/first/title&quot;,
+			&quot;type&quot;: &quot;replace&quot;
+		},
+		{
+			&quot;url&quot;: &quot;mydata.json#/first/html_url&quot;,
+			&quot;type&quot;: &quot;prop&quot;,
+			&quot;prop&quot;: &quot;href&quot;
+		}
+	]'&gt;Generic location&lt;/a&gt;</code></pre>
+
 				</li>
 			</ul>
 		</li>
@@ -168,37 +219,291 @@
 </section>
 
 <section>
+<h2>HTML5 <code>template</code> element in the specification</h2>
+
+<p>Official reference:</p>
+<ul>
+	<li><a href="https://www.w3.org/TR/html52/semantics-scripting.html#the-template-element">HTML5.2 W3C Working Draft - 4.12.3. The <code>template</code> element</a></li>
+	<li><a href="https://www.w3.org/TR/html5/scripting-1.html#the-template-element">HTML5 W3C Recommendation - 4.11.3 The <code>template</code> element</a></li>
+	<li><a href="https://html.spec.whatwg.org/multipage/scripting.html#the-template-element">WHATWG Living standard - 4.12.3 The <code>template</code> element</a></li>
+</ul>
+
+<p>The following was extracted from HTML5.2 spec:</p>
+
+<h3>Contexts in which this element can be used.</h3>
+<p>The following is a <em>non-normative</em> description of where the element can be used. This information is redundant with the content models of elements that allow this one as a child, and is provided only as a convenience.</p>
+<ul>
+	<li>Where <a href="https://www.w3.org/TR/html52/dom.html#metadata-content-2">metadata content</a> is expected.</li>
+	<li>Where <a href="https://www.w3.org/TR/html52/dom.html#phrasing-content-2">phrasing content</a> is expected.</li>
+	<li>Where <a href="https://www.w3.org/TR/html52/dom.html#script-supporting-elements-2">script-supporting</a> elements are expected.</li>
+	<li>As a child of a <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-colgroup">colgroup</a></code> element that doesn’t have a span attribute.</li>
+</ul>
+
+<h3>Content model</h3>
+<p>A normative description of what content must be included as children and descendants of the element.</p>
+
+<ul>
+	<li>Either: <a href="https://www.w3.org/TR/html52/dom.html#metadata-content-2">Metadata content</a>.</li>
+	<li>Or: <a href="https://www.w3.org/TR/html52/dom.html#flow-content-2">Flow content</a>.</li>
+	<li>Or: The content model of <code>&lt;ol&gt;</code> and <code><a href="https://www.w3.org/TR/html52/grouping-content.html#elementdef-ul">&lt;ul&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/grouping-content.html#elementdef-dl">&lt;dl&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/grouping-content.html#elementdef-figure">&lt;figure&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/textlevel-semantics.html#elementdef-ruby">&lt;ruby&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/semantics-embedded-content.html#elementdef-object">&lt;object&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code>&lt;video&gt;</code> and <code><a href="https://www.w3.org/TR/html52/semantics-embedded-content.html#elementdef-audio">audio</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-table">&lt;table&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-colgroup">&lt;colgroup&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-thead">&lt;thead&gt;</a></code>, <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-tbody">&lt;tbody&gt;</a></code>, and <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-tfoot">&lt;tfoot&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-tr">&lt;tr&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/sec-forms.html#elementdef-fieldset">&lt;fieldset&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/sec-forms.html#elementdef-select">&lt;select&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/interactive-elements.html#elementdef-details">&lt;details&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/interactive-elements.html#elementdef-menu">&lt;menu&gt;</a></code> elements whose <code>type</code> attribute is in the <a href="https://www.w3.org/TR/html52/interactive-elements.html#statedef-menu-popup-menu">popup menu</a> state.</li>
+</ul>
+
+<p>Note that the following elements, incomplete list, have a content model that could expect script-supporting elements: <code>ol</code>, <code>ul</code>, <code>dl</code>, <code>table</code>, <code>thead</code>, <code>tbody</code>, <code>tfoot</code>, <code>tr</code>, <code>select</code>, <code>menu</code></p>
+</section>
+
+<section>
+<h2>Cache busting</h2>
+<p>Before to use the cache busting mechanism with your data json instance, it's highly recommended to configure your server properly instead.</p>
+<p>Various strategy can be set on the server side and those are communicated to the browser through an http header as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>.</p>
+</section>
+
+<section>
 	<h2>Configuration options</h2>
 	<table class="table">
 	<thead>
 	<tr>
-	<th>Option</th>
-	<th>Description</th>
-	<th>How to configure</th>
-	<th>Values</th>
-	</tr>
+		<th>Option</th>
+		<th>Description</th>
+		<th>How to configure</th>
+		<th>Values</th>
+		</tr>
 	</thead>
 	<tbody>
 	<tr>
-	<td>Insertion type</td>
-	<td>Configure the origin and destination of the content to be extracted from a JSON file.</td>
-	<td>Add the configuration attribute to the affected element with the value being the URL followed by a JSON pointer hash of the data to be inserted.</td>
-	<td>
-		<dl>
-			<dt><code>data-json-after</code>:</dt>
-			<dd>Insert content after the element</dd>
-			<dt><code>data-json-append</code>:</dt>
-			<dd>Insert content at the end of the element</dd>
-			<dt><code>data-json-before</code>:</dt>
-			<dd>Insert content before the element</dd>
-			<dt><code>data-json-prepend</code>:</dt>
-			<dd>Insert content at the start of the element</dd>
-			<dt><code>data-json-replace</code>:</dt>
-			<dd>Replace content inside the element</dd>
-			<dt><code>data-json-replacewith</code>:</dt>
-			<dd>Replace the element by the content</dd>
-		</dl>
-	</td>
+		<td>Insertion type</td>
+		<td>Configure the origin and destination of the content to be extracted from a JSON file.</td>
+		<td>Add the configuration attribute to the affected element with the value being the URL followed by a JSON pointer hash of the data to be inserted.</td>
+		<td>
+			<dl>
+				<dt><code>data-json-after</code>:</dt>
+				<dd>Insert content after the element</dd>
+				<dt><code>data-json-append</code>:</dt>
+				<dd>Insert content at the end of the element</dd>
+				<dt><code>data-json-before</code>:</dt>
+				<dd>Insert content before the element</dd>
+				<dt><code>data-json-prepend</code>:</dt>
+				<dd>Insert content at the start of the element</dd>
+				<dt><code>data-json-replace</code>:</dt>
+				<dd>Replace content inside the element</dd>
+				<dt><code>data-json-replacewith</code>:</dt>
+				<dd>Replace the element by the content</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>url</code></td>
+		<td><strong>Required</strong>. Define the url or the dataset name to use. When used in a template mode, the URL should point to an array object.</td>
+		<td>You can follow the url or the dataset name by a <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a>.</td>
+		<td>
+			<dl>
+				<dt><code>data-wb-json='{ "url": "location/of/json/file.json#/" }'</code></dt>
+				<dd>The url are a json file</dd>
+				<dt><code>data-wb-json='{ "url": "[datasetName]#/" }'</code></dt>
+				<dd>The url is a reference to a dataset managed by a json-manager defined in the page</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>type</code></td>
+		<td>Configure the origin and destination of the content to be extracted from a JSON file. Similar of using the insertion type.</td>
+		<td>Add a value to type that is recongnized, if leaved it it will assume it's means template.</td>
+		<td>
+			<dl>
+				<dt><code>template</code></dt>
+				<dd>(Default) Apply the HTML template by using the json.</dd>
+				<dt><code>addclass</code></dt>
+				<dd>Add a class to the element</dd>
+				<dt><code>after</code></dt>
+				<dd>Insert content after the element</dd>
+				<dt><code>append</code></dt>
+				<dd>Insert content at the end of the element</dd>
+				<dt><code>attr</code></dt>
+				<dd>Change an attribute on the element. It's require also the configuration <code>attr</code> which contain the attribute name.</dd>
+				<dt><code>before</code></dt>
+				<dd>Insert content before the element</dd>
+				<dt><code>removeclass</code></dt>
+				<dd>Remove a class to the element</dd>
+				<dt><code>replace</code></dt>
+				<dd>Replace content inside the element</dd>
+				<dt><code>replacewith</code></dt>
+				<dd>Replace the element by the content</dd>
+				<dt><code>prepend</code></dt>
+				<dd>Insert content at the start of the element</dd>
+				<dt><code>prop</code></dt>
+				<dd>Change a property on the element. It's require also the configuration <code>prop</code> which contain the attribute name.</dd>
+				<dt><code>val</code></dt>
+				<dd>Set a value on an input element.</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>attr</code></td>
+		<td>Specify the element attribute name. Only required when <code>type="attr"</code>.</td>
+		<td><code>data-wb-json='{ "url": "", "type": "attr", "attr": "href" }'</code></td>
+		<td>A valid attribute name supported by the element and be one of the following <code>href, src, data-*, aria-*, role, pattern, min, max, step</code>.</td>
+	</tr>
+	<tr>
+		<td><code>prop</code></td>
+		<td>Specify the element attribute name. Only required when <code>type="prop"</code>.</td>
+		<td><code>data-wb-json='{ "url": "", "type": "prop", "prop": "disabled" }'</code></td>
+		<td>A valid attribute considered as a propperty supported by the element and be one of the following <code>checked, selected, disabled, required, readonly, multiple</code>.</td>
+	</tr>
+	<tr>
+		<td><code>queryall</code></td>
+		<td>Template only. Selects elements inside the cloned template. It's assumed the mapping represent the number of returned results of this query.</td>
+		<td><code>data-wb-json='{ "url": "", "queryall": "li" }'</code></td>
+		<td>Contain a valid <a href="https://www.w3.org/TR/selectors/">CSS selector</a>.</td>
+	</tr>
+	<tr>
+		<td><code>tobeclone</code></td>
+		<td>Template only. Selects an elements inside the template that will be cloned for the mapping and the insertion. It's assumed the mapping represent the number of returned results of this query. When it's specified, this returning value is considered as the root of the mapping object selector and for the queryall options.</td>
+		<td><code>data-wb-json='{ "url": "", "queryall": "li" }'</code></td>
+		<td>
+			<dl>
+				<dt>Default</dt>
+				<dd>All the children elements of the source template</dd>
+				<dt>If defined</dt>
+				<dd>A valid <a href="https://www.w3.org/TR/selectors/">CSS selector</a>.</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>filter</code></td>
+		<td>Template only. Validating for truthness to allow array items to be processed by the template. Contains an array of evaluation criteria for array items.</td>
+		<td><code>data-wb-json='{ "url": "", "filter": [ {evaluation object} ] }'</code></td>
+		<td>
+			Evaluation object have the following property
+			<dl>
+				<dt><code>path</code></dt>
+				<dd>Required. JSON pointer to the data being evaluated</dd>
+				<dt><code>value</code></dt>
+				<dd>Required. Value of witch the data would be evaluated</dd>
+				<dt><code>optional</code></dt>
+				<dd>Indicated if the evaluation is optional.</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td>Evaluation object <code>path</code></td>
+		<td>Template only, for evaluation object and required. JSON pointer to the data being evaluated. It's must start with an "/". </td>
+		<td><code>data-wb-json='{ "url": "", "filter": [ { "path": "/JSON Pointer" } ] }'</code></td>
+		<td>A valid <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a></td>
+	</tr>
+	<tr>
+		<td>Evaluation object <code>value</code></td>
+		<td>Template only, for evaluation object and required. </td>
+		<td><code>data-wb-json='{ "url": "", "filter": [ { "value": "A value" } ] }'</code></td>
+		<td>Any value that could be compared with the information retreived form the path.</td>
+	</tr>
+	<tr>
+		<td>Evaluation object <code>optional</code></td>
+		<td>Template only and for evaluation object.</td>
+		<td><code>data-wb-json='{ "url": "", "filter": [ { "optional": true } ] }'</code></td>
+		<td>True or false. If omited it will be false by default.</td>
+	</tr>
+	<tr>
+		<td><code>filternot</code></td>
+		<td>Template only. Validating for falsness to disallow an array items to be processed by the template. Contains an array of evaluation criteria for array items.</td>
+		<td><code>data-wb-json='{ "url": "", "filternot": [ {evaluation object} ] }'</code></td>
+		<td>
+			Evaluation object have the following property
+			<dl>
+				<dt><code>path</code></dt>
+				<dd>Required. JSON pointer to the data being evaluated</dd>
+				<dt><code>value</code></dt>
+				<dd>Required. Value of witch the data would be evaluated</dd>
+				<dt><code>optional</code></dt>
+				<dd>Indicated if the evaluation is optional.</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>source</code></td>
+		<td>Template only. Pointer to the template elements. Not required when the template is the child of the host element.</td>
+		<td><code>data-wb-json='{ "url": "", "source": "#idToMyTemplate" }'</code></td>
+		<td>JQuery selector that represent the template element on the current page.</td>
+	</tr>
+	<tr>
+		<td><code>mapping</code></td>
+		<td>Template only. Array of string represeting a JSON pointer or object where it specify how to bind the data with the template content. If the configuration <code>queryall</code> is used, the number of items in the mapping must match the number of returning result of the queryall. In the other hand, if <code>queryall</code> configuration is not specified, than each mapping object must define a <code>selector</code> configuration.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ "JSON Pointer", "JSON Pointer" ] }'</code> or <code>data-wb-json='{ "url": "", "mapping": [ {mapping object}, {mapping object} ] }'</code></td>
+		<td>When queryall is not specified, it's is an array of string with a the JSON pointer. (Equivalent to the value in the Mapping object)</td>
+	</tr>
+
+
+
+	<tr>
+		<td>Mapping object <code>selector</code></td>
+		<td>Template only, for mapping object and required when <code>queryall</code> is not specified. Should selects one element inside the cloned template.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "selector": "A CSS Selector" } ] }'</code></td>
+		<td>A valid <a href="https://www.w3.org/TR/selectors/">CSS selector</a>.</td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>value</code></td>
+		<td>Template only, for mapping object and required when <code>queryall</code> is not specified. JSON Pointer representing the data to be mapped.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "value": "A JSON Pointer" } ] }'</code></td>
+		<td>A valid <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a></td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>placeholder</code></td>
+		<td>Template only, for mapping object and optinal when <code>queryall</code> is not specified. String representing the placeholder to replace by the selected data</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "placeholder": "{{name}}" } ] }'</code></td>
+		<td>A findable string in the selected element in the template.</td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>attr</code></td>
+		<td>Template only, for mapping object and optional when <code>queryall</code> is not specified. Name of an attribute where the selected data will replace his value.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "attr": "href" } ] }'</code></td>
+		<td>A valid attribute of the selected element.</td>
+	</tr>
+	<tr>
+		<td><code>appendto</code></td>
+		<td>Template only. When the elements are outside the editing area, this specified the element to use to append the template. Specifying the data-json directly of the elements should remain how it is used.</td>
+		<td><code>data-wb-json='{ "url": "", "appendto": "title" }'</code></td>
+		<td>A valid jQuery selector.</td>
+	</tr>
+	<tr>
+		<td><code>nocache</code></td>
+		<td>Prevent caching. Prior using the functionality, use the various caching strategies that can be set and communicated through http header from your server, as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>. Also, please note that some server may not like to have an query appended to his url and you may get an HTTP error like "400 Bad Request" or "404 Not Found". Like a page served by a domino server will return 404 error if the query string do not start with "<code>?open</code>", "<code>?openDocument</code>" or "<code>?readForm</code>".</td>
+		<td><code>data-wb-json='{ "url": "", "nocache": true }'</code> or <code>data-wb-json='{ "url": "", "nocache": "nocache" }'</code></td>
+		<td>
+			<dl>
+				<dt>Default</dt>
+				<dd>The browser will manage the cache based on how the server has sent the file.</dd>
+				<dt><code>true</code></dt>
+				<dd>Boolean, Use the same cache buster id for the user session. Clossing and opening the tab should generate a new cache busting id.</dd>
+				<dt><code>nocache</code></dt>
+				<dd>String, A new id is generated everytime the file is fetched</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>nocachekey</code></td>
+		<td>Prevent caching. Optional, it defined what query parameter name to use for the cache busting.</td>
+		<td><code>data-wb-json='{ "url": "", "nocache": true, "nocachekey": "wbCacheBust" }'</code></td>
+		<td>
+			<dl>
+				<dt>Default</dt>
+				<dd>Will use "<code>wbCacheBust</code>" for the parameter name.</dd>
+				<dt>String</dt>
+				<dd>URL pre-encoded string</dd>
+			</dl>
+		</td>
+	</tr>
+
 	</tbody>
 	</table>
 </section>
@@ -251,6 +556,4 @@
 <section>
 	<h2>Source code</h2>
 	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/data-json">Data JSON plugin source code on GitHub</a></p>
-	<h3>Dependency</h3>
-	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/json-fetch">JSON fetch plugin source code on GitHub</a></p>
 </section>

--- a/site/pages/docs/ref/data-json/data-json-fr.hbs
+++ b/site/pages/docs/ref/data-json/data-json-fr.hbs
@@ -4,9 +4,9 @@
 	"language": "fr",
 	"category": "Plugiciels",
 	"categoryfile": "plugins",
-	"description": "Insertion de contenu extrait d'un fichier JSON.",
+	"description": "Insertion de contenu extrait d'un fichier JSON et prends avantage de l'élément template du HTML 5.",
 	"altLangPrefix": "data-json",
-	"dateModified": "2016-11-07"
+	"dateModified": "2017-01-31"
 }
 ---
 <div class="wb-prettify all-pre"></div>
@@ -14,26 +14,35 @@
 <div lang="en">
 <p><strong>Needs translation</strong></p>
 
+
 <section>
 	<h2>Purpose</h2>
-	<p>Insert content extracted from a JSON file.</p>
+	<p>Insert content extracted from a JSON file or provided by a dataset.</p>
+	<p>The role of this plugin is to display selected data into HTML elements, if you need to manipulate the data prior it get displayed or you need to interact with, then use this plugin in conjonction with the JSON-manager plugin that support dataset.</p>
 </section>
 <section>
 	<h2>Use when</h2>
 	<p>When you need to display the same atomic information on multiple pages. Like a fee for a services that is re-use across multiple pages.</p>
+	<p>To insert repeatitive content by using HTML5 template element.</p>
 </section>
 <section>
 	<h2>Do not use when</h2>
 	<ul>
-		<li>To insert HTML content, use <a href="../data-ajax/data-ajax-en.html">data-ajax</a> instead.</li>
-		<li>For inserting data that only apply for one unique page.</li>
+		<li>To insert block of HTML content, instead use <a href="../data-ajax/data-ajax-en.html">data-ajax</a> with the filtering option if neccessary.</li>
+		<li>For inserting data that only apply to an unique page.</li>
 	</ul>
 </section>
 <section>
 	<h2>Working example</h2>
+	<p>English:</p>
 	<ul>
-		<li><a href="../../../demos/data-json/data-json-en.html">English example</a></li>
-		<li><a href="../../../demos/data-json/data-json-fr.html">French example</a></li>
+		<li><a href="../../../demos/data-json/data-json-en.html">Data JSON</a></li>
+		<li><a href="../../../demos/data-json/template-en.html">HTML 5 template</a></li>
+	</ul>
+	<p>French:</p>
+	<ul>
+		<li><a href="../../../demos/data-json/data-json-fr.html" hreflang="fr">Data JSON</a></li>
+		<li><a href="../../../demos/data-json/template-fr.html" hreflang="fr" lang="fr">Gabarit HTML 5</a></li>
 	</ul>
 </section>
 <section>
@@ -41,55 +50,101 @@
 
 	<ol>
 		<li>Create a <a href="https://www.google.ca/search?q=validate+JSON#q=validate+JSON">valid JSON file</a></li>
-		<li>
-			<p>Add one of the following data-json attributes to an element, with the attribute value being the URL of the JSON file followed by a <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a> URL hash:</p>
+		<li>The one of the following:
 			<ul>
 				<li>
-				<p><code>data-json-after</code>: Insert content after the element</p>
-				<pre><code>&lt;span data-json-after=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
+					<p>Add one of the following data-json attributes to an element, with the attribute value being the URL of the JSON file followed by a <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a> URL hash:</p>
+					<ul>
+						<li>
+						<p><code>data-json-after</code>: Insert content after the element</p>
+						<pre><code>&lt;span data-json-after=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+						<li>
+						<p><code>data-json-append</code>: Insert content at the end of the element</p>
+						<pre><code>&lt;span data-json-append=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+						<li>
+						<p><code>data-json-before</code>: Insert content before the element</p>
+						<pre><code>&lt;span data-json-before=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+						<li>
+						<p><code>data-json-prepend</code>: Insert content at the start of the element</p>
+						<pre><code>&lt;span data-json-prepend=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+						<li>
+						<p><code>data-json-replace</code>: Replace content inside the element</p>
+						<pre><code>&lt;span data-json-replace=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+						<li>
+						<p><code>data-json-replacewith</code>: Replace the element by the content</p>
+						<pre><code>&lt;span data-json-replacewith=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
+			...
+		&lt;/span&gt;</code></pre>
+						</li>
+					</ul>
 				</li>
 				<li>
-				<p><code>data-json-append</code>: Insert content at the end of the element</p>
-				<pre><code>&lt;span data-json-append=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
+					<p>For HTML5 templating, add the attribute <code>data-wb-json</code> on the elements you wanted to append items. The following populate a list:</p>
+					<pre><code>&lt;ul data-wb-json='{
+		&quot;url&quot;: &quot;data-en.json#/anArray&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/name&quot;
+		]
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;</code></pre>
+					<p>Where:</p>
+					<dl class="dl-horizontal">
+						<dt><code>url</code></dt>
+						<dd>JSON file location or dataset name followed by an optional JSON pointer</dd>
+						<dt><code>queryall</code></dt>
+						<dd>Contain a valid <a href="https://www.w3.org/TR/selectors/">CSS selector</a>.</dd>
+						<dt><code>mapping</code></dt>
+						<dd>Array of JSON pointer, as many as the return result of <code>queryall</code> applied on the <code>&lt;template&gt;</code> element.</dd>
+					</dl>
+					<p>Note: When using the template for filling a table, wrap your rows template into a <code>table</code> element in order to avoid a bug in Internet Explorer.</p>
 				</li>
 				<li>
-				<p><code>data-json-before</code>: Insert content before the element</p>
-				<pre><code>&lt;span data-json-before=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
-				</li>
-				<li>
-				<p><code>data-json-prepend</code>: Insert content at the start of the element</p>
-				<pre><code>&lt;span data-json-prepend=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
-				</li>
-				<li>
-				<p><code>data-json-replace</code>: Replace content inside the element</p>
-				<pre><code>&lt;span data-json-replace=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
-				</li>
-				<li>
-				<p><code>data-json-replacewith</code>: Replace the element by the content</p>
-				<pre><code>&lt;span data-json-replacewith=&quot;json/data-en.json#/JSON/Pointer&quot;&gt;
-	...
-&lt;/span&gt;</code></pre>
+					<p>Use the data for shapping multiple area of an HTML element</p>
+					<pre><code>&lt;a href=&quot;generic/location.html&quot; data-wb-json='[
+		{
+			&quot;url&quot;: &quot;mydata.json#/first/title&quot;,
+			&quot;type&quot;: &quot;replace&quot;
+		},
+		{
+			&quot;url&quot;: &quot;mydata.json#/first/html_url&quot;,
+			&quot;type&quot;: &quot;prop&quot;,
+			&quot;prop&quot;: &quot;href&quot;
+		}
+	]'&gt;Generic location&lt;/a&gt;</code></pre>
+
 				</li>
 			</ul>
 		</li>
 	</ol>
 </section>
+</div>
 
 <section>
-<h2>Selecting data</h2>
+<h2>Selection de donnée</h2>
 
-<p>(Source: <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer, RCF6901</a>)</p>
-<p>For example, given the JSON document</p>
+<p>(Source: <a href="https://tools.ietf.org/html/rfc6901" hreflang="en">Pointeur JSON, RCF6901</a>)</p>
+
+<p>Par exemple, prennont ce document JSON</p>
+
 <pre><code>{
 	"foo": ["bar", "baz"],
 	"": 0,
@@ -102,15 +157,17 @@
 	" ": 7,
 	"m~n": 8
 }</code></pre>
-<p>The following URI fragment identifiers evaluate to the accompanying values:</p>
+
+<p>Voici les résultats après que le pointeur JSON aient été évalué à partir du fragments d'URI.</p>
+
 <table class="table">
 	<tr>
-		<th>URI fragment</th>
-		<th>Returning value</th>
+		<th>Fragment d'URI</th>
+		<th>Valeur retourné</th>
 	</tr>
 	<tr>
 		<td><code>#</code></td>
-		<td>The whole document</td>
+		<td>Tout le document</td>
 	</tr>
 	<tr>
 		<td><code>#/foo</code></td>
@@ -160,14 +217,68 @@
 </section>
 
 <section>
-<h2>Issue that you may encounter</h2>
+<h2>Problème potentiel qui peuvent survenir</h2>
 <dl>
-	<dt>Display nothing, plugin seems to be broken.</dt>
-	<dd>Ensure that your <a href="https://www.google.ca/search?q=validate+JSON#q=validate+JSON">JSON file is valid</a></dd>
+	<dt>Aucun affichage, le composant semble disfonctionelle.</dt>
+	<dd>Veuillez vérifier que votre <a href="https://www.google.ca/search?q=validate+JSON#q=validate+JSON" hreflang="en">fichier JSON est valide.</a></dd>
 
-	<dt>Recently updated data do not display</dt>
-	<dd>Refresh your browser cache by opening a new tab the JSON file and then do a hard refresh <kbd>Ctrl + F5</kbd> or by testing your page from a new private mode session of your browser.</dd>
+	<dt>La mise à jour récente des données ne s'affiche pas.</dt>
+	<dd>Mettez à jour le cache de votre furteur en ouvrant un nouvel onglet pour consulter le fichier JSON et forcé la mise à jour en appuyant sur <kbd>Ctrl + F5</kbd> ou bien faite l'essai de page qui utilise ce plugin dans une nouvelle session du mode privé de votre furteur.</dd>
 </dl>
+</section>
+
+<div lang="en">
+
+<section>
+<h2>HTML5 <code>template</code> element in the specification</h2>
+
+<p>Official reference:</p>
+<ul>
+	<li><a href="https://www.w3.org/TR/html52/semantics-scripting.html#the-template-element">HTML5.2 W3C Working Draft - 4.12.3. The <code>template</code> element</a></li>
+	<li><a href="https://www.w3.org/TR/html5/scripting-1.html#the-template-element">HTML5 W3C Recommendation - 4.11.3 The <code>template</code> element</a></li>
+	<li><a href="https://html.spec.whatwg.org/multipage/scripting.html#the-template-element">WHATWG Living standard - 4.12.3 The <code>template</code> element</a></li>
+</ul>
+
+<p>The following was extracted from HTML5.2 spec:</p>
+
+<h3>Contexts in which this element can be used.</h3>
+<p>The following is a <em>non-normative</em> description of where the element can be used. This information is redundant with the content models of elements that allow this one as a child, and is provided only as a convenience.</p>
+<ul>
+	<li>Where <a href="https://www.w3.org/TR/html52/dom.html#metadata-content-2">metadata content</a> is expected.</li>
+	<li>Where <a href="https://www.w3.org/TR/html52/dom.html#phrasing-content-2">phrasing content</a> is expected.</li>
+	<li>Where <a href="https://www.w3.org/TR/html52/dom.html#script-supporting-elements-2">script-supporting</a> elements are expected.</li>
+	<li>As a child of a <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-colgroup">colgroup</a></code> element that doesn’t have a span attribute.</li>
+</ul>
+
+<h3>Content model</h3>
+<p>A normative description of what content must be included as children and descendants of the element.</p>
+
+<ul>
+	<li>Either: <a href="https://www.w3.org/TR/html52/dom.html#metadata-content-2">Metadata content</a>.</li>
+	<li>Or: <a href="https://www.w3.org/TR/html52/dom.html#flow-content-2">Flow content</a>.</li>
+	<li>Or: The content model of <code>&lt;ol&gt;</code> and <code><a href="https://www.w3.org/TR/html52/grouping-content.html#elementdef-ul">&lt;ul&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/grouping-content.html#elementdef-dl">&lt;dl&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/grouping-content.html#elementdef-figure">&lt;figure&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/textlevel-semantics.html#elementdef-ruby">&lt;ruby&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/semantics-embedded-content.html#elementdef-object">&lt;object&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code>&lt;video&gt;</code> and <code><a href="https://www.w3.org/TR/html52/semantics-embedded-content.html#elementdef-audio">audio</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-table">&lt;table&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-colgroup">&lt;colgroup&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-thead">&lt;thead&gt;</a></code>, <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-tbody">&lt;tbody&gt;</a></code>, and <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-tfoot">&lt;tfoot&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/tabular-data.html#elementdef-tr">&lt;tr&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/sec-forms.html#elementdef-fieldset">&lt;fieldset&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/sec-forms.html#elementdef-select">&lt;select&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/interactive-elements.html#elementdef-details">&lt;details&gt;</a></code> elements.</li>
+	<li>Or: The content model of <code><a href="https://www.w3.org/TR/html52/interactive-elements.html#elementdef-menu">&lt;menu&gt;</a></code> elements whose <code>type</code> attribute is in the <a href="https://www.w3.org/TR/html52/interactive-elements.html#statedef-menu-popup-menu">popup menu</a> state.</li>
+</ul>
+
+<p>Note that the following elements, incomplete list, have a content model that could expect script-supporting elements: <code>ol</code>, <code>ul</code>, <code>dl</code>, <code>table</code>, <code>thead</code>, <code>tbody</code>, <code>tfoot</code>, <code>tr</code>, <code>select</code>, <code>menu</code></p>
+</section>
+
+<section>
+<h2>Cache busting</h2>
+<p>Before to use the cache busting mechanism with your data json instance, it's highly recommended to configure your server properly instead.</p>
+<p>Various strategy can be set on the server side and those are communicated to the browser through an http header as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>.</p>
 </section>
 
 <section>
@@ -175,33 +286,235 @@
 	<table class="table">
 	<thead>
 	<tr>
-	<th>Option</th>
-	<th>Description</th>
-	<th>How to configure</th>
-	<th>Values</th>
-	</tr>
+		<th>Option</th>
+		<th>Description</th>
+		<th>How to configure</th>
+		<th>Values</th>
+		</tr>
 	</thead>
 	<tbody>
 	<tr>
-	<td>Insertion type</td>
-	<td>Configure the origin and destination of the content to be extracted from a JSON file.</td>
-	<td>Add the configuration attribute to the affected element with the value being the URL followed by a JSON pointer hash of the data to be inserted.</td>
-	<td>
-		<dl>
-			<dt><code>data-json-after</code>:</dt>
-			<dd>Insert content after the element</dd>
-			<dt><code>data-json-append</code>:</dt>
-			<dd>Insert content at the end of the element</dd>
-			<dt><code>data-json-before</code>:</dt>
-			<dd>Insert content before the element</dd>
-			<dt><code>data-json-prepend</code>:</dt>
-			<dd>Insert content at the start of the element</dd>
-			<dt><code>data-json-replace</code>:</dt>
-			<dd>Replace content inside the element</dd>
-			<dt><code>data-json-replacewith</code>:</dt>
-			<dd>Replace the element by the content</dd>
-		</dl>
-	</td>
+		<td>Insertion type</td>
+		<td>Configure the origin and destination of the content to be extracted from a JSON file.</td>
+		<td>Add the configuration attribute to the affected element with the value being the URL followed by a JSON pointer hash of the data to be inserted.</td>
+		<td>
+			<dl>
+				<dt><code>data-json-after</code>:</dt>
+				<dd>Insert content after the element</dd>
+				<dt><code>data-json-append</code>:</dt>
+				<dd>Insert content at the end of the element</dd>
+				<dt><code>data-json-before</code>:</dt>
+				<dd>Insert content before the element</dd>
+				<dt><code>data-json-prepend</code>:</dt>
+				<dd>Insert content at the start of the element</dd>
+				<dt><code>data-json-replace</code>:</dt>
+				<dd>Replace content inside the element</dd>
+				<dt><code>data-json-replacewith</code>:</dt>
+				<dd>Replace the element by the content</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>url</code></td>
+		<td><strong>Required</strong>. Define the url or the dataset name to use. When used in a template mode, the URL should point to an array object.</td>
+		<td>You can follow the url or the dataset name by a <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a>.</td>
+		<td>
+			<dl>
+				<dt><code>data-wb-json='{ "url": "location/of/json/file.json#/" }'</code></dt>
+				<dd>The url are a json file</dd>
+				<dt><code>data-wb-json='{ "url": "[datasetName]#/" }'</code></dt>
+				<dd>The url is a reference to a dataset managed by a json-manager defined in the page</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>type</code></td>
+		<td>Configure the origin and destination of the content to be extracted from a JSON file. Similar of using the insertion type.</td>
+		<td>Add a value to type that is recongnized, if leaved it it will assume it's means template.</td>
+		<td>
+			<dl>
+				<dt><code>template</code></dt>
+				<dd>(Default) Apply the HTML template by using the json.</dd>
+				<dt><code>addclass</code></dt>
+				<dd>Add a class to the element</dd>
+				<dt><code>after</code></dt>
+				<dd>Insert content after the element</dd>
+				<dt><code>append</code></dt>
+				<dd>Insert content at the end of the element</dd>
+				<dt><code>attr</code></dt>
+				<dd>Change an attribute on the element. It's require also the configuration <code>attr</code> which contain the attribute name.</dd>
+				<dt><code>before</code></dt>
+				<dd>Insert content before the element</dd>
+				<dt><code>removeclass</code></dt>
+				<dd>Remove a class to the element</dd>
+				<dt><code>replace</code></dt>
+				<dd>Replace content inside the element</dd>
+				<dt><code>replacewith</code></dt>
+				<dd>Replace the element by the content</dd>
+				<dt><code>prepend</code></dt>
+				<dd>Insert content at the start of the element</dd>
+				<dt><code>prop</code></dt>
+				<dd>Change a property on the element. It's require also the configuration <code>prop</code> which contain the attribute name.</dd>
+				<dt><code>val</code></dt>
+				<dd>Set a value on an input element.</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>attr</code></td>
+		<td>Specify the element attribute name. Only required when <code>type="attr"</code>.</td>
+		<td><code>data-wb-json='{ "url": "", "type": "attr", "attr": "href" }'</code></td>
+		<td>A valid attribute name supported by the element and be one of the following <code>href, src, data-*, aria-*, role, pattern, min, max, step</code>.</td>
+	</tr>
+	<tr>
+		<td><code>prop</code></td>
+		<td>Specify the element attribute name. Only required when <code>type="prop"</code>.</td>
+		<td><code>data-wb-json='{ "url": "", "type": "prop", "prop": "disabled" }'</code></td>
+		<td>A valid attribute considered as a propperty supported by the element and be one of the following <code>checked, selected, disabled, required, readonly, multiple</code>.</td>
+	</tr>
+	<tr>
+		<td><code>queryall</code></td>
+		<td>Template only. Selects elements inside the cloned template. It's assumed the mapping represent the number of returned results of this query.</td>
+		<td><code>data-wb-json='{ "url": "", "queryall": "li" }'</code></td>
+		<td>Contain a valid <a href="https://www.w3.org/TR/selectors/">CSS selector</a>.</td>
+	</tr>
+	<tr>
+		<td><code>tobeclone</code></td>
+		<td>Template only. Selects an elements inside the template that will be cloned for the mapping and the insertion. It's assumed the mapping represent the number of returned results of this query. When it's specified, this returning value is considered as the root of the mapping object selector and for the queryall options.</td>
+		<td><code>data-wb-json='{ "url": "", "queryall": "li" }'</code></td>
+		<td>
+			<dl>
+				<dt>Default</dt>
+				<dd>All the children elements of the source template</dd>
+				<dt>If defined</dt>
+				<dd>A valid <a href="https://www.w3.org/TR/selectors/">CSS selector</a>.</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>filter</code></td>
+		<td>Template only. Validating for truthness to allow array items to be processed by the template. Contains an array of evaluation criteria for array items.</td>
+		<td><code>data-wb-json='{ "url": "", "filter": [ {evaluation object} ] }'</code></td>
+		<td>
+			Evaluation object have the following property
+			<dl>
+				<dt><code>path</code></dt>
+				<dd>Required. JSON pointer to the data being evaluated</dd>
+				<dt><code>value</code></dt>
+				<dd>Required. Value of witch the data would be evaluated</dd>
+				<dt><code>optional</code></dt>
+				<dd>Indicated if the evaluation is optional.</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td>Evaluation object <code>path</code></td>
+		<td>Template only, for evaluation object and required. JSON pointer to the data being evaluated. It's must start with an "/". </td>
+		<td><code>data-wb-json='{ "url": "", "filter": [ { "path": "/JSON Pointer" } ] }'</code></td>
+		<td>A valid <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a></td>
+	</tr>
+	<tr>
+		<td>Evaluation object <code>value</code></td>
+		<td>Template only, for evaluation object and required. </td>
+		<td><code>data-wb-json='{ "url": "", "filter": [ { "value": "A value" } ] }'</code></td>
+		<td>Any value that could be compared with the information retreived form the path.</td>
+	</tr>
+	<tr>
+		<td>Evaluation object <code>optional</code></td>
+		<td>Template only and for evaluation object.</td>
+		<td><code>data-wb-json='{ "url": "", "filter": [ { "optional": true } ] }'</code></td>
+		<td>True or false. If omited it will be false by default.</td>
+	</tr>
+	<tr>
+		<td><code>filternot</code></td>
+		<td>Template only. Validating for falsness to disallow an array items to be processed by the template. Contains an array of evaluation criteria for array items.</td>
+		<td><code>data-wb-json='{ "url": "", "filternot": [ {evaluation object} ] }'</code></td>
+		<td>
+			Evaluation object have the following property
+			<dl>
+				<dt><code>path</code></dt>
+				<dd>Required. JSON pointer to the data being evaluated</dd>
+				<dt><code>value</code></dt>
+				<dd>Required. Value of witch the data would be evaluated</dd>
+				<dt><code>optional</code></dt>
+				<dd>Indicated if the evaluation is optional.</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>source</code></td>
+		<td>Template only. Pointer to the template elements. Not required when the template is the child of the host element.</td>
+		<td><code>data-wb-json='{ "url": "", "source": "#idToMyTemplate" }'</code></td>
+		<td>JQuery selector that represent the template element on the current page.</td>
+	</tr>
+	<tr>
+		<td><code>mapping</code></td>
+		<td>Template only. Array of string represeting a JSON pointer or object where it specify how to bind the data with the template content. If the configuration <code>queryall</code> is used, the number of items in the mapping must match the number of returning result of the queryall. In the other hand, if <code>queryall</code> configuration is not specified, than each mapping object must define a <code>selector</code> configuration.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ "JSON Pointer", "JSON Pointer" ] }'</code> or <code>data-wb-json='{ "url": "", "mapping": [ {mapping object}, {mapping object} ] }'</code></td>
+		<td>When queryall is not specified, it's is an array of string with a the JSON pointer. (Equivalent to the value in the Mapping object)</td>
+	</tr>
+
+
+
+	<tr>
+		<td>Mapping object <code>selector</code></td>
+		<td>Template only, for mapping object and required when <code>queryall</code> is not specified. Should selects one element inside the cloned template.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "selector": "A CSS Selector" } ] }'</code></td>
+		<td>A valid <a href="https://www.w3.org/TR/selectors/">CSS selector</a>.</td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>value</code></td>
+		<td>Template only, for mapping object and required when <code>queryall</code> is not specified. JSON Pointer representing the data to be mapped.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "value": "A JSON Pointer" } ] }'</code></td>
+		<td>A valid <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a></td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>placeholder</code></td>
+		<td>Template only, for mapping object and optinal when <code>queryall</code> is not specified. String representing the placeholder to replace by the selected data</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "placeholder": "{{name}}" } ] }'</code></td>
+		<td>A findable string in the selected element in the template.</td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>attr</code></td>
+		<td>Template only, for mapping object and optional when <code>queryall</code> is not specified. Name of an attribute where the selected data will replace his value.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "attr": "href" } ] }'</code></td>
+		<td>A valid attribute of the selected element.</td>
+	</tr>
+	<tr>
+		<td><code>appendto</code></td>
+		<td>Template only. When the elements are outside the editing area, this specified the element to use to append the template. Specifying the data-json directly of the elements should remain how it is used.</td>
+		<td><code>data-wb-json='{ "url": "", "appendto": "title" }'</code></td>
+		<td>A valid jQuery selector.</td>
+	</tr>
+	<tr>
+		<td><code>nocache</code></td>
+		<td>Prevent caching. Prior using the functionality, use the various caching strategies that can be set and communicated through http header from your server, as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>. Also, please note that some server may not like to have an query appended to his url and you may get an HTTP error like "400 Bad Request" or "404 Not Found". Like a page served by a domino server will return 404 error if the query string do not start with "<code>?open</code>", "<code>?openDocument</code>" or "<code>?readForm</code>".</td>
+		<td><code>data-wb-json='{ "url": "", "nocache": true }'</code> or <code>data-wb-json='{ "url": "", "nocache": "nocache" }'</code></td>
+		<td>
+			<dl>
+				<dt>Default</dt>
+				<dd>The browser will manage the cache based on how the server has sent the file.</dd>
+				<dt><code>true</code></dt>
+				<dd>Boolean, Use the same cache buster id for the user session. Clossing and opening the tab should generate a new cache busting id.</dd>
+				<dt><code>nocache</code></dt>
+				<dd>String, A new id is generated everytime the file is fetched</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td><code>nocachekey</code></td>
+		<td>Prevent caching. Optional, it defined what query parameter name to use for the cache busting.</td>
+		<td><code>data-wb-json='{ "url": "", "nocache": true, "nocachekey": "wbCacheBust" }'</code></td>
+		<td>
+			<dl>
+				<dt>Default</dt>
+				<dd>Will use "<code>wbCacheBust</code>" for the parameter name.</dd>
+				<dt>String</dt>
+				<dd>URL pre-encoded string</dd>
+			</dl>
+		</td>
+	</tr>
+
 	</tbody>
 	</table>
 </section>
@@ -254,7 +567,5 @@
 <section>
 	<h2>Source code</h2>
 	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/data-json">Data JSON plugin source code on GitHub</a></p>
-	<h3>Dependency</h3>
-	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/json-fetch">JSON fetch plugin source code on GitHub</a></p>
 </section>
 </div>

--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -255,6 +255,16 @@ var getUrlParts = function( url ) {
 			"#999999"
 		],
 
+		// Get and generate a unique session id
+		sessionGUID: function() {
+			var sessionId = sessionStorage.getItem( "wb-Session-GUID" );
+			if ( !sessionId ) {
+				sessionId = wb.guid();
+				sessionStorage.setItem( "wb-Session-GUID", sessionId );
+			}
+			return sessionId;
+		},
+
 		// Add a selector to be targeted by timerpoke
 		add: function( selector ) {
 			var exists = false,
@@ -535,6 +545,11 @@ Modernizr.load( [
 		nope: [
 			"plyfll!meter.min.js",
 			"plyfll!meter.min.css"
+		]
+	}, {
+		test: ( "content" in document.createElement( "template" ) ),
+		nope: [
+			"plyfll!template.min.js"
 		]
 	}, {
 		test: Modernizr.touch,

--- a/src/plugins/ajax-fetch/ajax-fetch.js
+++ b/src/plugins/ajax-fetch/ajax-fetch.js
@@ -23,13 +23,34 @@ $document.on( "ajax-fetch.wb", function( event ) {
 		fetchOpts = event.fetch,
 		urlParts = fetchOpts.url.split( " " ),
 		url = urlParts[ 0 ],
-		urlHash = url.split( "#" )[ 1 ],
+		urlSubParts = url.split( "#" ),
+		urlHash = urlSubParts[ 1 ],
 		selector = urlParts[ 1 ] || ( urlHash ? "#" + urlHash : false ),
-		fetchData, callerId;
+		fetchData, callerId, fetchNoCacheURL, urlSub,
+		fetchNoCache = fetchOpts.nocache,
+		fetchNoCacheKey = fetchOpts.nocachekey || wb.cacheBustKey || "wbCacheBust";
 
 	// Separate the URL from the filtering criteria
 	if ( selector ) {
 		fetchOpts.url = urlParts[ 0 ];
+	}
+
+	if ( fetchNoCache ) {
+		if ( fetchNoCache === "nocache" ) {
+			fetchNoCacheURL = wb.guid();
+		} else {
+			fetchNoCacheURL = wb.sessionGUID();
+		}
+		fetchNoCacheURL = fetchNoCacheKey + "=" + fetchNoCacheURL;
+
+		urlSub = urlSubParts[ 0 ];
+		if ( urlSub.indexOf( "?" ) !== -1 ) {
+			url = urlSub + "&" + fetchNoCacheURL + ( urlHash ? "#" + urlHash : "" );
+		} else {
+			url = urlSub + "?" + fetchNoCacheURL + ( urlHash ? "#" + urlHash : "" );
+		}
+
+		fetchOpts.url = url;
 	}
 
 	// Filter out any events triggered by descendants

--- a/src/plugins/data-ajax/data-ajax-en.hbs
+++ b/src/plugins/data-ajax/data-ajax-en.hbs
@@ -303,3 +303,42 @@
 		</details>
 	</section>
 </section>
+
+<section>
+	<h2>Alternative syntax</h2>
+	<p>Consult the <a href="../../docs/ref/data-ajax/data-ajax-en.html">documentation</a> for more information regarding the following alternative syntaxt.</p>
+	<h3>Example</h3>
+	<div data-wb-ajax='{
+			"url": "ajax/data-ajax-extra-en.html",
+			"type": "append"
+		}' class="original">
+		<section>
+			<h4>Hello World</h4>
+			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+		</section>
+	</div>
+	<details>
+			<summary>View code</summary>
+			<section>
+				<h4>In-page HTML</h4>
+				<pre><code>&lt;div data-wb-ajax='{
+		"url": "ajax/data-ajax-extra-en.html",
+		"type": "append"
+	}' class="original"&gt;
+	&lt;section&gt;
+		&lt;h4&gt;Hello World&lt;/h4&gt;
+		&lt;p&gt;Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.&lt;/p&gt;
+	&lt;/section&gt;
+&lt;/div&gt;</code></pre>
+			</section>
+
+			<section>
+				<h4>data-ajax-extra-en.html</h4>
+				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
+	&lt;h4&gt;I was ajaxed in&lt;/h4&gt;
+	&lt;p&gt;I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in.&lt;/p&gt;
+&lt;/section&gt;</code></pre>
+			</section>
+		</details>
+</section>
+

--- a/src/plugins/data-ajax/data-ajax-fr.hbs
+++ b/src/plugins/data-ajax/data-ajax-fr.hbs
@@ -42,8 +42,8 @@
 			<section>
 				<h4>data-ajax-extra-fr.html</h4>
 				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
-	&lt;h4&gt;I was ajaxed in&lt;/h4&gt;
-	&lt;p&gt;I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in.&lt;/p&gt;
+	&lt;h4&gt;J'ai été affiché via Ajax&lt;/h4&gt;
+	&lt;p&gt;J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax.&lt;/p&gt;
 &lt;/section&gt;</code></pre>
 			</section>
 
@@ -83,8 +83,8 @@
 			<section>
 				<h4>data-ajax-extra-fr.html</h4>
 				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
-	&lt;h4&gt;I was ajaxed in&lt;/h4&gt;
-	&lt;p&gt;I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in.&lt;/p&gt;
+	&lt;h4&gt;J'ai été affiché via Ajax&lt;/h4&gt;
+	&lt;p&gt;J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax.&lt;/p&gt;
 &lt;/section&gt;</code></pre>
 			</section>
 
@@ -128,8 +128,8 @@
 			<section>
 				<h4>data-ajax-extra-fr.html</h4>
 				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
-	&lt;h4&gt;I was ajaxed in&lt;/h4&gt;
-	&lt;p&gt;I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in.&lt;/p&gt;
+	&lt;h4&gt;J'ai été affiché via Ajax&lt;/h4&gt;
+	&lt;p&gt;J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax.&lt;/p&gt;
 &lt;/section&gt;</code></pre>
 			</section>
 
@@ -169,8 +169,8 @@
 			<section>
 				<h4>data-ajax-extra-fr.html</h4>
 				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
-	&lt;h4&gt;I was ajaxed in&lt;/h4&gt;
-	&lt;p&gt;I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in.&lt;/p&gt;
+	&lt;h4&gt;J'ai été affiché via Ajax&lt;/h4&gt;
+	&lt;p&gt;J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax.&lt;/p&gt;
 &lt;/section&gt;</code></pre>
 			</section>
 
@@ -222,8 +222,8 @@
 			<section>
 				<h4>data-ajax-extra-fr.html</h4>
 				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
-	&lt;h4&gt;I was ajaxed in&lt;/h4&gt;
-	&lt;p&gt;I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in.&lt;/p&gt;
+	&lt;h4&gt;J'ai été affiché via Ajax&lt;/h4&gt;
+	&lt;p&gt;J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax.&lt;/p&gt;
 &lt;/section&gt;</code></pre>
 			</section>
 
@@ -300,4 +300,41 @@
 			</section>
 		</details>
 	</section>
+</section>
+<section>
+	<h2>Syntaxe alternative</h2>
+	<p>Veuillez consulter la <a href="../../docs/ref/data-ajax/data-ajax-fr.html">documentation</a> pour de plus ample renseignement concernant cette syntaxe alternative.</p>
+	<h3>Exemple</h3>
+	<div data-wb-ajax='{
+			"url": "ajax/data-ajax-extra-fr.html",
+			"type": "append"
+		}' class="original">
+		<section>
+			<h4>Bonjour tout le monde</h4>
+			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+		</section>
+	</div>
+	<details>
+			<summary>Visualiser le code</summary>
+			<section>
+				<h4>HTML dans la page</h4>
+				<pre><code>&lt;div data-wb-ajax='{
+		"url": "ajax/data-ajax-extra-fr.html",
+		"type": "append"
+	}' class="original"&gt;
+	&lt;section&gt;
+		&lt;h4&gt;Bonjour tout le monde&lt;/h4&gt;
+		&lt;p&gt;Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.&lt;/p&gt;
+	&lt;/section&gt;
+&lt;/div&gt;</code></pre>
+			</section>
+
+			<section>
+				<h4>data-ajax-extra-fr.html</h4>
+				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
+	&lt;h4&gt;J'ai été affiché via Ajax&lt;/h4&gt;
+	&lt;p&gt;J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax.&lt;/p&gt;
+&lt;/section&gt;</code></pre>
+			</section>
+		</details>
 </section>

--- a/src/plugins/data-ajax/data-ajax.js
+++ b/src/plugins/data-ajax/data-ajax.js
@@ -16,12 +16,21 @@
  * page.
  */
 var componentName = "wb-data-ajax",
+	shortName = "wb-ajax",
 	selectors = [
 		"[data-ajax-after]",
 		"[data-ajax-append]",
 		"[data-ajax-before]",
 		"[data-ajax-prepend]",
-		"[data-ajax-replace]"
+		"[data-ajax-replace]",
+		"[data-" + shortName + "]"
+	],
+	ajaxTypes = [
+		"before",
+		"replace",
+		"after",
+		"append",
+		"prepend"
 	],
 	selectorsLength = selectors.length,
 	selector = selectors.join( "," ),
@@ -36,31 +45,41 @@ var componentName = "wb-data-ajax",
 	 * @param {jQuery Event} event Event that triggered this handler
 	 * @param {string} ajaxType The type of AJAX operation, either after, append, before or replace
 	 */
-	init = function( event, ajaxType ) {
+	init = function( event ) {
 
 		// Start initialization
 		// returns DOM object = proceed with init
 		// returns undefined = do not proceed with init (e.g., already initialized)
-		var elm = wb.init( event, componentName + "-" + ajaxType, selector );
+		var ajxInfo = getAjxInfo( event.target ),
+			ajaxType = ajxInfo.type,
+			elm = wb.init( event, componentName + "-" + ajaxType, selector );
 
 		if ( elm ) {
 
-			ajax.apply( this, arguments );
+			ajax.call( this, event, ajxInfo );
 
 			// Identify that initialization has completed
 			wb.ready( $( elm ), componentName, [ ajaxType ] );
 		}
 	},
 
-	ajax = function( event, ajaxType ) {
+	ajax = function( event, ajxInfo ) {
 		var elm = event.target,
 			$elm = $( elm ),
 			settings = window[ componentName ],
-			url = elm.getAttribute( "data-ajax-" + ajaxType ),
-			fetchObj = {
-				url: url
-			},
+			url,
+			fetchObj,
 			urlParts;
+
+		if ( !ajxInfo ) {
+			ajxInfo = getAjxInfo( elm );
+		}
+		url = ajxInfo.url;
+		fetchObj = {
+			url: url,
+			nocache: ajxInfo.nocache,
+			nocachekey: ajxInfo.nocachekey
+		};
 
 		// Detect CORS requests
 		if ( settings && ( url.substr( 0, 4 ) === "http" || url.substr( 0, 2 ) === "//" ) ) {
@@ -78,62 +97,86 @@ var componentName = "wb-data-ajax",
 			type: "ajax-fetch.wb",
 			fetch: fetchObj
 		} );
+	},
+
+	// Get Info and return { "url": "the/ajax/URL", "atype" }
+	getAjxInfo = function( elm ) {
+		var ajaxType,
+			len = ajaxTypes.length,
+			i, url, dtAttr, nocache, nocachekey;
+
+		for ( i = 0; i !== len; i += 1 ) {
+			ajaxType = ajaxTypes[ i ];
+			url = elm.getAttribute( "data-ajax-" + ajaxType );
+			if ( url ) {
+				break;
+			}
+		}
+
+		if ( !url ) {
+			dtAttr = wb.getData( $( elm ), shortName );
+			url = dtAttr.url;
+			ajaxType = dtAttr.type;
+			if ( ajaxTypes.indexOf( ajaxType ) === -1 || !url ) {
+				throw "Invalid ajax type or missing url";
+			}
+			nocache = dtAttr.nocache;
+			nocachekey = dtAttr.nocachekey;
+		}
+
+		return {
+			"url": url,
+			"type": ajaxType,
+			"nocache": nocache,
+			"nocachekey": nocachekey
+		};
+	},
+
+	ajxFetched = function( elm, fetchObj ) {
+		var $elm = $( elm ),
+			ajxInfo = getAjxInfo( elm ),
+			ajaxType = ajxInfo.type,
+			content, jQueryCaching;
+
+		// ajax-fetched event
+		content = fetchObj.response;
+		if ( content &&  content.length > 0 ) {
+
+			//Prevents the force caching of nested resources
+			jQueryCaching = jQuery.ajaxSettings.cache;
+			jQuery.ajaxSettings.cache = true;
+
+			// "replace" is the only event that doesn't map to a jQuery function
+			if ( ajaxType === "replace" ) {
+				$elm.html( content );
+			} else {
+				$elm[ ajaxType ]( content );
+			}
+
+			//Resets the initial jQuery caching setting
+			jQuery.ajaxSettings.cache = jQueryCaching;
+
+			$elm.trigger( contentUpdatedEvent, { "ajax-type": ajaxType, "content": content } );
+		}
 	};
 
 $document.on( "timerpoke.wb " + initEvent + " " + updateEvent + " ajax-fetched.wb", selector, function( event ) {
-	var eventTarget = event.target,
-		ajaxTypes = [
-			"before",
-			"replace",
-			"after",
-			"append",
-			"prepend"
-		],
-		len = ajaxTypes.length,
-		$elm, ajaxType, i, content, jQueryCaching;
-
-	for ( i = 0; i !== len; i += 1 ) {
-		ajaxType = ajaxTypes[ i ];
-		if ( this.getAttribute( "data-ajax-" + ajaxType ) !== null ) {
-			break;
-		}
-	}
+	var eventTarget = event.target;
 
 	switch ( event.type ) {
 
 	case "timerpoke":
 	case "wb-init":
-		init( event, ajaxType );
+		init( event );
 		break;
 	case "wb-update":
-		ajax( event, ajaxType );
+		ajax( event );
 		break;
 	default:
 
 		// Filter out any events triggered by descendants
 		if ( event.currentTarget === eventTarget ) {
-			$elm = $( eventTarget );
-
-			// ajax-fetched event
-			content = event.fetch.response;
-			if ( content &&  content.length > 0 ) {
-
-				//Prevents the force caching of nested resources
-				jQueryCaching = jQuery.ajaxSettings.cache;
-				jQuery.ajaxSettings.cache = true;
-
-				// "replace" is the only event that doesn't map to a jQuery function
-				if ( ajaxType === "replace" ) {
-					$elm.html( content );
-				} else {
-					$elm[ ajaxType ]( content );
-				}
-
-				//Resets the initial jQuery caching setting
-				jQuery.ajaxSettings.cache = jQueryCaching;
-
-				$elm.trigger( contentUpdatedEvent, { "ajax-type": ajaxType, "content": content } );
-			}
+			ajxFetched( eventTarget, event.fetch );
 		}
 	}
 

--- a/src/plugins/data-json/data-json-en.hbs
+++ b/src/plugins/data-json/data-json-en.hbs
@@ -7,140 +7,274 @@
 	"tag": "data-json",
 	"parentdir": "data-json",
 	"altLangPrefix": "data-json",
-	"dateModified": "2016-11-07"
+	"dateModified": "2017-01-31"
 }
 ---
 <p>Insert content extracted from a JSON file.</p>
 
 <div class="wb-prettify all-pre"></div>
 
-<div class="well">
-	<p>Data selection is done by an JSON Pointer URI Fragment as described in <a href="https://tools.ietf.org/html/rfc6901#section-6">section 6 of RFC6901</a></p>
+
+<div class="col-md-5 pull-right">
+<aside class="panel panel-info">
+  <header class="panel-heading">
+   <h2 class="panel-title">Selecting JSON property</h2>
+  </header>
+  <div class="panel-body">
+   <p>Data selection can be completed with a JSON Pointer URI Fragment as described in <a href="https://tools.ietf.org/html/rfc6901#section-6">section 6 of RFC6901</a> and documented in the <a href="../../docs/ref/data-json/data-json-en.html">data-json documentation.</a></p>
+  </div>
+</aside>
 </div>
 
-<p>The following attribute is supported:</p>
-
-<dl class="dl-horizontal">
-	<dt><code>data-json-after</code></dt>
-	<dd>Insert content after an element</dd>
-
-	<dt><code>data-json-append</code></dt>
-	<dd>Insert content at the end of an element</dd>
-
-	<dt><code>data-json-before</code></dt>
-	<dd>Insert content before an element</dd>
-
-	<dt><code>data-json-prepend</code></dt>
-	<dd>Insert content at the start of an element</dd>
-
-	<dt><code>data-json-replace</code></dt>
-	<dd>Replace content inside an element</dd>
-
-	<dt><code>data-json-replacewith</code></dt>
-	<dd>Replace an element by the content</dd>
-</dl>
-
-<h2>Example</h2>
-
-<p>My product ABC cost <a data-json-replacewith="demo/data-en.json#/fees/ABC" href="#">(consult our fees schedule)</a></p>
-
-<pre><code>&lt;p&gt;My product ABC cost &lt;a data-json-replacewith=&quot;demo/data-en.json#/fees/ABC&quot; href=&quot;#&quot;&gt;(consult our fees schedule)&lt;/a&gt;&lt;/p&gt;</code></pre>
-
-
-<p>Your are currently viewing the product &quot;<span data-json-replace="demo/data-en.json#/product">Unknown</span>&quot;</p>
-
-<pre><code>&lt;p&gt;Your are currently viewing the product &amp;quot;&lt;span data-json-replace=&quot;demo/data-en.json#/products/en&quot;&gt;Unknown&lt;/span&gt;&amp;quot;&lt;/p&gt;</code></pre>
-
-<h3>Content of <code>json/data-en.json</code></h3>
-<pre><code>{
+<details>
+	<summary>JSON data used by the following examples</summary>
+	<p>File: <code>demo/data-en.json</code></p>
+	<pre><code>{
 	"fees": {
 		"ABC": "20$"
 	},
-	"products": "Hello world"
+	"product": "Hello world",
+	"products": [
+		"My new product",
+		"My second product",
+		"My product number 3"
+	],
+	"status": "text-muted",
+	"iamtrue": true,
+	"iamfalse": false,
+	"jour":"2016-11-05T01:42:31Z",
+	"anArray": [
+		{ "name": "Item 1", "prop": "red" },
+		{ "name": "Item 2", "prop": "blue" },
+		{ "name": "Item 3", "prop": "yellow" },
+		{ "name": "Item 4", "prop": "purple" }
+	]
 }</code></pre>
+</details>
 
-<h2>Selecting data</h2>
+<h2>Basic example</h2>
+<p>My product ABC cost <a data-json-replacewith="demo/data-en.json#/fees/ABC" href="#">(consult our fees schedule)</a></p>
 
-<p>(Source: <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer, RCF6901</a>)</p>
+<p class="mrgn-tp-md">Your are currently viewing the product &quot;<span data-json-replace="demo/data-en.json#/product">Unknown</span>&quot;</p>
 
-<p>For example, given the JSON document</p>
+<p class="mrgn-tp-md" data-wb-json='[
+		{
+			"url": "demo/data-en.json#/product",
+			"type": "replace"
+		},
+		{
+			"url": "demo/data-en.json#/status",
+			"type": "addclass"
+		}
+	]'>This is a paragraph.</p>
 
-<pre><code>{
-	"foo": ["bar", "baz"],
-	"": 0,
-	"a/b": 1,
-	"c%d": 2,
-	"e^f": 3,
-	"g|h": 4,
-	"i\\j": 5,
-	"k\"l": 6,
-	" ": 7,
-	"m~n": 8
-}</code></pre>
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;p&gt;My product ABC cost &lt;a data-json-replacewith=&quot;demo/data-en.json#/fees/ABC&quot; href=&quot;#&quot;&gt;(consult our fees schedule)&lt;/a&gt;&lt;/p&gt;
 
-<p>The following URI fragment identifiers evaluate to the accompanying values:</p>
+&lt;p class=&quot;mrgn-tp-md&quot;&gt;Your are currently viewing the product &amp;quot;&lt;span data-json-replace=&quot;demo/data-en.json#/products/en&quot;&gt;Unknown&lt;/span&gt;&amp;quot;&lt;/p&gt;
 
-<table class="table">
-	<tr>
-		<th>URI fragment</th>
-		<th>Returning value</th>
-	</tr>
-	<tr>
-		<td><code>#</code></td>
-		<td>The whole document</td>
-	</tr>
-	<tr>
-		<td><code>#/foo</code></td>
-		<td><code>["bar", "baz"]</code></td>
-	</tr>
-	<tr>
-		<td><code>#/foo/0</code></td>
-		<td><code>"bar"</code></td>
-	</tr>
-	<tr>
-		<td><code>#/</code></td>
-		<td>0</td>
-	</tr>
-	<tr>
-		<td><code>#/a~1b</code></td>
-		<td>1</td>
-	</tr>
-	<tr>
-		<td><code>#/c%25d</code></td>
-		<td>2</td>
-	</tr>
-	<tr>
-		<td><code>#/e%5Ef</code></td>
-		<td>3</td>
-	</tr>
-	<tr>
-		<td><code>#/g%7Ch</code></td>
-		<td>4</td>
-	</tr>
-	<tr>
-		<td><code>#/i%5Cj</code></td>
-		<td>5</td>
-	</tr>
-	<tr>
-		<td><code>#/k%22l</code></td>
-		<td>6</td>
-	</tr>
-	<tr>
-		<td><code>#/%20</code></td>
-		<td>7</td>
-	</tr>
-	<tr>
-		<td><code>#/m~0n</code></td>
-		<td>8</td>
-	</tr>
-</table>
+&lt;p class=&quot;mrgn-tp-md&quot; data-wb-json='
+	[
+		{
+			&quot;url&quot;: &quot;demo/data-en.json#/product&quot;,
+			&quot;type&quot;: &quot;replace&quot;
+		},
+		{
+			&quot;url&quot;: &quot;demo/data-en.json#/status&quot;,
+			&quot;type&quot;: &quot;addclass&quot;
+		}
+	]'&gt;This is a paragraph.&lt;/p&gt;</code></pre>
+</details>
 
-<h2>Issue that you may encounter</h2>
 
-<dl>
-	<dt>Display nothing, plugin seems to be broken.</dt>
-	<dd>Ensure that your <a href="https://www.google.ca/search?q=validate+JSON#q=validate+JSON">JSON file is valid</a></dd>
+<h2>Inserting content...</h2>
 
-	<dt>Recently updated data do not display</dt>
-	<dd>Refresh your browser cache by opening a new tab the JSON file and then do a hard refresh <kbd>Ctrl + F5</kbd> or by testing your page from a new private mode session of your browser.</dd>
-</dl>
+<div class="row">
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">After an element (<code>after</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-after="demo/data-en.json#/product">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-en.json#/product", "type": "after" }'>pharetra.</strong></p>
+	</figure>
+</div>
+
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">At the end of an element (<code>append</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-append="demo/data-en.json#/product">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-en.json#/product", "type": "append" }'>pharetra.</strong></p>
+	</figure>
+</div>
+
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Before an element (<code>before</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-before="demo/data-en.json#/product">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-en.json#/product", "type": "before" }'>pharetra.</strong></p>
+	</figure>
+</div>
+
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">At the start of an element (<code>prepend</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-prepend="demo/data-en.json#/product">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-en.json#/product", "type": "prepend" }'>pharetra.</strong></p>
+	</figure>
+</div>
+</div>
+
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;After an element (&lt;code&gt;after&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-after=&quot;demo/data-en.json#/product&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/product&quot;, &quot;type&quot;: &quot;after&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;At the end of an element (&lt;code&gt;append&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-append=&quot;demo/data-en.json#/product&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/product&quot;, &quot;type&quot;: &quot;append&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Before an element (&lt;code&gt;before&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-before=&quot;demo/data-en.json#/product&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/product&quot;, &quot;type&quot;: &quot;before&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;At the start of an element (&lt;code&gt;prepend&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-prepend=&quot;demo/data-en.json#/product&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/product&quot;, &quot;type&quot;: &quot;prepend&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+
+<h2>Replacing...</h2>
+<div class="row">
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Content inside the element (<code>replace</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-replace="demo/data-en.json#/product">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-en.json#/product", "type": "replace" }'>pharetra.</strong></p>
+	</figure>
+</div>
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">The element by the content (<code>replacewith</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-replacewith="demo/data-en.json#/product">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-en.json#/product", "type": "replacewith" }'>pharetra.</strong></p>
+	</figure>
+</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Content inside the element (&lt;code&gt;replace&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-replace=&quot;demo/data-en.json#/product&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/product&quot;, &quot;type&quot;: &quot;replace&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;The element by the content (&lt;code&gt;replacewith&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-replacewith=&quot;demo/data-en.json#/product&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/product&quot;, &quot;type&quot;: &quot;replacewith&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+<h2>CSS class manipulation</h2>
+<div class="row">
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Add a class name (<code>addclass</code>)</figcaption>
+		<p data-wb-json='{ "url": "demo/data-en.json#/status", "type": "addclass" }'>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+	</figure>
+</div>
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Remove a class name (<code>removeclass</code>)</figcaption>
+		<p class="text-muted" data-wb-json='{ "url": "demo/data-en.json#/status", "type": "removeclass" }'>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+	</figure>
+</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Add a class name (&lt;code&gt;addclass&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/status&quot;, &quot;type&quot;: &quot;addclass&quot; }'&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Remove a class name (&lt;code&gt;removeclass&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p class=&quot;text-muted&quot; data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/status&quot;, &quot;type&quot;: &quot;removeclass&quot; }'&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+
+<h2>Update property and value</h2>
+
+<div class="row">
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Property (<code>prop</code>)</figcaption>
+		<div class="checkbox">
+		   <label><input type="checkbox" value="" data-wb-json='{ "url": "demo/data-en.json#/iamtrue", "type": "prop", "prop": "checked" }'>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</label>
+			<label><input type="checkbox" value="" checked="checked" data-wb-json='{ "url": "demo/data-en.json#/iamfalse", "type": "prop", "prop": "checked" }'>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</label>
+		</div>
+	</figure>
+</div>
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Value (<code>val</code>)</figcaption>
+		<div class="form-group">
+			<label class="col-sm-4 control-label" for="label-3">Lorem ipsum</label>
+			<div class="col-md-8">
+				<input id="label-3" type="text" class="form-control" data-wb-json='{ "url": "demo/data-en.json#/status", "type": "val" }' />
+			</div>
+		</div>
+	</figure>
+</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Property (&lt;code&gt;prop&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;div class=&quot;checkbox&quot;&gt;
+		   &lt;label&gt;&lt;input type=&quot;checkbox&quot; value=&quot;&quot; data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/iamtrue&quot;, &quot;type&quot;: &quot;prop&quot;, &quot;prop&quot;: &quot;checked&quot; }'&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/label&gt;
+			&lt;label&gt;&lt;input type=&quot;checkbox&quot; value=&quot;&quot; checked=&quot;checked&quot; data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/iamfalse&quot;, &quot;type&quot;: &quot;prop&quot;, &quot;prop&quot;: &quot;checked&quot; }'&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/label&gt;
+		&lt;/div&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Value (&lt;code&gt;val&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;div class=&quot;form-group&quot;&gt;
+			&lt;label class=&quot;col-sm-4 control-label&quot; for=&quot;label-3&quot;&gt;Lorem ipsum&lt;/label&gt;
+			&lt;div class=&quot;col-md-8&quot;&gt;
+				&lt;input id=&quot;label-3&quot; type=&quot;text&quot; class=&quot;form-control&quot; data-wb-json='{ &quot;url&quot;: &quot;demo/data-en.json#/status&quot;, &quot;type&quot;: &quot;val&quot; }' /&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;</code></pre>
+</details>

--- a/src/plugins/data-json/data-json-fr.hbs
+++ b/src/plugins/data-json/data-json-fr.hbs
@@ -7,143 +7,277 @@
 	"tag": "data-json",
 	"parentdir": "data-json",
 	"altLangPrefix": "data-json",
-	"dateModified": "2016-11-07"
+	"dateModified": "2017-01-31"
 }
 ---
 <p>Insertion de contenu extrait d'un fichier JSON</p>
 
 <div class="wb-prettify all-pre"></div>
 
-<div class="well">
-	<p>La sélection des données est fait à l'aide d'un pointeur JSON représentant le « hash » de l'URL. (<a href="https://tools.ietf.org/html/rfc6901#section-6">section 6 of RFC6901</a>)</p>
+
+<div class="col-md-5 pull-right">
+<aside class="panel panel-info">
+  <header class="panel-heading">
+   <h2 class="panel-title">Sélectioner du contenu JSON</h2>
+  </header>
+  <div class="panel-body">
+   <p>La sélection de donnée est fait à l'aide d'un pointeur JSON représentant le « hash » de l'URL tel que décris dans <a href="https://tools.ietf.org/html/rfc6901#section-6" hreflang="en">la section 6 du RFC6901</a> et dans la <a href="../../docs/ref/data-json/data-json-fr.html">documentation du data-json</a>.</p>
+  </div>
+</aside>
 </div>
 
-<p>Les attribut suivantes sont supporté:</p>
-
-<dl class="dl-horizontal">
-	<dt><code>data-json-after</code></dt>
-	<dd>Insérer du contenu après l'élément</dd>
-
-	<dt><code>data-json-append</code></dt>
-	<dd>Ajouter du contenu à la fin de l'élément</dd>
-
-	<dt><code>data-json-before</code></dt>
-	<dd>Insérer le contenu avant l'élément</dd>
-
-	<dt><code>data-json-prepend</code></dt>
-	<dd>Ajouter le contenu au début de l'élément</dd>
-
-	<dt><code>data-json-replace</code></dt>
-	<dd>Remplace le contenu de l'élément</dd>
-
-	<dt><code>data-json-replacewith</code></dt>
-	<dd>Remplace l'élément</dd>
-</dl>
-
-
-<h2>Exemple</h2>
-
-<p>Mon produit ABC coûte <a data-json-replacewith="demo/data-fr.json#/fees/ABC" href="#">(consulter notre liste de frais)</a></p>
-
-
-<pre><code>Mon produit ABC coûte &lt;a data-json-replacewith=&quot;demo/data-fr.json#/fees/ABC&quot; href=&quot;#&quot;&gt;(consulter notre liste de frais)&lt;/a&gt;</code></pre>
-
-<p>Vous consultez le produits &quot;<span data-json-replace="demo/data-fr.json#/produit">Inconnue</span>&quot;</p>
-
-
-<pre><code>Vous consultez le produits &amp;quot;&lt;span data-json-replace=&quot;demo/data-fr.json#/produit&quot;&gt;Inconnue&lt;/span&gt;&amp;quot;</code></pre>
-
-
-<h3>Contenu du fichier <code>json/data-fr.json</code></h3>
-<pre><code>{
-	"fees": {
+<details>
+	<summary>Donnée JSON utilisé pour les examples suivantes</summary>
+	<p>Fichier: <code>demo/data-fr.json</code></p>
+	<pre><code>{
+	"frais": {
 		"ABC": "20$"
 	},
-	"produit": "Bonjour le monde"
+	"produit": "Bonjour le monde",
+	"produits": [
+		"Mon nouveau produit",
+		"Mon deuxième produit",
+		"Mon produit numéro 3"
+	],
+	"etats": "text-muted",
+	"jesuisvrai": true,
+	"jesuisfaux": false,
+	"jour":"2016-11-05T01:42:31Z",
+	"unTableau": [
+		{ "nom": "Item 1", "prop": "rouge" },
+		{ "nom": "Item 2", "prop": "bleu" },
+		{ "nom": "Item 3", "prop": "jaune" },
+		{ "nom": "Item 4", "prop": "violet" }
+	],
+	"bureaux": [
+		{ "nom": "Jean Edmonds, Tour nord", "num": 300, "rue": "Slater", "ville": "Ottawa", "css": "bg-success" },
+		{ "nom": "Place du portage, Phase I", "num": 50, "rue": "Victoria", "ville": "Gatineau", "css": "bg-danger" }
+	]
 }</code></pre>
+</details>
 
-<h2>Selection de donnée</h2>
+<h2>Example</h2>
+<p>Mon produit ABC coûte <a data-json-replacewith="demo/data-fr.json#/frais/ABC" href="#">(consulter notre liste de frais)</a></p>
 
-<p>(Source: <a href="https://tools.ietf.org/html/rfc6901" hreflang="en">Pointeur JSON, RCF6901</a>)</p>
+<p class="mrgn-tp-md">Vous consultez le produits "Bonjour le monde" &quot;<span data-json-replace="demo/data-fr.json#/produit">Inconnue</span>&quot;</p>
 
-<p>Par exemple, prennont ce document JSON</p>
+<p class="mrgn-tp-md" data-wb-json='[
+		{
+			"url": "demo/data-fr.json#/produit",
+			"type": "replace"
+		},
+		{
+			"url": "demo/data-fr.json#/etats",
+			"type": "addclass"
+		}
+	]'>This is a paragraph.</p>
 
-<pre><code>{
-	"foo": ["bar", "baz"],
-	"": 0,
-	"a/b": 1,
-	"c%d": 2,
-	"e^f": 3,
-	"g|h": 4,
-	"i\\j": 5,
-	"k\"l": 6,
-	" ": 7,
-	"m~n": 8
-}</code></pre>
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;p&gt;Mon produit ABC coûte &lt;a data-json-replacewith=&quot;demo/data-fr.json#/frais/ABC&quot; href=&quot;#&quot;&gt;(consulter notre liste de frais)&lt;/a&gt;&lt;/p&gt;
 
-<p>Voici les résultats après que le pointeur JSON aient été évalué à partir du fragments d'URI.</p>
+&lt;p class=&quot;mrgn-tp-md&quot;&gt;Vous consultez le produits &quot;Bonjour le monde&quot; &amp;quot;&lt;span data-json-replace=&quot;demo/data-fr.json#/produit&quot;&gt;Inconnue&lt;/span&gt;&amp;quot;&lt;/p&gt;
 
-<table class="table">
-	<tr>
-		<th>Fragment d'URI</th>
-		<th>Valeur retourné</th>
-	</tr>
-	<tr>
-		<td><code>#</code></td>
-		<td>Tout le document</td>
-	</tr>
-	<tr>
-		<td><code>#/foo</code></td>
-		<td><code>["bar", "baz"]</code></td>
-	</tr>
-	<tr>
-		<td><code>#/foo/0</code></td>
-		<td><code>"bar"</code></td>
-	</tr>
-	<tr>
-		<td><code>#/</code></td>
-		<td>0</td>
-	</tr>
-	<tr>
-		<td><code>#/a~1b</code></td>
-		<td>1</td>
-	</tr>
-	<tr>
-		<td><code>#/c%25d</code></td>
-		<td>2</td>
-	</tr>
-	<tr>
-		<td><code>#/e%5Ef</code></td>
-		<td>3</td>
-	</tr>
-	<tr>
-		<td><code>#/g%7Ch</code></td>
-		<td>4</td>
-	</tr>
-	<tr>
-		<td><code>#/i%5Cj</code></td>
-		<td>5</td>
-	</tr>
-	<tr>
-		<td><code>#/k%22l</code></td>
-		<td>6</td>
-	</tr>
-	<tr>
-		<td><code>#/%20</code></td>
-		<td>7</td>
-	</tr>
-	<tr>
-		<td><code>#/m~0n</code></td>
-		<td>8</td>
-	</tr>
-</table>
+&lt;p class=&quot;mrgn-tp-md&quot; data-wb-json='[
+		{
+			&quot;url&quot;: &quot;demo/data-fr.json#/produit&quot;,
+			&quot;type&quot;: &quot;replace&quot;
+		},
+		{
+			&quot;url&quot;: &quot;demo/data-fr.json#/etats&quot;,
+			&quot;type&quot;: &quot;addclass&quot;
+		}
+	]'&gt;This is a paragraph.&lt;/p&gt;</code></pre>
+</details>
 
-<h2>Problème potentiel qui peuvent survenir</h2>
 
-<dl>
-	<dt>Aucun affichage, le composant semble disfonctionelle.</dt>
-	<dd>Veuillez vérifier que votre <a href="https://www.google.ca/search?q=validate+JSON#q=validate+JSON" hreflang="en">fichier JSON est valide.</a></dd>
+<h2>Insertion de contenu...</h2>
 
-	<dt>La mise à jour récente des données ne s'affiche pas.</dt>
-	<dd>Mettez à jour le cache de votre furteur en ouvrant un nouvel onglet pour consulter le fichier JSON et forcé la mise à jour en appuyant sur <kbd>Ctrl + F5</kbd> ou bien faite l'essai de page qui utilise ce plugin dans une nouvelle session du mode privé de votre furteur.</dd>
-</dl>
+<div class="row">
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Après l'élément (<code>after</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-after="demo/data-fr.json#/produit">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-fr.json#/produit", "type": "after" }'>pharetra.</strong></p>
+	</figure>
+</div>
+
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">À la fin de l'élément (<code>append</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-append="demo/data-fr.json#/produit">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-fr.json#/produit", "type": "append" }'>pharetra.</strong></p>
+	</figure>
+</div>
+
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Avant l'élément (<code>before</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-before="demo/data-fr.json#/produit">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-fr.json#/produit", "type": "before" }'>pharetra.</strong></p>
+	</figure>
+</div>
+
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Au début de l'élément (<code>prepend</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-prepend="demo/data-fr.json#/produit">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-fr.json#/produit", "type": "prepend" }'>pharetra.</strong></p>
+	</figure>
+</div>
+</div>
+
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Après l'élément (&lt;code&gt;after&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-after=&quot;demo/data-fr.json#/produit&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/produit&quot;, &quot;type&quot;: &quot;after&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;À la fin de l'élément (&lt;code&gt;append&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-append=&quot;demo/data-fr.json#/produit&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/produit&quot;, &quot;type&quot;: &quot;append&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Avant l'élément (&lt;code&gt;before&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-before=&quot;demo/data-fr.json#/produit&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/produit&quot;, &quot;type&quot;: &quot;before&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Au début de l'élément (&lt;code&gt;prepend&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-prepend=&quot;demo/data-fr.json#/produit&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/produit&quot;, &quot;type&quot;: &quot;prepend&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+
+<h2>Remplacement...</h2>
+<div class="row">
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Contenu de l'élément (<code>replace</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-replace="demo/data-fr.json#/produit">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-fr.json#/produit", "type": "replace" }'>pharetra.</strong></p>
+	</figure>
+</div>
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">L'élément (<code>replacewith</code>)</figcaption>
+		<p>Lorem ipsum dolor sit amet, consectetur adipiscing <strong data-json-replacewith="demo/data-fr.json#/produit">elit.</strong></p>
+		<p>Vivamus ut turpis a elit laoreet <strong data-wb-json='{ "url": "demo/data-fr.json#/produit", "type": "replacewith" }'>pharetra.</strong></p>
+	</figure>
+</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Contenu de l'élément (&lt;code&gt;replace&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-replace=&quot;demo/data-fr.json#/produit&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/produit&quot;, &quot;type&quot;: &quot;replace&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;L'élément (&lt;code&gt;replacewith&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing &lt;strong data-json-replacewith=&quot;demo/data-fr.json#/produit&quot;&gt;elit.&lt;/strong&gt;&lt;/p&gt;
+		&lt;p&gt;Vivamus ut turpis a elit laoreet &lt;strong data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/produit&quot;, &quot;type&quot;: &quot;replacewith&quot; }'&gt;pharetra.&lt;/strong&gt;&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+<h2>Manipulation des classes CSS</h2>
+<div class="row">
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Ajout d'une classe (<code>addclass</code>)</figcaption>
+		<p data-wb-json='{ "url": "demo/data-fr.json#/etats", "type": "addclass" }'>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+	</figure>
+</div>
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Enlever une classe (<code>removeclass</code>)</figcaption>
+		<p class="text-muted" data-wb-json='{ "url": "demo/data-fr.json#/etats", "type": "removeclass" }'>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+	</figure>
+</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Ajout d'une classe (&lt;code&gt;addclass&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/etats&quot;, &quot;type&quot;: &quot;addclass&quot; }'&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Enlever une classe (&lt;code&gt;removeclass&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;p class=&quot;text-muted&quot; data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/etats&quot;, &quot;type&quot;: &quot;removeclass&quot; }'&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/p&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+
+<h2>Mettre à jour des propriétés et des valeurs</h2>
+
+<div class="row">
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Propriété (<code>prop</code>)</figcaption>
+		<div class="checkbox">
+		   <label><input type="checkbox" value="" data-wb-json='{ "url": "demo/data-fr.json#/jesuisvrai", "type": "prop", "prop": "checked" }'>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</label>
+			<label><input type="checkbox" value="" checked="checked" data-wb-json='{ "url": "demo/data-fr.json#/jesuisfaux", "type": "prop", "prop": "checked" }'>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</label>
+		</div>
+	</figure>
+</div>
+<div class="col-md-6">
+	<figure>
+		<figcaption class="h3">Valeur (<code>val</code>)</figcaption>
+		<div class="form-group">
+			<label class="col-sm-4 control-label" for="label-3">Lorem ipsum</label>
+			<div class="col-md-8">
+				<input id="label-3" type="text" class="form-control" data-wb-json='{ "url": "demo/data-fr.json#/etats", "type": "val" }' />
+			</div>
+		</div>
+	</figure>
+</div>
+</div>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Propriété (&lt;code&gt;prop&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;div class=&quot;checkbox&quot;&gt;
+		   &lt;label&gt;&lt;input type=&quot;checkbox&quot; value=&quot;&quot; data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/jesuisvrai&quot;, &quot;type&quot;: &quot;prop&quot;, &quot;prop&quot;: &quot;checked&quot; }'&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/label&gt;
+			&lt;label&gt;&lt;input type=&quot;checkbox&quot; value=&quot;&quot; checked=&quot;checked&quot; data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/jesuisfaux&quot;, &quot;type&quot;: &quot;prop&quot;, &quot;prop&quot;: &quot;checked&quot; }'&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/label&gt;
+		&lt;/div&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;
+&lt;div class=&quot;col-md-6&quot;&gt;
+	&lt;figure&gt;
+		&lt;figcaption class=&quot;h3&quot;&gt;Valeur (&lt;code&gt;val&lt;/code&gt;)&lt;/figcaption&gt;
+		&lt;div class=&quot;form-group&quot;&gt;
+			&lt;label class=&quot;col-sm-4 control-label&quot; for=&quot;label-3&quot;&gt;Lorem ipsum&lt;/label&gt;
+			&lt;div class=&quot;col-md-8&quot;&gt;
+				&lt;input id=&quot;label-3&quot; type=&quot;text&quot; class=&quot;form-control&quot; data-wb-json='{ &quot;url&quot;: &quot;demo/data-fr.json#/etats&quot;, &quot;type&quot;: &quot;val&quot; }' /&gt;
+			&lt;/div&gt;
+		&lt;/div&gt;
+	&lt;/figure&gt;
+&lt;/div&gt;</code></pre>
+</details>

--- a/src/plugins/data-json/data-json.js
+++ b/src/plugins/data-json/data-json.js
@@ -1,10 +1,11 @@
 /**
  * @title WET-BOEW Data Json [data-json-after], [data-json-append],
- * [data-json-before], [data-json-prepend], [data-json-replace] and [data-json-replacewith]
+ * [data-json-before], [data-json-prepend], [data-json-replace], [data-json-replacewith] and [data-wb-json]
  * @overview Insert content extracted from JSON file.
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @duboisp
  */
+ /*global jsonpointer */
 ( function( $, window, wb ) {
 "use strict";
 
@@ -15,19 +16,25 @@
  * variables that are common to all instances of the plugin on a page.
  */
 var componentName = "wb-data-json",
+	shortName = "wb-json",
 	selectors = [
 		"[data-json-after]",
 		"[data-json-append]",
 		"[data-json-before]",
 		"[data-json-prepend]",
 		"[data-json-replace]",
-		"[data-json-replacewith]"
+		"[data-json-replacewith]",
+		"[data-" + shortName + "]"
 	],
+	allowJsonTypes = [ "after", "append", "before", "prepend", "val" ],
+	allowAttrNames = /(href|src|data-*|pattern|min|max|step)/,
+	allowPropNames = /(checked|selected|disabled|required|readonly|multiple)/,
 	selectorsLength = selectors.length,
 	selector = selectors.join( "," ),
 	initEvent = "wb-init." + componentName,
 	updateEvent = "wb-update." + componentName,
 	contentUpdatedEvent = "wb-contentupdated",
+	dataQueue = componentName + "-queue",
 	$document = wb.doc,
 	s,
 
@@ -36,30 +43,76 @@ var componentName = "wb-data-json",
 	 * @param {jQuery Event} event Event that triggered this handler
 	 * @param {string} ajaxType The type of JSON operation, either after, append, before or replace
 	 */
-	init = function( event, ajaxType ) {
+	init = function( event ) {
 
 		// Start initialization
 		// returns DOM object = proceed with init
 		// returns undefined = do not proceed with init (e.g., already initialized)
-		var elm = wb.init( event, componentName + "-" + ajaxType, selector );
+		var elm = wb.init( event, componentName, selector ),
+			$elm;
 
 		if ( elm ) {
 
-			ajax.apply( this, arguments );
+			var jsonCoreTypes = [
+					"before",
+					"replace",
+					"replacewith",
+					"after",
+					"append",
+					"prepend"
+				],
+				jsonType, jsondata,
+				i, i_len = jsonCoreTypes.length, i_cache,
+				lstCall = [],
+				url;
+
+			$elm = $( elm );
+
+			for ( i = 0; i !== i_len; i += 1 ) {
+				jsonType = jsonCoreTypes[ i ];
+				url = elm.getAttribute( "data-json-" + jsonType );
+				if ( url !== null ) {
+					lstCall.push( {
+						type: jsonType,
+						url: url
+					} );
+				}
+			}
+
+			jsondata = wb.getData( $elm, shortName );
+
+			if ( jsondata && jsondata.url ) {
+				lstCall.push( jsondata );
+			} else if ( jsondata && $.isArray( jsondata ) ) {
+				i_len = jsondata.length;
+				for ( i = 0; i !== i_len; i += 1 ) {
+					lstCall.push( jsondata[ i ] );
+				}
+			}
+
+			// Save it to the dataJSON object.
+			$elm.data( dataQueue, lstCall );
+
+			i_len = lstCall.length;
+			for ( i = 0; i !== i_len; i += 1 ) {
+				i_cache = lstCall[ i ];
+				loadJSON( elm, i_cache.url, i, i_cache.nocache, i_cache.nocachekey );
+			}
 
 			// Identify that initialization has completed
-			wb.ready( $( elm ), componentName, [ ajaxType ] );
+			wb.ready( $elm, componentName );
 		}
 	},
 
-	ajax = function( event, ajaxType ) {
-		var elm = event.target,
-			$elm = $( elm ),
-			settings = window[ componentName ],
-			url = elm.getAttribute( "data-json-" + ajaxType ),
+	loadJSON = function( elm, url, refId, nocache, nocachekey ) {
+		var $elm = $( elm ),
 			fetchObj = {
-				url: url
+				url: url,
+				refId: refId,
+				nocache: nocache,
+				nocachekey: nocachekey
 			},
+			settings = window[ componentName ],
 			urlParts;
 
 		// Detect CORS requests
@@ -78,73 +131,326 @@ var componentName = "wb-data-json",
 			type: "json-fetch.wb",
 			fetch: fetchObj
 		} );
+	},
+
+
+	// Manage JSON value After the json data has been fetched. This function can deal with array.
+	jsonFetched = function( event ) {
+
+		var elm = event.target,
+			$elm = $( elm ),
+			lstCall = $elm.data( dataQueue ),
+			fetchObj = event.fetch,
+			itmSettings = lstCall[ fetchObj.refId ],
+			jsonType = itmSettings.type,
+			attrname = itmSettings.prop || itmSettings.attr,
+			showEmpty = itmSettings.showempty,
+			content = fetchObj.response,
+			typeOfContent = typeof content,
+			jQueryCaching;
+
+		if ( showEmpty || typeOfContent !== "undefined" ) {
+
+			if ( showEmpty && typeOfContent === "undefined" ) {
+				content = "";
+			}
+
+			//Prevents the force caching of nested resources
+			jQueryCaching = jQuery.ajaxSettings.cache;
+			jQuery.ajaxSettings.cache = true;
+
+			// "replace" and "replaceWith" doesn't map to a jQuery function
+			if ( !jsonType ) {
+				jsonType = "template";
+				applyTemplate( elm, itmSettings, content );
+			} else if ( jsonType === "replace" ) {
+				$elm.html( content );
+			} else if ( jsonType === "replacewith" ) {
+				$elm.replaceWith( content );
+			} else if ( jsonType === "addclass" ) {
+				$elm.addClass( content );
+			} else if ( jsonType === "removeclass" ) {
+				$elm.removeClass( content );
+			} else if ( jsonType === "prop" && attrname && allowPropNames.test( attrname ) ) {
+				$elm.prop( attrname, content );
+			} else if ( jsonType === "attr" && attrname && allowAttrNames.test( attrname ) ) {
+				$elm.attr( attrname, content );
+			} else if ( typeof $elm[ jsonType ] === "function" && allowJsonTypes.indexOf( jsonType ) !== -1 ) {
+				$elm[ jsonType ]( content );
+			} else {
+				throw componentName + " do not support type: " + jsonType;
+			}
+
+			//Resets the initial jQuery caching setting
+			jQuery.ajaxSettings.cache = jQueryCaching;
+
+			$elm.trigger( contentUpdatedEvent, { "json-type": jsonType, "content": content } );
+		}
+	},
+
+	// Apply the template as per the configuration
+	applyTemplate = function( elm, settings, content ) {
+
+		var mapping = settings.mapping,
+			mapping_len = mapping.length,
+			filterTrueness = settings.filter || [],
+			filterFaslseness = settings.filternot || [],
+			queryAll = settings.queryall,
+			i, i_len, i_cache,
+			j, j_cache,
+			basePntr,
+			clone, selElements,
+			cached_node,
+			cached_textContent,
+			cached_value,
+			selectorToClone = settings.tobeclone,
+			elmClass = elm.className,
+			elmAppendTo = elm,
+			dataTable,
+			template = settings.source ? document.querySelector( settings.source ) : elm.querySelector( "template" );
+
+		if ( !$.isArray( content ) ) {
+			content = [ content ];
+		}
+		i_len = content.length;
+
+		// Special support for adding row to a wb-table
+		// Condition must be meet:
+		//  * The element need to be a table
+		//  * Data-table need to be initialized
+		//  * The mapping need to be an array of string
+		if ( elm.tagName === "TABLE" && mapping && elmClass.indexOf( "wb-tables.inited" ) !== -1 && typeof mapping[ 0 ] === "string" ) {
+			dataTable = $( elm ).dataTable( { "retrieve": true } ).api();
+			for ( i = 0; i < i_len; i += 1 ) {
+				i_cache = content[ i ];
+				if ( filterPassJSON( i_cache, filterTrueness, filterFaslseness ) ) {
+					basePntr = "/" + i;
+					cached_value = [];
+					for ( j = 0; j < mapping_len; j += 1 ) {
+						cached_value.push( jsonpointer.get( content, basePntr + mapping[ j ] ) );
+					}
+					dataTable.row.add( cached_value );
+				}
+			}
+			dataTable.draw();
+			return;
+		}
+
+		if ( !template ) {
+			return;
+		}
+
+		if ( settings.appendto ) {
+			elmAppendTo = $( settings.appendto ).get( 0 );
+		}
+
+		for ( i = 0; i < i_len; i += 1 ) {
+			i_cache = content[ i ];
+
+			if ( filterPassJSON( i_cache, filterTrueness, filterFaslseness ) ) {
+
+				basePntr = "/" + i;
+
+				if ( !selectorToClone ) {
+					clone = template.content.cloneNode( true );
+				} else {
+					clone = template.content.querySelector( selectorToClone ).cloneNode( true );
+				}
+
+				// clone = templateContent( template ); //template.content.cloneNode( true );
+				if ( queryAll ) {
+					selElements = clone.querySelectorAll( queryAll );
+
+					for ( j = 0; j < mapping_len; j += 1 ) {
+						j_cache = mapping[ j ];
+						cached_node = selElements[ j ];
+						if ( typeof j_cache === "string" ) {
+							cached_value = jsonpointer.get( content, basePntr + j_cache );
+						} else {
+							if ( j_cache.attr ) {
+								cached_node =  cached_node.getAttributeNode( j_cache.attr );
+							}
+
+							cached_textContent = cached_node.textContent || "";
+							cached_value = jsonpointer.get( content, basePntr + j_cache.value );
+
+							if ( j_cache.placeholder ) {
+								cached_value = cached_textContent.replace( j_cache.placeholder, cached_value );
+							}
+						}
+						cached_node.textContent = cached_value;
+					}
+				} else {
+					for ( j = 0; j < mapping_len; j += 1 ) {
+						j_cache = mapping[ j ];
+
+						if ( j_cache.selector ) {
+							cached_node = clone.querySelector( j_cache.selector );
+						} else {
+							cached_node = clone;
+						}
+
+						if ( j_cache.attr ) {
+							cached_node =  cached_node.getAttributeNode( j_cache.attr );
+						}
+
+						cached_textContent = cached_node.textContent || "";
+						cached_value = jsonpointer.get( content, basePntr + j_cache.value );
+
+						if ( j_cache.placeholder ) {
+							cached_value = cached_textContent.replace( j_cache.placeholder, cached_value );
+						}
+
+						cached_node.textContent = cached_value;
+					}
+				}
+
+				elmAppendTo.appendChild( clone );
+			}
+		}
+	},
+
+	// Filtering a JSON
+	// Return true if trueness && falseness
+	// Return false if !( trueness && falseness )
+	// trueness and falseness is an array of { "path": "", "value": "" } object
+	filterPassJSON = function( obj, trueness, falseness ) {
+		var i, i_cache,
+			trueness_len = trueness.length,
+			falseness_len = falseness.length,
+			compareResult = false,
+			isEqual;
+
+		if ( trueness_len || falseness_len ) {
+
+			for ( i = 0; i < trueness_len; i += 1 ) {
+				i_cache = trueness[ i ];
+				isEqual = _equalsJSON( jsonpointer.get( obj, i_cache.path ), i_cache.value );
+
+				if ( i_cache.optional ) {
+					compareResult = compareResult || isEqual;
+				} else if ( !isEqual ) {
+					return false;
+				} else {
+					compareResult = true;
+				}
+			}
+			if ( trueness_len && !compareResult ) {
+				return false;
+			}
+
+			for ( i = 0; i < falseness_len; i += 1 ) {
+				i_cache = falseness[ i ];
+				isEqual = _equalsJSON( jsonpointer.get( obj, i_cache.path ), i_cache.value );
+
+				if ( isEqual && !i_cache.optional || isEqual && i_cache.optional ) {
+					return false;
+				}
+			}
+
+		}
+		return true;
+	},
+
+	//
+	_equalsJSON = function( a, b ) {
+		switch ( typeof a ) {
+		case "undefined":
+			return false;
+		case "boolean":
+		case "string":
+		case "number":
+			return a === b;
+		case "object":
+			if ( a === null ) {
+				return b === null;
+			}
+			if ( $.isArray( a ) ) {
+				if (  $.isArray( b ) || a.length !== b.length ) {
+					return false;
+				}
+				for ( var i = 0, l = a.length; i < l; i++ ) {
+					if ( !_equalsJSON( a[ i ], b[ i ] ) ) {
+						return false;
+					}
+				}
+				return true;
+			}
+			var bKeys = _objectKeys( b ),
+				bLength = bKeys.length;
+			if ( _objectKeys( a ).length !== bLength ) {
+				return false;
+			}
+			for ( var i = 0; i < bLength; i++ ) {
+				if ( !_equalsJSON( a[ i ], b[ i ] ) ) {
+					return false;
+				}
+			}
+			return true;
+		default:
+			return false;
+		}
+	},
+	_objectKeys = function( obj ) {
+		if ( $.isArray( obj ) ) {
+			var keys = new Array( obj.length );
+			for ( var k = 0; k < keys.length; k++ ) {
+				keys[ k ] = "" + k;
+			}
+			return keys;
+		}
+		if ( Object.keys ) {
+			return Object.keys( obj );
+		}
+		var keys = [];
+		for ( var i in obj ) {
+			if ( obj.hasOwnProperty( i ) ) {
+				keys.push( i );
+			}
+		}
+		return keys;
+	},
+
+	// Manage JSON value After the json data has been fetched
+	jsonUpdate = function( event ) {
+		var elm = event.target,
+			$elm = $( elm ),
+			lstCall = $elm.data( dataQueue ),
+			refId = lstCall.length,
+			wbJsonConfig = event[ "wb-json" ];
+
+		if ( !( wbJsonConfig.url && ( wbJsonConfig.type || wbJsonConfig.source ) ) ) {
+			throw "Data JSON update not configured properly";
+		}
+
+		lstCall.push( wbJsonConfig );
+		$elm.data( dataQueue, lstCall );
+
+		loadJSON( elm, wbJsonConfig.url, refId );
 	};
 
-$document.on( "timerpoke.wb " + initEvent + " " + updateEvent + " json-fetched.wb", selector, function( event ) {
-	var eventTarget = event.target,
-		ajaxTypes = [
-			"before",
-			"replace",
-			"replacewith",
-			"after",
-			"append",
-			"prepend"
-		],
-		len = ajaxTypes.length,
-		$elm, ajaxType, i, content, jQueryCaching;
+$document.on( "json-failed.wb", selector, function( ) {
+	throw "Bad JSON Fetched from url in " + componentName;
+} );
 
-	for ( i = 0; i !== len; i += 1 ) {
-		ajaxType = ajaxTypes[ i ];
-		if ( this.getAttribute( "data-json-" + ajaxType ) !== null ) {
+$document.on( "timerpoke.wb " + initEvent + " " + updateEvent + " json-fetched.wb", selector, function( event ) {
+
+	if ( event.currentTarget === event.target ) {
+		switch ( event.type ) {
+
+		case "timerpoke":
+		case "wb-init":
+			init( event );
+			break;
+		case "wb-update":
+			jsonUpdate( event );
+			break;
+		default:
+			jsonFetched( event );
 			break;
 		}
 	}
 
-	switch ( event.type ) {
-
-	case "timerpoke":
-	case "wb-init":
-		init( event, ajaxType );
-		break;
-	case "wb-update":
-		ajax( event, ajaxType );
-		break;
-	default:
-
-		// Filter out any events triggered by descendants
-		if ( event.currentTarget === eventTarget ) {
-			$elm = $( eventTarget );
-
-			// json-fetched event
-			content = event.fetch.response;
-			if ( content &&  content.length > 0 ) {
-
-				//Prevents the force caching of nested resources
-				jQueryCaching = jQuery.ajaxSettings.cache;
-				jQuery.ajaxSettings.cache = true;
-
-				// "replace" and "replaceWith" doesn't map to a jQuery function
-				if ( ajaxType === "replace" ) {
-					$elm.html( content );
-				} else if ( ajaxType === "replacewith" ) {
-					$elm.replaceWith( content );
-				} else {
-					$elm[ ajaxType ]( content );
-				}
-
-				//Resets the initial jQuery caching setting
-				jQuery.ajaxSettings.cache = jQueryCaching;
-
-				$elm.trigger( contentUpdatedEvent, { "ajax-type": ajaxType, "content": content } );
-			}
-		}
-	}
-
-	/*
-	 * Since we are working with events we want to ensure that we are being
-	 * passive about our control, so returning true allows for events to always
-	 * continue
-	 */
 	return true;
 } );
 

--- a/src/plugins/data-json/demo/data-en.json
+++ b/src/plugins/data-json/demo/data-en.json
@@ -2,5 +2,24 @@
 	"fees": {
 		"ABC": "20$"
 	},
-	"product": "Hello world"
+	"product": "Hello world",
+	"products": [
+		"My new product",
+		"My second product",
+		"My product number 3"
+	],
+	"status": "text-muted",
+	"iamtrue": true,
+	"iamfalse": false,
+	"jour":"2016-11-05T01:42:31Z",
+	"anArray": [
+		{ "name": "Item 1", "prop": "red" },
+		{ "name": "Item 2", "prop": "blue" },
+		{ "name": "Item 3", "prop": "yellow" },
+		{ "name": "Item 4", "prop": "purple" }
+	],
+	"offices": [
+		{ "name": "Jean Edmonds, North Tower", "num": 300, "street": "Slater", "city": "Ottawa", "css": "bg-success" },
+		{ "name": "Place du portage, Phase I", "num": 50, "street": "Victoria", "city": "Gatineau", "css": "bg-danger" }
+	]
 }

--- a/src/plugins/data-json/demo/data-fr.json
+++ b/src/plugins/data-json/demo/data-fr.json
@@ -1,6 +1,25 @@
 {
-	"fees": {
+	"frais": {
 		"ABC": "20$"
 	},
-	"produit": "Bonjour le monde"
+	"produit": "Bonjour le monde",
+	"produits": [
+		"Mon nouveau produit",
+		"Mon deuxième produit",
+		"Mon produit numéro 3"
+	],
+	"etats": "text-muted",
+	"jesuisvrai": true,
+	"jesuisfaux": false,
+	"jour":"2016-11-05T01:42:31Z",
+	"unTableau": [
+		{ "nom": "Item 1", "prop": "rouge" },
+		{ "nom": "Item 2", "prop": "bleu" },
+		{ "nom": "Item 3", "prop": "jaune" },
+		{ "nom": "Item 4", "prop": "violet" }
+	],
+	"bureaux": [
+		{ "nom": "Jean Edmonds, Tour nord", "num": 300, "rue": "Slater", "ville": "Ottawa", "css": "bg-success" },
+		{ "nom": "Place du portage, Phase I", "num": 50, "rue": "Victoria", "ville": "Gatineau", "css": "bg-danger" }
+	]
 }

--- a/src/plugins/data-json/template-en.hbs
+++ b/src/plugins/data-json/template-en.hbs
@@ -1,0 +1,523 @@
+---
+{
+	"title": "Template HTML 5",
+	"language": "en",
+	"category": "Plugins",
+	"description": "Leverage HTML 5 template element by using the data json plugin.",
+	"tag": "data-json",
+	"parentdir": "data-json",
+	"altLangPrefix": "template",
+	"dateModified": "2017-01-31"
+}
+---
+<p>Leverage HTML 5 <code>&lt;template&gt;</code> element by using the data json plugin.</p>
+
+<div class="wb-prettify all-pre"></div>
+
+<details>
+	<summary>JSON data used by the following examples</summary>
+	<p>File: <code>demo/data-en.json</code></p>
+	<pre><code>{
+	&quot;fees&quot;: {
+		&quot;ABC&quot;: &quot;20$&quot;
+	},
+	&quot;product&quot;: &quot;Hello world&quot;,
+	&quot;products&quot;: [
+		&quot;My new product&quot;,
+		&quot;My second product&quot;,
+		&quot;My product number 3&quot;
+	],
+	&quot;status&quot;: &quot;text-muted&quot;,
+	&quot;iamtrue&quot;: true,
+	&quot;iamfalse&quot;: false,
+	&quot;jour&quot;:&quot;2016-11-05T01:42:31Z&quot;,
+	&quot;anArray&quot;: [
+		{ &quot;name&quot;: &quot;Item 1&quot;, &quot;prop&quot;: &quot;red&quot; },
+		{ &quot;name&quot;: &quot;Item 2&quot;, &quot;prop&quot;: &quot;blue&quot; },
+		{ &quot;name&quot;: &quot;Item 3&quot;, &quot;prop&quot;: &quot;yellow&quot; },
+		{ &quot;name&quot;: &quot;Item 4&quot;, &quot;prop&quot;: &quot;purple&quot; }
+	],
+	&quot;offices&quot;: [
+		{ &quot;name&quot;: &quot;Jean Edmonds, North Tower&quot;, &quot;num&quot;: 300, &quot;street&quot;: &quot;Slater&quot;, &quot;city&quot;: &quot;Ottawa&quot;, &quot;css&quot;: &quot;bg-success&quot; },
+		{ &quot;name&quot;: &quot;Place du portage, Phase I&quot;, &quot;num&quot;: 50, &quot;street&quot;: &quot;Victoria&quot;, &quot;city&quot;: &quot;Gatineau&quot;, &quot;css&quot;: &quot;bg-danger&quot; },
+	]
+}</code></pre>
+</details>
+
+
+<h2>List</h2>
+
+
+<div class="row">
+<div class="col-md-6">
+
+<p>Definition list:</p>
+<dl class="dl-horizontal" data-wb-json='{
+		"url": "demo/data-en.json#/anArray",
+		"mapping": [
+			{ "selector": "dt", "value": "/name" },
+			{ "selector": "dd", "value": "/prop" }
+		]
+	}'>
+	<template>
+		<dt></dt>
+		<dd></dd>
+	</template>
+</dl>
+
+</div>
+<div class="col-md-3">
+
+<p>Unordered:</p>
+<ul class="lst-spcd" data-wb-json='{
+		"url": "demo/data-en.json#/anArray",
+		"queryall": "li",
+		"mapping": [
+			"/name"
+		]
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ul>
+
+</div>
+<div class="col-md-3">
+
+<p>Ordered:</p>
+<ol class="lst-spcd" data-wb-json='{
+		"url": "demo/data-en.json#/anArray",
+		"queryall": "li",
+		"mapping": [
+			"/name"
+		]
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ol>
+
+</div>
+
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;p&gt;Definition list:&lt;/p&gt;
+&lt;dl class=&quot;dl-horizontal&quot; data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-en.json#/anArray&quot;,
+		&quot;mapping&quot;: [
+			{ &quot;selector&quot;: &quot;dt&quot;, &quot;value&quot;: &quot;/name&quot; },
+			{ &quot;selector&quot;: &quot;dd&quot;, &quot;value&quot;: &quot;/prop&quot; }
+		]
+	}'&gt;
+	&lt;template&gt;
+		&lt;dt&gt;&lt;/dt&gt;
+		&lt;dd&gt;&lt;/dd&gt;
+	&lt;/template&gt;
+&lt;/dl&gt;
+
+&lt;p&gt;Unordered:&lt;/p&gt;
+&lt;ul class=&quot;lst-spcd&quot; data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-en.json#/anArray&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/name&quot;
+		]
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;Ordered:&lt;/p&gt;
+&lt;ol class=&quot;lst-spcd&quot; data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-en.json#/anArray&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/name&quot;
+		]
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ol&gt;</code></pre>
+</details>
+
+
+<h2>Filtering</h2>
+
+<div class="row">
+<div class="col-md-3">
+
+<p>If <strong>positive</strong> condition:</p>
+
+<ul data-wb-json='{
+		"url": "demo/data-en.json#/anArray",
+		"queryall": "li",
+		"mapping": [
+			"/name"
+		],
+		"filter": [
+			{ "path": "/prop", "value": "blue" }
+		]
+
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ul>
+
+
+</div>
+
+
+<div class="col-md-3">
+
+<p>If <strong>negative</strong> condition:</p>
+
+<ul data-wb-json='{
+		"url": "demo/data-en.json#/anArray",
+		"queryall": "li",
+		"mapping": [
+			"/name"
+		],
+		"filternot": [
+			{ "path": "/prop", "value": "blue" }
+		]
+
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ul>
+
+
+</div>
+
+
+<div class="col-md-6">
+
+<p>Combinaison of both condition:</p>
+
+<ul data-wb-json='{
+		"url": "demo/data-en.json#/anArray",
+		"queryall": "li",
+		"mapping": [
+			"/name"
+		],
+		"filter": [
+			{ "path": "/prop", "value": "yellow", "optional": true },
+			{ "path": "/prop", "value": "blue", "optional": true }
+		],
+		"filternot": [
+			{ "path": "/prop", "value": "blue" }
+		]
+
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ul>
+
+
+</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;p&gt;If &lt;strong&gt;positive&lt;strong&gt; condition:&lt;/p&gt;
+&lt;ul data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-en.json#/anArray&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/name&quot;
+		],
+		&quot;filter&quot;: [
+			{ &quot;path&quot;: &quot;/prop&quot;, &quot;value&quot;: &quot;blue&quot; }
+		]
+
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;If &lt;strong&gt;negative&lt;/strong&gt; condition:&lt;/p&gt;
+&lt;ul data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-en.json#/anArray&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/name&quot;
+		],
+		&quot;filternot&quot;: [
+			{ &quot;path&quot;: &quot;/prop&quot;, &quot;value&quot;: &quot;blue&quot; }
+		]
+
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;Combinaison of both condition:&lt;/p&gt;
+&lt;ul data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-en.json#/anArray&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/name&quot;
+		],
+		&quot;filter&quot;: [
+			{ &quot;path&quot;: &quot;/prop&quot;, &quot;value&quot;: &quot;yellow&quot;, &quot;optional&quot;: true },
+			{ &quot;path&quot;: &quot;/prop&quot;, &quot;value&quot;: &quot;blue&quot;, &quot;optional&quot;: true }
+		],
+		&quot;filternot&quot;: [
+			{ &quot;path&quot;: &quot;/prop&quot;, &quot;value&quot;: &quot;blue&quot; }
+		]
+
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;</code></pre>
+</details>
+
+
+<h2>Table</h2>
+
+<div class="alert alert-info">
+	<p>Note: When you are using the templating to feed table rows, there is an issue when the <code>&lt;template&gt;</code> element are located inside the table element only when using <abbr title="Internet Explorer">IE</abbr>. The workaround is to move the <code>&lt;template&gt;</code> outside the <code>&lt;table&gt;</code>, ideally next to it, and then to include a <code>&lt;table&gt;</code> inside the <code>&lt;template&gt;</code> followed by your templated row. Then simply configure <code>tobeclone</code> and <code>source</code> to connect data json with the template.</p>
+</div>
+
+<table class="table">
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>Number</th>
+			<th>Street</th>
+			<th>City</th>
+		</tr>
+	</thead>
+	<tbody data-wb-json='{
+			"url": "demo/data-en.json#/offices",
+			"tobeclone": "tr",
+			"queryall": "td",
+			"source": "#tbl1",
+			"mapping": [
+				"/name",
+				"/num",
+				"/street",
+				"/city"
+			]
+		}'>
+	</tbody>
+</table>
+
+<template id="tbl1">
+	<table>
+		<tr>
+			<td></td>
+			<td></td>
+			<td></td>
+			<td></td>
+		</tr>
+	</table>
+</template>
+
+<table class="table">
+	<caption>Modifying attribute and place holder</caption>
+	<thead>
+		<tr>
+			<th>Name</th>
+			<th>Number</th>
+			<th>Street</th>
+			<th>City</th>
+		</tr>
+	</thead>
+	<tbody data-wb-json='{
+		"url": "demo/data-en.json#/offices",
+		"source": "#tbl2",
+		"tobeclone": "tr",
+		"mapping": [
+			{ "selector": "td", "value": "/name", "placeholder": "[[name]]" },
+			{ "selector": "td:nth-child(2)", "value": "/css", "attr": "class" },
+			{ "selector": "td:nth-child(2)", "value": "/num" },
+			{ "selector": "td:nth-last-child(2)", "value": "/street" },
+			{ "selector": "td:last-child", "value": "/city" }
+		]
+	}'>
+		<tr>
+			<td>Place du centre</td>
+			<td>200</td>
+			<td>Promenade du Portage</td>
+			<td>Gatineau</td>
+		</tr>
+		<tr>
+			<td>Jean Edmonds, South Tower</td>
+			<td>365</td>
+			<td>Laurier Ave W</td>
+			<td>Ottawa</td>
+		</tr>
+	</tbody>
+</table>
+
+<template id="tbl2">
+	<table>
+		<tr>
+			<td>Name is: [[name]]</td>
+			<td class=""></td>
+			<td></td>
+			<td></td>
+		</tr>
+	</table>
+</template>
+
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;table class=&quot;table&quot;&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Name&lt;/th&gt;
+			&lt;th&gt;Number&lt;/th&gt;
+			&lt;th&gt;Street&lt;/th&gt;
+			&lt;th&gt;City&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody data-wb-json='{
+			&quot;url&quot;: &quot;demo/data-en.json#/offices&quot;,
+			&quot;tobeclone&quot;: &quot;tr&quot;,
+			&quot;queryall&quot;: &quot;td&quot;,
+			&quot;source&quot;: &quot;#tbl1&quot;,
+			&quot;mapping&quot;: [
+				&quot;/name&quot;,
+				&quot;/num&quot;,
+				&quot;/street&quot;,
+				&quot;/city&quot;
+			]
+		}'&gt;
+	&lt;/tbody&gt;
+&lt;/table&gt;
+
+&lt;template id=&quot;tbl1&quot;&gt;
+	&lt;table&gt;
+		&lt;tr&gt;
+			&lt;td&gt;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
+		&lt;/tr&gt;
+	&lt;/table&gt;
+&lt;/template&gt;
+
+&lt;table class=&quot;table&quot;&gt;
+	&lt;caption&gt;Modifying attribute and place holder&lt;/caption&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Name&lt;/th&gt;
+			&lt;th&gt;Number&lt;/th&gt;
+			&lt;th&gt;Street&lt;/th&gt;
+			&lt;th&gt;City&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-en.json#/offices&quot;,
+		&quot;source&quot;: &quot;#tbl2&quot;,
+		&quot;tobeclone&quot;: &quot;tr&quot;,
+		&quot;mapping&quot;: [
+			{ &quot;selector&quot;: &quot;td&quot;, &quot;value&quot;: &quot;/name&quot;, &quot;placeholder&quot;: &quot;[[name]]&quot; },
+			{ &quot;selector&quot;: &quot;td:nth-child(2)&quot;, &quot;value&quot;: &quot;/css&quot;, &quot;attr&quot;: &quot;class&quot; },
+			{ &quot;selector&quot;: &quot;td:nth-child(2)&quot;, &quot;value&quot;: &quot;/num&quot; },
+			{ &quot;selector&quot;: &quot;td:nth-last-child(2)&quot;, &quot;value&quot;: &quot;/street&quot; },
+			{ &quot;selector&quot;: &quot;td:last-child&quot;, &quot;value&quot;: &quot;/city&quot; }
+		]
+	}'&gt;
+		&lt;tr&gt;
+			&lt;td&gt;Place du centre&lt;/td&gt;
+			&lt;td&gt;200&lt;/td&gt;
+			&lt;td&gt;Promenade du Portage&lt;/td&gt;
+			&lt;td&gt;Gatineau&lt;/td&gt;
+		&lt;/tr&gt;
+		&lt;tr&gt;
+			&lt;td&gt;Jean Edmonds, South Tower&lt;/td&gt;
+			&lt;td&gt;365&lt;/td&gt;
+			&lt;td&gt;Laurier Ave W&lt;/td&gt;
+			&lt;td&gt;Ottawa&lt;/td&gt;
+		&lt;/tr&gt;
+	&lt;/tbody&gt;
+&lt;/table&gt;
+
+&lt;template id=&quot;tbl2&quot;&gt;
+	&lt;table&gt;
+		&lt;tr&gt;
+			&lt;td&gt;Name is: [[name]]&lt;/td&gt;
+			&lt;td class=&quot;&quot;&gt;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
+		&lt;/tr&gt;
+	&lt;/table&gt;
+&lt;/template&gt;</code></pre>
+</details>
+
+
+<h2>Use <code>template</code> placeholder for appending to an element</h2>
+
+<template id="metadatacontent"  data-wb-json='{
+		"url": "demo/data-en.json",
+		"appendto": "title",
+		"source": "#metadatacontent",
+		"mapping": [
+			{ "value": "/product", "placeholder": "[[great]]" }
+		]
+	}'> *** [[great]] ***</template>
+
+<p>(To see this working example, take a look at the <code>title</code> element on this page)</p>
+
+<pre><code>&lt;template id=&quot;metadatacontent&quot;  data-wb-json='{
+		&quot;url&quot;: &quot;data-en.json&quot;,
+		&quot;appendto&quot;: &quot;title&quot;,
+		&quot;source&quot;: &quot;#metadatacontent&quot;,
+		&quot;mapping&quot;: [
+			{ &quot;value&quot;: &quot;/product&quot;, &quot;placeholder&quot;: &quot;[[great]]&quot; }
+		]
+	}'&gt; *** [[great]] ***&lt;/template&gt;</code></pre>
+
+
+<h2>Layout a RSS feeds</h2>
+
+<p>The following RSS feeds is provided through the <a href="https://developer.yahoo.com/yql/guide/yql_url.html">Yahoo YQL Web Service URLs</a>. The direct link to the rss feed is: <a href="http://www.tc.gc.ca/mediaroom/rss/road.xml"><code>http://www.tc.gc.ca/mediaroom/rss/road.xml</code></a></p>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div data-wb-json='{
+		&quot;url&quot;: &quot;https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20feed%20where%20url%20%3D%20&amp;#39;http%3A%2F%2Fwww.tc.gc.ca%2Fmediaroom%2Frss%2Froad.xml&amp;#39;%20limit%2019&amp;amp;format=json#/query/results/item&quot;,
+		&quot;mapping&quot;: [
+			{ &quot;selector&quot;: &quot;h3&quot;, &quot;value&quot;: &quot;/title&quot;, &quot;placeholder&quot;: &quot;&quot; },
+			{ &quot;selector&quot;: &quot;a&quot;, &quot;value&quot;: &quot;/description&quot; },
+			{ &quot;selector&quot;: &quot;a&quot;, &quot;value&quot;: &quot;/link&quot;, &quot;attr&quot;: &quot;href&quot; },
+			{ &quot;selector&quot;: &quot;span&quot;, &quot;value&quot;: &quot;/pubDate&quot;, &quot;placeholder&quot;: &quot;[[pubdate]]&quot; }
+		]
+	}'&gt;
+
+	&lt;template&gt;
+		&lt;h3&gt;&lt;/h3&gt;
+		&lt;p&gt;&lt;span&gt;Publish on [[pubdate]]&lt;/span&gt; &lt;a href=&quot;&quot;&gt;&lt;/a&gt;&lt;/p&gt;
+	&lt;/template&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+<div data-wb-json='{
+		"url": "https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20feed%20where%20url%20%3D%20&#39;http%3A%2F%2Fwww.tc.gc.ca%2Fmediaroom%2Frss%2Froad.xml&#39;%20limit%2019&amp;format=json#/query/results/item",
+		"mapping": [
+			{ "selector": "h3", "value": "/title", "placeholder": "" },
+			{ "selector": "a", "value": "/description" },
+			{ "selector": "a", "value": "/link", "attr": "href" },
+			{ "selector": "span", "value": "/pubDate", "placeholder": "[[pubdate]]" }
+		]
+	}'>
+
+	<template>
+		<h3></h3>
+		<p><span>Publish on [[pubdate]]</span> <a href=""></a></p>
+	</template>
+</div>

--- a/src/plugins/data-json/template-fr.hbs
+++ b/src/plugins/data-json/template-fr.hbs
@@ -1,0 +1,514 @@
+---
+{
+	"title": "Gabarit HTML 5",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Prendre avantage de l'élément template du HTML 5 avec le plugiciel data json",
+	"tag": "data-json",
+	"parentdir": "data-json",
+	"altLangPrefix": "template",
+	"dateModified": "2017-01-31"
+}
+---
+<p>Prendre avantage de l'élément <code>&lt;template&gt;</code> du HTML 5 avec le plugiciel data json</p>
+
+<div class="wb-prettify all-pre"></div>
+
+<details>
+	<summary>Donnée JSON utilisé pour les examples suivantes</summary>
+	<p>Fichier: <code>demo/data-fr.json</code></p>
+	<pre><code>{
+	"frais": {
+		"ABC": "20$"
+	},
+	"produit": "Bonjour le monde",
+	"produits": [
+		"Mon nouveau produit",
+		"Mon deuxième produit",
+		"Mon produit numéro 3"
+	],
+	"etats": "text-muted",
+	"jesuisvrai": true,
+	"jesuisfaux": false,
+	"jour":"2016-11-05T01:42:31Z",
+	"unTableau": [
+		{ "nom": "Item 1", "prop": "rouge" },
+		{ "nom": "Item 2", "prop": "bleu" },
+		{ "nom": "Item 3", "prop": "jaune" },
+		{ "nom": "Item 4", "prop": "violet" }
+	],
+	"bureaux": [
+		{ "nom": "Jean Edmonds, Tour nord", "num": 300, "rue": "Slater", "ville": "Ottawa", "css": "bg-success" },
+		{ "nom": "Place du portage, Phase I", "num": 50, "rue": "Victoria", "ville": "Gatineau", "css": "bg-danger" }
+	]
+}</code></pre>
+</details>
+
+
+<h2>Liste</h2>
+
+
+<div class="row">
+<div class="col-md-6">
+
+<p>Liste de définition:</p>
+<dl class="dl-horizontal" data-wb-json='{
+		"url": "demo/data-fr.json#/unTableau",
+		"mapping": [
+			{ "selector": "dt", "value": "/nom" },
+			{ "selector": "dd", "value": "/prop" }
+		]
+	}'>
+	<template>
+		<dt></dt>
+		<dd></dd>
+	</template>
+</dl>
+
+</div>
+<div class="col-md-3">
+
+<p>Non-ordonnée:</p>
+<ul class="lst-spcd" data-wb-json='{
+		"url": "demo/data-fr.json#/unTableau",
+		"queryall": "li",
+		"mapping": [
+			"/nom"
+		]
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ul>
+
+</div>
+<div class="col-md-3">
+
+<p>Ordonnée:</p>
+<ol class="lst-spcd" data-wb-json='{
+		"url": "demo/data-fr.json#/unTableau",
+		"queryall": "li",
+		"mapping": [
+			"/nom"
+		]
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ol>
+
+</div>
+
+</div>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;p&gt;Liste de définition:&lt;/p&gt;
+&lt;dl class=&quot;dl-horizontal&quot; data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-fr.json#/unTableau&quot;,
+		&quot;mapping&quot;: [
+			{ &quot;selector&quot;: &quot;dt&quot;, &quot;value&quot;: &quot;/nom&quot; },
+			{ &quot;selector&quot;: &quot;dd&quot;, &quot;value&quot;: &quot;/prop&quot; }
+		]
+	}'&gt;
+	&lt;template&gt;
+		&lt;dt&gt;&lt;/dt&gt;
+		&lt;dd&gt;&lt;/dd&gt;
+	&lt;/template&gt;
+&lt;/dl&gt;
+
+&lt;p&gt;Non-ordonnée:&lt;/p&gt;
+&lt;ul class=&quot;lst-spcd&quot; data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-fr.json#/unTableau&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/nom&quot;
+		]
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;Ordonnée:&lt;/p&gt;
+&lt;ol class=&quot;lst-spcd&quot; data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-fr.json#/unTableau&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/nom&quot;
+		]
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ol&gt;</code></pre>
+</details>
+
+
+<h2>Filtrage</h2>
+
+<div class="row">
+<div class="col-md-3">
+
+<p>Lors d'une condition <strong>affirmative</strong> :</p>
+<ul data-wb-json='{
+		"url": "demo/data-fr.json#/unTableau",
+		"queryall": "li",
+		"mapping": [
+			"/nom"
+		],
+		"filter": [
+			{ "path": "/prop", "value": "bleu" }
+		]
+
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ul>
+
+</div>
+<div class="col-md-3">
+
+<p>Lors d'une condition <strong>négative</strong> :</p>
+<ul data-wb-json='{
+		"url": "demo/data-fr.json#/unTableau",
+		"queryall": "li",
+		"mapping": [
+			"/nom"
+		],
+		"filternot": [
+			{ "path": "/prop", "value": "bleu" }
+		]
+
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ul>
+
+</div>
+<div class="col-md-6">
+
+<p>Combinaison des deux conditions :</p>
+<ul data-wb-json='{
+		"url": "demo/data-fr.json#/unTableau",
+		"queryall": "li",
+		"mapping": [
+			"/nom"
+		],
+		"filter": [
+			{ "path": "/prop", "value": "jaune", "optional": true },
+			{ "path": "/prop", "value": "bleu", "optional": true }
+		],
+		"filternot": [
+			{ "path": "/prop", "value": "bleu" }
+		]
+
+	}'>
+	<template>
+		<li></li>
+	</template>
+</ul>
+
+
+</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;p&gt;Lors d'une condition &lt;strong&gt;affirmative&lt;/strong&gt; :&lt;/p&gt;
+&lt;ul data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-fr.json#/unTableau&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/nom&quot;
+		],
+		&quot;filter&quot;: [
+			{ &quot;path&quot;: &quot;/prop&quot;, &quot;value&quot;: &quot;bleu&quot; }
+		]
+
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;Lors d'une condition &lt;strong&gt;négative&lt;/strong&gt; :&lt;/p&gt;
+&lt;ul data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-fr.json#/unTableau&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/nom&quot;
+		],
+		&quot;filternot&quot;: [
+			{ &quot;path&quot;: &quot;/prop&quot;, &quot;value&quot;: &quot;bleu&quot; }
+		]
+
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;
+
+&lt;p&gt;Combinaison des deux conditions :&lt;/p&gt;
+&lt;ul data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-fr.json#/unTableau&quot;,
+		&quot;queryall&quot;: &quot;li&quot;,
+		&quot;mapping&quot;: [
+			&quot;/nom&quot;
+		],
+		&quot;filter&quot;: [
+			{ &quot;path&quot;: &quot;/prop&quot;, &quot;value&quot;: &quot;jaune&quot;, &quot;optional&quot;: true },
+			{ &quot;path&quot;: &quot;/prop&quot;, &quot;value&quot;: &quot;bleu&quot;, &quot;optional&quot;: true }
+		],
+		&quot;filternot&quot;: [
+			{ &quot;path&quot;: &quot;/prop&quot;, &quot;value&quot;: &quot;bleu&quot; }
+		]
+
+	}'&gt;
+	&lt;template&gt;
+		&lt;li&gt;&lt;/li&gt;
+	&lt;/template&gt;
+&lt;/ul&gt;</code></pre>
+</details>
+
+
+<h2>Tableau</h2>
+
+<div class="alert alert-info">
+	<p>Veuillez noter: Lorsque vous utilisé un template pour ajouter des lignes à un tableau, il existe une problématique lorsque l'élement <code>&lt;template&gt;</code> est situé à l'intérieur de l'élément <code>&lt;table&gt;</code> et ce seulement avec le fureteur <abbr title="Internet Explorer">IE</abbr>. Afin de contourner le problème, il suffit de déplacer l'élément <code>&lt;template&gt;</code> en dehors de la porté dudit tableau. Idéalement il serait situé à la suite de celui-ci. D'ailleurs, il sera necessaire d'ajouter l'élément <code>&lt;table&gt;</code> à l'intérieur du <code>&lt;template&gt;</code> afin de définir le gabarit de vos ligne. Par la suite, il vous suffira de configurer <code>tobeclone</code> et <code>source</code> afin d'établir un lien entre votre gabarit et le plugiciel data json.</p>
+</div>
+
+<table class="table">
+	<thead>
+		<tr>
+			<th>Nom</th>
+			<th>Numéro</th>
+			<th>Rue</th>
+			<th>Ville</th>
+		</tr>
+	</thead>
+	<tbody data-wb-json='{
+			"url": "demo/data-fr.json#/bureaux",
+			"tobeclone": "tr",
+			"queryall": "td",
+			"source": "#tbl1",
+			"mapping": [
+				"/nom",
+				"/num",
+				"/rue",
+				"/ville"
+			]
+		}'>
+	</tbody>
+</table>
+
+<template id="tbl1">
+	<table>
+		<tr>
+			<td></td>
+			<td></td>
+			<td></td>
+			<td></td>
+		</tr>
+	</table>
+</template>
+
+<table class="table">
+	<caption>Modifier des attributs et utiliser des espaces réservé</caption>
+	<thead>
+		<tr>
+			<th>Nom</th>
+			<th>Numéro</th>
+			<th>Rue</th>
+			<th>Ville</th>
+		</tr>
+	</thead>
+	<tbody data-wb-json='{
+		"url": "demo/data-fr.json#/bureaux",
+		"source": "#tbl2",
+		"tobeclone": "tr",
+		"mapping": [
+			{ "selector": "td", "value": "/nom", "placeholder": "[[nom]]" },
+			{ "selector": "td:nth-child(2)", "value": "/css", "attr": "class" },
+			{ "selector": "td:nth-child(2)", "value": "/num" },
+			{ "selector": "td:nth-last-child(2)", "value": "/rue" },
+			{ "selector": "td:last-child", "value": "/ville" }
+		]
+	}'>
+		<tr>
+			<td>Place du centre</td>
+			<td>200</td>
+			<td>Promenade du Portage</td>
+			<td>Gatineau</td>
+		</tr>
+		<tr>
+			<td>Jean Edmonds, Tour sud</td>
+			<td>365</td>
+			<td>Laurier ave O</td>
+			<td>Ottawa</td>
+		</tr>
+	</tbody>
+</table>
+
+<template id="tbl2">
+	<table>
+		<tr>
+			<td>Le nom est: [[nom]]</td>
+			<td class=""></td>
+			<td></td>
+			<td></td>
+		</tr>
+	</table>
+</template>
+
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;table class=&quot;table&quot;&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Nom&lt;/th&gt;
+			&lt;th&gt;Numéro&lt;/th&gt;
+			&lt;th&gt;Rue&lt;/th&gt;
+			&lt;th&gt;Ville&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody data-wb-json='{
+			&quot;url&quot;: &quot;demo/data-fr.json#/bureaux&quot;,
+			&quot;tobeclone&quot;: &quot;tr&quot;,
+			&quot;queryall&quot;: &quot;td&quot;,
+			&quot;source&quot;: &quot;#tbl1&quot;,
+			&quot;mapping&quot;: [
+				&quot;/nom&quot;,
+				&quot;/num&quot;,
+				&quot;/rue&quot;,
+				&quot;/ville&quot;
+			]
+		}'&gt;
+	&lt;/tbody&gt;
+&lt;/table&gt;
+
+&lt;template id=&quot;tbl1&quot;&gt;
+	&lt;table&gt;
+		&lt;tr&gt;
+			&lt;td&gt;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
+		&lt;/tr&gt;
+	&lt;/table&gt;
+&lt;/template&gt;
+
+&lt;table class=&quot;table&quot;&gt;
+	&lt;caption&gt;Modifier des attributs et utiliser des espaces réservé&lt;/caption&gt;
+	&lt;thead&gt;
+		&lt;tr&gt;
+			&lt;th&gt;Nom&lt;/th&gt;
+			&lt;th&gt;Numéro&lt;/th&gt;
+			&lt;th&gt;Rue&lt;/th&gt;
+			&lt;th&gt;Ville&lt;/th&gt;
+		&lt;/tr&gt;
+	&lt;/thead&gt;
+	&lt;tbody data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-fr.json#/bureaux&quot;,
+		&quot;source&quot;: &quot;#tbl2&quot;,
+		&quot;tobeclone&quot;: &quot;tr&quot;,
+		&quot;mapping&quot;: [
+			{ &quot;selector&quot;: &quot;td&quot;, &quot;value&quot;: &quot;/nom&quot;, &quot;placeholder&quot;: &quot;[[nom]]&quot; },
+			{ &quot;selector&quot;: &quot;td:nth-child(2)&quot;, &quot;value&quot;: &quot;/css&quot;, &quot;attr&quot;: &quot;class&quot; },
+			{ &quot;selector&quot;: &quot;td:nth-child(2)&quot;, &quot;value&quot;: &quot;/num&quot; },
+			{ &quot;selector&quot;: &quot;td:nth-last-child(2)&quot;, &quot;value&quot;: &quot;/rue&quot; },
+			{ &quot;selector&quot;: &quot;td:last-child&quot;, &quot;value&quot;: &quot;/ville&quot; }
+		]
+	}'&gt;
+		&lt;tr&gt;
+			&lt;td&gt;Place du centre&lt;/td&gt;
+			&lt;td&gt;200&lt;/td&gt;
+			&lt;td&gt;Promenade du Portage&lt;/td&gt;
+			&lt;td&gt;Gatineau&lt;/td&gt;
+		&lt;/tr&gt;
+		&lt;tr&gt;
+			&lt;td&gt;Jean Edmonds, Tour sud&lt;/td&gt;
+			&lt;td&gt;365&lt;/td&gt;
+			&lt;td&gt;Laurier ave O&lt;/td&gt;
+			&lt;td&gt;Ottawa&lt;/td&gt;
+		&lt;/tr&gt;
+	&lt;/tbody&gt;
+&lt;/table&gt;
+
+&lt;template id=&quot;tbl2&quot;&gt;
+	&lt;table&gt;
+		&lt;tr&gt;
+			&lt;td&gt;Le nom est: [[nom]]&lt;/td&gt;
+			&lt;td class=&quot;&quot;&gt;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
+			&lt;td&gt;&lt;/td&gt;
+		&lt;/tr&gt;
+	&lt;/table&gt;
+&lt;/template&gt;</code></pre>
+</details>
+
+
+<h2>Utilisé l'espace réserver avec un <code>template</code> pour ajouter à un élément</h2>
+
+<template id="metadatacontent"  data-wb-json='{
+		"url": "demo/data-fr.json",
+		"appendto": "title",
+		"source": "#metadatacontent",
+		"mapping": [
+			{ "value": "/produit", "placeholder": "[[fantastique]]" }
+		]
+	}'> *** [[fantastique]] ***</template>
+
+<p>(Pour voir cet example pratique, regarder le contenu de l'élément <code>title</code> de cette page)</p>
+
+<pre><code>&lt;template id=&quot;metadatacontent&quot;  data-wb-json='{
+		&quot;url&quot;: &quot;demo/data-fr.json&quot;,
+		&quot;appendto&quot;: &quot;title&quot;,
+		&quot;source&quot;: &quot;#metadatacontent&quot;,
+		&quot;mapping&quot;: [
+			{ &quot;value&quot;: &quot;/produit&quot;, &quot;placeholder&quot;: &quot;[[fantastique]]&quot; }
+		]
+	}'&gt; *** [[fantastique]] ***&lt;/template&gt;</code></pre>
+
+
+<h2>Mise en forme d'un flux RSS</h2>
+
+<p>Le flux RSS suivant est lu à partir du service web <a href="https://developer.yahoo.com/yql/guide/yql_url.html" hreflang="en" lang="en">Yahoo YQL Web Service URLs</a>. Le lien directe vers le flux RSS est : <a href="http://www.tc.gc.ca/medias/rss/routier.xml"><code>http://www.tc.gc.ca/medias/rss/routier.xml</code></a></p>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div data-wb-json='{
+		&quot;url&quot;: &quot;https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20feed%20where%20url%20%3D%20&amp;#39;http%3A%2F%2Fwww.tc.gc.ca%2Fmedias%2Frss%2Froutier.xml&amp;#39;%20limit%2019&amp;amp;format=json#/query/results/item&quot;,
+		&quot;mapping&quot;: [
+			{ &quot;selector&quot;: &quot;h3&quot;, &quot;value&quot;: &quot;/title&quot;, &quot;placeholder&quot;: &quot;&quot; },
+			{ &quot;selector&quot;: &quot;a&quot;, &quot;value&quot;: &quot;/description&quot; },
+			{ &quot;selector&quot;: &quot;a&quot;, &quot;value&quot;: &quot;/link&quot;, &quot;attr&quot;: &quot;href&quot; },
+			{ &quot;selector&quot;: &quot;span&quot;, &quot;value&quot;: &quot;/pubDate&quot;, &quot;placeholder&quot;: &quot;[[pubdate]]&quot; }
+		]
+	}'&gt;
+
+	&lt;template&gt;
+		&lt;h3&gt;&lt;/h3&gt;
+		&lt;p&gt;&lt;span&gt;Publish on [[pubdate]]&lt;/span&gt; &lt;a href=&quot;&quot;&gt;&lt;/a&gt;&lt;/p&gt;
+	&lt;/template&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+<div data-wb-json='{
+		"url": "https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20feed%20where%20url%20%3D%20&#39;http%3A%2F%2Fwww.tc.gc.ca%2Fmedias%2Frss%2Froutier.xml&#39;%20limit%2019&amp;format=json#/query/results/item",
+		"mapping": [
+			{ "selector": "h3", "value": "/title", "placeholder": "" },
+			{ "selector": "a", "value": "/description" },
+			{ "selector": "a", "value": "/link", "attr": "href" },
+			{ "selector": "span", "value": "/pubDate", "placeholder": "[[pubjour]]" }
+		]
+	}'>
+
+	<template>
+		<h3></h3>
+		<p><span>Publié le [[pubjour]]</span> <a href=""></a></p>
+	</template>
+</div>

--- a/src/polyfills/template/template.js
+++ b/src/polyfills/template/template.js
@@ -1,0 +1,56 @@
+/**
+ * @title WET-BOEW Template polyfill
+ * @overview The <template> element hold elements for Javascript and templating usage. Based on code from http://ironlasso.com/template-tag-polyfill-for-internet-explorer/
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @duboisp
+ */
+( function( $, document, wb ) {
+"use strict";
+
+/*
+ * Variable and function definitions.
+ * These are global to the polyfill - meaning that they will be initialized once per page.
+ */
+var componentName = "wb-template",
+	selector = "template",
+	initEvent = "wb-init." + componentName,
+	$document = wb.doc,
+
+	/**
+	 * @method init
+	 * @param {jQuery Event} event Event that triggered the function call
+	 */
+	init = function( event ) {
+
+		// Start initialization
+		// returns DOM object = proceed with init
+		// returns undefined = do not proceed with init (e.g., already initialized)
+		var elm = wb.init( event, componentName, selector );
+
+		if ( elm && !elm.content ) {
+
+			var elPlate = elm,
+				qContent,
+				docContent;
+
+			qContent = elPlate.childNodes;
+			docContent = document.createDocumentFragment();
+
+			while ( qContent[ 0 ] ) {
+				docContent.appendChild( qContent[ 0 ] );
+			}
+
+			elPlate.content = docContent;
+
+			// Identify that initialization has completed
+			wb.ready( $( elm ), componentName );
+		}
+	};
+
+// Bind the events of the polyfill
+$document.on( "timerpoke.wb " + initEvent, selector, init );
+
+// Add the timer poke to initialize the polyfill
+wb.add( selector );
+
+} )( jQuery, document, wb );


### PR DESCRIPTION
This PR update the data-json plugin to add new functionality like supporting ```<template>``` element, providing more options on how to insert json data and referring to a dataset in url. The dataset feature will allow to slightly manipulate the data, by a middleware plugin during the fetch operation. The dataset feature is required and will be demonstrated by the upcoming JSON manager that I am currently finalizing it.

Data JSON
http://universallabs.org/wet/labs/data-json/dist-1.1-b1/demos/data-json/data-json-en.html
http://universallabs.org/wet/labs/data-json/dist-1.1-b1/demos/data-json/data-json-fr.html

Template HTML 5
http://universallabs.org/wet/labs/data-json/dist-1.1-b1/demos/data-json/template-en.html
http://universallabs.org/wet/labs/data-json/dist-1.1-b1/demos/data-json/template-fr.html

Documentation
http://universallabs.org/wet/labs/data-json/dist-1.1-b1/docs/ref/data-json/data-json-en.html

---

@LaurentGoderre said in #7618
> That data-json plugin sounds redundant to me. If you want binding like this, shouldn't you use something like angular instead of creating a pseudo angular?

@LaurentGoderre I agree that both may have similar functionality, but angular aren't integrated to wet-boew yet.

I remember that, two-three years ago, there have been informal discussion about interacting with an API in wet-boew but nothing concrete was delivered. The data-json plugin is concrete, tested, functional and ready to be use on production.

If the functionality supported by data-json plugin could be replaced by a better plugin, I am proposing to re-visit it when it will be the time to migrating existing plugins for the next major release which would require major features re-write.

---

This PR also include updates that allow to change the url of data-ajax before it gets loaded. fix #7782

@rlambert27 As discussed in #7782, it's now ready for testing.

I didn't included intentionally an explicit working example for the cache busting feature because a proper server configuration should be use and are very preferable. Instead I added a demo of an alternative syntax of calling the data-ajax plugin. With that alternative syntax you can add the configuration option ```"nocache": true``` for session caching busting  or ```"nocache": "nocache"``` to always reset the cache. That feature is also implemented in data-json.

Data Ajax - (added an alternative syntax)
http://universallabs.org/wet/labs/data-json/dist-1.1-b1/demos/data-ajax/data-ajax-en.html
http://universallabs.org/wet/labs/data-json/dist-1.1-b1/demos/data-ajax/data-ajax-fr.html

Documentation:
http://universallabs.org/wet/labs/data-json/dist-1.1-b1/docs/ref/data-ajax/data-ajax-en.html
