### PR TITLE
Collapsible alerts: Horizontally re-aligned summary arrows/headings to be flush with content.

### DIFF
--- a/src/plugins/collapsible-alerts/base.scss
+++ b/src/plugins/collapsible-alerts/base.scss
@@ -42,7 +42,7 @@ details {
 			}
 
 			:first-child {
-				margin-left: .4em;
+				margin-left: .2em;
 
 				&:before {
 					color: #000;
@@ -95,7 +95,7 @@ details {
 			&.alert {
 				> {
 					summary {
-						margin-left: 1.4em;
+						margin-left: 1.2em;
 
 						&:before {
 							content: "\25BA\a0";
@@ -120,7 +120,7 @@ details {
 				&.alert {
 					> {
 						summary {
-							margin-right: 1.4em;
+							margin-right: 1.2em;
 						}
 					}
 				}


### PR DESCRIPTION
I've provided screenshot of what this change would look like in IE11 (with #7894 in place) below. Firefox and Blink/Webkit browsers look similar to the JavaScript screenshots in all modes (since they natively support ``details``).

**IE11 screenshots (with #7894 in place)...**

**JavaScript:**
* Before:
![ie11_js_before](https://cloud.githubusercontent.com/assets/1907279/22994800/411221f0-f396-11e6-9af8-87f72790b6dd.png)
* After:
![ie11_js_after](https://cloud.githubusercontent.com/assets/1907279/22994805/48072bae-f396-11e6-8be8-52be7d7100bf.png)

**Wbdisable:**
* Before:
![ie11_wbdisable_before](https://cloud.githubusercontent.com/assets/1907279/22994834/5f79e09c-f396-11e6-90c2-e233f30a48bf.png)
* After:
![ie11_wbdisable_after](https://cloud.githubusercontent.com/assets/1907279/22994841/6553bd44-f396-11e6-8601-f13a6f7e05e7.png)

**PS:** Once #7894 is merged, this PR will need to be rebased (since it changes property values on some lines #7894 indented).

CC @duboisp