### PR TITLE
Multimedia player: Fixed timeline/volume bar layout issues in IE10+/Edge.

### DIFF
--- a/src/plugins/multimedia/_base.scss
+++ b/src/plugins/multimedia/_base.scss
@@ -260,6 +260,7 @@ $mm-volume-thumb-width: 10px;
 		/* Important Thing */
 		-webkit-appearance: none;
 		background: $mm-progress-bg-color;
+		background-clip: padding-box;
 		border: 7px solid #3e3e3e;
 		border-radius: 14px;
 		color: $mm-progress-fg-color;
@@ -326,6 +327,8 @@ $mm-volume-thumb-width: 10px;
 			}
 
 			&::-ms-track {
+				border: 0;
+				color: transparent;
 				height: 4px;
 			}
 


### PR DESCRIPTION
* Timeline bar:
  * Removed faint light grey border from the far left/right edges of the bar.
* Volume slider:
  * Removed vertical black lines.
  * Removed black border.

**Screenshots (IE11):**
* **Before:**
![wet4 0-multimedia-player-ui-ie11-before](https://user-images.githubusercontent.com/1907279/31395681-54e007d2-adaf-11e7-8ed8-f9a08c51afde.png)
* **After:**
![wet4 0-multimedia-player-ui-ie11-after](https://user-images.githubusercontent.com/1907279/31395687-5775f1b4-adaf-11e7-9154-1bdae76d2078.png)