### PR TITLE
Core CSS - Fixed an overloading issue with col-*-auto on responsive breakpoints

### DIFF
--- a/src/base/views/_screen-lg-min.scss
+++ b/src/base/views/_screen-lg-min.scss
@@ -10,3 +10,6 @@
 	clear: right;
 }
 
+.col-lg-auto {
+	width: auto;
+}

--- a/src/base/views/_screen-md-min.scss
+++ b/src/base/views/_screen-md-min.scss
@@ -16,3 +16,6 @@
 	}
 }
 
+.col-md-auto {
+	width: auto;
+}

--- a/src/base/views/_screen-sm-min.scss
+++ b/src/base/views/_screen-sm-min.scss
@@ -3,3 +3,6 @@
   @title: Small view and over (screen only)
  */
 
+.col-sm-auto {
+	width: auto;
+}

--- a/src/base/views/_screen.scss
+++ b/src/base/views/_screen.scss
@@ -81,11 +81,15 @@
 	}
 }
 
-// col-auto extension to Bootstrap grid
+// Column auto (col-auto) extension for Bootstrap grid
+// Baseline style for column auto - same style as defined in: assets/stylesheets/bootstrap/mixins/_grid-framework.scss
 .col-xs-auto, .col-sm-auto, .col-md-auto, .col-lg-auto {
 	min-height: 1px;
-	padding-left: 15px;
-	padding-right: 15px;
-	width: auto;
+	padding-left:  ($grid-gutter-width / 2);
+	padding-right: ($grid-gutter-width / 2);
+	position: relative;
 }
 
+.col-xs-auto {
+	width: auto;
+}


### PR DESCRIPTION
This fix the issue was when we tried to achieve the design in GCweb repo for the institutional-arms.

The problematic use case:
We were using a ```col-md-auto``` for the follow us content block with a ```pull-right``` and were not able to apply the ```col-xs-12``` in order to remote the ```pull-right``` effect. The ```col-md-auto``` was persisting.

With this PR, ```col-*-auto``` will be defined with the screen size, the same was that the other ```col-*-[1-12]``` work for responsive breakpoints.

/cc @lucas-hay 