### PR TITLE
Menu: Focus styling on menu items with no submenu

### DIFF
--- a/src/plugins/menu/ajax/menu-include-en.html
+++ b/src/plugins/menu/ajax/menu-include-en.html
@@ -70,7 +70,7 @@
 					</li>
 				</ul>
 			</li>
-			<li><a href="#lorc" class="item">No Submenu</a></li>
+			<li><a href="#" class="item">No Submenu</a></li>
 		</ul>
 	</div>
 </div>

--- a/src/plugins/menu/ajax/menu-include-en.html
+++ b/src/plugins/menu/ajax/menu-include-en.html
@@ -70,6 +70,7 @@
 					</li>
 				</ul>
 			</li>
+			<li><a href="#lorc" class="item">No Submenu</a></li>
 		</ul>
 	</div>
 </div>

--- a/src/plugins/menu/ajax/menu-include-fr.html
+++ b/src/plugins/menu/ajax/menu-include-fr.html
@@ -70,7 +70,7 @@
 					</li>
 				</ul>
 			</li>
-			<li><a href="#" class="item">Sans Sous-Menu</a></li>
+			<li><a href="#" class="item">Sans sous-menu</a></li>
 		</ul>
 	</div>
 </div>

--- a/src/plugins/menu/ajax/menu-include-fr.html
+++ b/src/plugins/menu/ajax/menu-include-fr.html
@@ -70,6 +70,7 @@
 					</li>
 				</ul>
 			</li>
+			<li><a href="#" class="item">Sans Sous-Menu</a></li>
 		</ul>
 	</div>
 </div>

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -438,12 +438,14 @@ var componentName = "wb-menu",
 
 		menuClose( $elm.find( ".active" ), true );
 
+		menu.addClass( "active" );
+
 		// Ignore if doesn't have a submenu
 		if ( menuLink.attr( "aria-haspopup" ) === "true" ) {
 
 			// Add the open state classes
 			menu
-				.addClass( "active sm-open" )
+				.addClass( "sm-open" )
 				.children( ".sm" )
 					.addClass( "open" )
 					.attr( {


### PR DESCRIPTION
Resolves Issue #7146 by adding "active" class to focused menu items even if they don't have a submenu.
Adds menu item with no submenu to example menu.