### PR TITLE
build: Update Selenium browsers for vendor support

### DIFF
--- a/browsers.json
+++ b/browsers.json
@@ -3,7 +3,7 @@
     "platform": "Linux"
 },{
     "browserName": "firefox",
-    "platform": "OS X 10.9"
+    "platform": "OS X 10.13"
 },{
     "browserName": "firefox",
     "platform": "Windows 7"
@@ -12,23 +12,19 @@
     "platform": "Linux"
 },{
     "browserName": "chrome",
-    "platform": "Mac 10.9"
+    "platform": "Mac 10.13"
 },{
     "browserName": "chrome",
     "platform": "Windows 7"
 },{
     "browserName": "safari",
-    "platform": "OS X 10.9"
+    "platform": "OS X 10.13"
+},{
+    "browserName": "MicrosoftEdge",
+    "platform": "Windows 10",
+    "version": "16.16299"
 },{
     "browserName": "internet explorer",
     "platform": "Windows 7",
-    "version": "9"
-},{
-    "browserName": "internet explorer",
-    "platform": "Windows 7",
-    "version": "10"
-},{
-    "browserName": "internet explorer",
-    "platform": "Windows 8.1",
     "version": "11"
 }]


### PR DESCRIPTION
- Used http://gs.statcounter.com/ for some basics on the OS market.
- Dropped IE 9 and 10 as they are no longer supported by MS
- Added Microsoft Edge to the matrix

Note: it looks like the Sauce integration has been off since May https://saucelabs.com/u/wet-boew-bot
