### PR TITLE
Carousel: Improved video outlines in Firefox.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -260,6 +260,7 @@ $carousel-tablist-tabcount-color: #000 !default;
 $carousel-tabpanel-figcaption-color: #fff !default;
 $carousel-tabpanel-link-color: $carousel-tabpanel-figcaption-color !default;
 $carousel-tabpanel-figcaption-bg-color: $clrDarkBlue !default;
+$carousel-tabpanel-outline-color-inner: #fff !default;
 $carousel-tabpanel-outline-offset: 2px !default;
 
 // Carousel Style 2 with Thumbnails

--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -56,7 +56,7 @@ $tab-margin-width: 10px;
 					@extend %carousel-tabpanel-link-outline-common;
 					height: calc(100% - #{$carousel-tabpanel-outline-offset * 2});
 					margin: 2px;
-					outline-color: #FFF;
+					outline-color: $carousel-tabpanel-outline-color-inner;
 					width: calc(100% - #{$carousel-tabpanel-outline-offset * 2});
 				}
 
@@ -84,6 +84,13 @@ $tab-margin-width: 10px;
 }
 
 %carousel-tabpanel-video {
+	.display {
+		&:focus-within {
+			outline: 1px dotted $carousel-tabpanel-outline-color-inner;
+			outline-offset: -2px;
+		}
+	}
+
 	video {
 		&:focus {
 			outline-offset: -1px;


### PR DESCRIPTION
In Firefox, the multimedia player's video element can receive focus separately from the player's controls. When this happens, a focus outline should appear around the video's viewport.

In carousels that contain multimedia player implementations, when videos gain focus, an outline used to appear around the video viewport. Since overflowing is disabled in the carousel's container, outlines can't visually-appear beyond the container's boundaries. So video outlines were setup to appear inside the viewport. As a result, since the outlines were dark grey, they were prone to running into contrast issues if the viewport contained a dark image. Video viewport outlines also weren't consistent with how outlines are done in normal carousel panels.

To resolve both the contrast issue and the inconsistency, this commit adds a white "inner" outline to carousel videos. Combined with the original outline, it creates a two-toned white/dark grey effect that should retain a high contrast regardless of what's shown in the video viewport. It only impacts Firefox and only appears when an multimedia player is situated inside a carousel. It won't take effect in any other browsers, nor in noscript/wbdisable modes.

**Screenshots (Firefox Developer Edition 57.0b7):**

* **Dark carousel video with focus (before):**
![carousel-video1-before](https://user-images.githubusercontent.com/1907279/31498765-e2da35c6-af30-11e7-877b-d2383ba1e63a.png)

* **Dark carousel video with focus (after):**
![carousel-video1-after](https://user-images.githubusercontent.com/1907279/31498772-e487a304-af30-11e7-9abf-3b1f76f1a1d1.png)

* **Bright carousel video with focus (before):**
![carousel-video2-before](https://user-images.githubusercontent.com/1907279/31498777-e61e4fba-af30-11e7-8376-bc3474d6c28a.png)

* **Bright carousel video with focus (after):**
![carousel-video2-after](https://user-images.githubusercontent.com/1907279/31498779-e7ad3a8a-af30-11e7-97c6-fd087edcff75.png)
