### PR TITLE
Filter: Add extra filter functionality (AND and OR patterns)

### DIFF
--- a/site/pages/docs/ref/filter/filter-en.hbs
+++ b/site/pages/docs/ref/filter/filter-en.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Filters through content and only show content that match a certain keyword.",
 	"altLangPrefix": "filter",
-	"dateModified": "2017-07-21"
+	"dateModified": "2018-05-23"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -42,11 +42,21 @@
 				<dd>Otherwise specified, it will filter and search for content in <code>&lt;li&gt;</code> then hide the group, default sub <code>&lt;section&gt;</code>, if there is not more list item</dd>
 
 				<dt>If set on a <code>&lt;table&gt;</code> with multiple <code>&lt;tbody&gt;</code></dt>
-				<dd>Otherwise specified, it will filter rows and search for content in <code>&lt;th&gt;</code> contained in <code>&lt;tbody&gt;</code> except the row containing <code>&lt;th& scope="rowgroup|row"gt;</code>. It is assumed those row is used to identify the row group header as the default scope for a row is "row".</dd>
+				<dd>Otherwise specified, it will filter rows and search for content in <code>&lt;th&gt;</code> contained in <code>&lt;tbody&gt;</code> except the row containing <code>&lt;th scope="rowgroup|row"&gt;</code>. It is assumed those row is used to identify the row group header as the default scope for a row is "row".</dd>
 
 				<dt>If set on any other element, like <code>&lt;ul&gt;</code> or <code>&lt;table&gt;</code> with one or zero <code>&lt;tbody&gt;</code></dt>
 				<dd>Otherwise specified, it will filter and search on <code>&lt;li&gt;</code> or on <code>&lt;tr&gt;</code> in <code>&lt;tbody&gt;</code> for tables</dd>
 			</dl>
+		</li>
+		<li>
+			<p><strong>Optional:</strong> Override the default search type to perform an AND or an ORs search by passing a JSON array through the <code>data-wb-filter</code> attribute and setting the <code>filterType</code> parameter.</p>
+
+			<p>By default the filter plugin will apply an exact pattern match when searching through content.</p>
+
+			<pre><code>&lt;ul class=&quot;wb-filter&quot; data-wb-filter='{ "filterType": "and" }'&gt;
+	&lt;li&gt;Alberta&lt;/li&gt;
+	...
+&lt;/ul&gt;</code></pre>
 		</li>
 		<li>Test the feature to see if it is properly configured and show correctly the number of total entries and the same upon filtering. If the number match, you are done.</li>
 		<li>In the scenario of those number don't match or you want to filter in a complex design, see the feature configuration below and make your own adjustment.</li>
@@ -67,7 +77,7 @@
 		 * @settings: JSON object of the user setting set on plugin initialisation
 		 */
 		filterCallback: function( $field, $elm, settings ) {
-			var $sections =	$elm.find( &quot;section&quot; ),
+			var $sections = $elm.find( &quot;section&quot; ),
 				sectionsLength = $sections.length,
 				s, $section;
 
@@ -159,6 +169,21 @@
 					</dl>
 				</td>
 			</tr>
+			<tr>
+				<td><code>filterType</code></td>
+				<td>Sets the type of search operator that will be applied to the filter. By default the filter will search for an exact pattern match, however developers can set the filter to search using an OR or AND operator.</td>
+				<td><code>data-wb-filter='{"filterType": "<em>[Type of search]</em>"}'</code></td>
+				<td>
+					<dl>
+						<dt>None (default):</dt>
+						<dd>Will use the default exact pattern match when searching for items</dd>
+						<dt><code>and</code>:</dt>
+						<dd>Will use an AND operator between search terms. Only items that contain all search terms will be shown</dd>
+						<dt><code>or</code>:</dt>
+						<dd>Will use an OR operator between search terms. All items that contain any of the supplied search terms will be shown</dd>
+					</dl>
+				</td>
+			</tr>
 		</tbody>
 	</table>
 </section>
@@ -197,6 +222,142 @@
 					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
 });</code></pre>
 				</td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+
