### PR TITLE
Core: Ensure getUrlParts() always returns slash-prefixed pathnames.

### DIFF
--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -24,7 +24,7 @@ var getUrlParts = function( url ) {
 			host: a.host,
 			hostname: a.hostname,
 			port: a.port,
-			pathname: a.pathname,
+			pathname: a.pathname.replace( /^([^\/])/, "/$1" ), // Prefix pathname with a slash in browsers that don't natively do it (i.e. all versions of IE and possibly early versions of Edge). See pull request #8110.
 			protocol: a.protocol,
 			hash: a.hash,
 			search: a.search,


### PR DESCRIPTION
According to the W3C's HTML specification (https://w3c.github.io/html/browsers.html#dom-location-pathname), the pathname attribute must always start with a forward slash character. Virtually every browser does this. But due to a browser bug (https://connect.microsoft.com/IE/feedbackdetail/view/1002846/pathname-incorrect-for-out-of-document-elements), all versions of Internet Explorer and early versions of Edge omit the forward slash from pathnames retrieved from generated a elements that weren't added to the body.

Since getUrlParts() works by generating an a element that never gets added to the body, any pathname attributes returned by it are affected.

This commit fixes it by inserting a forward slash at the beginning of any pathnames that lack one. It borrows a regex from the NavCurrent plugin that's already in use for the same purpose.

Fixes #8109 and doesn't interfere with the tabbed interface plugin (i.e. the only other WET/GCWeb plugin that uses pathnames extracted from getUrlParts()).