### PR TITLE
menu - Fix for GCweb issue #1335

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -177,8 +177,12 @@ var componentName = "wb-menu",
 					// Menu item without a section
 					if ( parent.nodeName.toLowerCase() === "li" ) {
 						linkHtml = parent.innerHTML;
-
-					// Non-list menu item without a section
+						
+					// Non-list menu items without a section and that contain their own link
+					} else if ( parent.getElementsByTagName( "a" )[ 0 ] === section.getElementsByTagName( "a" )[ 0 ] ) {
+						linkHtml = section.innerHTML;
+						
+					// Non-list menu item without a section and whose siblings contain a link		
 					} else {
 						linkHtml = "<a href='" +
 							parent.getElementsByTagName( "a" )[ 0 ].href + "'>" +

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -178,7 +178,7 @@ var componentName = "wb-menu",
 					if ( parent.nodeName.toLowerCase() === "li" ) {
 						linkHtml = parent.innerHTML;
 
-					// Non-list menu item without a section		
+					// Non-list menu item without a section
 					} else {
 						linkHtml = "<a href='" +
 							parent.getElementsByTagName( "a" )[ 0 ].href + "'>" +

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -747,7 +747,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 
 				// If the parent menu is a menubar
 				if ( $parentMenu.attr( "role" ) === "menubar" ) {
-					$menuLink = $menu.siblings("a");
+					$menuLink = $menu.siblings( "a" );
 
 					// Escape key = Close menu and return to menu bar item
 					if ( which === 27 ) {

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -177,12 +177,8 @@ var componentName = "wb-menu",
 					// Menu item without a section
 					if ( parent.nodeName.toLowerCase() === "li" ) {
 						linkHtml = parent.innerHTML;
-						
-					// Non-list menu items without a section and that contain their own link
-					} else if ( parent.getElementsByTagName( "a" )[ 0 ] === section.getElementsByTagName( "a" )[ 0 ] ) {
-						linkHtml = section.innerHTML;
-						
-					// Non-list menu item without a section and whose siblings contain a link		
+
+					// Non-list menu item without a section		
 					} else {
 						linkHtml = "<a href='" +
 							parent.getElementsByTagName( "a" )[ 0 ].href + "'>" +
@@ -751,7 +747,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 
 				// If the parent menu is a menubar
 				if ( $parentMenu.attr( "role" ) === "menubar" ) {
-					$menuLink = $parent.children( "[href=#" + $menu.attr( "id" ) + "]" );
+					$menuLink = $menu.siblings("a");
 
 					// Escape key = Close menu and return to menu bar item
 					if ( which === 27 ) {


### PR DESCRIPTION
Fixes unusual left/right arrow behavior in menu bar.

This bug occurs when the code looks for a link to the current menu at line 750. It would do so by looking for an element with href=#menu.id. This did not work on Canada.ca since the elements did not have this attribute.

The fix looks through the menu's siblings to find the link instead. Since a menu cannot have more than one link attached to it, this should not cause any issues.