+<section>
+	<h2>Test Cases</h2>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>ID</th>
+				<th>Test Scenario</th>
+				<th>Test Steps</th>
+				<th>Test Data</th>
+				<th>Expected Results</th>
+				<th>Actual&nbsp;Results</th>
+				<th>Pass/Fail</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>01</td>
+				<td>Check "exact" filtertype identifies correct matches when something is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "Exact pattern match (default)" section</li>
+						<li>Enter "Alberta" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "Alberta"</td>
+				<td>
+					<p>Only the "Alberta" entry should be shown.</p>
+					<p>All other entries should be hidden.</p>
+					<p>The filter plugin text should read: "Showing 1 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
+			</tr>
+			<tr>
+				<td>02</td>
+				<td>Check "exact" filtertype returns no results when nothing is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "Exact pattern match (default)" section</li>
+						<li>Enter "No Way" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "No Way"</td>
+				<td>
+					<p>No matched entries should be shown.</p>
+					<p>The filter plugin text should read: "Showing 0 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
+			</tr>
+			<tr>
+				<td>03</td>
+				<td>Check "and" filtertype identifies correct matches when something is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "AND operator" section</li>
+						<li>Enter "New Lab" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "New Lab"</td>
+				<td>
+					<p>Only the "Newfoundland &amp; Labrador" entry should be shown.</p>
+					<p>All other entries should be hidden.</p>
+					<p>The filter plugin text should read: "Showing 1 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
+			</tr>
+			<tr>
+				<td>04</td>
+				<td>Check "and" filtertype returns no results when nothing is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "AND operator" section</li>
+						<li>Enter "Ontario Yukon" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "Ontario Yukon"</td>
+				<td>
+					<p>No matched entries should be shown.</p>
+					<p>The filter plugin text should read: "Showing 0 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
+			</tr>
+			<tr>
+				<td>05</td>
+				<td>Check "or" filtertype identifies correct matches when something is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "OR operator" section</li>
+						<li>Enter "Ontario Alberta" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "Ontario Alberta"</td>
+				<td>
+					<p>Only the "Ontario" and the "Alberta" entries should be shown.</p>
+					<p>All other entries should be hidden.</p>
+					<p>The filter plugin text should read: "Showing 2 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
+			</tr>
+			<tr>
+				<td>06</td>
+				<td>Check "or" filtertype returns no results when nothing is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "OR operator" section</li>
+						<li>Enter "Joe Jane Blah" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "Joe Jane Blah"</td>
+				<td>
+					<p>No matched entries should be shown.</p>
+					<p>The filter plugin text should read: "Showing 0 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
 			</tr>
 		</tbody>
 	</table>

--- a/site/pages/docs/ref/filter/filter-fr.hbs
+++ b/site/pages/docs/ref/filter/filter-fr.hbs
@@ -6,13 +6,14 @@
 	"categoryfile": "plugins",
 	"description": "Filtre du contenu et n'affiche que le contenu ayant un certain mot-clé.",
 	"altLangPrefix": "filter",
-	"dateModified": "2017-07-21"
+	"dateModified": "2018-05-23"
 }
 ---
 
+<div class="wb-prettify all-pre hide"></div>
+
 <div lang="en">
 <p><strong>Needs translation</strong></p>
-
 
 <section>
 	<h2>Purpose</h2>
@@ -45,11 +46,20 @@
 				<dd>Otherwise specified, it will filter and search for content in <code>&lt;li&gt;</code> then hide the group, default sub <code>&lt;section&gt;</code>, if there is not more list item</dd>
 
 				<dt>If set on a <code>&lt;table&gt;</code> with multiple <code>&lt;tbody&gt;</code></dt>
