### PR TITLE
Fix date picker closing prematurely in some cases

### DIFF
--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -233,6 +233,7 @@ var getUrlParts = function( url ) {
 		ielt8: ( oldie < 8 ),
 		ielt9: ( oldie < 9 ),
 		ielt10: ( oldie < 10 ),
+		ie11: ( !!navigator.userAgent.match( /Trident\/7\./ ) ),
 
 		selectors: [],
 

--- a/src/plugins/calendar/calendar.js
+++ b/src/plugins/calendar/calendar.js
@@ -321,7 +321,10 @@ $document.on( "click vclick touchstart", ".cal-month-prev, .cal-month-next", fun
 		type: navigateEvent,
 		year: date.getFullYear(),
 		month: date.getMonth()
-	} ).trigger( "focusin" );
+	} );
+	if ( wb.ie11 ) {
+		$calendar.trigger( "focusin" );
+	}
 } );
 
 $document.on( "keydown", selector, function( event ) {

--- a/src/plugins/calendar/calendar.js
+++ b/src/plugins/calendar/calendar.js
@@ -321,7 +321,7 @@ $document.on( "click vclick touchstart", ".cal-month-prev, .cal-month-next", fun
 		type: navigateEvent,
 		year: date.getFullYear(),
 		month: date.getMonth()
-	} );
+	} ).trigger( "focusin" );
 } );
 
 $document.on( "keydown", selector, function( event ) {


### PR DESCRIPTION
On some systems the focus is lost when disabling the previous and next buttons, this causes the [date picker polyfill](https://github.com/wet-boew/wet-boew/blob/69e2931ff562d253b30a8f84caf4a9b8a5c7061a/src/polyfills/datepicker/datepicker.js#L261) to close prematurely.

I was able to reproduce this bug using the [date picker example page](http://wet-boew.github.io/v4.0-ci/demos/datepicker/datepicker-en.html) on several GoC systems running IE 11.0.9600.18816 and Windows 7 SP1, however I was unable to reproduce it at my home.