### PR TITLE
Do not block collapsible component init on whole document

### DIFF
--- a/src/plugins/collapsible-alerts/collapsible-alerts.js
+++ b/src/plugins/collapsible-alerts/collapsible-alerts.js
@@ -16,7 +16,7 @@ var componentName = "wb-collapsible",
 	selector = "details.alert",
 	initEvent = "wb-init." + componentName,
 	$document = wb.doc,
-	details, key,
+	key,
 
 	/**
 	 * @method init
@@ -27,9 +27,11 @@ var componentName = "wb-collapsible",
 		// Start initialization
 		// returns DOM object = proceed with init
 		// returns undefined = do not proceed with init (e.g., already initialized)
-		details = wb.init( event, componentName, selector );
+		var details = wb.init( event, componentName, selector ),
+			$details;
 
 		if ( details ) {
+			$details = $( details );
 
 			key = "alert-collapsible-state-" + details.getAttribute( "id" );
 
@@ -58,7 +60,7 @@ var componentName = "wb-collapsible",
 			} catch ( e ) {}
 
 			// Identify that initialization has completed
-			wb.ready( $document, componentName );
+			wb.ready( $details, componentName );
 		}
 	};
 
@@ -72,7 +74,8 @@ if ( Modernizr.details ) {
 	$document.on( "click keydown toggle." + componentName, selector + " summary", function( event ) {
 		var which = event.which,
 			currentTarget = event.currentTarget,
-			isClosed;
+			isClosed,
+			details;
 
 		// Ignore middle/right mouse buttons and wb-toggle enhanced summary elements (except for toggle)
 		if ( ( !which || which === 1 ) &&


### PR DESCRIPTION
This uses a technique similar to other plugins (https://github.com/wet-boew/wet-boew/blob/master/src/plugins/filter/filter.js#L94) to, if I understand how this works correctly, prevent the initialization of the component from blocking on the whole document.

In small documents, the difference is negligible, but in large documents with many collapsible alerts, this is much better, which addresses the performance issue here: https://github.com/wet-boew/wet-boew/issues/7125#issuecomment-144518981