### PR TITLE
Grid - col-XX-auto - Fix an overflow issue

### DIFF
--- a/src/base/views/_screen.scss
+++ b/src/base/views/_screen.scss
@@ -87,7 +87,6 @@
 	min-height: 1px;
 	padding-left:  ($grid-gutter-width / 2);
 	padding-right: ($grid-gutter-width / 2);
-	position: relative;
 }
 
 .col-xs-auto {


### PR DESCRIPTION
Fix an issue when the col-md-auto overflow on the first column content preventing the user to click on link inside that first column, like in the following scenario:

```xml
<div class="row">
 <div class="col-md-4 pull-right">
   <p>... content ...</p>
   <p><a href="#">A link</a></p>
 </div>
 <div class="col-md-auto">
   <p>... long content that need to be on the right side on the preceding column and then it will flow under it  providing the impression of being full width. ...</p>
 </div>
</div>
```