-				<dd>Otherwise specified, it will filter rows and search for content in <code>&lt;th&gt;</code> contained in <code>&lt;tbody&gt;</code> except the row containing <code>&lt;th& scope="rowgroup|row"gt;</code>. It is assumed those row is used to identify the row group header as the default scope for a row is "row".</dd>
+				<dd>Otherwise specified, it will filter rows and search for content in <code>&lt;th&gt;</code> contained in <code>&lt;tbody&gt;</code> except the row containing <code>&lt;th scope="rowgroup|row"&gt;</code>. It is assumed those row is used to identify the row group header as the default scope for a row is "row".</dd>
 
 				<dt>If set on any other element, like <code>&lt;ul&gt;</code> or <code>&lt;table&gt;</code> with one or zero <code>&lt;tbody&gt;</code></dt>
 				<dd>Otherwise specified, it will filter and search on <code>&lt;li&gt;</code> or on <code>&lt;tr&gt;</code> in <code>&lt;tbody&gt;</code> for tables</dd>
 			</dl>
+		</li>
+		<li>
+			<p><strong>Optional:</strong> Override the default search type to perform an AND or an OR search by passing a JSON array through the <code>data-wb-filter</code> attribute and setting the <code>filterType</code> parameter.</p>
+			<p>By default the filter plugin will apply an exact pattern match when searching through content.</p>
+
+			<pre><code>&lt;ul class=&quot;wb-filter&quot; data-wb-filter='{ "filterType": "and" }'&gt;
+	&lt;li&gt;Alberta&lt;/li&gt;
+	...
+&lt;/ul&gt;</code></pre>
 		</li>
 		<li>Test the feature to see if it is properly configured and show correctly the number of total entries and the same upon filtering. If the number match, you are done.</li>
 		<li>In the scenario of those number don't match or you want to filter in a complex design, see the feature configuration below and make your own adjustment.</li>
@@ -70,7 +80,7 @@
 		 * @settings: JSON object of the user setting set on plugin initialisation
 		 */
 		filterCallback: function( $field, $elm, settings ) {
-			var $sections =	$elm.find( &quot;section&quot; ),
+			var $sections = $elm.find( &quot;section&quot; ),
 				sectionsLength = $sections.length,
 				s, $section;
 
@@ -162,6 +172,21 @@
 					</dl>
 				</td>
 			</tr>
+			<tr>
+				<td><code>filterType</code></td>
+				<td>Sets the type of search operator that will be applied to the filter. By default the filter will search for an exact pattern match, however developers can set the filter to search using an OR or AND operator.</td>
+				<td><code>data-wb-filter='{"filterType": "<em>[Type of search]</em>"}'</code></td>
+				<td>
+					<dl>
+						<dt>None (default):</dt>
+						<dd>Will use the default exact pattern match when searching for items</dd>
+						<dt><code>and</code>:</dt>
+						<dd>Will use an AND operator between search terms. Only items that contain all search terms will be shown</dd>
+						<dt><code>or</code>:</dt>
+						<dd>Will use an OR operator between search terms. All items that contain any of the supplied search terms will be shown</dd>
+					</dl>
+				</td>
+			</tr>
 		</tbody>
 	</table>
 </section>
@@ -200,6 +225,142 @@
 					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
 });</code></pre>
 				</td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+
