### PR TITLE
Theme index: Revised link text to end with page languages.

### DIFF
--- a/theme/site/pages/index-en.hbs
+++ b/theme/site/pages/index-en.hbs
@@ -5,7 +5,7 @@
 	"parentdir": "theme-wet-boew",
 	"language": "en",
 	"altLangPrefix": "index",
-	"dateModified": "2014-08-15"
+	"dateModified": "2017-05-03",
 }
 ---
 <section>
@@ -21,26 +21,26 @@
 <section>
 	<h2 id="{{this}}">{{#with ..}}{{i18n "lang-en" language=../this}}{{/with}}</h2>
 	<ul>
-		<li><a href="content-{{this}}.html">Content page</a></li>
-		<li><a href="content-secmenu-{{this}}.html">Content page - Secondary menu</a></li>
-		<li><a href="content-nosearchlang-{{this}}.html">Content page - No search or language selection link</a></li>
-		<li><a href="content-nositemenubc-{{this}}.html">Content page - No site menu or breadcrumb trail</a></li>
-		<li><a href="content-nosearchlangsitemenubc-{{this}}.html">Content page - No search, language selection link, site menu or breadcrumb trail</a></li>
-		<li><a href="content-signedoff-{{this}}.html">Content page - Signed Off</a></li>
-		<li><a href="content-signedon-{{this}}.html">Content page - Signed On</a></li>
+		<li><a href="content-{{this}}.html">Content page<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-secmenu-{{this}}.html">Content page - Secondary menu<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-nosearchlang-{{this}}.html">Content page - No search or language selection link<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-nositemenubc-{{this}}.html">Content page - No site menu or breadcrumb trail<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-nosearchlangsitemenubc-{{this}}.html">Content page - No search, language selection link, site menu or breadcrumb trail<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-signedoff-{{this}}.html">Content page - Signed Off<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-signedon-{{this}}.html">Content page - Signed On<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
 		{{#is this "en"}}
-		<li><a href="splashpage-en.html">Splash page</a></li>
-		<li><a href="404-en.html">404 error page</a></li>
-		<li><a href="404-en-fr.html">404 error page (English/French)</a></li>
-		<li><a href="servermessage-en-fr.html">Server message page (English/French)</a></li>
+		<li><a href="splashpage-en.html">Splash page<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
+		<li><a href="404-en.html">404 error page<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
+		<li><a href="404-en-fr.html">404 error page - English/French</a></li>
+		<li><a href="servermessage-en-fr.html">Server message page - English/French</a></li>
 		{{/is}}
 		{{#is this "fr"}}
-		<li><a href="splashpage-fr.html">Splash page</a></li>
-		<li><a href="404-fr.html">404 error page</a></li>
-		<li><a href="404-fr-en.html">404 error page (French/English)</a></li>
-		<li><a href="servermessage-fr-en.html">Server message page (French/English)</a></li>
+		<li><a href="splashpage-fr.html">Splash page<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
+		<li><a href="404-fr.html">404 error page<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
+		<li><a href="404-fr-en.html">404 error page - French/English</a></li>
+		<li><a href="servermessage-fr-en.html">Server message page - French/English</a></li>
 		{{/is}}
-		<li><a href="servermessage-{{this}}.html">Server message page</a></li>
+		<li><a href="servermessage-{{this}}.html">Server message page<span class="wb-inv">{{#with ..}} - {{i18n "lang-en" language=../this}}{{/with}}</span></a></li>
 	</ul>
 </section>
 {{/withSort}}

--- a/theme/site/pages/index-fr.hbs
+++ b/theme/site/pages/index-fr.hbs
@@ -5,7 +5,7 @@
 	"parentdir": "theme-wet-boew",
 	"language": "fr",
 	"altLangPrefix": "index",
-	"dateModified": "2014-08-15"
+	"dateModified": "2017-05-03"
 }
 ---
 <section>
@@ -21,26 +21,26 @@
 <section>
 	<h2 id="{{this}}">{{#with ..}}{{i18n "lang-fr" language=../this}}{{/with}}</h2>
 	<ul>
-		<li><a href="content-{{this}}.html">Page de contenu</a></li>
-		<li><a href="content-secmenu-{{this}}.html">Page de contenu - Menu secondaire</a></li>
-		<li><a href="content-nosearchlang-{{this}}.html">Page de contenu - Sans recherche ou lien de sélection de la langue</a></li>
-		<li><a href="content-nositemenubc-{{this}}.html">Page de contenu - Sans menu du site ou fil d'Ariane</a></li>
-		<li><a href="content-nosearchlangsitemenubc-{{this}}.html">Page de contenu - Sans recherche, lien de sélection de la langue, menu du site ou fil d'Ariane</a></li>
-		<li><a href="content-signedoff-{{this}}.html">Page de contenu - Session Fermée</a></li>
-		<li><a href="content-signedon-{{this}}.html">Page de contenu - Session Ouverte</a></li>
+		<li><a href="content-{{this}}.html">Page de contenu<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-secmenu-{{this}}.html">Page de contenu - Menu secondaire<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-nosearchlang-{{this}}.html">Page de contenu - Sans recherche ou lien de sélection de la langue<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-nositemenubc-{{this}}.html">Page de contenu - Sans menu du site ou fil d'Ariane<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-nosearchlangsitemenubc-{{this}}.html">Page de contenu - Sans recherche, lien de sélection de la langue, menu du site ou fil d'Ariane<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-signedoff-{{this}}.html">Page de contenu - Session Fermée<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
+		<li><a href="content-signedon-{{this}}.html">Page de contenu - Session Ouverte<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
 		{{#is this "en"}}
-		<li><a href="splashpage-en.html">Page d'entrée</a></li>
-		<li><a href="404-en.html">Page d'erreur 404</a></li>
-		<li><a href="404-en-fr.html">Page d'erreur 404 (anglais/français)</a></li>
-		<li><a href="servermessage-en-fr.html">Page de message du serveur (anglais/français)</a></li>
+		<li><a href="splashpage-en.html">Page d'entrée<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
+		<li><a href="404-en.html">Page d'erreur 404<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
+		<li><a href="404-en-fr.html">Page d'erreur 404 - anglais/français</a></li>
+		<li><a href="servermessage-en-fr.html">Page de message du serveur - anglais/français</a></li>
 		{{/is}}
 		{{#is this "fr"}}
-		<li><a href="splashpage-fr.html">Page d'entrée</a></li>
-		<li><a href="404-fr.html">Page d'erreur 404</a></li>
-		<li><a href="404-fr-en.html">Page d'erreur 404 (français/anglais)</a></li>
-		<li><a href="servermessage-fr-en.html">Page de message du serveur (français/anglais)</a></li>
+		<li><a href="splashpage-fr.html">Page d'entrée<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
+		<li><a href="404-fr.html">Page d'erreur 404<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
+		<li><a href="404-fr-en.html">Page d'erreur 404 - français/anglais</a></li>
+		<li><a href="servermessage-fr-en.html">Page de message du serveur - français/anglais</a></li>
 		{{/is}}
-		<li><a href="servermessage-{{this}}.html">Page de message du serveur</a></li>
+		<li><a href="servermessage-{{this}}.html">Page de message du serveur<span class="wb-inv">{{#with ..}} - {{i18n "lang-fr" language=../this}}{{/with}}</span></a></li>
 	</ul>
 </section>
 {{/withSort}}


### PR DESCRIPTION
* Added hidden link text containing " - [Language]" to the end of all page template links. This makes each link's text unique, which can benefit screen reader users that may encounter them out of context.
* Revised the bilingual 404 error and server message page's links to end with " - [Language]/[Language]" (instead of " ([Language]/[Language])") for consistency.