### PR TITLE
Fix #8419 Data Ajax: Not working in Basic HTML mode

### DIFF
--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -273,7 +273,7 @@ var getUrlParts = function( url ) {
 				i;
 
 			// Lets ensure we are not running if things are disabled
-			if ( wb.isDisabled && selector !== "#wb-tphp" ) {
+			if ( wb.isDisabled && ( selector !== "#wb-tphp" && $.inArray( selector, [ "[data-ajax-after]", "[data-ajax-append]", "[data-ajax-before]", "[data-ajax-prepend]", "[data-ajax-replace]", "[data-wb-ajax]" ] ) === -1 ) ) {
 				return 0;
 			}
 


### PR DESCRIPTION
This fix allows the plugin Data-Ajax to run in Basic Html mode. I didn't implement a special init event.