### PR TITLE
Build: Modified sass-lint settings to require EOF newlines.

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -4,6 +4,7 @@ options:
 rules:
   class-name-format: 0
   function-name-format: 0
+  final-newline: 2
   id-name-format: 0
   indentation:
     - 2


### PR DESCRIPTION
Sass-lint doesn't require SCSS files to end with a newline by default. However, WET's .editorconfig file and ESLint's default settings do.

This commit makes WET's sass-lint settings consistent with those in that respect.