### PR TITLE
Documentation: Updated several links in French version history page.

### DIFF
--- a/site/pages/docs/versions/index-fr.hbs
+++ b/site/pages/docs/versions/index-fr.hbs
@@ -25,86 +25,86 @@
 			<tr>
 				<td>v4.0.24</td>
 				<td><time>2017-02-22</time></td>
-				<td><a href="v4.0/v4.0.24-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.24</span></a></td>
-				<td><a href="dwnld-en.html#v4024">Téléchargements<span class="wb-inv"> - v4.0.24</span></a></td>
+				<td><a href="v4.0/v4.0.24-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.24</span></a></td>
+				<td><a href="dwnld-fr.html#v4024">Téléchargements<span class="wb-inv"> - v4.0.24</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.23</td>
 				<td><time>2016-11-16</time></td>
-				<td><a href="v4.0/v4.0.23-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.23</span></a></td>
-				<td><a href="dwnld-en.html#v4023">Téléchargements<span class="wb-inv"> - v4.0.23</span></a></td>
+				<td><a href="v4.0/v4.0.23-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.23</span></a></td>
+				<td><a href="dwnld-fr.html#v4023">Téléchargements<span class="wb-inv"> - v4.0.23</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.22</td>
 				<td><time>2016-08-09</time></td>
-				<td><a href="v4.0/v4.0.22-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.22</span></a></td>
-				<td><a href="dwnld-en.html#v4022">Téléchargements<span class="wb-inv"> - v4.0.22</span></a></td>
+				<td><a href="v4.0/v4.0.22-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.22</span></a></td>
+				<td><a href="dwnld-fr.html#v4022">Téléchargements<span class="wb-inv"> - v4.0.22</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.21</td>
 				<td><time>2016-04-11</time></td>
-				<td><a href="v4.0/v4.0.21-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.21</span></a></td>
-				<td><a href="dwnld-en.html#v4021">Téléchargements<span class="wb-inv"> - v4.0.21</span></a></td>
+				<td><a href="v4.0/v4.0.21-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.21</span></a></td>
+				<td><a href="dwnld-fr.html#v4021">Téléchargements<span class="wb-inv"> - v4.0.21</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.20</td>
 				<td><time>2015-12-16</time></td>
-				<td><a href="v4.0/v4.0.20-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.20</span></a></td>
-				<td><a href="dwnld-en.html#v4020">Téléchargements<span class="wb-inv"> - v4.0.20</span></a></td>
+				<td><a href="v4.0/v4.0.20-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.20</span></a></td>
+				<td><a href="dwnld-fr.html#v4020">Téléchargements<span class="wb-inv"> - v4.0.20</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.19+2</td>
 				<td><time>2015-12-02</time></td>
-				<td><a href="v4.0/v4.0.19-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.19</span></a></td>
-				<td><a href="dwnld-en.html#v4019">Téléchargements<span class="wb-inv"> - v4.0.19</span></a></td>
+				<td><a href="v4.0/v4.0.19-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.19</span></a></td>
+				<td><a href="dwnld-fr.html#v4019">Téléchargements<span class="wb-inv"> - v4.0.19</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.18</td>
 				<td><time>2015-09-22</time></td>
-				<td><a href="v4.0/v4.0.18-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.18</span></a></td>
-				<td><a href="dwnld-en.html#v4018">Téléchargements<span class="wb-inv"> - v4.0.18</span></a></td>
+				<td><a href="v4.0/v4.0.18-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.18</span></a></td>
+				<td><a href="dwnld-fr.html#v4018">Téléchargements<span class="wb-inv"> - v4.0.18</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.17</td>
 				<td><time>2015-08-21</time></td>
-				<td><a href="v4.0/v4.0.17-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.17</span></a></td>
-				<td><a href="dwnld-en.html#v4017">Téléchargements<span class="wb-inv"> - v4.0.17</span></a></td>
+				<td><a href="v4.0/v4.0.17-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.17</span></a></td>
+				<td><a href="dwnld-fr.html#v4017">Téléchargements<span class="wb-inv"> - v4.0.17</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.16</td>
 				<td><time>2015-07-21</time></td>
-				<td><a href="v4.0/v4.0.16-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.16</span></a></td>
-				<td><a href="dwnld-en.html#v4016">Téléchargements<span class="wb-inv"> - v4.0.16</span></a></td>
+				<td><a href="v4.0/v4.0.16-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.16</span></a></td>
+				<td><a href="dwnld-fr.html#v4016">Téléchargements<span class="wb-inv"> - v4.0.16</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.15</td>
 				<td><time>2015-06-23</time></td>
-				<td><a href="v4.0/v4.0.15-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.15</span></a></td>
-				<td><a href="dwnld-en.html#v4015">Téléchargements<span class="wb-inv"> - v4.0.15</span></a></td>
+				<td><a href="v4.0/v4.0.15-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.15</span></a></td>
+				<td><a href="dwnld-fr.html#v4015">Téléchargements<span class="wb-inv"> - v4.0.15</span></a></td>
 			</tr>
             <tr>
 				<td>v4.0.14</td>
 				<td><time>2015-05-19</time></td>
-				<td><a href="v4.0/v4.0.14-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.14</span></a></td>
-				<td><a href="dwnld-en.html#v4014">Téléchargements<span class="wb-inv"> - v4.0.14</span></a></td>
+				<td><a href="v4.0/v4.0.14-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.14</span></a></td>
+				<td><a href="dwnld-fr.html#v4014">Téléchargements<span class="wb-inv"> - v4.0.14</span></a></td>
 			</tr>
             <tr>
 				<td>v4.0.13</td>
 				<td><time>2015-04-21</time></td>
-				<td><a href="v4.0/v4.0.13-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.13</span></a></td>
-				<td><a href="dwnld-en.html#v4013">Téléchargements<span class="wb-inv"> - v4.0.13</span></a></td>
+				<td><a href="v4.0/v4.0.13-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.13</span></a></td>
+				<td><a href="dwnld-fr.html#v4013">Téléchargements<span class="wb-inv"> - v4.0.13</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.12</td>
 				<td><time>2015-03-23</time></td>
-				<td><a href="v4.0/v4.0.12-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.12</span></a></td>
-				<td><a href="dwnld-en.html#v4012">Téléchargements<span class="wb-inv"> - v4.0.12</span></a></td>
+				<td><a href="v4.0/v4.0.12-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.12</span></a></td>
+				<td><a href="dwnld-fr.html#v4012">Téléchargements<span class="wb-inv"> - v4.0.12</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.11</td>
 				<td><time>2015-02-17</time></td>
-				<td><a href="v4.0/v4.0.11-en.html">Notes d'utilisation<span class="wb-inv"> - v4.0.11</span></a></td>
-				<td><a href="dwnld-en.html#v4011">Téléchargements<span class="wb-inv"> - v4.0.11</span></a></td>
+				<td><a href="v4.0/v4.0.11-fr.html">Notes d'utilisation<span class="wb-inv"> - v4.0.11</span></a></td>
+				<td><a href="dwnld-fr.html#v4011">Téléchargements<span class="wb-inv"> - v4.0.11</span></a></td>
 			</tr>
 			<tr>
 				<td>v4.0.10</td>


### PR DESCRIPTION
All entries since v4.0.11 were previously linking to English release notes/downloads pages, even though French counterparts of all of those pages exist. This commit updates all affected links to point to equivalent French pages.