### PR TITLE
Menu: Removed space character prefixes from summary elements in small view.

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -116,7 +116,7 @@ var componentName = "wb-menu",
 			menuitem = " role='menuitem'",
 			sectionHtml = "<li><details>" + "<summary class='mb-item" +
 				( $section.hasClass( "wb-navcurr" ) || $section.children( ".wb-navcurr" ).length !== 0 ? " wb-navcurr'" : "'" ) +
-				" aria-haspopup='true'> <span" + menuitem + ">" +
+				" aria-haspopup='true'><span" + menuitem + ">" +
 				$section.text() + "</span></summary>" +
 				"<ul class='list-unstyled mb-sm' role='menu' aria-expanded='false' aria-hidden='true'>";
 


### PR DESCRIPTION
#7942 modified the mobile menu plugin to generate span elements within summary elements. But [as a part of that change, the plugin began inserting a space character at the start of each summary](https://github.com/shawnthompson/wet-boew/blob/db036187a52a837803f2f9a4fb3590004ee52a5b/src/plugins/menu/menu.js#L119). This negatively impacted their visual layouts, since the extra space is unnecessary and since it causes summaries to look horizontally misaligned (compared to nearby links).

This commit fixes the layout issues by removing the aforementioned space character from the menu plugin.

**Screenshots (Firefox Developer Edition 55.0b6):**
* **Before (from 4.0.25 to present):**
![mobile-menu_before](https://user-images.githubusercontent.com/1907279/27877154-9e95bd00-6187-11e7-817d-ec905f70905e.png)
* **After (also looked like this in 4.0.24 and under):**
![mobile-menu_after](https://user-images.githubusercontent.com/1907279/27877177-ada887e6-6187-11e7-893f-748fee09ae2b.png)