### PR TITLE
Site: Removed metadata comments from page templates.

### DIFF
--- a/site/layouts/core.hbs
+++ b/site/layouts/core.hbs
@@ -8,9 +8,7 @@
 		{{>license}}
 		<title>{{>pagetitle}}</title>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
-		<!-- Meta data -->
 		{{>metadata}}
-		<!-- Meta data-->
 		{{>headresources}}
 	</head>
 	<body {{#if pageclass}}class="{{pageclass}}" {{/if}}vocab="http://schema.org/" typeof="WebPage">

--- a/site/layouts/servermessage.hbs
+++ b/site/layouts/servermessage.hbs
@@ -9,9 +9,7 @@
 		wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html -->
 		<title>{{title}}</title>
 		<meta content="width=device-width, initial-scale=1" name="viewport" />
-		<!-- Meta data -->
 		<meta name="robots" content="noindex, nofollow, noarchive" />
-		<!-- Meta data-->
 		{{>headresources}}
 	</head>
 	<body vocab="http://schema.org/" typeof="WebPage">


### PR DESCRIPTION
WET's page templates don't contain any similar comments that describe other blocks of code. Furthermore, the second metadata comment in each template wasn't actually followed by any metadata.