### PR TITLE
Overlay plugin: Added space key support for overlay links.

### DIFF
--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -240,13 +240,13 @@ $document.on( "click vclick", "." + closeClass, function( event ) {
 } );
 
 // Handler for clicking on a source link for the overlay
-$document.on( "click vclick", "." + linkClass, function( event ) {
+$document.on( "click vclick keydown", "." + linkClass, function( event ) {
 	var which = event.which,
 		sourceLink = event.currentTarget,
 		overlayId = sourceLink.hash.substring( 1 );
 
 	// Ignore if not initialized and middle/right mouse buttons
-	if ( initialized && ( !which || which === 1 ) ) {
+	if ( initialized && ( !which || which === 1 || which === 32 ) ) {
 		event.preventDefault();
 
 		// Introduce a delay to prevent outside activity detection


### PR DESCRIPTION
Since overlay links are coded with a role="button" attribute, they should function like buttons. Therefore, when an overlay link has focus, it should be possible to press a keyboard's space key to activate it and open its overlay. That previously wasn't happening since overlay links weren't associated to any keyboard event handlers.

This commit addresses it by adding "keydown" alongside the overlay link's pre-existing click handlers and restricting it to the space key.