### PR TITLE
Base/Theme: Added a content area background colour variable.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -47,6 +47,7 @@ $link-color: #295376 !default;
 $link-hover-color: #0535d2 !default;
 
 // WET Custom
+$content-bg: null !default;
 $main-bg: null !default;
 $link-visited-color: #7834bc !default;
 

--- a/src/base/views/_screen.scss
+++ b/src/base/views/_screen.scss
@@ -6,9 +6,33 @@
 	display: none !important;
 }
 
+%content-background-color {
+	background-color: $content-bg;
+}
+
+@if $content-bg {
+	body {
+		> {
+			header {
+				+ {
+					div {
+						&.container {
+							@extend %content-background-color;
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
 @if $main-bg {
 	main {
 		background-color: $main-bg;
+	}
+} @else if $content-bg {
+	main {
+		@extend %content-background-color;
 	}
 }
 

--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -237,6 +237,8 @@ $tab-margin-width: 10px;
 						background: $tablist-active-bg-color;
 					} @else if $main-bg {
 						background: $main-bg
+					} @else if $content-bg {
+						background: $content-bg
 					} @else {
 						background: $body-bg;
 					}

--- a/theme/_variables.scss
+++ b/theme/_variables.scss
@@ -7,7 +7,7 @@ $body-bg: #f9f9f9; // Body element's background colour (Bootstrap override).
 $breadcrumb-bg: #fff; // Inner background colour (Bootstrap override).
 
 // Main
-$main-bg: #fff; // Main element's background colour (WET override).
+$main-bg: $breadcrumb-bg; // Main element's background colour (WET override).
 
 // Sign in / off
 $wb-so-background-color: #fff;


### PR DESCRIPTION
* Base:
  * Adds a $content-bg variable.
  * If a theme assigns a colour to $content-bg:
    * It's set as the background colour of the content area's container div in pages that contain secondary menus.
    * It's set as the background colour of the main element and the tabbed interface's active summary, unless a colour has been assigned to $main-bg.
* Theme:
  * Adjusts the $main-bg variable's declaration to re-use $breadcrumb-bg's value.
* Mostly addresses #7918.

**Note:** This will need to be merged alongside a few other upcoming PRs for other themes. I'll remove "[Do not merge]" from the subject once they're ready.