### PR TITLE
Overlay/Lightbox: Removed unused "hdrClose" and "ftrClose" IDs.

### DIFF
--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -279,7 +279,7 @@ var componentName = "wb-lbx",
 				}
 				spanTextFtr = spanTextFtr.replace( "'", "&#39;" );
 
-				overlayCloseFtr = "<button type='button' id='ftrClose' class='btn btn-sm btn-primary pull-left " + closeClassFtr +
+				overlayCloseFtr = "<button type='button' class='btn btn-sm btn-primary pull-left " + closeClassFtr +
 					"' title='" + closeTextFtr + " " + spanTextFtr + "'>" +
 					closeTextFtr +
 					"<span class='wb-inv'>" + spanTextFtr + "</span></button>";

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -78,7 +78,7 @@ var componentName = "wb-overlay",
 					footer.style.border = "0";
 				}
 
-				overlayCloseFtr = "<button type='button' id='ftrClose' class='btn btn-sm btn-primary " + closeClassFtr +
+				overlayCloseFtr = "<button type='button' class='btn btn-sm btn-primary " + closeClassFtr +
 					"' style='" + buttonStyle +
 					"' title='" + closeTextFtr + " " + spanTextFtr + "'>" +
 					closeTextFtr +
@@ -99,7 +99,7 @@ var componentName = "wb-overlay",
 				closeText = i18nText.closeOverlay;
 			}
 			closeText = closeText.replace( "'", "&#39;" );
-			overlayClose = "<button type='button' id='hdrClose' class='mfp-close " + closeClass +
+			overlayClose = "<button type='button' class='mfp-close " + closeClass +
 				"' title='" + closeText + "'>&#xd7;<span class='wb-inv'> " +
 				closeText + "</span></button>";
 


### PR DESCRIPTION
Both of those plugins were hardcoding one of those IDs into the close buttons they inject, but weren't using them for any functionality. No SCSS selectors targeted them either. So they didn't serve any meaningful purpose. All they did in practice was cause HTML validation errors on post-JavaScript HTML markup in pages that contain multiple instances of either plugin.

Furthermore, alternate CSS classes can be used to target those buttons. Specifically (depending on the context): "mfp-close", "overlay-close" or "popup-modal-dismiss".

Fixes #8284.

CC @shawnthompson @thekodester