### PR TITLE
chore: EditorConfig tabs -> tab

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ root = true
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
-indent_style = tabs
+indent_style = tab
 indent_size = 4
 
 [{package.json,bower.json,*.md}]


### PR DESCRIPTION
I was wondering why my IDE was still using spaces in the Gruntfile, turns out we had typo'd it from the start :stuck_out_tongue_closed_eyes: 