### PR TITLE
Bump jQuery to final 1.x and 2.x releases

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -310,7 +310,7 @@ module.exports = (grunt) ->
 		coreDist: "dist/wet-boew"
 		themeDist: "dist/theme-wet-boew"
 		jqueryVersion: "<%= pkg.dependencies.jquery %>"
-		jqueryOldIEVersion: "1.11.1"
+		jqueryOldIEVersion: "1.12.4"
 		MathJaxVersion: "<%= pkg.dependencies.mathjax %>"
 		banner: "/*!\n * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)\n * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html\n" +
 				" * v<%= pkg.version %> - " + "<%= grunt.template.today('yyyy-mm-dd') %>\n *\n */"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1390,7 +1390,7 @@
       "resolved": "https://registry.npmjs.org/datatables/-/datatables-1.10.13.tgz",
       "integrity": "sha1-m7Lexvfc8CBJoA5PDn0/4AnDk0Y=",
       "requires": {
-        "jquery": "2.1.4"
+        "jquery": "2.2.4"
       }
     },
     "date-time": {
@@ -5528,16 +5528,16 @@
       }
     },
     "jquery": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.1.4.tgz",
-      "integrity": "sha1-IoveaYoMYUMdwmMKahVPFYkNIxc="
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
+      "integrity": "sha1-LInWiJterFIqfuoywUUhVZxsvwI="
     },
     "jquery-validation": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.17.0.tgz",
       "integrity": "sha512-XddiAwhGdWhcIJ+W3ri3KG8uTPMua4TPYuUIC8/E7lOyqdScG5xHuy9YishlKc0c/lIQai77EX7hxMdTSYCEjA==",
       "requires": {
-        "jquery": "2.1.4"
+        "jquery": "2.2.4"
       }
     },
     "js-base64": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "datatables": "1.10.13",
     "es5-shim": "2.3.0",
     "html5shiv": "^3.7.3",
-    "jquery": "2.1.4",
+    "jquery": "2.2.4",
     "jquery-validation": "1.17.0",
     "magnific-popup": "git+https://github.com/wet-boew/Magnific-Popup.git#1.0.0+keyboard_trap_fix",
     "mathjax": "2.7.1",


### PR DESCRIPTION
A markup change might be required for those still supporting IE < 9 and those wanting to opt into the newer 2.x release

Closes #8047