### PR TITLE
Table parser: Removed unused variables.

### DIFF
--- a/src/plugins/deps/tableparser.js
+++ b/src/plugins/deps/tableparser.js
@@ -38,12 +38,10 @@ var componentName = "wb-tableparser",
 			colgroupFrame = [],
 			columnFrame = [],
 			uidElem = 0,
-			currentRowLevel = 0,
 			currentRowPos = 0,
 			spannedRow = [],
 			tableCellWidth = 0,
 			headerRowGroupCompleted = false,
-			currentTbodyID,
 			theadRowStack = [],
 			stackRowHeader = false,
 
@@ -307,7 +305,7 @@ var componentName = "wb-tableparser",
 				tmpStack = [], tmpStackCurr, tmpStackCell,
 				dataColgroup, dataColumns, colgroup, col,
 				hcolgroup, currColPos,
-				currColgroupStructure, colFrmId, bigTotalColgroupFound,
+				currColgroupStructure, bigTotalColgroupFound,
 				theadRSNext, theadRSNextCell, cell, gzCol, theadRS;
 
 			if ( groupZero.colgrouphead || rowgroupheadercalled ) {
@@ -603,7 +601,6 @@ var componentName = "wb-tableparser",
 					type: 2
 				};
 				currColgroupStructure = [];
-				colFrmId = 0;
 				bigTotalColgroupFound = false;
 
 				$.each( colgroupFrame, function() {
@@ -612,8 +609,6 @@ var componentName = "wb-tableparser",
 						cgrp,
 						parentHeader,
 						summaryAttached;
-
-					colFrmId += 1;
 
 					if ( bigTotalColgroupFound || groupZero.colgrp[ 0 ] ) {
 						$obj.trigger( {
@@ -1560,7 +1555,6 @@ var componentName = "wb-tableparser",
 						// Remove any rowgroup header found.
 						rowgroupHeaderRowStack = [];
 
-						currentTbodyID += 1;
 						finalizeRowGroup();
 
 						currentRowGroupElement = undefined;
@@ -1593,7 +1587,6 @@ var componentName = "wb-tableparser",
 						// Remove any rowgroup header found.
 						rowgroupHeaderRowStack = [];
 
-						currentTbodyID += 1;
 						finalizeRowGroup();
 
 						currentRowGroupElement = undefined;
@@ -1889,7 +1882,6 @@ var componentName = "wb-tableparser",
 					}
 				}
 			}
-			currentRowLevel += 1;
 
 			// Add the row to the groupZero
 			if ( !groupZero.row ) {
@@ -2192,7 +2184,6 @@ var componentName = "wb-tableparser",
 				spannedRow = []; /* Cleanup of any spanned row */
 				rowgroupHeaderRowStack = []; /* Remove any rowgroup header found. */
 
-				currentTbodyID += 1;
 			} else if ( nodeName === "tr" ) {
 
 				// This are suppose to be a simple table


### PR DESCRIPTION
Apart from being declared and assigned at several points, they're not otherwise used.

Affected variables:
* currentRowLevel
* currentTbodyID
* colFrmId

These changes are needed to make the parser compliant with WET's ESLint rules.