### PR TITLE
Boostrap bump to 3.3.7

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -315,7 +315,6 @@ module.exports = (grunt) ->
 		banner: "/*!\n * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)\n * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html\n" +
 				" * v<%= pkg.version %> - " + "<%= grunt.template.today('yyyy-mm-dd') %>\n *\n */"
 		modernizrBanner: "/*! Modernizr (Custom Build) | MIT & BSD */\n"
-		glyphiconsBanner: "/*!\n * GLYPHICONS Halflings for Twitter Bootstrap by GLYPHICONS.com | Licensed under http://www.apache.org/licenses/LICENSE-2.0\n */"
 		i18nGDocsID: "1BmMrKN6Rtx-dwgPNEZD6AIAQdI4nNlyVVVCml0U594o"
 		i18nGDocsSheet: 1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-boew",
-  "version": "4.0.28-development",
+  "version": "4.0.29-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -485,9 +485,9 @@
       }
     },
     "bootstrap-sass": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.1.tgz",
-      "integrity": "sha1-NJERPWWAr/4r42dgBunXgVvpVCA="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
+      "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg="
     },
     "bower-config": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "bootstrap-sass": "3.3.1",
+    "bootstrap-sass": "^3.3.7",
     "code-prettify": "^0.1.0",
     "datatables": "1.10.13",
     "es5-shim": "2.3.0",

--- a/src/base/_bootstrap.scss
+++ b/src/base/_bootstrap.scss
@@ -3,12 +3,6 @@
 $icon-font-path: "#{$wb-core-path}/fonts/";
 
 
-/* TODO: Remove this block when including bootstrap 3.3.5 */
-/*!
- * Bootstrap v3.3.1 (http://getbootstrap.com)
- * Copyright 2011-2015 Twitter, Inc.
- * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
- */
 /*!
  * GLYPHICONS Halflings for Twitter Bootstrap by GLYPHICONS.com | Licensed under http://www.apache.org/licenses/LICENSE-2.0
  */


### PR DESCRIPTION
Not too much functional except dropping some explicit vendor prefixes removed, removing some focus overrides, and a few additional glyph icons. Full diff for their project can be seen https://github.com/twbs/bootstrap-sass/compare/v3.3.1...v3.3.7

I add https://github.com/wet-boew/wet-boew/commit/48ac0fd9611ca093ed802c210fde67ba0c42ead9 where you can see what changed in the compiled CSS.