### PR TITLE
LightBox / dependency loading/executing racing issue

### DIFF
--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -251,6 +251,9 @@ var componentName = "wb-lbx",
 		// Load Magnific Popup dependency and bind the init event handler
 		Modernizr.load( {
 			load: "site!deps/jquery.magnific-popup" + wb.getMode() + ".js",
+			testReady: function() {
+				return $.magnificPopup;
+			},
 			complete: function() {
 
 				// Set the dependency i18nText only once


### PR DESCRIPTION
To resolve the bug (Jquery doesn't fire) when we got the following error in wet-boew.min.js

Unsupported format of the sourcemapUnhandled exception at line 8, column 73294 in https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_26/js/wet-boew.min.js

0x800a138f - JavaScript runtime error: Unable to get property 'defaults' of undefined or null reference

Content of wet-boew.min.js column 73294 is

,"lbx-title"),b.data=c}}),Modernizr.load({"load":"site!deps/jquery.magnific-popup"+d.getMode()+".js","complete":function(){a.extend(!0,a.magnificPopup.defaults,h),o.trigger(m)}})}

Need to be tested with <script src="https://www.canada.ca/etc/designs/canada/cdts/gcweb/v4_0_26/js/wet-boew.min.js"></script>

Could also resolve issue #7972