### PR TITLE
Build: Made sasslint task's src globbing patterns more specific.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -580,11 +580,9 @@ module.exports = (grunt) ->
 			all:
 				expand: true
 				src: [
-						"**/*.scss"
-						"!lib/**"
-						"!node_modules/**"
-						"!dist/**"
-						"!wet-boew-dist/**"
+						"site/**/*.scss"
+						"src/**/*.scss"
+						"theme/**/*.scss"
 						"!src/**/sprites/**"
 					]
 


### PR DESCRIPTION
The "sasslint" task was previously setup to include any SCSS files as sources on a global scale. Exclusion patterns were used to omit anything within the lib, node_modules, dist and wet-boew-dist folders. That resulted in really slow linting performance in Windows environments. That setup was also inconsistent with most of the other tasks. Apart from the "gh-pages" task, all other tasks' source inclusion patterns are more specific and don't rely so heavily on exclusion patterns.

This commit improves the "sasslint" task's performance (especially on Windows) by making its source inclusion patterns more specific and by reducing its reliance on exclusion patterns.

On my Windows 7 notebook (which uses a really slow HDD), the original "sasslint" task would take nearly 9 minutes to run after a cold boot. Subsequent runs would take between 75-90 seconds. Subsequent runs with the updated "sasslint" task only take 2 seconds. That's even faster than the 3.5-5 seconds it usually took for the original version of that task to run in Travis-CI.

@nschonni @LaurentGoderre FYI.