### PR TITLE
Data Ajax: Fixed typos in documentation.

### DIFF
--- a/site/pages/docs/ref/data-ajax/data-ajax-en.hbs
+++ b/site/pages/docs/ref/data-ajax/data-ajax-en.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "A basic AjaxLoader wrapper that inserts AJAXed-in content.",
 	"altLangPrefix": "data-ajax",
-	"dateModified": "2015-03-09"
+	"dateModified": "2017-06-07"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -101,13 +101,13 @@
 &lt;/section&gt;</code></pre>
 				</li>
 				<li>
-					<p><code>data-ajax-before</code>: Insert content at the start of the element</p>
+					<p><code>data-ajax-prepend</code>: Insert content at the start of the element</p>
 					<pre><code>&lt;section data-ajax-prepend=&quot;ajax/data-ajax-extra-en.html&quot;&gt;
 	...
 &lt;/section&gt;</code></pre>
 				</li>
 				<li>
-					<p><code>data-ajax-before</code>: Replace the element with the content</p>
+					<p><code>data-ajax-replace</code>: Replace the element with the content</p>
 					<pre><code>&lt;section data-ajax-replace=&quot;ajax/data-ajax-extra-en.html&quot;&gt;
 	...
 &lt;/section&gt;</code></pre>

--- a/site/pages/docs/ref/data-ajax/data-ajax-fr.hbs
+++ b/site/pages/docs/ref/data-ajax/data-ajax-fr.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Un enveloppeur simple pour AjaxLoader qui insère de contenu télécharger via AJAX.",
 	"altLangPrefix": "data-ajax",
-	"dateModified": "2015-03-09"
+	"dateModified": "2017-06-07"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -104,13 +104,13 @@
 &lt;/section&gt;</code></pre>
 				</li>
 				<li>
-					<p><code>data-ajax-before</code>: Insert content at the start of the element</p>
+					<p><code>data-ajax-prepend</code>: Insert content at the start of the element</p>
 					<pre><code>&lt;section data-ajax-prepend=&quot;ajax/data-ajax-extra-en.html&quot;&gt;
 	...
 &lt;/section&gt;</code></pre>
 				</li>
 				<li>
-					<p><code>data-ajax-before</code>: Replace the element with the content</p>
+					<p><code>data-ajax-replace</code>: Replace the element with the content</p>
 					<pre><code>&lt;section data-ajax-replace=&quot;ajax/data-ajax-extra-en.html&quot;&gt;
 	...
 &lt;/section&gt;</code></pre>


### PR DESCRIPTION
* Renamed second instance of "data-ajax-before" to "data-ajax-prepend" in the how to implement section. It's associated to an explanation and code sample for "data-ajax-prepend".
* Renamed third instance of "data-ajax-before" to "data-ajax-replace" in the how to implement section. It's associated to an explanation and code sample for "data-ajax-replace".