### PR TITLE
CSS: Added lst-none class for removing only bullets from lists (fixes #8001)

### DIFF
--- a/src/base/lists/_base.scss
+++ b/src/base/lists/_base.scss
@@ -23,6 +23,10 @@
 	list-style-type: decimal;
 }
 
+.lst-none {
+	list-style-type: none;
+}
+
 .lst-spcd {
 	> {
 		li {


### PR DESCRIPTION
Leave a comment