### PR TITLE
Revert "Menu aria validation" #7942

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -85,6 +85,8 @@ var componentName = "wb-menu",
 			$subMenu = $elm.siblings( "ul" );
 
 			$elm.attr( {
+				"aria-posinset": ( i + 1 ),
+				"aria-setsize": length,
 				role: "menuitem"
 			} );
 
@@ -113,11 +115,12 @@ var componentName = "wb-menu",
 		// Use details/summary for the collapsible mechanism
 		var k, $elm, elm, $item, $subItems, subItemsLength,
 			$section = $( section ),
-			menuitem = " role='menuitem'",
+			posinset = "' aria-posinset='",
+			menuitem = " role='menuitem' aria-setsize='",
 			sectionHtml = "<li><details>" + "<summary class='mb-item" +
 				( $section.hasClass( "wb-navcurr" ) || $section.children( ".wb-navcurr" ).length !== 0 ? " wb-navcurr'" : "'" ) +
-				" aria-haspopup='true'><span" + menuitem + ">" +
-				$section.text() + "</span></summary>" +
+				menuitem + sectionsLength + posinset + ( sectionIndex + 1 ) +
+				"' aria-haspopup='true'>" + $section.text() + "</summary>" +
 				"<ul class='list-unstyled mb-sm' role='menu' aria-expanded='false' aria-hidden='true'>";
 
 		// Convert each of the list items into WAI-ARIA menuitems
@@ -131,8 +134,9 @@ var componentName = "wb-menu",
 			if ( elm && subItemsLength === 0 && elm.nodeName.toLowerCase() === "a" ) {
 				sectionHtml += "<li>" + $item[ 0 ].innerHTML.replace(
 						/(<a\s)/,
-						"$1" + menuitem +
-							" tabindex='-1' "
+						"$1" + menuitem + itemsLength +
+							posinset + ( k + 1 ) +
+							"' tabindex='-1' "
 					) + "</li>";
 			} else {
 				sectionHtml += createCollapsibleSection( elm, k, itemsLength, $subItems, $subItems.length );
@@ -185,8 +189,9 @@ var componentName = "wb-menu",
 					sectionHtml += "<li class='no-sect'>" +
 						linkHtml.replace(
 							/(<a\s)/,
-							"$1 class='mb-item' " + "role='menuitem'" +
-								" tabindex='-1' "
+							"$1 class='mb-item' " + "role='menuitem' aria-setsize='" +
+								sectionsLength + "' aria-posinset='" + ( j + 1 ) +
+								"' tabindex='-1' "
 						) + "</li>";
 				}
 			}
@@ -302,11 +307,11 @@ var componentName = "wb-menu",
 				}
 
 				// Let's now populate the DOM since we have done all the work in a documentFragment
-				panelDOM.innerHTML = "<div class='modal-header'><div class='modal-title'>" +
+				panelDOM.innerHTML = "<header class='modal-header'><div class='modal-title'>" +
 						document.getElementById( "wb-glb-mn" )
 							.getElementsByTagName( "h2" )[ 0 ]
 								.innerHTML +
-						"</div></div><div class='modal-body'>" + panel + "</div>";
+						"</div></header><div class='modal-body'>" + panel + "</div>";
 				panelDOM.className += " wb-overlay modal-content overlay-def wb-panel-r";
 				$panel
 					.trigger( "wb-init.wb-overlay" )


### PR DESCRIPTION
Revert the changes applied by PR #7942 as it introduced a major keyboard navigation issue.

**Current issue** 
On small device, when the user open the site menu, the user can not navigate through the menu items with a keyboard. Because of that, we can highly presume, it cause major issues to assistive technology that are trying to access it from a small device (see #8081 and #8088).

**Immediate solution proposal** 
Revert the changes for now and then take the time to investigate what issue #7942 is trying to solve and then propose a long term solution which are not conflicting with or degrading the existing implemented solution.

**Revert rational**
The information available from PR #7942 , from issue #7939 and #7795 are insufficient. They are not expressing enough research about finding why it was originally implemented like that and they are not showing that an extensive testing was completed with major browser and with assistive technology. 
Please note that at the time the original solution was designed, it was mentioned to me that it was producing a valid HTML markup. We have found that a similar design approach was used and still used by the tabbed interface when entering in mobile mode.

**Future solution**
The proposed solution will need extensive testing with all supported browser and assistive technology.
Prior to merge the new solution, the following task would need to be completed
* Validate or invalidate the need of using ```aria-setsize``` and ```aria-posinset```. Those attribute was added based on bad user experience for navigating the menu (including mobile) with an assistive technology like NVDA and JAW.
* Research and cite the actual reference in the WAI-ARIA specification that explicitly said it's not conforming to spec. Even if the Nu validator are reporting an error, we need to ensure that is not a bug in the validator or a miss-interpretation of the spec by the validator. 
* Documents the markup structure of current menu template and the enhanced menu template.
* Design and propose a few enhanced menu markup structure showing alternate solution along with an explanation of the navigation model.
* Investigate the tabbed interface mobile mode which use a similar mobile design approach and make proposal/recommendation.
* For the implementation of the solution, the developer would need to closely review the code in the menu.js, to look at how the "keydown" event is managed, ensure the new approach is consistent for the megamenu vs the mobile menu and the most important to do a lot of testing. 

----
ps: If this PR is merged, I would open an new official issue to track the progression of the long term solution.

/cc @lucas-hay @shawnthompson @EricDunsworth @masterbee @rlambert27 