### PR TITLE
EditorConfig: Added .*/sitemenureplace/unset overrides and removed KML one.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,9 +10,20 @@ insert_final_newline = true
 indent_style = tab
 indent_size = 4
 
-[{*.json,*kml,*.md}]
+[{.*,*.json,*.md}]
 indent_style = space
 indent_size = 2
 
+[site/includes/sitemenureplace.hbs]
+insert_final_newline = false
+
 [*.csv]
 trim_trailing_whitespace = false
+
+# Tracked third party files
+[{dep/modernizr-custom.js,src/polyfills/events/mobile.js,src/polyfills/slider/slider.js}]
+charset = unset
+trim_trailing_whitespace = unset
+insert_final_newline = unset
+indent_style = unset
+indent_size = unset


### PR DESCRIPTION
* Added dot-prefixed files to 2 space indentation formats. Most already use 2 spaces. The few that aren't appear to be structured as JSON data.
* Removed KML from 2 space indentation formats. It turns out that the Geomap plugin's KML demo file doesn't only use 2 space indentation... It uses a mix of tabs and spaces (with tabs being much more prominent).
* Added a no final newline override for the "sitemenureplace" include. It's an HBS file that only contains a data attribute for use in a parent include's nav element.
* Added unset overrides for tracked third party JavaScript files. This should prevent any other overrides from affecting them if they're updated in the future.