### PR TITLE
Multimedia player: Made volume slider's layout more consistent across browsers.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -219,7 +219,10 @@ $mm-ctrl-outline-color: #4aafff !default;
 $mm-ctrl-cc-color: #4aafff !default;
 
 $mm-volume-bg-color: #aaa !default;
+$mm-volume-thumb-border: 1px solid #707070 !default;
 $mm-volume-thumb-color: #fff !default;
+$mm-volume-thumb-height: 1.3em !default;
+$mm-volume-thumb-width: 10px !default;
 
 
 //== Tabs

--- a/src/plugins/multimedia/_base.scss
+++ b/src/plugins/multimedia/_base.scss
@@ -2,9 +2,6 @@
   Multimedia Player Code
  */
 
-$mm-volume-thumb-height: 1.3em;
-$mm-volume-thumb-width: 10px;
-
 %multimedia-display-none {
 	display: none;
 }
@@ -306,13 +303,24 @@ $mm-volume-thumb-width: 10px;
 			padding: 0;
 			width: 7em;
 
+			&:focus {
+				/* Prevent Webkit/Blink browsers from defaulting to a -2px outline offset. */
+				outline-offset: 0;
+			}
+
 			&::-webkit-slider-runnable-track {
 				background: $mm-volume-bg-color;
 				height: 4px;
 			}
 
 			&::-webkit-slider-thumb {
-				margin-top: -8px;
+				-webkit-appearance: none;
+				background: $mm-volume-thumb-color;
+				border: $mm-volume-thumb-border;
+				box-sizing: content-box;
+				height: $mm-volume-thumb-height;
+				margin-top: -9px;
+				width: $mm-volume-thumb-width;
 			}
 
 			&::-moz-range-track {
@@ -321,6 +329,8 @@ $mm-volume-thumb-width: 10px;
 			}
 
 			&::-moz-range-thumb {
+				background: $mm-volume-thumb-color;
+				border: $mm-volume-thumb-border;
 				border-radius: 0;
 				height: $mm-volume-thumb-height;
 				width: $mm-volume-thumb-width;
@@ -342,8 +352,9 @@ $mm-volume-thumb-width: 10px;
 
 			&::-ms-thumb {
 				background: $mm-volume-thumb-color;
-				border: 1px outset #fff;
-				height: 1.3em;
+				border: $mm-volume-thumb-border;
+				height: $mm-volume-thumb-height;
+				width: $mm-volume-thumb-width;
 			}
 		}
 	}
@@ -366,7 +377,8 @@ $mm-volume-thumb-width: 10px;
 
 	.fd-slider-handle {
 		background: $mm-volume-thumb-color;
-		border: 1px outset #fff;
+		border: $mm-volume-thumb-border;
+		box-sizing: content-box;
 		width: $mm-volume-thumb-width;
 	}
 }


### PR DESCRIPTION
* Adjusted the volume slider's "thumb" (thick vertical line) dimensions, vertical position, inner colour and background colour to look virtually identical across all mainstream browsers. These changes are especially noticeable in Webkit/Blink browsers.
* Prevented Webkit/Blink browsers from defaulting to using a negative outline offset that overlaps the slider track/thumb.
* Moved volume thumb's width and height SCSS variable declarations into the core variables file.
* Added a border SCSS variable for the volume slider's thumb.

**Screenshots:**

* **Firefox:**
  * **Before:**
![multimedia-controls-firefox-before](https://user-images.githubusercontent.com/1907279/31561314-7b792c3e-b025-11e7-8355-0cae44835c24.png)
  * **After:**
![multimedia-controls-firefox-after](https://user-images.githubusercontent.com/1907279/31561310-776c31c2-b025-11e7-96b9-10e5b9f3f23c.png)
* **Internet Explorer 11:**
  * **Before:**
![multimedia-controls-ie11-before](https://user-images.githubusercontent.com/1907279/31561329-88420ec2-b025-11e7-9934-4cbe6c47116a.png)
  * **After:**
![multimedia-controls-ie11-after](https://user-images.githubusercontent.com/1907279/31561332-8976cabc-b025-11e7-8c19-8f549e35bad1.png)
* **Opera:**
  * **Before:**
![multimedia-controls-opera-before](https://user-images.githubusercontent.com/1907279/31561334-8b0b3fe8-b025-11e7-8d87-3986d531b7ca.png)
  * **After:**
![multimedia-controls-opera-after-v3](https://user-images.githubusercontent.com/1907279/31615533-d98d7c42-b257-11e7-8daa-41c8ff251805.png)