### PR TITLE
Menu: Fix enter and spacebar behaviour, focus by first letter, close nested submenus

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -421,7 +421,16 @@ var componentName = "wb-menu",
 				.attr( {
 					"aria-hidden": "true",
 					"aria-expanded": "false"
-				} );
+				} )
+
+				// Close nested submenus
+				.find( "details" )
+					.removeAttr( "open" )
+					.children( "ul" )
+						.attr( {
+							"aria-hidden": "true",
+							"aria-expanded": "false"
+						} );
 
 		if ( removeActive ) {
 			$elm.removeClass( "active" );

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -676,7 +676,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 				);
 
 			// Enter sub-menu
-			} else if ( hasPopup && ( which === ENTER_KC || which === UP_KC || which === DOWN_KC ) ) {
+			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC || which === UP_KC || which === DOWN_KC ) ) {
 				event.preventDefault();
 				$parent = $menuItem.parent();
 				$subMenu = $parent.find( ".sm" );
@@ -716,8 +716,8 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 					which === UP_KC ? -1 : 1
 				);
 
-			// Enter or right arrow with a submenu
-			} else if ( hasPopup && ( which === ENTER_KC || which === RIGHT_KC ) ) {
+			// Enter, space, or right arrow with a submenu
+			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC || which === RIGHT_KC ) ) {
 				$parent = $menuItem.parent();
 
 				if ( which === RIGHT_KC ) {

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -746,10 +746,8 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 
 							menuContainer.scrollTop = menuItemOffsetTop;
 						}
-					}
 
