### PR TITLE
feat(form-valid): Bump jQuery Validation to 1.17.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-boew",
-  "version": "4.0.28-development",
+  "version": "4.0.29-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5524,9 +5524,9 @@
       "integrity": "sha1-IoveaYoMYUMdwmMKahVPFYkNIxc="
     },
     "jquery-validation": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.15.1.tgz",
-      "integrity": "sha1-fBZXEbYR9tzloSrj5IVcELWj4zE=",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.17.0.tgz",
+      "integrity": "sha512-XddiAwhGdWhcIJ+W3ri3KG8uTPMua4TPYuUIC8/E7lOyqdScG5xHuy9YishlKc0c/lIQai77EX7hxMdTSYCEjA==",
       "requires": {
         "jquery": "2.1.4"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "es5-shim": "2.3.0",
     "html5shiv": "^3.7.3",
     "jquery": "2.1.4",
-    "jquery-validation": "1.15.1",
+    "jquery-validation": "1.17.0",
     "magnific-popup": "git+https://github.com/wet-boew/Magnific-Popup.git#1.0.0+keyboard_trap_fix",
     "mathjax": "2.7.1",
     "proj4": "2.3.3",


### PR DESCRIPTION
Removes duplicate aria-required and adds a few additional validators

Full version diff can be seen here https://github.com/jquery-validation/jquery-validation/compare/1.15.1...1.17.0