### PR TITLE
Build - Remove copy of docs folder for MathJax

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1066,7 +1066,6 @@ module.exports = (grunt) ->
 					src: [
 						"MathJax.js"
 						"config/**"
-						"docs/**"
 						"extensions/**"
 						"jax/**"
 						"localization/**"


### PR DESCRIPTION
After the content of the docs MathJax folder is copied, it make the build script fails during the bootlint check.