### PR TITLE
Theme: Added footer/cite elements into placeholder content's blockquote.

### DIFF
--- a/site/includes/placeholdercontent.hbs
+++ b/site/includes/placeholdercontent.hbs
@@ -103,4 +103,5 @@
 </form>
 <blockquote>
 	<p>"<code>blockquote</code>"</p>
+	<footer><code>footer</code> <cite><code>cite</code></cite></footer>
 </blockquote>

--- a/theme/site/pages/content-nosearchlang.hbs
+++ b/theme/site/pages/content-nosearchlang.hbs
@@ -8,7 +8,7 @@
 	"languagetoggle": "false",
 	"breadcrumb3": "true",
 	"breadcrumb3-title": "WET theme",
-	"dateModified": "2014-02-19"
+	"dateModified": "2017-11-22"
 }
 ---
 {{>placeholdercontent}}

--- a/theme/site/pages/content-nosearchlangsitemenubc.hbs
+++ b/theme/site/pages/content-nosearchlangsitemenubc.hbs
@@ -8,7 +8,7 @@
 	"languagetoggle": "false",
 	"sitemenu": "false",
 	"breadcrumb": "false",
-	"dateModified": "2014-02-19"
+	"dateModified": "2017-11-22"
 }
 ---
 {{>placeholdercontent}}

--- a/theme/site/pages/content-nositemenubc.hbs
+++ b/theme/site/pages/content-nositemenubc.hbs
@@ -6,7 +6,7 @@
 	"parentdir": "theme-wet-boew",
 	"sitemenu": "false",
 	"breadcrumb": "false",
-	"dateModified": "2014-02-19"
+	"dateModified": "2017-11-22"
 }
 ---
 {{>placeholdercontent}}

--- a/theme/site/pages/content-secmenu.hbs
+++ b/theme/site/pages/content-secmenu.hbs
@@ -7,7 +7,7 @@
 	"secondarymenu": "true",
 	"breadcrumb3": "true",
 	"breadcrumb3-title": "WET theme",
-	"dateModified": "2014-02-19"
+	"dateModified": "2017-11-22"
 }
 ---
 {{>placeholdercontent}}

--- a/theme/site/pages/content-signedoff.hbs
+++ b/theme/site/pages/content-signedoff.hbs
@@ -6,7 +6,7 @@
 	"parentdir": "theme-wet-boew",
 	"breadcrumb3": "true",
 	"breadcrumb3-title": "WET theme",
-	"dateModified": "2014-02-19",
+	"dateModified": "2017-11-22",
 	"signed": "off"
 }
 ---

--- a/theme/site/pages/content-signedon.hbs
+++ b/theme/site/pages/content-signedon.hbs
@@ -6,7 +6,7 @@
 	"parentdir": "theme-wet-boew",
 	"breadcrumb3": "true",
 	"breadcrumb3-title": "WET theme",
-	"dateModified": "2014-02-19",
+	"dateModified": "2017-11-22",
 	"signed": "on"
 }
 ---

--- a/theme/site/pages/content.hbs
+++ b/theme/site/pages/content.hbs
@@ -6,7 +6,7 @@
 	"parentdir": "theme-wet-boew",
 	"breadcrumb3": "true",
 	"breadcrumb3-title": "WET theme",
-	"dateModified": "2014-02-19"
+	"dateModified": "2017-11-22"
 }
 ---
 {{>placeholdercontent}}


### PR DESCRIPTION
This addition makes the theme pages' placeholder content demonstrate how Bootstrap 3.3.1's CSS adds a dash in front of blockquote elements that contain footer elements for citations. It may prove useful to anyone that refers to the placeholder content when coding blockquote citations in real content.

Bootstrap 3.3.1's blockquote guidance can be found at https://bootstrapdocs.com/v3.3.1/docs/css/#type-blockquotes.

**Screenshot:**
![v4 0-blockquote-citation-v2](https://user-images.githubusercontent.com/1907279/33137342-b48be326-cf75-11e7-9d6a-b8a17debc069.png)