-					// Ensure the menu is opened or stays open
-					if ( ( !isOpen && which === RIGHT_KC ) || ( isOpen && which === ENTER_KC ) ) {
+						// Ensure the menu is opened or stays open
 						$menuItem.trigger( "click" );
 					}
 

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -699,7 +699,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 				event.preventDefault();
 				selectByLetter(
 					which,
-					$menuItem.parent().find( "> ul > li > a" ).get()
+					$menuItem.parent().find( "> ul > li > a, > ul > li > details > summary" ).get()
 				);
 			}
 

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -655,6 +655,14 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 		if ( which === TAB_KC ) {
 			menuClose( $( selector + " .active" ), true );
 
+		//Enter or spacebar on a link = follow the link and close menus
+		} else if ( menuItem.nodeName === "A" && menuItem.hasAttribute( "href" ) &&
+			( which === ENTER_KC || which === SPACE_KC ) ) {
+
+			event.preventDefault();
+			menuItem.click();
+			menuClose( $( selector + " .active" ), true );
+
 		// Menu item is within a menu bar
 		} else if ( inMenuBar ) {
 

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -639,26 +639,36 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 		$menuLink, $parentMenu, $parent, $subMenu, result,
 		menuitemSelector, isOpen, menuItemOffsetTop, menuContainer;
 
+	// Define keycodes. (Make const when WET supports ES6)
+	var TAB_KC = 9,
+		ENTER_KC = 13,
+		ESC_KC = 27,
+		LEFT_KC = 37,
+		UP_KC = 38,
+		RIGHT_KC = 39,
+		DOWN_KC = 40,
+		SPACE_KC = 32;
+
 	if ( !( event.ctrlKey || event.altKey || event.metaKey ) ) {
 
 		// Tab key = Hide all sub-menus
-		if ( which === 9 ) {
+		if ( which === TAB_KC ) {
 			menuClose( $( selector + " .active" ), true );
 
 		// Menu item is within a menu bar
 		} else if ( inMenuBar ) {
 
 			// Left / right arrow = Previous / next menu item
-			if ( which === 37 || which === 39 ) {
+			if ( which === LEFT_KC || which === RIGHT_KC ) {
 				event.preventDefault();
 				menuIncrement(
 					$menu.find( "> li > a" ),
 					$menuItem,
-					which === 37 ? -1 : 1
+					which === LEFT_KC ? -1 : 1
 				);
 
 			// Enter sub-menu
-			} else if ( hasPopup && ( which === 13 || which === 38 || which === 40 ) ) {
+			} else if ( hasPopup && ( which === ENTER_KC || which === UP_KC || which === DOWN_KC ) ) {
 				event.preventDefault();
 				$parent = $menuItem.parent();
 				$subMenu = $parent.find( ".sm" );
@@ -672,7 +682,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 				$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent );
 
 			// Hide sub-menus and set focus
-			} else if ( which === 27 ) {
+			} else if ( which === ESC_KC ) {
 				event.preventDefault();
 				menuClose( $menu.closest( selector ).find( ".active" ), false );
 
@@ -690,19 +700,19 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 			menuitemSelector = menuItemSelector;
 
 			// Up / down arrow = Previous / next menu item
-			if ( which === 38 || which === 40 ) {
+			if ( which === UP_KC || which === DOWN_KC ) {
 				event.preventDefault();
 				menuIncrement(
 					$menu.children( "li" ).find( menuitemSelector ),
 					$menuItem,
-					which === 38 ? -1 : 1
+					which === UP_KC ? -1 : 1
 				);
 
 			// Enter or right arrow with a submenu
-			} else if ( hasPopup && ( which === 13 || which === 39 ) ) {
+			} else if ( hasPopup && ( which === ENTER_KC || which === RIGHT_KC ) ) {
 				$parent = $menuItem.parent();
 
-				if ( which === 39 ) {
+				if ( which === RIGHT_KC ) {
 					event.preventDefault();
 				}
 
@@ -731,7 +741,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 					}
 
 					// Ensure the menu is opened or stays open
-					if ( ( !isOpen && which === 39 ) || ( isOpen && which === 13 ) ) {
+					if ( ( !isOpen && which === RIGHT_KC ) || ( isOpen && which === ENTER_KC ) ) {
 						$menuItem.trigger( "click" );
 					}
 
@@ -747,10 +757,10 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 				}
 
 			// Escape, left / right arrow without a submenu
-			} else if ( which === 27 || which === 37 || which === 39 ) {
+			} else if ( which === ESC_KC || which === LEFT_KC || which === RIGHT_KC ) {
 				$parent = $menu.parent();
 				$parentMenu = $parent.closest( "[role^='menu']" );
-				if ( which === 37 || which === 39 ) {
+				if ( which === LEFT_KC || which === RIGHT_KC ) {
 					event.preventDefault();
 				}
 
@@ -759,7 +769,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 					$menuLink = $menu.siblings( "a" );
 
 					// Escape key = Close menu and return to menu bar item
-					if ( which === 27 ) {
+					if ( which === ESC_KC ) {
 						event.preventDefault();
 						$menuLink.trigger( focusEvent );
 
@@ -773,13 +783,13 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 						menuIncrement(
 							$parentMenu.find( "> li > a" ),
 							$menuLink,
-							which === 37 ? -1 : 1
+							which === LEFT_KC ? -1 : 1
 						);
 					}
 
 				// Escape or left arrow: Go up a level if there is a higher-level
 				// menu or close the current submenu if there isn't
-				} else if ( which !== 39 ) {
+				} else if ( which !== RIGHT_KC ) {
 					$subMenu = $parentMenu.length !== 0 ? $menu : $menuItem;
 
 					// There is a higher-level menu

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -720,9 +720,9 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC || which === RIGHT_KC ) ) {
 				$parent = $menuItem.parent();
 
-				if ( which === RIGHT_KC ) {
-					event.preventDefault();
-				}
+				// Prevent handling by details.js polyfill
+				event.stopImmediatePropagation();
+				event.preventDefault();
 
 				// If the menu item is a summary element
 				if ( menuItem.nodeName.toLowerCase( "summary" ) ) {

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -838,6 +838,12 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 	}
 } );
 
+// Prevent Firefox from double-triggering menu behaviour
+$document.on( "keyup", selector + " [role=menuitem]", function( event ) {
+	event.preventDefault();
+	return false;
+} );
+
 // Close the mobile panel if switching to medium, large or extra large view
 $document.on( "mediumview.wb largeview.wb xlargeview.wb", function() {
 	var mobilePanel = document.getElementById( "mb-pnl" );


### PR DESCRIPTION
Thoroughly tested in Chrome 67, Firefox 61, IE11.
Fixes Issue #8418 and a number of undocumented issues.

Fixes to behaviour:
- Spacebar and enter now behave as in ARIA recommendation (except in IE11 detail/summary).
 - As with right arrow key, enter or spacebar expands a submenu and focuses its first item.
 - If item has no submenu (ie. is a link), activates the item by emulating click.
- Nested submenus close on blur (except in mobile menu).
- Nested submenus and their items can be selected by letter from a focused top-level menuitem.

Code style improvements:
- symbolic variables for keycodes
- remove unneeded conditionals

Unresolved issues:
- Mobile menus do not collapse on blur.
- IE11 does not allow enter and spacebar to expand detail/summary with correct behaviour.