### PR TITLE
Menu: Enter and Spacebar behaviour

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -421,7 +421,9 @@ var componentName = "wb-menu",
 				.attr( {
 					"aria-hidden": "true",
 					"aria-expanded": "false"
-				} );
+				} )
+				.find( "details" )
+					.removeAttr( "open" );
 
 		if ( removeActive ) {
 			$elm.removeClass( "active" );

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -630,26 +630,36 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 		$menuLink, $parentMenu, $parent, $subMenu, result,
 		menuitemSelector, isOpen, menuItemOffsetTop, menuContainer;
 
+	// Define keycodes. (Make const when WET supports ES6)
+	var TAB_KC = 9,
+			ENTER_KC = 13,
+			ESC_KC = 27,
+			LEFT_KC = 37,
+			UP_KC = 38,
+			RIGHT_KC = 39,
+			DOWN_KC = 40,
+			SPACE_KC = 32;
+
 	if ( !( event.ctrlKey || event.altKey || event.metaKey ) ) {
 
 		// Tab key = Hide all sub-menus
-		if ( which === 9 ) {
+		if ( which === TAB_KC ) {
 			menuClose( $( selector + " .active" ), true );
 
 		// Menu item is within a menu bar
 		} else if ( inMenuBar ) {
 
 			// Left / right arrow = Previous / next menu item
-			if ( which === 37 || which === 39 ) {
+			if ( which === LEFT_KC || which === RIGHT_KC ) {
 				event.preventDefault();
 				menuIncrement(
 					$menu.find( "> li > a" ),
 					$menuItem,
-					which === 37 ? -1 : 1
+					which === LEFT_KC ? -1 : 1
 				);
 
 			// Enter sub-menu
-			} else if ( hasPopup && ( which === 13 || which === 38 || which === 40 ) ) {
+			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC || which === UP_KC || which === DOWN_KC ) ) {
 				event.preventDefault();
 				$parent = $menuItem.parent();
 				$subMenu = $parent.find( ".sm" );
@@ -663,7 +673,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 				$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent );
 
 			// Hide sub-menus and set focus
-			} else if ( which === 27 ) {
+			} else if ( which === ESC_KC ) {
 				event.preventDefault();
 				menuClose( $menu.closest( selector ).find( ".active" ), false );
 
@@ -681,21 +691,18 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 			menuitemSelector = menuItemSelector;
 
 			// Up / down arrow = Previous / next menu item
-			if ( which === 38 || which === 40 ) {
+			if ( which === UP_KC || which === DOWN_KC ) {
 				event.preventDefault();
 				menuIncrement(
 					$menu.children( "li" ).find( menuitemSelector ),
 					$menuItem,
-					which === 38 ? -1 : 1
+					which === UP_KC ? -1 : 1
 				);
 
-			// Enter or right arrow with a submenu
-			} else if ( hasPopup && ( which === 13 || which === 39 ) ) {
+			// Enter, space, or right arrow with a submenu
+			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC || which === RIGHT_KC ) ) {
 				$parent = $menuItem.parent();
-
-				if ( which === 39 ) {
-					event.preventDefault();
-				}
+				event.preventDefault();
 
 				// If the menu item is a summary element
 				if ( menuItem.nodeName.toLowerCase( "summary" ) ) {
@@ -722,7 +729,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 					}
 
 					// Ensure the menu is opened or stays open
-					if ( ( !isOpen && which === 39 ) || ( isOpen && which === 13 ) ) {
+					if ( !isOpen && ( which === RIGHT_KC || which === ENTER_KC || which === SPACE_KC ) ) {
 						$menuItem.trigger( "click" );
 					}
 
@@ -738,10 +745,10 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 				}
 
 			// Escape, left / right arrow without a submenu
-			} else if ( which === 27 || which === 37 || which === 39 ) {
+			} else if ( which === ESC_KC || which === LEFT_KC || which === RIGHT_KC ) {
 				$parent = $menu.parent();
 				$parentMenu = $parent.closest( "[role^='menu']" );
-				if ( which === 37 || which === 39 ) {
+				if ( which === LEFT_KC || which === RIGHT_KC ) {
 					event.preventDefault();
 				}
 
@@ -750,7 +757,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 					$menuLink = $menu.siblings( "a" );
 
 					// Escape key = Close menu and return to menu bar item
-					if ( which === 27 ) {
+					if ( which === ESC_KC ) {
 						event.preventDefault();
 						$menuLink.trigger( focusEvent );
 
@@ -764,13 +771,13 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 						menuIncrement(
 							$parentMenu.find( "> li > a" ),
 							$menuLink,
-							which === 37 ? -1 : 1
+							which === LEFT_KC ? -1 : 1
 						);
 					}
 
 				// Escape or left arrow: Go up a level if there is a higher-level
 				// menu or close the current submenu if there isn't
-				} else if ( which !== 39 ) {
+				} else if ( which !== RIGHT_KC ) {
 					$subMenu = $parentMenu.length !== 0 ? $menu : $menuItem;
 
 					// There is a higher-level menu

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -634,13 +634,13 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 
 	// Define keycodes. (Make const when WET supports ES6)
 	var TAB_KC = 9,
-			ENTER_KC = 13,
-			ESC_KC = 27,
-			LEFT_KC = 37,
-			UP_KC = 38,
-			RIGHT_KC = 39,
-			DOWN_KC = 40,
-			SPACE_KC = 32;
+		ENTER_KC = 13,
+		ESC_KC = 27,
+		LEFT_KC = 37,
+		UP_KC = 38,
+		RIGHT_KC = 39,
+		DOWN_KC = 40,
+		SPACE_KC = 32;
 
 	if ( !( event.ctrlKey || event.altKey || event.metaKey ) ) {
 


### PR DESCRIPTION
Fixes Issue #8418 

Behaviour of enter and spacebar within menus now follows [ARIA 1.1 Practices for Menus](https://www.w3.org/TR/wai-aria-practices-1.1/#menu):

- Enter or spacebar expand a submenu and place focus on its first item.
- Enter activates an item which does not have a submenu.
- Spacebar does not activate an item which does not have a submenu (maintains default behaviour).
  - Note: Activating an item with spacebar is an optional behaviour; I have chosen to omit it.