### PR TITLE
Theme: Reference SVG logos with img element instead of object.

### DIFF
--- a/site/includes/brand.hbs
+++ b/site/includes/brand.hbs
@@ -1,6 +1,6 @@
 <div id="wb-sttl" class="col-md-8">
 	<a href="{{assets}}/index-{{#contains language "fr"}}{{language}}{{else}}en{{/contains}}.html">
-		<object type="image/svg+xml" tabindex="-1" data="{{assets}}/../{{site.theme}}/assets/logo.svg"></object>
+		<img src="{{assets}}/../{{site.theme}}/assets/logo.svg" alt="" />
 		<span>{{{i18n "site-title"}}}<span class="wb-inv">{{{i18n "comma-space"}}}</span><small>{{{i18n "site-tagline"}}}</small></span>
 	</a>
 </div>

--- a/site/layouts/splashpage.hbs
+++ b/site/layouts/splashpage.hbs
@@ -3,21 +3,23 @@
 	"layout": "core.hbs"
 }
 ---
-<header role="banner">
-	<div id="wb-bnr">
-		<div class="container">
-			<div class="row mrgn-tp-lg mrgn-bttm-lg">
-				<div class="col-md-8 col-md-offset-2">
-					<object type="image/svg+xml" tabindex="-1" role="img" data="{{assets}}/../{{site.theme}}/assets/logo.svg" aria-label="{{{i18n "site-title"}}}"></object>
+<div class="wb-sppe">
+	<header role="banner">
+		<div id="wb-bnr">
+			<div class="container">
+				<div class="row mrgn-tp-lg mrgn-bttm-lg">
+					<div id="wb-spllg" class="col-md-8 col-md-offset-2">
+						<img src="{{assets}}/../{{site.theme}}/assets/logo.svg" alt="{{{i18n "site-title"}}}" />
+					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-</header>
-<main role="main" property="mainContentOfPage" class="container">
-	<div class="row mrgn-tp-lg">
-		<div class="col-md-12">
-			{{>body}}
+	</header>
+	<main role="main" property="mainContentOfPage" class="container">
+		<div class="row mrgn-tp-lg">
+			<div class="col-md-12">
+				{{>body}}
+			</div>
 		</div>
-	</div>
-</main>
+	</main>
+</div>

--- a/theme/banner/_base.scss
+++ b/theme/banner/_base.scss
@@ -2,7 +2,10 @@
  Banner
  */
 
+// Needed for backwards compatibility with WET 4.0.27 and below's HTML markup.
+// Remove object references from all of this theme's logo selectors in WET 4.1+.
 .wb-sppe {
+	img,
 	object {
 		width: 100%;
 	}

--- a/theme/banner/_print.scss
+++ b/theme/banner/_print.scss
@@ -1,11 +1,25 @@
 /*
  Banner (print view)
  */
+%theme-wet-boew-banner-img-print-brightness-0 {
+	img {
+		filter: brightness(0);
+	}
+}
+
 #wb-bar {
 	@extend %theme-wet-boew-print-display-none-important;
 }
 
+.wb-sppe {
+	header {
+		@extend %theme-wet-boew-banner-img-print-brightness-0;
+	}
+}
+
 #wb-sttl {
+	@extend %theme-wet-boew-banner-img-print-brightness-0;
+
 	a {
 		&:after {
 			@extend %theme-wet-boew-print-display-none-important;


### PR DESCRIPTION
* Fixes #8276.
* Adds a print CSS filter to change the logo's brightness to 0%:
  * Needed for Gecko, Blink and possibly Webkit due to their buggy handling of inline SVG media queries when the img element is used. When printing, they apply screen-only queries and ignore print-only queries.
  * Prevents the fallback PNG logo from being coloured white when printing in browsers that support CSS filters.
* Retains the SVG logo's inline screen media query to prevent issues in browsers that correctly handle them and lack support for CSS filters (i.e. Internet Explorer 10-11).
* Restores the splash page's "wb-sppe" class (which was inadvertently removed in #6113):
  * Allows the splash page's logo image to be specifically targeted by the print CSS filer.
  * Indirectly brings back #5293's fix for the splash page logo's size in Internet Explorer 10-11 (which also fixes the fallback PNG logo's size in all browsers).