### PR TITLE
Build: Added lintspaces task to check for .editorconfig compliance.

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -234,6 +234,7 @@ module.exports = (grunt) ->
 		[
 			"eslint"
 			"sasslint"
+			"lintspaces"
 		]
 	)
 
@@ -585,6 +586,53 @@ module.exports = (grunt) ->
 				map: "src/plugins/geomap/assets/sprites_geomap.png"
 				staticImagePath: '#{$wb-assets-path}'
 				output: "scss"
+
+		lintspaces:
+			all:
+				src: [
+						# Root files
+						".*rc"
+						".editorconfig"
+						".eslint*"
+						".git*"
+						".*.{json,yml}"
+						".npmignore"
+						"*.{json,md}"
+						"Gruntfile.coffee"
+						"Licen?e-*.txt"
+						"Rakefile"
+
+						# Folders
+						"dep/**"
+						"script/**"
+						"site/**"
+						"src/**"
+						"theme/**"
+
+						# Exemptions...
+
+						# Images
+						"!site/pages/docs/img/*.{jpg,png}"
+						"!src/plugins/**/*.{jpg,png}"
+						"!src/polyfills/**/*.{jpg,png}"
+						"!theme/assets/*.{ico,jpg,png}"
+
+						# Tracked third party files
+						# Prevents lintspaces from immediately aborting upon encountering .editorconfig properties that use the "unset" value.
+						"!dep/modernizr-custom.js"
+						"!src/polyfills/events/mobile.js"
+						"!src/polyfills/slider/slider.js"
+
+						# Untracked generated files
+						"!site/data/i18n/*.json"
+						"!src/plugins/*/sprites/_sprites_*.scss"
+					],
+				options:
+					editorconfig: ".editorconfig",
+					ignores: [
+						"js-comments"
+					],
+					showCodes: true
 
 		sasslint:
 			options:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,21 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/commander": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
+      "dev": true,
+      "requires": {
+        "commander": "2.11.0"
+      }
+    },
+    "@types/semver": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+      "dev": true
+    },
     "CSSselect": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/CSSselect/-/CSSselect-0.4.1.tgz",
@@ -1545,6 +1560,12 @@
       "integrity": "sha1-mWedO70EcVb81FDT0B7rkGhpHoM=",
       "dev": true
     },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1715,6 +1736,38 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "editorconfig": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.0.tgz",
+      "integrity": "sha512-j7JBoj/bpNzvoTQylfRZSc85MlLNKWQiq5y6gwKhmqD2h1eZ+tH4AXbkhEJD468gjDna/XMx2YtSkCxBRX9OGg==",
+      "dev": true,
+      "requires": {
+        "@types/commander": "2.12.2",
+        "@types/semver": "5.5.0",
+        "commander": "2.11.0",
+        "lru-cache": "4.1.3",
+        "semver": "5.5.0",
+        "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+          "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
+        },
+        "semver": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "dev": true
+        }
       }
     },
     "ee-first": {
@@ -4031,6 +4084,16 @@
         }
       }
     },
+    "grunt-lintspaces": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/grunt-lintspaces/-/grunt-lintspaces-0.8.3.tgz",
+      "integrity": "sha512-D0PVIDjaPC2UZtvBeYKT1SgSEmqxgTwcYfJu/YcLl0SjV2SAf9jJWClFMqeo1Vmp3+0mALiRcyRRAYEp+WtQBQ==",
+      "dev": true,
+      "requires": {
+        "junitwriter": "0.3.1",
+        "lintspaces": "0.6.2"
+      }
+    },
     "grunt-markdownlint": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/grunt-markdownlint/-/grunt-markdownlint-1.1.3.tgz",
@@ -5543,6 +5606,12 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "dev": true
+    },
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
@@ -5945,6 +6014,45 @@
         }
       }
     },
+    "junitwriter": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/junitwriter/-/junitwriter-0.3.1.tgz",
+      "integrity": "sha1-fADvwTauVmMJc7E98MAtZ5Y6r1o=",
+      "dev": true,
+      "requires": {
+        "dateformat": "1.0.11",
+        "merge": "1.2.0",
+        "mkdirp": "0.5.0",
+        "xmlbuilder": "2.6.2"
+      },
+      "dependencies": {
+        "dateformat": {
+          "version": "1.0.11",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+          "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
+          "dev": true,
+          "requires": {
+            "get-stdin": "4.0.1",
+            "meow": "3.7.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+          "integrity": "sha1-HXMHam35hs2TROFecfzAWkyavxI=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        }
+      }
+    },
     "kew": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
@@ -6016,6 +6124,17 @@
       "dev": true,
       "requires": {
         "uc.micro": "1.0.5"
+      }
+    },
+    "lintspaces": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/lintspaces/-/lintspaces-0.6.2.tgz",
+      "integrity": "sha512-2WBNDTbVXtR+EFljfzMjjhbLHrlAfusQmznOigX2v+FnnnwyV03ZgwyuTkLJvba7E2Yy02vR60/hurpM6nRjJQ==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.6.0",
+        "editorconfig": "0.15.0",
+        "rc": "1.2.8"
       }
     },
     "load-grunt-tasks": {
@@ -6481,9 +6600,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
-    },
-    "magnific-popup": {
-      "version": "git+https://github.com/wet-boew/Magnific-Popup.git#4a2964f4ea087258631323fec6fe4494c7fe0079"
     },
     "map-obj": {
       "version": "1.0.1",
@@ -7828,6 +7944,32 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
           "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true
         }
       }
@@ -10535,6 +10677,23 @@
           "requires": {
             "minimist": "0.0.8"
           }
+        }
+      }
+    },
+    "xmlbuilder": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.6.2.tgz",
+      "integrity": "sha1-+Rb20Q1F3BcbG+Lm5nP7bgzDXQo=",
+      "dev": true,
+      "requires": {
+        "lodash": "3.5.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.5.0.tgz",
+          "integrity": "sha1-Gbs/TVEnjwuMgY7RRcdOz5/kDm0=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "grunt-html": "^5.0.0",
     "grunt-i18n-csv": "^0.1.0",
     "grunt-imagine": "^0.3.6",
+    "grunt-lintspaces": "^0.8.3",
     "grunt-markdownlint": "^1.1.3",
     "grunt-mocha": "~0.4.12",
     "grunt-postcss": "^0.9.0",


### PR DESCRIPTION
* Added "lintspaces" at the end of the "test" task (which runs as part of the dist build).
* Inherits rules from the repo's .editorconfig file.
* Checks all of the repo's tracked files (minus comments, non-SVG images and third party JavaScript files).

**PS:**
This PR only introduces the linter itself. #8450 and #8451 should be merged-in beforehand, followed by a manual Travis-CI rebuild. The linter should start passing afterwards.