### PR TITLE
Search: Fixed layout issues with minified HTML.

### DIFF
--- a/theme/search/_screen-sm-max.scss
+++ b/theme/search/_screen-sm-max.scss
@@ -6,16 +6,3 @@
 		display: inline-block;
 	}
 }
-
-#wb-srch-sub {
-	float: right;
-	margin-left: 5px;
-}
-
-[dir=rtl] {
-	#wb-srch-sub {
-		float: left;
-		margin-left: 0;
-		margin-right: 5px;
-	}
-}

--- a/theme/search/_screen.scss
+++ b/theme/search/_screen.scss
@@ -1,0 +1,17 @@
+/*
+  WET-BOEW
+  @title: Search all screen views
+ */
+
+#wb-srch-sub {
+	float: right;
+	margin-left: 5px;
+}
+
+[dir=rtl] {
+	#wb-srch-sub {
+		float: left;
+		margin-left: 0;
+		margin-right: 5px;
+	}
+}

--- a/theme/theme.scss
+++ b/theme/theme.scss
@@ -29,6 +29,7 @@
  */
 /* All screen views */
 @media screen {
+	@import "search/screen";
 	@import "views/screen";
 }
 


### PR DESCRIPTION
In medium/large views, the search field/button's layout used to rely on space/line break/tab characters being present in-between their elements in HTML markup. Their presence produced a space in-between the search field/button. But in pages that use minified HTML, the space disappeared, which made the field and button "stick" together.

It turns out that the search feature's small view and under SCSS file contained selectors that produced a predictable amount of space in noscript/wbdisable mode.

This commit moves the aforementioned selectors into a screen SCSS file, thereby resolving medium/large view's layout issues.

**Screenshots:**
* **Before (minified):**
![before_minified](https://user-images.githubusercontent.com/1907279/27339693-77900a0e-55a6-11e7-828f-a0b60e27df9f.png)
* **Before (unminified):**
![before_unminified](https://user-images.githubusercontent.com/1907279/27339696-7a22741e-55a6-11e7-9dda-cbde5b97e53a.png)
* **After (minified and unminified):**
![after_both](https://user-images.githubusercontent.com/1907279/27339699-7b9ce39c-55a6-11e7-8f3f-f5cad0dccf30.png)