### PR TITLE
EditorConfig: Added global JSON/KML/CSV overrides.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,6 +10,9 @@ insert_final_newline = true
 indent_style = tabs
 indent_size = 4
 
-[{package.json,bower.json,*.md}]
+[{*.json,*kml,*.md}]
 indent_style = space
 indent_size = 2
+
+[*.csv]
+trim_trailing_whitespace = false


### PR DESCRIPTION
* Added JSON and KML as formats that should use a 2 space indentation style. Reasoning:
  * JSON: The vast majority of the repo's tracked JSON files are already using 2 spaces. Only "site/data/site.json" is currently using tabs.
  * KML: Its official documentation doesn't define a specific indentation style, but seems to unofficially use 2 spaces. The Geomap plugin's KML demo file ("src/plugins/geomap/demo/*.kml") is already using 2 spaces.
* Disabled whitespace trimming in CSV files. In WET's i18n CSV file, some lines end with strings that intentionally finish off with whitespace characters.