+<section>
+	<h2>Test Cases</h2>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>ID</th>
+				<th>Test Scenario</th>
+				<th>Test Steps</th>
+				<th>Test Data</th>
+				<th>Expected Results</th>
+				<th>Actual&nbsp;Results</th>
+				<th>Pass/Fail</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>01</td>
+				<td>Check "exact" filtertype identifies correct matches when something is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "Exact pattern match (default)" section</li>
+						<li>Enter "Alberta" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "Alberta"</td>
+				<td>
+					<p>Only the "Alberta" entry should be shown.</p>
+					<p>All other entries should be hidden.</p>
+					<p>The filter plugin text should read: "Showing 1 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
+			</tr>
+			<tr>
+				<td>02</td>
+				<td>Check "exact" filtertype returns no results when nothing is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "Exact pattern match (default)" section</li>
+						<li>Enter "No Way" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "No Way"</td>
+				<td>
+					<p>No matched entries should be shown.</p>
+					<p>The filter plugin text should read: "Showing 0 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
+			</tr>
+			<tr>
+				<td>03</td>
+				<td>Check "and" filtertype identifies correct matches when something is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "AND operator" section</li>
+						<li>Enter "New Lab" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "New Lab"</td>
+				<td>
+					<p>Only the "Newfoundland &amp; Labrador" entry should be shown.</p>
+					<p>All other entries should be hidden.</p>
+					<p>The filter plugin text should read: "Showing 1 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
+			</tr>
+			<tr>
+				<td>04</td>
+				<td>Check "and" filtertype returns no results when nothing is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "AND operator" section</li>
+						<li>Enter "Ontario Yukon" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "Ontario Yukon"</td>
+				<td>
+					<p>No matched entries should be shown.</p>
+					<p>The filter plugin text should read: "Showing 0 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
+			</tr>
+			<tr>
+				<td>05</td>
+				<td>Check "or" filtertype identifies correct matches when something is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "OR operator" section</li>
+						<li>Enter "Ontario Alberta" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "Ontario Alberta"</td>
+				<td>
+					<p>Only the "Ontario" and the "Alberta" entries should be shown.</p>
+					<p>All other entries should be hidden.</p>
+					<p>The filter plugin text should read: "Showing 2 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
+			</tr>
+			<tr>
+				<td>06</td>
+				<td>Check "or" filtertype returns no results when nothing is found</td>
+				<td>
+					<ol>
+						<li>Visit the <a href="../../../demos/filter/filter-en.html">working example</a> page</li>
+						<li>Scroll down to the "Applying additional search filters" section</li>
+						<li>Find the Filter Plugin under the "OR operator" section</li>
+						<li>Enter "Joe Jane Blah" in the Filter text field</li>
+					</ol>
+				</td>
+				<td>Search term: "Joe Jane Blah"</td>
+				<td>
+					<p>No matched entries should be shown.</p>
+					<p>The filter plugin text should read: "Showing 0 filtered from 13 total entries"</p>
+				</td>
+				<td>As expected</td>
+				<td>Pass</td>
 			</tr>
 		</tbody>
 	</table>

--- a/src/plugins/filter/filter-en.hbs
+++ b/src/plugins/filter/filter-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "filter",
 	"parentdir": "filter",
 	"altLangPrefix": "filter",
-	"dateModified": "2017-07-21"
+	"dateModified": "2018-05-23"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -15,6 +15,7 @@
 	<li><a href="#flt-section">Filtering items in sections</a></li>
 	<li><a href="#flt-list">List filtering</a></li>
 	<li><a href="#flt-table">Table filtering</a></li>
+	<li><a href="#flt-search">Applying additional search filters</a></li>
 </ul>
 
 <h2 id="flt-section">Filtering items in sections</h2>
@@ -335,7 +336,7 @@
 	<li>British Columbia</li>
 	<li>Manitoba</li>
 	<li>New Brunswick</li>
-	<li>Newfoundland & Labrador</li>
+	<li>Newfoundland &amp; Labrador</li>
 	<li>Northwest Territories</li>
 	<li>Nova Scotia</li>
 	<li>Nunavut</li>
@@ -689,3 +690,94 @@
 	&lt;/tbody&gt;
 	...
 &lt;/table&gt;</code></pre>
