### PR TITLE
breaking: Stop using `.required` for validation

### DIFF
--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -84,7 +84,7 @@ var componentName = "wb-frmvld",
 						$inputs = $formElms.filter( "input" ),
 						$pattern = $inputs.filter( "[pattern]" ),
 						submitted = false,
-						$required = $formElms.filter( "[required], [data-rule-required], .required" ),
+						$required = $formElms.filter( "[required], [data-rule-required]" ),
 						errorFormId = "errors-" + ( !formId ? "default" : formId ),
 						settings = $.extend(
 							true,


### PR DESCRIPTION
jQuery validation removed support for these CSS based rules but we had our own hack that kept doing it.

Related to #8091