### PR TITLE
Multimedia player: Revised second video demos to use TTML captions.

### DIFF
--- a/src/plugins/multimedia/cpts-lg2-en.hbs
+++ b/src/plugins/multimedia/cpts-lg2-en.hbs
@@ -5,73 +5,73 @@
 	"tag": "multimedia",
 	"parentdir": "multimedia",
 	"altLangPrefix": "multimedia",
-	"dateModified": "2014-02-19"
+	"dateModified": "2017-02-20"
 }
 ---
 <div id="inline-captions">
 	<section>
 		<h2>Transcript</h2>
-		<p class="wb-vd" data-load="vd"><strong>(Animated pen draws a red line that leads into the text Training and development.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="1.40s" data-dur="3.33s" data-load="tt">Hi, my name is Eric, and I'm a Service Canada employee.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Cut to a close-up of the Host.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="4.73s" data-dur="2.73s" data-load="tt">Each and every day, Canadians are improving their job </span>
-		<span class="wb-tmtxt" data-begin="7.46s" data-dur="2.14s" data-load="tt">skills or changing their career paths.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(LINE DRAWING GRAPHIC: Stairs appear and our stick person walks towards them, stops. Question marks appear around his head.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="9.60s" data-dur="1.66s" data-load="tt">Are you thinking about taking that step?</span></p>
-		<p><span class="wb-tmtxt" data-begin="11.26s" data-dur="2.04s" data-load="tt">If so, did you know that you can research </span>
-		<span class="wb-tmtxt" data-begin="13.30s" data-dur="2.40s" data-load="tt">more than 300 job profiles online?</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(LINE DRAWING GRAPHIC: Stick person appears with briefcase. And then wearing a hard hat and swinging a hammer.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="15.70s" data-dur="2.30s" data-load="tt">Plus, you can find out what skills you'll need </span>
-		<span class="wb-tmtxt" data-begin="18.00s" data-dur="1.70s" data-load="tt">to get the job that interests you.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Medium shot of Host. LINE DRAWING GRAPHIC: The (actual) Job Bank’s Training and learning page appears. The words “Training, Career and Worker Information” are highlighted.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="19.70s" data-dur="2.43s" data-load="tt">Job Bank's Training and Careers site lets you explore </span>
-		<span class="wb-tmtxt" data-begin="22.13s" data-dur="3.07s" data-load="tt">adult-learning choices and explains the various options </span>
-		<span class="wb-tmtxt" data-begin="25.20s" data-dur="1.93s" data-load="tt">that are available to help you pay </span>
-		<span class="wb-tmtxt" data-begin="27.13s" data-dur="1.50s" data-load="tt">for the training you need.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Medium shot of Host.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="28.63s" data-dur="1.80s" data-load="tt">You can even find counsellors, teachers, </span>
-		<span class="wb-tmtxt" data-begin="30.43s" data-dur="2.10s" data-load="tt">and other resources near you if you'd like to have </span>
-		<span class="wb-tmtxt" data-begin="32.53s" data-dur="2.13s" data-load="tt">more information before you make a decision.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Medium shot of Host.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="34.66s" data-dur="1.74s" data-load="tt">And the support doesn't end there.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Medium shot of Host. (actual) Service Canada home page. Dissolve to (actual) Labour Market Information site.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="36.40s" data-dur="2.73s" data-load="tt">From the alphabetical index on our Service Canada home page, </span>
-		<span class="wb-tmtxt" data-begin="39.13s" data-dur="2.93s" data-load="tt">you can link to the Labour Market Information site.</span></p>
-		<p><span class="wb-tmtxt" data-begin="42.06s" data-dur="2.10s" data-load="tt">There, you'll find out what kinds of jobs are available, </span>
-		<span class="wb-tmtxt" data-begin="44.16s" data-dur="2.50s" data-load="tt">by area, across the country, and what skills you'll need </span>
-		<span class="wb-tmtxt" data-begin="46.66s" data-dur="1.74s" data-load="tt">to get those jobs.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Medium shot of Host. LINE DRAWING GRAPHIC: our stick person in a classroom setting.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="48.40s" data-dur="2.23s" data-load="tt">But, what if you decide to go for full-time training?</span></p>
-		<p><span class="wb-tmtxt" data-begin="50.63s" data-dur="2.67s" data-load="tt">Well, there are a number of loans and grants available </span>
-		<span class="wb-tmtxt" data-begin="53.30s" data-dur="2.13s" data-load="tt">that could help you with the costs.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Medium shot of Host.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="55.43s" data-dur="2.33s" data-load="tt">For example, there's the Apprenticeship Incentive Grant </span>
-		<span class="wb-tmtxt" data-begin="57.76s" data-dur="2.20s" data-load="tt">for those who've completed the first or second level </span>
-		<span class="wb-tmtxt" data-begin="59.96s" data-dur="1.60s" data-load="tt">of their apprenticeship.</span></p>
-		<p><span class="wb-tmtxt" data-begin="61.56s" data-dur="2.54s" data-load="tt">And for those who've completed the entire apprenticeship, </span>
-		<span class="wb-tmtxt" data-begin="64.10s" data-dur="1.30s" data-load="tt">in a specific trade, </span>
-		<span class="wb-tmtxt" data-begin="65.40s" data-dur="2.06s" data-load="tt">there's the Apprenticeship Completion Grant.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Show (actual) Canada Student Loans Program – Permanent Disability Benefit web page. Words “Student Loans Program” and “Study Grant” appear.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="67.46s" data-dur="1.67s" data-load="tt">If you have a permanent disability, </span>
-		<span class="wb-tmtxt" data-begin="69.13s" data-dur="2.50s" data-load="tt">you may want to look into the Canada Student Loans program, </span>
-		<span class="wb-tmtxt" data-begin="71.63s" data-dur="2.20s" data-load="tt">or apply for a study grant.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Show main Life-Long Learning Plan program pages.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="73.83s" data-dur="2.70s" data-load="tt">Under the Life-Long Learning Plan program, </span>
-		<span class="wb-tmtxt" data-begin="76.53s" data-dur="2.73s" data-load="tt">you can find out how to use some of your RRSP funds </span>
-		<span class="wb-tmtxt" data-begin="79.26s" data-dur="2.37s" data-load="tt">to pay for your education or training.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Medium shot of Host.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="81.63s" data-dur="2.47s" data-load="tt">Whatever you see yourself doing, </span>
-		<span class="wb-tmtxt" data-begin="84.10s" data-dur="2.73s" data-load="tt">why not take the time to discover all your options?</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(LINE DRAWING GRAPHIC: our stick person waves.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="86.83s" data-dur="2.73s" data-load="tt">Doing your homework now can help you get </span>
-		<span class="wb-tmtxt" data-begin="89.56s" data-dur="2.74s" data-load="tt">on the right path to finding the work you want.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Our stick person appears typing at computer and desk. (actual) Canada homepage, Job Bank and LMI pages loom out from the computer.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="92.30s" data-dur="2.40s" data-load="tt">Be sure to check out our Service Canada Web site.</span></p>
-		<p><span class="wb-tmtxt" data-begin="94.70s" data-dur="1.80s" data-load="tt">There you'll find the tools and information </span>
-		<span class="wb-tmtxt" data-begin="96.50s" data-dur="1.80s" data-load="tt">you need to continue your education and training.</span></p>
-		<p><span class="wb-tmtxt" data-begin="98.30s" data-dur="2.53s" data-load="tt">It really is time well spent.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Tight shot of the Host. LINE DRAWING GRAPHIC: Service Canada logo. Stick person takes a bow.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="100.83s" data-dur="2.70s" data-load="tt">At Service Canada, we're people serving people.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Dip to black.)</strong></p>
+		<p><strong>(Animated pen draws a red line that leads into the text Training and development.)</strong></p>
+		<p>Hi, my name is Eric, and I'm a Service Canada employee.</p>
+		<p><strong>(Cut to a close-up of the Host.)</strong></p>
+		<p>Each and every day, Canadians are improving their job
+		skills or changing their career paths.</p>
+		<p><strong>(LINE DRAWING GRAPHIC: Stairs appear and our stick person walks towards them, stops. Question marks appear around his head.)</strong></p>
+		<p>Are you thinking about taking that step?</p>
+		<p>If so, did you know that you can research
+		more than 300 job profiles online?</p>
+		<p><strong>(LINE DRAWING GRAPHIC: Stick person appears with briefcase. And then wearing a hard hat and swinging a hammer.)</strong></p>
+		<p>Plus, you can find out what skills you'll need
+		to get the job that interests you.</p>
+		<p><strong>(Medium shot of Host. LINE DRAWING GRAPHIC: The (actual) Job Bank’s Training and learning page appears. The words “Training, Career and Worker Information” are highlighted.)</strong></p>
+		<p>Job Bank's Training and Careers site lets you explore
+		adult-learning choices and explains the various options
+		that are available to help you pay
+		for the training you need.</p>
+		<p><strong>(Medium shot of Host.)</strong></p>
+		<p>You can even find counsellors, teachers,
+		and other resources near you if you'd like to have
+		more information before you make a decision.</p>
+		<p><strong>(Medium shot of Host.)</strong></p>
+		<p>And the support doesn't end there.</p>
+		<p><strong>(Medium shot of Host. (actual) Service Canada home page. Dissolve to (actual) Labour Market Information site.)</strong></p>
+		<p>From the alphabetical index on our Service Canada home page,
+		you can link to the Labour Market Information site.</p>
+		<p>There, you'll find out what kinds of jobs are available,
+		by area, across the country, and what skills you'll need
+		to get those jobs.</p>
+		<p><strong>(Medium shot of Host. LINE DRAWING GRAPHIC: our stick person in a classroom setting.)</strong></p>
+		<p>But, what if you decide to go for full-time training?</p>
+		<p>Well, there are a number of loans and grants available
+		that could help you with the costs.</p>
+		<p><strong>(Medium shot of Host.)</strong></p>
+		<p>For example, there's the Apprenticeship Incentive Grant
+		for those who've completed the first or second level
+		of their apprenticeship.</p>
+		<p>And for those who've completed the entire apprenticeship,
+		in a specific trade,
+		there's the Apprenticeship Completion Grant.</p>
+		<p><strong>(Show (actual) Canada Student Loans Program – Permanent Disability Benefit web page. Words “Student Loans Program” and “Study Grant” appear.)</strong></p>
+		<p>If you have a permanent disability,
+		you may want to look into the Canada Student Loans program,
+		or apply for a study grant.</p>
+		<p><strong>(Show main Life-Long Learning Plan program pages.)</strong></p>
+		<p>Under the Life-Long Learning Plan program,
+		you can find out how to use some of your RRSP funds
+		to pay for your education or training.</p>
+		<p><strong>(Medium shot of Host.)</strong></p>
+		<p>Whatever you see yourself doing,
+		why not take the time to discover all your options?</p>
+		<p><strong>(LINE DRAWING GRAPHIC: our stick person waves.)</strong></p>
+		<p>Doing your homework now can help you get
+		on the right path to finding the work you want.</p>
+		<p><strong>(Our stick person appears typing at computer and desk. (actual) Canada homepage, Job Bank and LMI pages loom out from the computer.)</strong></p>
+		<p>Be sure to check out our Service Canada Web site.</p>
+		<p>There you'll find the tools and information
+		you need to continue your education and training.</p>
+		<p>It really is time well spent.</p>
+		<p><strong>(Tight shot of the Host. LINE DRAWING GRAPHIC: Service Canada logo. Stick person takes a bow.)</strong></p>
+		<p>At Service Canada, we're people serving people.</p>
+		<p><strong>(Dip to black.)</strong></p>
 	</section>
 </div>

--- a/src/plugins/multimedia/cpts-lg2-fr.hbs
+++ b/src/plugins/multimedia/cpts-lg2-fr.hbs
@@ -5,79 +5,79 @@
 	"tag": "multimedia",
 	"parentdir": "multimedia",
 	"altLangPrefix": "multimedia",
-	"dateModified": "2014-07-20"
+	"dateModified": "2017-02-20"
 }
 ---
 <div id="inline-captions">
 	<section>
 		<h2>Transcription</h2>
-		<p class="wb-vd" data-load="vd"><strong>(La vidéo débute par une image de l'animatrice s'avançant vers la caméra. Un trait rouge suit le texte «&#160;Développement des compétences&#160;».)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="2.20s" data-dur="3.10s" data-load="tt">Bonjour, je m'appelle Amélie et je travaille </span>
-		<span class="wb-tmtxt" data-begin="5.30s" data-dur="1.63s" data-load="tt">à Service Canada.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Coupure et gros plan de l'animatrice.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="6.93s" data-dur="2.27s" data-load="tt">Vous savez sans doute que tous les jours, </span>
-		<span class="wb-tmtxt" data-begin="9.20s" data-dur="2.63s" data-load="tt">de nombreux Canadiens perfectionnent leurs </span>
-		<span class="wb-tmtxt" data-begin="11.83s" data-dur="2.10s" data-load="tt">compétences ou changent d'emploi.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(DESSIN AU TRAIT&#160;: Le bonhomme-allumettes se dirige vers l'animatrice, puis s'arrête. Des points d'interrogation apparaissent autour de sa tête.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="13.93s" data-dur="1.73s" data-load="tt">Vous pensez faire comme eux?</span></p>
-		<p><span class="wb-tmtxt" data-begin="15.66s" data-dur="2.90s" data-load="tt">Sachez que vous pouvez avoir accès à plus de 300 profils </span>
-		<span class="wb-tmtxt" data-begin="18.56s" data-dur="4.07s" data-load="tt">d'emploi en ligne et en apprendre plus</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(DESSIN AU TRAIT&#160;: Le bonhomme allumettes tient une mallette. Un autre bonhomme allumettes portant un casque de protection et tenant un marteau apparaît à l'écran.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="22.63s" data-dur="3.20s" data-load="tt">sur les compétences requises pour obtenir l'emploi </span>
-		<span class="wb-tmtxt" data-begin="25.83s" data-dur="2.07s" data-load="tt">qui vous intéresse.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Plan moyen de l'animatrice. Une page du site Guichet emplois apparaît à l'écran et les mots «&#160;Information de formation, carrière et travailleurs&#160;» sont mis en évidence. Les mots «&#160;Section Formation et carrière du site Guichet emplois&#160;» apparaissent à l'intérieur d'une bulle.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="27.90s" data-dur="2.50s" data-load="tt">La section Formation et carrière du site Guichet </span>
-		<span class="wb-tmtxt" data-begin="30.40s" data-dur="3.70s" data-load="tt">emplois vous permet de voir les choix qui s'offrent </span>
-		<span class="wb-tmtxt" data-begin="34.10s" data-dur="3.30s" data-load="tt">aux adultes en matière d'apprentissage et d'en </span>
-		<span class="wb-tmtxt" data-begin="37.40s" data-dur="3.33s" data-load="tt">savoir plus sur les moyens à votre disposition pour vous </span>
-		<span class="wb-tmtxt" data-begin="40.73s" data-dur="3.57s" data-load="tt">aider à payer la formation dont vous avez besoin.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Plan moyen de l'animatrice.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="44.30s" data-dur="3.03s" data-load="tt">Vous y trouverez aussi une liste de conseillers, </span>
-		<span class="wb-tmtxt" data-begin="47.33s" data-dur="3.13s" data-load="tt">d'enseignants et d'autres ressources dans votre </span>
-		<span class="wb-tmtxt" data-begin="50.46s" data-dur="2.90s" data-load="tt">localité, auprès de qui vous pourrez obtenir plus </span>
-		<span class="wb-tmtxt" data-begin="53.36s" data-dur="3.04s" data-load="tt">de renseignements avant de prendre une décision.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Plan moyen de l'animatrice.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="56.40s" data-dur="1.53s" data-load="tt">Et ce n'est pas tout!</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Plan moyen de l'animatrice. La page Web «&#160;Information sur le marché du travail&#160;» apparaît à l'écran.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="57.93s" data-dur="2.90s" data-load="tt">Vous y obtiendrez divers renseignements, </span>
-		<span class="wb-tmtxt" data-begin="60.83s" data-dur="2.87s" data-load="tt">comme les types d'emploi offerts, par région, </span>
-		<span class="wb-tmtxt" data-begin="63.70s" data-dur="3.26s" data-load="tt">partout au pays, et vous pourrez en apprendre plus </span>
-		<span class="wb-tmtxt" data-begin="66.96s" data-dur="2.70s" data-load="tt">sur les compétences requises pour obtenir </span>
-		<span class="wb-tmtxt" data-begin="69.66s" data-dur="1.74s" data-load="tt">l'un de ces emplois.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Plan moyen de l'animatrice. DESSIN AU TRAIT&#160;: Le bonhomme allumettes est dans une salle de classe.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="71.40s" data-dur="3.20s" data-load="tt">Si vous décidez de suivre une formation à plein temps, </span>
-		<span class="wb-tmtxt" data-begin="74.60s" data-dur="2.66s" data-load="tt">vous pourriez avoir droit des prêts, </span>
-		<span class="wb-tmtxt" data-begin="77.26s" data-dur="3.60s" data-load="tt">à des bourses et à des subventions pour vous aider </span>
-		<span class="wb-tmtxt" data-begin="80.86s" data-dur="2.00s" data-load="tt">à en payer les coûts.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Plan moyen de l'animatrice.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="82.86s" data-dur="2.90s" data-load="tt">Par exemple, les personnes qui ont terminé la première </span>
-		<span class="wb-tmtxt" data-begin="85.76s" data-dur="2.80s" data-load="tt">ou la deuxième année d'un programme d'apprentissage </span>
-		<span class="wb-tmtxt" data-begin="88.56s" data-dur="2.80s" data-load="tt">peuvent avoir droit à la Subvention </span>
-		<span class="wb-tmtxt" data-begin="91.36s" data-dur="2.27s" data-load="tt">incitative aux apprentis.</span></p>
-		<p><span class="wb-tmtxt" data-begin="93.63s" data-dur="2.10s" data-load="tt">Et celles qui ont terminé leur programme </span>
-		<span class="wb-tmtxt" data-begin="95.73s" data-dur="3.50s" data-load="tt">peuvent avoir droit à la Subvention à l'achèvement </span>
-		<span class="wb-tmtxt" data-begin="99.23s" data-dur="2.00s" data-load="tt">de la formation d'apprenti.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(La page Web «&#160;Prêt d'études canadien – Disposition applicable aux étudiants ayant une invalidité permanente&#160;» apparaît à l'écran. Les mots «&#160;Bourses d'études&#160;» et «&#160;Programme canadien de prêts aux étudiants&#160;» apparaissent à l'intérieur d'une bulle.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="101.23s" data-dur="3.43s" data-load="tt">Si vous êtes atteint d'une incapacité permanente, </span>
-		<span class="wb-tmtxt" data-begin="104.66s" data-dur="2.70s" data-load="tt">vous pourriez avoir droit des bourses d'études </span>
-		<span class="wb-tmtxt" data-begin="107.36s" data-dur="2.84s" data-load="tt">ou à une subvention dans le cadre du Programme canadien </span>
-		<span class="wb-tmtxt" data-begin="110.20s" data-dur="2.63s" data-load="tt">de prêts aux étudiants.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(La page Web «&#160;Régime d'encouragement à l'éducation permanente&#160;» apparaît à l'écran. DESSIN AU TRAIT&#160;: Le bonhomme-allumettes pointe vers l'écran.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="112.83s" data-dur="2.67s" data-load="tt">Et grâce au Régime d'encouragement à l'éducation </span>
-		<span class="wb-tmtxt" data-begin="115.50s" data-dur="3.40s" data-load="tt">permanente, vous pourriez utiliser les fonds de vos </span>
-		<span class="wb-tmtxt" data-begin="118.90s" data-dur="3.53s" data-load="tt">REER pour payer vos études ou votre formation.</span></p>
-		<p><span class="wb-tmtxt" data-begin="122.43s" data-dur="2.57s" data-load="tt">Peu importe votre choix de carrière, </span>
-		<span class="wb-tmtxt" data-begin="125.00s" data-dur="2.63s" data-load="tt">prenez le temps de bien examiner toutes </span>
-		<span class="wb-tmtxt" data-begin="127.63s" data-dur="2.40s" data-load="tt">les possibilités qui s'offrent à vous.</span></p>
-		<p><span class="wb-tmtxt" data-begin="130.03s" data-dur="1.70s" data-load="tt">Vous ne le regretterez pas, </span>
-		<span class="wb-tmtxt" data-begin="131.73s" data-dur="2.40s" data-load="tt">puisque votre choix sera bien réfléchi.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(DESSIN AU TRAIT&#160;: Le bonhomme allumettes est assis à un bureau et travaille à l'ordinateur. La page d'accueil du site de Service Canada apparaît à l'écran.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="134.13s" data-dur="3.60s" data-load="tt">N'oubliez pas de consulter le site Web de Service Canada.</span></p>
-		<p><span class="wb-tmtxt" data-begin="137.73s" data-dur="2.97s" data-load="tt">Vous y trouverez les outils et les renseignements </span>
-		<span class="wb-tmtxt" data-begin="140.70s" data-dur="2.93s" data-load="tt">dont vous avez besoin pour poursuivre vos études </span>
-		<span class="wb-tmtxt" data-begin="143.63s" data-dur="1.63s" data-load="tt">et votre formation.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(Gros plan de l'animatrice. DESSIN AU TRAIT&#160;: Le logo de Service Canada apparaît et le bonhomme allumettes fait un salut.)</strong></p>
-		<p><span class="wb-tmtxt" data-begin="145.26s" data-dur="2.50s" data-load="tt">À Service Canada, nous sommes au service des gens.</span></p>
-		<p class="wb-vd" data-load="vd"><strong>(L'écran devient noir.)</strong></p>
+		<p><strong>(La vidéo débute par une image de l'animatrice s'avançant vers la caméra. Un trait rouge suit le texte «&#160;Développement des compétences&#160;».)</strong></p>
+		<p>Bonjour, je m'appelle Amélie et je travaille
+		à Service Canada.</p>
+		<p><strong>(Coupure et gros plan de l'animatrice.)</strong></p>
+		<p>Vous savez sans doute que tous les jours,
+		de nombreux Canadiens perfectionnent leurs
+		compétences ou changent d'emploi.</p>
+		<p><strong>(DESSIN AU TRAIT&#160;: Le bonhomme-allumettes se dirige vers l'animatrice, puis s'arrête. Des points d'interrogation apparaissent autour de sa tête.)</strong></p>
+		<p>Vous pensez faire comme eux?</p>
+		<p>Sachez que vous pouvez avoir accès à plus de 300 profils
+		d'emploi en ligne et en apprendre plus</p>
+		<p><strong>(DESSIN AU TRAIT&#160;: Le bonhomme allumettes tient une mallette. Un autre bonhomme allumettes portant un casque de protection et tenant un marteau apparaît à l'écran.)</strong></p>
+		<p>sur les compétences requises pour obtenir l'emploi
+		qui vous intéresse.</p>
+		<p><strong>(Plan moyen de l'animatrice. Une page du site Guichet emplois apparaît à l'écran et les mots «&#160;Information de formation, carrière et travailleurs&#160;» sont mis en évidence. Les mots «&#160;Section Formation et carrière du site Guichet emplois&#160;» apparaissent à l'intérieur d'une bulle.)</strong></p>
+		<p>La section Formation et carrière du site Guichet
+		emplois vous permet de voir les choix qui s'offrent
+		aux adultes en matière d'apprentissage et d'en
+		savoir plus sur les moyens à votre disposition pour vous
+		aider à payer la formation dont vous avez besoin.</p>
+		<p><strong>(Plan moyen de l'animatrice.)</strong></p>
+		<p>Vous y trouverez aussi une liste de conseillers,
+		d'enseignants et d'autres ressources dans votre
+		localité, auprès de qui vous pourrez obtenir plus
+		de renseignements avant de prendre une décision.</p>
+		<p><strong>(Plan moyen de l'animatrice.)</strong></p>
+		<p>Et ce n'est pas tout!</p>
+		<p><strong>(Plan moyen de l'animatrice. La page Web «&#160;Information sur le marché du travail&#160;» apparaît à l'écran.)</strong></p>
+		<p>Vous y obtiendrez divers renseignements,
+		comme les types d'emploi offerts, par région,
+		partout au pays, et vous pourrez en apprendre plus
+		sur les compétences requises pour obtenir
+		l'un de ces emplois.</p>
+		<p><strong>(Plan moyen de l'animatrice. DESSIN AU TRAIT&#160;: Le bonhomme allumettes est dans une salle de classe.)</strong></p>
+		<p>Si vous décidez de suivre une formation à plein temps,
+		vous pourriez avoir droit des prêts,
+		à des bourses et à des subventions pour vous aider
+		à en payer les coûts.</p>
+		<p><strong>(Plan moyen de l'animatrice.)</strong></p>
+		<p>Par exemple, les personnes qui ont terminé la première
+		ou la deuxième année d'un programme d'apprentissage
+		peuvent avoir droit à la Subvention
+		incitative aux apprentis.</p>
+		<p>Et celles qui ont terminé leur programme
+		peuvent avoir droit à la Subvention à l'achèvement
+		de la formation d'apprenti.</p>
+		<p><strong>(La page Web «&#160;Prêt d'études canadien – Disposition applicable aux étudiants ayant une invalidité permanente&#160;» apparaît à l'écran. Les mots «&#160;Bourses d'études&#160;» et «&#160;Programme canadien de prêts aux étudiants&#160;» apparaissent à l'intérieur d'une bulle.)</strong></p>
+		<p>Si vous êtes atteint d'une incapacité permanente,
+		vous pourriez avoir droit des bourses d'études
+		ou à une subvention dans le cadre du Programme canadien
+		de prêts aux étudiants.</p>
+		<p><strong>(La page Web «&#160;Régime d'encouragement à l'éducation permanente&#160;» apparaît à l'écran. DESSIN AU TRAIT&#160;: Le bonhomme-allumettes pointe vers l'écran.)</strong></p>
+		<p>Et grâce au Régime d'encouragement à l'éducation
+		permanente, vous pourriez utiliser les fonds de vos
+		REER pour payer vos études ou votre formation.</p>
+		<p>Peu importe votre choix de carrière,
+		prenez le temps de bien examiner toutes
+		les possibilités qui s'offrent à vous.</p>
+		<p>Vous ne le regretterez pas,
+		puisque votre choix sera bien réfléchi.</p>
+		<p><strong>(DESSIN AU TRAIT&#160;: Le bonhomme allumettes est assis à un bureau et travaille à l'ordinateur. La page d'accueil du site de Service Canada apparaît à l'écran.)</strong></p>
+		<p>N'oubliez pas de consulter le site Web de Service Canada.</p>
+		<p>Vous y trouverez les outils et les renseignements
+		dont vous avez besoin pour poursuivre vos études
+		et votre formation.</p>
+		<p><strong>(Gros plan de l'animatrice. DESSIN AU TRAIT&#160;: Le logo de Service Canada apparaît et le bonhomme allumettes fait un salut.)</strong></p>
+		<p>À Service Canada, nous sommes au service des gens.</p>
+		<p><strong>(L'écran devient noir.)</strong></p>
 	</section>
 </div>

--- a/src/plugins/multimedia/demo/video2-captions-en.xml
+++ b/src/plugins/multimedia/demo/video2-captions-en.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xml:lang="en" xmlns="http://www.w3.org/2006/10/ttaf1" xmlns:tts="http://www.w3.org/2006/10/ttaf1#style">
+	<head>
+		<styling>
+			<style id="defaultSpeaker" tts:fontSize="12" tts:fontFamily="Arial" tts:fontWeight="normal" tts:fontStyle="normal" tts:textDecoration="none" tts:color="white" tts:backgroundColor="black" tts:textAlign="center"/>
+			<style id="defaultCaption" tts:fontSize="12" tts:fontFamily="Arial" tts:fontWeight="normal" tts:fontStyle="normal" tts:textDecoration="none" tts:color="white" tts:backgroundColor="black" tts:textAlign="center"/>
+		</styling>
+	</head>
+	<body style="defaultCaption" id="thebody" xml:id="b1">
+		<div begin="1.40s" dur="3.33s">Hi, my name is Eric, and I'm a Service Canada employee.</div>
+
+		<div begin="4.73s" dur="2.73s">Each and every day, Canadians are improving their job</div>
+		<div begin="7.46s" dur="2.14s">skills or changing their career paths.</div>
+
+		<div begin="9.60s" dur="1.66s">Are you thinking about taking that step?</div>
+
+		<div begin="11.26s" dur="2.04s">If so, did you know that you can research</div>
+		<div begin="13.30s" dur="2.40s">more than 300 job profiles online?</div>
+
+		<div begin="15.70s" dur="2.30s">Plus, you can find out what skills you'll need</div>
+		<div begin="18.00s" dur="1.70s">to get the job that interests you.</div>
+
+		<div begin="19.70s" dur="2.43s">Job Bank's Training and Careers site lets you explore</div>
+		<div begin="22.13s" dur="3.07s">adult-learning choices and explains the various options</div>
+		<div begin="25.20s" dur="1.93s">that are available to help you pay</div>
+		<div begin="27.13s" dur="1.50s">for the training you need.</div>
+
+		<div begin="28.63s" dur="1.80s">You can even find counsellors, teachers,</div>
+		<div begin="30.43s" dur="2.10s">and other resources near you if you'd like to have</div>
+		<div begin="32.53s" dur="2.13s">more information before you make a decision.</div>
+
+		<div begin="34.66s" dur="1.74s">And the support doesn't end there.</div>
+
+		<div begin="36.40s" dur="2.73s">From the alphabetical index on our Service Canada home page,</div>
+		<div begin="39.13s" dur="2.93s">you can link to the Labour Market Information site.</div>
+
+		<div begin="42.06s" dur="2.10s">There, you'll find out what kinds of jobs are available,</div>
+		<div begin="44.16s" dur="2.50s">by area, across the country, and what skills you'll need</div>
+		<div begin="46.66s" dur="1.74s">to get those jobs.</div>
+
+		<div begin="48.40s" dur="2.23s">But, what if you decide to go for full-time training?</div>
+
+		<div begin="50.63s" dur="2.67s">Well, there are a number of loans and grants available</div>
+		<div begin="53.30s" dur="2.13s">that could help you with the costs.</div>
+
+		<div begin="55.43s" dur="2.33s">For example, there's the Apprenticeship Incentive Grant</div>
+		<div begin="57.76s" dur="2.20s">for those who've completed the first or second level</div>
+		<div begin="59.96s" dur="1.60s">of their apprenticeship.</div>
+
+		<div begin="61.56s" dur="2.54s">And for those who've completed the entire apprenticeship,</div>
+		<div begin="64.10s" dur="1.30s">in a specific trade,</div>
+		<div begin="65.40s" dur="2.06s">there's the Apprenticeship Completion Grant.</div>
+
+		<div begin="67.46s" dur="1.67s">If you have a permanent disability,</div>
+		<div begin="69.13s" dur="2.50s">you may want to look into the Canada Student Loans program,</div>
+		<div begin="71.63s" dur="2.20s">or apply for a study grant.</div>
+
+		<div begin="73.83s" dur="2.70s">Under the Life-Long Learning Plan program,</div>
+		<div begin="76.53s" dur="2.73s">you can find out how to use some of your RRSP funds</div>
+		<div begin="79.26s" dur="2.37s">to pay for your education or training.</div>
+
+		<div begin="81.63s" dur="2.47s">Whatever you see yourself doing,</div>
+		<div begin="84.10s" dur="2.73s">why not take the time to discover all your options?</div>
+
+		<div begin="86.83s" dur="2.73s">Doing your homework now can help you get</div>
+		<div begin="89.56s" dur="2.74s">on the right path to finding the work you want.</div>
+
+		<div begin="92.30s" dur="2.40s">Be sure to check out our Service Canada Web site.</div>
+
+		<div begin="94.70s" dur="1.80s">There you'll find the tools and information</div>
+		<div begin="96.50s" dur="1.80s">you need to continue your education and training.</div>
+
+		<div begin="98.30s" dur="2.53s">It really is time well spent.</div>
+
+		<div begin="100.83s" dur="2.70s">At Service Canada, we're people serving people.</div>
+	</body>
+</tt>

--- a/src/plugins/multimedia/demo/video2-captions-fr.xml
+++ b/src/plugins/multimedia/demo/video2-captions-fr.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<tt xml:lang="fr" xmlns="http://www.w3.org/2006/10/ttaf1" xmlns:tts="http://www.w3.org/2006/10/ttaf1#style">
+	<head>
+		<styling>
+			<style id="defaultSpeaker" tts:fontSize="12" tts:fontFamily="Arial" tts:fontWeight="normal" tts:fontStyle="normal" tts:textDecoration="none" tts:color="white" tts:backgroundColor="black" tts:textAlign="center"/>
+			<style id="defaultCaption" tts:fontSize="12" tts:fontFamily="Arial" tts:fontWeight="normal" tts:fontStyle="normal" tts:textDecoration="none" tts:color="white" tts:backgroundColor="black" tts:textAlign="center"/>
+		</styling>
+	</head>
+	<body style="defaultCaption" id="thebody" xml:id="b1">
+		<div begin="2.20s" dur="3.10s">Bonjour, je m'appelle Amélie et je travaille</div>
+		<div begin="5.30s" dur="1.63s">à Service Canada.</div>
+
+		<div begin="6.93s" dur="2.27s">Vous savez sans doute que tous les jours,</div>
+		<div begin="9.20s" dur="2.63s">de nombreux Canadiens perfectionnent leurs</div>
+		<div begin="11.83s" dur="2.10s">compétences ou changent d'emploi.</div>
+
+		<div begin="13.93s" dur="1.73s">Vous pensez faire comme eux?</div>
+
+		<div begin="15.66s" dur="2.90s">Sachez que vous pouvez avoir accès à plus de 300 profils</div>
+		<div begin="18.56s" dur="4.07s">d'emploi en ligne et en apprendre plus</div>
+
+		<div begin="22.63s" dur="3.20s">sur les compétences requises pour obtenir l'emploi</div>
+		<div begin="25.83s" dur="2.07s">qui vous intéresse.</div>
+
+		<div begin="27.90s" dur="2.50s">La section Formation et carrière du site Guichet</div>
+		<div begin="30.40s" dur="3.70s">emplois vous permet de voir les choix qui s'offrent</div>
+		<div begin="34.10s" dur="3.30s">aux adultes en matière d'apprentissage et d'en</div>
+		<div begin="37.40s" dur="3.33s">savoir plus sur les moyens à votre disposition pour vous</div>
+		<div begin="40.73s" dur="3.57s">aider à payer la formation dont vous avez besoin.</div>
+
+		<div begin="44.30s" dur="3.03s">Vous y trouverez aussi une liste de conseillers,</div>
+		<div begin="47.33s" dur="3.13s">d'enseignants et d'autres ressources dans votre</div>
+		<div begin="50.46s" dur="2.90s">localité, auprès de qui vous pourrez obtenir plus</div>
+		<div begin="53.36s" dur="3.04s">de renseignements avant de prendre une décision.</div>
+
+		<div begin="56.40s" dur="1.53s">Et ce n'est pas tout!</div>
+
+		<div begin="57.93s" dur="2.90s">Vous y obtiendrez divers renseignements,</div>
+		<div begin="60.83s" dur="2.87s">comme les types d'emploi offerts, par région,</div>
+		<div begin="63.70s" dur="3.26s">partout au pays, et vous pourrez en apprendre plus</div>
+		<div begin="66.96s" dur="2.70s">sur les compétences requises pour obtenir</div>
+		<div begin="69.66s" dur="1.74s">l'un de ces emplois.</div>
+
+		<div begin="71.40s" dur="3.20s">Si vous décidez de suivre une formation à plein temps,</div>
+		<div begin="74.60s" dur="2.66s">vous pourriez avoir droit des prêts,</div>
+		<div begin="77.26s" dur="3.60s">à des bourses et à des subventions pour vous aider</div>
+		<div begin="80.86s" dur="2.00s">à en payer les coûts.</div>
+
+		<div begin="82.86s" dur="2.90s">Par exemple, les personnes qui ont terminé la première</div>
+		<div begin="85.76s" dur="2.80s">ou la deuxième année d'un programme d'apprentissage</div>
+		<div begin="88.56s" dur="2.80s">peuvent avoir droit à la Subvention</div>
+		<div begin="91.36s" dur="2.27s">incitative aux apprentis.</div>
+
+		<div begin="93.63s" dur="2.10s">Et celles qui ont terminé leur programme</div>
+		<div begin="95.73s" dur="3.50s">peuvent avoir droit à la Subvention à l'achèvement</div>
+		<div begin="99.23s" dur="2.00s">de la formation d'apprenti.</div>
+
+		<div begin="101.23s" dur="3.43s">Si vous êtes atteint d'une incapacité permanente,</div>
+		<div begin="104.66s" dur="2.70s">vous pourriez avoir droit des bourses d'études</div>
+		<div begin="107.36s" dur="2.84s">ou à une subvention dans le cadre du Programme canadien</div>
+		<div begin="110.20s" dur="2.63s">de prêts aux étudiants.</div>
+
+		<div begin="112.83s" dur="2.67s">Et grâce au Régime d'encouragement à l'éducation</div>
+		<div begin="115.50s" dur="3.40s">permanente, vous pourriez utiliser les fonds de vos</div>
+		<div begin="118.90s" dur="3.53s">REER pour payer vos études ou votre formation.</div>
+
+		<div begin="122.43s" dur="2.57s">Peu importe votre choix de carrière,</div>
+		<div begin="125.00s" dur="2.63s">prenez le temps de bien examiner toutes</div>
+		<div begin="127.63s" dur="2.40s">les possibilités qui s'offrent à vous.</div>
+
+		<div begin="130.03s" dur="1.70s">Vous ne le regretterez pas,</div>
+		<div begin="131.73s" dur="2.40s">puisque votre choix sera bien réfléchi.</div>
+
+		<div begin="134.13s" dur="3.60s">N'oubliez pas de consulter le site Web de Service Canada.</div>
+
+		<div begin="137.73s" dur="2.97s">Vous y trouverez les outils et les renseignements</div>
+		<div begin="140.70s" dur="2.93s">dont vous avez besoin pour poursuivre vos études</div>
+		<div begin="143.63s" dur="1.63s">et votre formation.</div>
+
+		<div begin="145.26s" dur="2.50s">À Service Canada, nous sommes au service des gens.</div>
+	</body>
+</tt>

--- a/src/plugins/multimedia/multimedia-en.hbs
+++ b/src/plugins/multimedia/multimedia-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "multimedia",
 	"parentdir": "multimedia",
 	"altLangPrefix": "multimedia",
-	"dateModified": "2017-01-26"
+	"dateModified": "2017-02-20"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -30,7 +30,7 @@
 
 	<div class="row">
 		<section class="col-md-6">
-			<h3 class="wb-inv">MPEG4 (H264 + AAC) and WebM (VP8) source and HTML captions</h3>
+			<h3>MPEG4 (H264 + AAC) and WebM (VP8) source with HTML captions</h3>
 			<figure class="wb-mltmd" data-wb-mltmd='{"shareUrl": "https://wet-boew.github.io/v4.0-ci/demos/multimedia/multimedia-en.html"}'>
 				<video poster="demo/video1-en.jpg" title="Looking for a Job">
 					<source type="video/webm" src="http://video2.servicecanada.gc.ca/video/boew-wet/te-lj-eng.webm" />
@@ -74,12 +74,12 @@
 		</section>
 
 		<section class="col-md-6">
-			<h3 class="wb-inv">MPEG4 (H264 + AAC) and WebM (VP8) source and HTML captions</h3>
+			<h3>MPEG4 (H264 + AAC) and WebM (VP8) source with TTML captions</h3>
 			<figure class="wb-mltmd" data-wb-mltmd='{"shareUrl": "https://wet-boew.github.io/v4.0-ci/demos/multimedia/multimedia-en.html"}'>
 				<video poster="demo/video2-en.jpg" title="Training and Development">
 					<source type="video/webm" src="http://video2.servicecanada.gc.ca/video/boew-wet/dc-td-eng.webm" />
 					<source type="video/mp4" src="http://video2.servicecanada.gc.ca/video/boew-wet/dc-td-eng.mp4" />
-					<track src="cpts-lg2-en.html" kind="captions" data-type="text/html" srclang="en" label="English" />
+					<track src="demo/video2-captions-en.xml" kind="captions" data-type="application/ttml+xml" srclang="en" label="English" />
 				</video>
 				<figcaption>
 					<p>Training and Development (<a href="cpts-lg2-en.html">Transcript</a>)</p>
@@ -94,7 +94,7 @@
 	&lt;video poster=&quot;demo/video2-en.jpg&quot; title=&quot;Training and Development&quot;&gt;
 		&lt;source type=&quot;video/webm&quot; src=&quot;http://video2.servicecanada.gc.ca/video/boew-wet/dc-td-eng.webm&quot; /&gt;
 		&lt;source type=&quot;video/mp4&quot; src=&quot;http://video2.servicecanada.gc.ca/video/boew-wet/dc-td-eng.mp4&quot; /&gt;
-		&lt;track src=&quot;cpts-lg2-en.html&quot; kind=&quot;captions&quot; data-type=&quot;text/html&quot; srclang=&quot;en&quot; label=&quot;English&quot; /&gt;
+		&lt;track src=&quot;demo/video2-captions-en.xml&quot; kind=&quot;captions&quot; data-type=&quot;application/ttml+xml&quot; srclang=&quot;en&quot; label=&quot;English&quot; /&gt;
 	&lt;/video&gt;
 	&lt;figcaption&gt;
 		&lt;p&gt;Training and Development (&lt;a href=&quot;cpts-lg2-en.html&quot;&gt;Transcript&lt;/a&gt;)&lt;/p&gt;
@@ -103,16 +103,20 @@
 				</section>
 
 				<section>
-					<h4>cpts-lg2-en.html</h4>
-					<pre><code>&lt;div id=&quot;inline-captions&quot;&gt;
-	&lt;section&gt;
-		&lt;h2&gt;Transcript&lt;/h2&gt;
-		&lt;p class=&quot;wb-vd&quot; data-load=&quot;vd&quot;&gt;&lt;strong&gt;(Animated pen draws a red line that leads into the text Training and development.)&lt;/strong&gt;&lt;/p&gt;
-		&lt;p&gt;&lt;span class=&quot;wb-tmtxt&quot; data-begin=&quot;1.40s&quot; data-dur=&quot;3.33s&quot; data-load=&quot;tt&quot;&gt;Hi, my name is Eric, and I'm a Service Canada employee.&lt;/span&gt;&lt;/p&gt;
-		&lt;p class=&quot;wb-vd&quot; data-load=&quot;vd&quot;&gt;&lt;strong&gt;(Cut to a close-up of the Host.)&lt;/strong&gt;&lt;/p&gt;
+					<h4>video2-captions-en.xml</h4>
+					<pre><code>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+&lt;tt xml:lang=&quot;en&quot; xmlns=&quot;http://www.w3.org/2006/10/ttaf1&quot; xmlns:tts=&quot;http://www.w3.org/2006/10/ttaf1#style&quot;&gt;
+	&lt;head&gt;
+		&lt;styling&gt;
+			&lt;style id=&quot;defaultSpeaker&quot; tts:fontSize=&quot;12&quot; tts:fontFamily=&quot;Arial&quot; tts:fontWeight=&quot;normal&quot; tts:fontStyle=&quot;normal&quot; tts:textDecoration=&quot;none&quot; tts:color=&quot;white&quot; tts:backgroundColor=&quot;black&quot; tts:textAlign=&quot;center&quot;/&gt;
+			&lt;style id=&quot;defaultCaption&quot; tts:fontSize=&quot;12&quot; tts:fontFamily=&quot;Arial&quot; tts:fontWeight=&quot;normal&quot; tts:fontStyle=&quot;normal&quot; tts:textDecoration=&quot;none&quot; tts:color=&quot;white&quot; tts:backgroundColor=&quot;black&quot; tts:textAlign=&quot;center&quot;/&gt;
+		&lt;/styling&gt;
+	&lt;/head&gt;
+	&lt;body style=&quot;defaultCaption&quot; id=&quot;thebody&quot; xml:id=&quot;b1&quot;&gt;
+		&lt;div begin=&quot;1.40s&quot; dur=&quot;3.33s&quot;&gt;Hi, my name is Eric, and I'm a Service Canada employee.&lt;/div&gt;
 		...
-	&lt;/section&gt;
-&lt;/div&gt;</code></pre>
+	&lt;/body&gt;
+&lt;/tt&gt;</code></pre>
 				</section>
 			</details>
 		</section>

--- a/src/plugins/multimedia/multimedia-fr.hbs
+++ b/src/plugins/multimedia/multimedia-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "multimedia",
 	"parentdir": "multimedia",
 	"altLangPrefix": "multimedia",
-	"dateModified": "2017-01-26"
+	"dateModified": "2017-02-20"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -30,7 +30,7 @@
 
 	<div class="row">
 		<section class="col-md-6">
-			<h3 class="wb-inv">MPEG4 (H264 + AAC) et WebM (VP8) avec les sous-titres au HTML</h3>
+			<h3>MPEG4 (H264 + AAC) et WebM (VP8) avec les sous-titres en HTML</h3>
 			<figure class="wb-mltmd" data-wb-mltmd='{"shareUrl": "https://wet-boew.github.io/v4.0-ci/demos/multimedia/multimedia-fr.html"}'>
 				<video poster="demo/video1-fr.jpg" title="Trouver un emploi">
 					<source type="video/webm" src="http://video2.servicecanada.gc.ca/video/boew-wet/te-lj-fra.webm" />
@@ -74,12 +74,12 @@
 		</section>
 
 		<section class="col-md-6">
-			<h3 class="wb-inv">MPEG4 (H264 + AAC) et WebM (VP8) avec les sous-titres au HTML</h3>
+			<h3>MPEG4 (H264 + AAC) et WebM (VP8) avec les sous-titres TTML</h3>
 			<figure class="wb-mltmd" data-wb-mltmd='{"shareUrl": "https://wet-boew.github.io/v4.0-ci/demos/multimedia/multimedia-fr.html"}'>
 				<video poster="demo/video2-fr.jpg" title="Video Example">
 					<source type="video/webm" src="http://video2.servicecanada.gc.ca/video/boew-wet/dc-td-fra.webm" />
 					<source type="video/mp4" src="http://video2.servicecanada.gc.ca/video/boew-wet/dc-td-fra.mp4" />
-					<track src="cpts-lg2-fr.html" kind="captions" data-type="text/html" srclang="fr" label="Français" />
+					<track src="demo/video2-captions-fr.xml" kind="captions" data-type="application/ttml+xml" srclang="fr" label="Français" />
 				</video>
 				<figcaption>
 					<p>Développement des compétences (<a href="cpts-lg2-fr.html">Transcription</a>)</p>
@@ -94,7 +94,7 @@
 	&lt;video poster=&quot;demo/video2-fr.jpg&quot; title=&quot;Video Example&quot;&gt;
 		&lt;source type=&quot;video/webm&quot; src=&quot;http://video2.servicecanada.gc.ca/video/boew-wet/dc-td-fra.webm&quot; /&gt;
 		&lt;source type=&quot;video/mp4&quot; src=&quot;http://video2.servicecanada.gc.ca/video/boew-wet/dc-td-fra.mp4&quot; /&gt;
-		&lt;track src=&quot;cpts-lg2-fr.html&quot; kind=&quot;captions&quot; data-type=&quot;text/html&quot; srclang=&quot;fr&quot; label=&quot;Français&quot; /&gt;
+		&lt;track src=&quot;demo/video2-captions-fr.xml&quot; kind=&quot;captions&quot; data-type=&quot;application/ttml+xml&quot; srclang=&quot;fr&quot; label=&quot;Français&quot; /&gt;
 	&lt;/video&gt;
 	&lt;figcaption&gt;
 		&lt;p&gt;Développement des compétences (&lt;a href=&quot;cpts-lg2-fr.html&quot;&gt;Transcription&lt;/a&gt;)&lt;/p&gt;
@@ -103,16 +103,21 @@
 				</section>
 
 				<section>
-					<h4>cpts-lg2-fr.html</h4>
-					<pre><code>&lt;div id=&quot;inline-captions&quot;&gt;
-	&lt;section&gt;
-		&lt;h2&gt;Transcription&lt;/h2&gt;
-		&lt;p class=&quot;wb-vd&quot; data-load=&quot;vd&quot;&gt;&lt;strong&gt;(La vidéo débute par une image de l'animatrice s'avançant vers la caméra. Un trait rouge suit le texte «&amp;#160;Développement des compétences&amp;#160;».)&lt;/strong&gt;&lt;/p&gt;
-		&lt;p&gt;&lt;span class=&quot;wb-tmtxt&quot; data-begin=&quot;2.20s&quot; data-dur=&quot;3.10s&quot; data-load=&quot;tt&quot;&gt;Bonjour, je m'appelle Amélie et je travaille &lt;/span&gt;
-		&lt;span class=&quot;wb-tmtxt&quot; data-begin=&quot;5.30s&quot; data-dur=&quot;1.63s&quot; data-load=&quot;tt&quot;&gt;à Service Canada.&lt;/span&gt;&lt;/p&gt;
+					<h4>video2-captions-fr.xml</h4>
+					<pre><code>&lt;?xml version=&quot;1.0&quot; encoding=&quot;UTF-8&quot;?&gt;
+&lt;tt xml:lang=&quot;fr&quot; xmlns=&quot;http://www.w3.org/2006/10/ttaf1&quot; xmlns:tts=&quot;http://www.w3.org/2006/10/ttaf1#style&quot;&gt;
+	&lt;head&gt;
+		&lt;styling&gt;
+			&lt;style id=&quot;defaultSpeaker&quot; tts:fontSize=&quot;12&quot; tts:fontFamily=&quot;Arial&quot; tts:fontWeight=&quot;normal&quot; tts:fontStyle=&quot;normal&quot; tts:textDecoration=&quot;none&quot; tts:color=&quot;white&quot; tts:backgroundColor=&quot;black&quot; tts:textAlign=&quot;center&quot;/&gt;
+			&lt;style id=&quot;defaultCaption&quot; tts:fontSize=&quot;12&quot; tts:fontFamily=&quot;Arial&quot; tts:fontWeight=&quot;normal&quot; tts:fontStyle=&quot;normal&quot; tts:textDecoration=&quot;none&quot; tts:color=&quot;white&quot; tts:backgroundColor=&quot;black&quot; tts:textAlign=&quot;center&quot;/&gt;
+		&lt;/styling&gt;
+	&lt;/head&gt;
+	&lt;body style=&quot;defaultCaption&quot; id=&quot;thebody&quot; xml:id=&quot;b1&quot;&gt;
+		&lt;div begin=&quot;2.20s&quot; dur=&quot;3.10s&quot;&gt;Bonjour, je m'appelle Amélie et je travaille&lt;/div&gt;
+		&lt;div begin=&quot;5.30s&quot; dur=&quot;1.63s&quot;&gt;à Service Canada.&lt;/div&gt;
 		...
-	&lt;/section&gt;
-&lt;/div&gt;</code></pre>
+	&lt;/body&gt;
+&lt;/tt&gt;</code></pre>
 				</section>
 			</details>
 		</section>


### PR DESCRIPTION
* Added TTML captions files for the second video, based on its HTML captions and the orphaned WET 3.x TTML files that #7867 removed.
  * French TTML file is now using an xml:lang="fr" attribute. The former French TTML file that #7867 removed was using xml:lang="en".
* Renamed and unveiled the demo pages' first two video headings. They were previously visually-hidden.
* Revised the second video's example and code samples in the demo pages.
* Removed HTML caption classes/data attributes from the second video's transcript pages.