+
+<h2 id="flt-search">Applying additional search filters</h2>
+
+<p>The filter plugin has three types of search methods available: exact pattern match (default), AND operator, and OR operator.</p>
+
+<h3>Exact pattern match (default)</h3>
+
+<p>Finds items that contain exactly what the user has specified.</p>
+
+<p>Not setting the <code>filterType</code> will tell the filter plugin to apply the default search pattern which is an exact pattern match to the search terms. Only items that contain the full and exact pattern that the user enters will be shown.</p>
+
+<ul class="wb-filter">
+	<li>Alberta</li>
+	<li>British Columbia</li>
+	<li>Manitoba</li>
+	<li>New Brunswick</li>
+	<li>Newfoundland &amp; Labrador</li>
+	<li>Northwest Territories</li>
+	<li>Nova Scotia</li>
+	<li>Nunavut</li>
+	<li>Ontario</li>
+	<li>Prince Edward Island</li>
+	<li>Quebec</li>
+	<li>Saskatchewan</li>
+	<li>Yukon</li>
+</ul>
+
+<h4>Source code</h4>
+
+<pre><code>&lt;ul class=&quot;wb-filter&quot;&gt;
+	&lt;li&gt;Alberta&lt;/li&gt;
+	...
+&lt;/ul&gt;</code></pre>
+
+<h3>AND operator</h3>
+
+<p>Finds items that contain all of the specified words.</p>
+
+<p>Setting the <code>filterType</code> to the <code>and</code> option will tell the filter plugin to apply an AND operator between search terms. Only items that contain all search terms will be shown.</p>
+
+<ul class="wb-filter" data-wb-filter='{ "filterType": "and" }'>
+	<li>Alberta</li>
+	<li>British Columbia</li>
+	<li>Manitoba</li>
+	<li>New Brunswick</li>
+	<li>Newfoundland &amp; Labrador</li>
+	<li>Northwest Territories</li>
+	<li>Nova Scotia</li>
+	<li>Nunavut</li>
+	<li>Ontario</li>
+	<li>Prince Edward Island</li>
+	<li>Quebec</li>
+	<li>Saskatchewan</li>
+	<li>Yukon</li>
+</ul>
+
+<h4>Source code</h4>
+
+<pre><code>&lt;ul class=&quot;wb-filter&quot; data-wb-filter='{ "filterType": "and" }'&gt;
+	&lt;li&gt;Alberta&lt;/li&gt;
+	...
+&lt;/ul&gt;</code></pre>
+
+<h3>OR operator</h3>
+
+<p>Finds items that contain at least one of the specified words.</p>
+
+<p>Setting the <code>filterType</code> to the <code>or</code> option will tell the filter plugin to apply an OR operator between search terms. All items that contain any of the supplied search terms will be shown.</p>
+
+<ul class="wb-filter" data-wb-filter='{ "filterType": "or" }'>
+	<li>Alberta</li>
+	<li>British Columbia</li>
+	<li>Manitoba</li>
+	<li>New Brunswick</li>
+	<li>Newfoundland &amp; Labrador</li>
+	<li>Northwest Territories</li>
+	<li>Nova Scotia</li>
+	<li>Nunavut</li>
+	<li>Ontario</li>
+	<li>Prince Edward Island</li>
+	<li>Quebec</li>
+	<li>Saskatchewan</li>
+	<li>Yukon</li>
+</ul>
+
+<h4>Source code</h4>
+
+<pre><code>&lt;ul class=&quot;wb-filter&quot; data-wb-filter='{ "filterType": "or" }'&gt;
+	&lt;li&gt;Alberta&lt;/li&gt;
+	...
+&lt;/ul&gt;</code></pre>

--- a/src/plugins/filter/filter-fr.hbs
+++ b/src/plugins/filter/filter-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "filter",
 	"parentdir": "filter",
 	"altLangPrefix": "filter",
-	"dateModified": "2017-07-22"
+	"dateModified": "2018-05-23"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -15,6 +15,7 @@
 	<li><a href="#flt-section">Filtrer des items par section</a></li>
 	<li><a href="#flt-list">Filtrer une liste</a></li>
 	<li><a href="#flt-table">Filtrer un tableau</a></li>
+	<li lang="en"><strong>Needs translation: </strong><a href="#flt-search">Applying additional search filters</a></li>
 </ul>
 
 <h2 id="flt-section">Filtrer des items par section</h2>
@@ -608,7 +609,6 @@
 	</tbody>
 </table>
 
-
 <h3>Source code</h3>
 <pre><code>&lt;table class=&quot;wb-filter table&quot;&gt;
 	&lt;caption&gt;Population de grande municipalité par provinces&lt;/caption&gt;
@@ -661,3 +661,96 @@
 	&lt;/tbody&gt;
 	...
 &lt;/table&gt;</code></pre>
