### PR TITLE
Fix dependency loading with readiness issue

### DIFF
--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -79,6 +79,9 @@ var componentName = "wb-tables",
 
 			Modernizr.load( {
 				load: [ "site!deps/jquery.dataTables" + wb.getMode() + ".js" ],
+				testReady: function() {
+					return ( $.fn.dataTable && $.fn.dataTable.version );
+				},
 				complete: function() {
 					var $elm = $( "#" + elmId ),
 						dataTableExt = $.fn.dataTableExt;


### PR DESCRIPTION
For testing this solution:

**wet-boew theme:**
* Working example index: http://universallabs.org/wet/labs/fixdeps-wet-boew/demos/index-en.html 
* Carousel: http://universallabs.org/wet/labs/fixdeps-wet-boew/demos/tabs/tabs-carousel-en.html
* Data Table: http://universallabs.org/wet/labs/fixdeps-wet-boew/demos/tables/tables-en.html

**GCWeb theme:**
* Working example index: http://universallabs.org/wet/labs/fixdeps-gcweb/unmin/demos/index-en.html 
* Carousel: http://universallabs.org/wet/labs/fixdeps-gcweb/unmin/demos/tabs/tabs-carousel-en.html
* Data Table: http://universallabs.org/wet/labs/fixdeps-gcweb/unmin/demos/tables/tables-en.html
* URL Mapping: http://universallabs.org/wet/labs/fixdeps-gcweb/unmin/demos/urlmapping/tblfilter-en.html

//cc @masterbee @MaximMartel @lucas-hay @thomasgohard