### PR TITLE
Collapsible alerts: Fixed summary arrow issues in IE11/Edge.

### DIFF
--- a/src/plugins/collapsible-alerts/base.scss
+++ b/src/plugins/collapsible-alerts/base.scss
@@ -89,38 +89,39 @@ details {
 	}
 }
 
-.no-details {
-	details {
-		&.alert,
-		&.alert[open] {
-			> {
-				summary {
-					margin-left: 1.4em;
-
-					&:before {
-						content: "\25BA\a0";
-					}
-				}
-			}
-
-			&[open] {
+.wb-enable {
+	&.no-details {
+		details {
+			&.alert {
 				> {
 					summary {
+						margin-left: 1.4em;
+
 						&:before {
-							content: "\25BC\a0";
+							content: "\25BA\a0";
+						}
+					}
+				}
+
+				&[open] {
+					> {
+						summary {
+							&:before {
+								content: "\25BC\a0";
+							}
 						}
 					}
 				}
 			}
 		}
-	}
 
-	&[dir="rtl"] {
-		details {
-			&.alert {
-				> {
-					summary {
-						margin-right: 1.4em;
+		&[dir="rtl"] {
+			details {
+				&.alert {
+					> {
+						summary {
+							margin-right: 1.4em;
+						}
 					}
 				}
 			}


### PR DESCRIPTION
* Prevents arrows from resizing/flickering on page load.
* Disables arrows in wbdisable/noscript modes.
* Prevents a CSS selector containing two consecutive open attributes ([open][open]) from getting generated.
* Fixes #7886.

@duboisp FYI I've only tested this in IE11. Feel free to double-check it in Edge if you want. Since this PR basically just added parent classes and didn't modify any CSS properties, it should work identically in both browsers.