+
+<div lang="en">
+	<h2 id="flt-search">Applying additional search filters</h2>
+
+	<p>The filter plugin has three types of search methods available: exact pattern match (default), AND operator, and OR operator.</p>
+
+	<h3>Exact pattern match (default)</h3>
+
+	<p>Finds items that contain exactly what the user has specified.</p>
+
+	<p>Not setting the <code>filterType</code> will tell the filter plugin to apply the default search pattern which is an exact pattern match to the search terms. Only items that contain the full and exact pattern that the user enters will be shown.</p>
+
+	<ul class="wb-filter">
+		<li>Alberta</li>
+		<li>British Columbia</li>
+		<li>Manitoba</li>
+		<li>New Brunswick</li>
+		<li>Newfoundland &amp; Labrador</li>
+		<li>Northwest Territories</li>
+		<li>Nova Scotia</li>
+		<li>Nunavut</li>
+		<li>Ontario</li>
+		<li>Prince Edward Island</li>
+		<li>Quebec</li>
+		<li>Saskatchewan</li>
+		<li>Yukon</li>
+	</ul>
+
+	<h4>Source code</h4>
+
+	<pre><code>&lt;ul class=&quot;wb-filter&quot;&gt;
+	&lt;li&gt;Alberta&lt;/li&gt;
+	...
+&lt;/ul&gt;</code></pre>
+
+	<h3>AND operator</h3>
+
+	<p>Finds items that contain all of the specified words.</p>
+
+	<p>Setting the <code>filterType</code> to the <code>and</code> option will tell the filter plugin to apply an AND operator between search terms. Only items that contain all search terms will be shown.</p>
+
+	<ul class="wb-filter" data-wb-filter='{ "filterType": "and" }'>
+		<li>Alberta</li>
+		<li>British Columbia</li>
+		<li>Manitoba</li>
+		<li>New Brunswick</li>
+		<li>Newfoundland &amp; Labrador</li>
+		<li>Northwest Territories</li>
+		<li>Nova Scotia</li>
+		<li>Nunavut</li>
+		<li>Ontario</li>
+		<li>Prince Edward Island</li>
+		<li>Quebec</li>
+		<li>Saskatchewan</li>
+		<li>Yukon</li>
+	</ul>
+
+	<h4>Source code</h4>
+
+	<pre><code>&lt;ul class=&quot;wb-filter&quot; data-wb-filter='{ "filterType": "and" }'&gt;
+	&lt;li&gt;Alberta&lt;/li&gt;
+	...
+&lt;/ul&gt;</code></pre>
+
+	<h3>OR operator</h3>
+
+	<p>Finds items that contain at least one of the specified words.</p>
+
+	<p>Setting the <code>filterType</code> to the <code>or</code> option will tell the filter plugin to apply an OR operator between search terms. All items that contain any of the supplied search terms will be shown.</p>
+
+	<ul class="wb-filter" data-wb-filter='{ "filterType": "or" }'>
+		<li>Alberta</li>
+		<li>British Columbia</li>
+		<li>Manitoba</li>
+		<li>New Brunswick</li>
+		<li>Newfoundland &amp; Labrador</li>
+		<li>Northwest Territories</li>
+		<li>Nova Scotia</li>
+		<li>Nunavut</li>
+		<li>Ontario</li>
+		<li>Prince Edward Island</li>
+		<li>Quebec</li>
+		<li>Saskatchewan</li>
+		<li>Yukon</li>
+	</ul>
+
+	<h4>Source code</h4>
+
+	<pre><code>&lt;ul class=&quot;wb-filter&quot; data-wb-filter='{ "filterType": "or" }'&gt;
+	&lt;li&gt;Alberta&lt;/li&gt;
+	...
+&lt;/ul&gt;</code></pre>
+</div>


### PR DESCRIPTION
Add extra filter functionality: 

Created a user defined parameter called "filterType" which developers can set to either "exact", "and", "or". 

Depending on the "filterType" selected, the filter plugin will apply that specific filter. 

The default is set to an exact pattern match.  