### PR TITLE
EditorConfig: Fixed typos in package.json/travis.yml's section name.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,6 @@ insert_final_newline = true
 indent_style = tabs
 indent_size = 4
 
-[{package.json},{bower.json}]
+[{package.json,bower.json}]
 indent_style = space
 indent_size = 2


### PR DESCRIPTION
The original section name for those files was written as [{...},{...}], which was invalid and prevented its coding styles from taking effect.

According to EditorConfig's documentation, the correct writing scheme for that kind of section name is [{...,...}]. This commit changes it to that.