### PR TITLE
package-lock.json: Updated to npm 5.10/6.x-friendly style.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "integrity": "sha512-0QEFiR8ljcHp9bAbWxecjVRuAMr16ivPiGOw6KFQBVrVd0RQIcM3xKdRisH2EDWgVWujiYtHwhSkSUoAAGzH7Q==",
       "dev": true,
       "requires": {
-        "commander": "2.11.0"
+        "commander": "*"
       }
     },
     "@types/semver": {
@@ -25,8 +25,8 @@
       "integrity": "sha1-+Kt+H4QYzmPNput713ioXX7EkrI=",
       "dev": true,
       "requires": {
-        "CSSwhat": "0.4.7",
-        "domutils": "1.4.3"
+        "CSSwhat": "0.4",
+        "domutils": "1.4"
       }
     },
     "CSSwhat": {
@@ -47,7 +47,7 @@
       "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.18",
+        "mime-types": "~2.1.18",
         "negotiator": "0.6.1"
       },
       "dependencies": {
@@ -63,7 +63,7 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         }
       }
@@ -80,7 +80,7 @@
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
       "requires": {
-        "acorn": "3.3.0"
+        "acorn": "^3.0.4"
       },
       "dependencies": {
         "acorn": {
@@ -97,8 +97,8 @@
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
-        "semver": "5.0.3"
+        "extend": "~3.0.0",
+        "semver": "~5.0.1"
       },
       "dependencies": {
         "semver": {
@@ -115,8 +115,8 @@
       "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
       "dev": true,
       "requires": {
-        "co": "4.6.0",
-        "json-stable-stringify": "1.0.1"
+        "co": "^4.6.0",
+        "json-stable-stringify": "^1.0.1"
       }
     },
     "ajv-keywords": {
@@ -131,9 +131,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -172,8 +172,8 @@
       "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
       "dev": true,
       "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.6"
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -194,13 +194,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -209,7 +209,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -220,8 +220,8 @@
       "integrity": "sha1-z9AeD7uj1srtBJ+9dY1A9lGW9Xw=",
       "dev": true,
       "requires": {
-        "underscore": "1.7.0",
-        "underscore.string": "2.4.0"
+        "underscore": "~1.7.0",
+        "underscore.string": "~2.4.0"
       }
     },
     "arr-diff": {
@@ -230,7 +230,7 @@
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
       "dev": true,
       "requires": {
-        "arr-flatten": "1.1.0"
+        "arr-flatten": "^1.0.1"
       }
     },
     "arr-flatten": {
@@ -263,7 +263,7 @@
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
       "dev": true,
       "requires": {
-        "array-uniq": "1.0.3"
+        "array-uniq": "^1.0.1"
       }
     },
     "array-uniq": {
@@ -296,10 +296,10 @@
       "integrity": "sha1-R6oeFD5qDNJ7BT6s7681eTCcbT8=",
       "dev": true,
       "requires": {
-        "fs-utils": "0.3.10",
-        "gray-matter": "0.2.8",
-        "handlebars-helper-i18n": "0.1.0",
-        "lodash": "2.4.2"
+        "fs-utils": "~0.3.6",
+        "gray-matter": "~0.2.8",
+        "handlebars-helper-i18n": "^0.1.0",
+        "lodash": "~2.4.1"
       }
     },
     "assemble-handlebars": {
@@ -308,8 +308,8 @@
       "integrity": "sha1-6jN3GX8IYbg3AIGdiwVaN2LH7jk=",
       "dev": true,
       "requires": {
-        "handlebars": "4.0.10",
-        "handlebars-helpers": "0.8.4"
+        "handlebars": "^4.0.6",
+        "handlebars-helpers": "^0.8.0"
       }
     },
     "assert-plus": {
@@ -342,12 +342,12 @@
       "integrity": "sha512-xBVQpGAcSNNS1PBnEfT+F9VF8ZJeoKZ121I3OVQ0n1F0SqVuj4oLI6yFeEviPV8Z/GjoqBRXcYis0oSS8zjNEg==",
       "dev": true,
       "requires": {
-        "browserslist": "3.2.4",
-        "caniuse-lite": "1.0.30000823",
-        "normalize-range": "0.1.2",
-        "num2fraction": "1.2.2",
-        "postcss": "6.0.21",
-        "postcss-value-parser": "3.3.0"
+        "browserslist": "^3.2.0",
+        "caniuse-lite": "^1.0.30000817",
+        "normalize-range": "^0.1.2",
+        "num2fraction": "^1.2.2",
+        "postcss": "^6.0.20",
+        "postcss-value-parser": "^3.2.3"
       }
     },
     "aws-sign2": {
@@ -368,9 +368,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
+        "chalk": "^1.1.3",
+        "esutils": "^2.0.2",
+        "js-tokens": "^3.0.2"
       }
     },
     "balanced-match": {
@@ -407,7 +407,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "binary-search": {
@@ -422,7 +422,7 @@
       "integrity": "sha1-/FQhoo/UImA2w7OJGmaiW8ZNIm4=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.0.6"
+        "readable-stream": "~2.0.5"
       },
       "dependencies": {
         "isarray": {
@@ -437,12 +437,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         }
       }
@@ -453,7 +453,7 @@
       "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3"
+        "inherits": "~2.0.0"
       }
     },
     "bluebird": {
@@ -469,15 +469,15 @@
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
         "iconv-lite": "0.4.19",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.1",
         "raw-body": "2.3.2",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.15"
       },
       "dependencies": {
         "debug": {
@@ -509,7 +509,7 @@
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "bootlint": {
@@ -518,18 +518,18 @@
       "integrity": "sha1-wEw3PWXf0KTQ33wtuz4ppuFQy3A=",
       "dev": true,
       "requires": {
-        "binary-search": "1.3.3",
-        "bluebird": "3.5.1",
-        "body-parser": "1.18.2",
-        "chalk": "1.1.3",
-        "cheerio": "0.19.0",
-        "commander": "2.11.0",
-        "debug": "2.6.8",
-        "express": "4.16.3",
-        "glob": "6.0.4",
-        "morgan": "1.9.0",
-        "semver": "5.5.0",
-        "void-elements": "2.0.1"
+        "binary-search": "^1.2.0",
+        "bluebird": "^3.0.5",
+        "body-parser": "^1.14.1",
+        "chalk": "^1.1.1",
+        "cheerio": "^0.19.0",
+        "commander": "^2.9.0",
+        "debug": "^2.1.1",
+        "express": "^4.11.2",
+        "glob": "^6.0.1",
+        "morgan": "^1.5.1",
+        "semver": "^5.0.3",
+        "void-elements": "^2.0.1"
       },
       "dependencies": {
         "glob": {
@@ -538,11 +538,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -551,7 +551,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "semver": {
@@ -573,9 +573,9 @@
       "integrity": "sha1-mPxbQah4cO+cu5KXY1z4H1UF/bE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "2.0.3",
-        "mout": "0.9.1",
-        "optimist": "0.6.1",
+        "graceful-fs": "~2.0.0",
+        "mout": "~0.9.0",
+        "optimist": "~0.6.0",
         "osenv": "0.0.3"
       }
     },
@@ -585,7 +585,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -595,9 +595,9 @@
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
       "dev": true,
       "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
+        "expand-range": "^1.8.1",
+        "preserve": "^0.2.0",
+        "repeat-element": "^1.1.2"
       }
     },
     "browserify-zlib": {
@@ -606,7 +606,7 @@
       "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
-        "pako": "0.2.9"
+        "pako": "~0.2.0"
       }
     },
     "browserslist": {
@@ -615,8 +615,8 @@
       "integrity": "sha512-Dwe62y/fNAcMfknzGJnkh7feISrrN0SmRvMFozb+Y2+qg7rfTIH5MS8yHzaIXcEWl8fPeIcdhZNQi1Lux+7dlg==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000823",
-        "electron-to-chromium": "1.3.42"
+        "caniuse-lite": "^1.0.30000821",
+        "electron-to-chromium": "^1.3.41"
       }
     },
     "buffer-crc32": {
@@ -643,7 +643,7 @@
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
       "dev": true,
       "requires": {
-        "callsites": "0.2.0"
+        "callsites": "^0.2.0"
       }
     },
     "callsites": {
@@ -658,8 +658,8 @@
       "integrity": "sha1-Gsp8TRlTWaLOmVV5NDPG5VQlEfI=",
       "dev": true,
       "requires": {
-        "sentence-case": "1.1.3",
-        "upper-case": "1.1.3"
+        "sentence-case": "^1.1.1",
+        "upper-case": "^1.1.1"
       }
     },
     "camelcase": {
@@ -674,8 +674,8 @@
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
       "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
+        "camelcase": "^2.0.0",
+        "map-obj": "^1.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -705,8 +705,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chalk": {
@@ -715,11 +715,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       }
     },
     "change-case": {
@@ -728,22 +728,22 @@
       "integrity": "sha1-LE/ePwY7tB0AzWjg1aCdthy+iU8=",
       "dev": true,
       "requires": {
-        "camel-case": "1.2.2",
-        "constant-case": "1.1.2",
-        "dot-case": "1.1.2",
-        "is-lower-case": "1.1.3",
-        "is-upper-case": "1.1.2",
-        "lower-case": "1.1.4",
-        "lower-case-first": "1.0.2",
-        "param-case": "1.1.2",
-        "pascal-case": "1.1.2",
-        "path-case": "1.1.2",
-        "sentence-case": "1.1.3",
-        "snake-case": "1.1.2",
-        "swap-case": "1.1.2",
-        "title-case": "1.1.2",
-        "upper-case": "1.1.3",
-        "upper-case-first": "1.1.2"
+        "camel-case": "^1.1.1",
+        "constant-case": "^1.1.0",
+        "dot-case": "^1.1.0",
+        "is-lower-case": "^1.1.0",
+        "is-upper-case": "^1.1.0",
+        "lower-case": "^1.1.1",
+        "lower-case-first": "^1.0.0",
+        "param-case": "^1.1.0",
+        "pascal-case": "^1.1.0",
+        "path-case": "^1.1.0",
+        "sentence-case": "^1.1.1",
+        "snake-case": "^1.1.0",
+        "swap-case": "^1.1.0",
+        "title-case": "^1.1.0",
+        "upper-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "check-dependencies": {
@@ -752,11 +752,11 @@
       "integrity": "sha1-ciM179TWTQyGqr/rdZiK+vhW0xg=",
       "dev": true,
       "requires": {
-        "bower-config": "0.5.3",
-        "chalk": "0.5.1",
-        "findup-sync": "0.1.3",
-        "lodash": "2.4.2",
-        "semver": "2.3.2"
+        "bower-config": "^0.5.2",
+        "chalk": "^0.5.1",
+        "findup-sync": "^0.1.3",
+        "lodash": "^2.4.1",
+        "semver": "^2.3.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -777,11 +777,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "has-ansi": {
@@ -790,7 +790,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "semver": {
@@ -805,7 +805,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -822,11 +822,11 @@
       "integrity": "sha1-dy5wFfLuKZZQltcepBdbdas1SSU=",
       "dev": true,
       "requires": {
-        "css-select": "1.0.0",
-        "dom-serializer": "0.1.0",
-        "entities": "1.1.1",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.10.1"
+        "css-select": "~1.0.0",
+        "dom-serializer": "~0.1.0",
+        "entities": "~1.1.1",
+        "htmlparser2": "~3.8.1",
+        "lodash": "^3.2.0"
       },
       "dependencies": {
         "dom-serializer": {
@@ -835,8 +835,8 @@
           "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.1.3",
-            "entities": "1.1.1"
+            "domelementtype": "~1.1.1",
+            "entities": "~1.1.1"
           }
         },
         "domelementtype": {
@@ -865,7 +865,7 @@
       "integrity": "sha1-K0sv1g8yRBCWIWriWiH6p0WA3IM=",
       "dev": true,
       "requires": {
-        "commander": "2.1.0"
+        "commander": "2.1.x"
       },
       "dependencies": {
         "commander": {
@@ -883,7 +883,7 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "3.2.11"
+        "glob": "~ 3.2.1"
       }
     },
     "cli-cursor": {
@@ -892,7 +892,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "1.0.1"
+        "restore-cursor": "^1.0.1"
       }
     },
     "cli-width": {
@@ -908,8 +908,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       }
     },
@@ -942,7 +942,7 @@
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "^1.1.1"
       }
     },
     "color-name": {
@@ -963,7 +963,7 @@
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -997,7 +997,7 @@
           "integrity": "sha1-krHbDU89tHsFMN9uFa6X21FNwvg=",
           "dev": true,
           "requires": {
-            "mime": "1.2.11",
+            "mime": "~1.2.11",
             "negotiator": "0.4.6"
           }
         },
@@ -1045,9 +1045,9 @@
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.3",
-        "typedarray": "0.0.6"
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
       },
       "dependencies": {
         "isarray": {
@@ -1062,13 +1062,13 @@
           "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.0.3",
+            "util-deprecate": "~1.0.1"
           }
         },
         "safe-buffer": {
@@ -1083,7 +1083,7 @@
           "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -1231,7 +1231,7 @@
           "integrity": "sha1-mOnfmn4t+ZSTG3zbSyprlpSnTwI=",
           "dev": true,
           "requires": {
-            "bytes": "1.0.0"
+            "bytes": "1"
           }
         },
         "send": {
@@ -1245,7 +1245,7 @@
             "finished": "1.2.2",
             "fresh": "0.2.2",
             "mime": "1.2.11",
-            "range-parser": "1.0.3"
+            "range-parser": "~1.0.0"
           }
         },
         "serve-static": {
@@ -1305,8 +1305,8 @@
       "integrity": "sha1-jsLKW6ND4Aqjjb9OIA/VrJB+/WM=",
       "dev": true,
       "requires": {
-        "snake-case": "1.1.2",
-        "upper-case": "1.1.3"
+        "snake-case": "^1.1.0",
+        "upper-case": "^1.1.1"
       }
     },
     "content-disposition": {
@@ -1369,8 +1369,8 @@
       "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.3",
-        "which": "1.3.0"
+        "lru-cache": "^4.0.1",
+        "which": "^1.2.9"
       },
       "dependencies": {
         "lru-cache": {
@@ -1379,8 +1379,8 @@
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "which": {
@@ -1389,7 +1389,7 @@
           "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -1400,7 +1400,7 @@
       "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1"
+        "boom": "2.x.x"
       }
     },
     "csrf-tokens": {
@@ -1409,9 +1409,9 @@
       "integrity": "sha1-SWclaLJwM0hkTqyvYc29wFS6VvI=",
       "dev": true,
       "requires": {
-        "rndm": "1.2.0",
-        "scmp": "0.0.3",
-        "uid2": "0.0.3"
+        "rndm": "1",
+        "scmp": "~0.0.3",
+        "uid2": "~0.0.2"
       }
     },
     "css-select": {
@@ -1420,10 +1420,10 @@
       "integrity": "sha1-sRIcpRhI3SZOIkTQWM7iVN7rRLA=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0",
-        "css-what": "1.0.0",
-        "domutils": "1.4.3",
-        "nth-check": "1.0.1"
+        "boolbase": "~1.0.0",
+        "css-what": "1.0",
+        "domutils": "1.4",
+        "nth-check": "~1.0.0"
       }
     },
     "css-what": {
@@ -1438,7 +1438,7 @@
       "integrity": "sha1-OmoE51Zcjp0ZvrSXZ8fslug2WAU=",
       "dev": true,
       "requires": {
-        "parserlib": "0.2.5"
+        "parserlib": "~0.2.2"
       }
     },
     "csurf": {
@@ -1447,7 +1447,7 @@
       "integrity": "sha1-OSj6I3WS7Vgkp8Ih2Fgb81ap2nY=",
       "dev": true,
       "requires": {
-        "csrf-tokens": "1.0.4"
+        "csrf-tokens": "~1.0.2"
       }
     },
     "csv": {
@@ -1469,7 +1469,7 @@
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
       "dev": true,
       "requires": {
-        "array-find-index": "1.0.2"
+        "array-find-index": "^1.0.1"
       }
     },
     "cwd": {
@@ -1478,8 +1478,8 @@
       "integrity": "sha1-+mq8GIlgdw9rE2+xmEBsjikfsoE=",
       "dev": true,
       "requires": {
-        "findup-sync": "0.1.3",
-        "normalize-path": "0.1.1"
+        "findup-sync": "~0.1.3",
+        "normalize-path": "^0.1.1"
       },
       "dependencies": {
         "normalize-path": {
@@ -1496,7 +1496,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.30"
+        "es5-ext": "^0.10.9"
       }
     },
     "dashdash": {
@@ -1505,7 +1505,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -1521,7 +1521,7 @@
       "resolved": "https://registry.npmjs.org/datatables/-/datatables-1.10.13.tgz",
       "integrity": "sha1-m7Lexvfc8CBJoA5PDn0/4AnDk0Y=",
       "requires": {
-        "jquery": "2.2.4"
+        "jquery": ">=1.7"
       }
     },
     "date-time": {
@@ -1530,7 +1530,7 @@
       "integrity": "sha1-GIdtC9pMGf5w3Tv0sDTygbEqQLY=",
       "dev": true,
       "requires": {
-        "time-zone": "0.1.0"
+        "time-zone": "^0.1.0"
       }
     },
     "dateformat": {
@@ -1578,7 +1578,7 @@
       "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
       "dev": true,
       "requires": {
-        "kind-of": "5.0.2"
+        "kind-of": "^5.0.2"
       },
       "dependencies": {
         "kind-of": {
@@ -1601,13 +1601,13 @@
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
       "dev": true,
       "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.2.8"
+        "globby": "^5.0.0",
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -1628,7 +1628,7 @@
       "integrity": "sha1-If6EbxakBWr4caZIYaHhYPGgQfc=",
       "dev": true,
       "requires": {
-        "lodash": "2.4.2"
+        "lodash": "~2.4.1"
       }
     },
     "depd": {
@@ -1655,8 +1655,8 @@
       "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
       "dev": true,
       "requires": {
-        "esutils": "2.0.2",
-        "isarray": "1.0.0"
+        "esutils": "^2.0.2",
+        "isarray": "^1.0.0"
       },
       "dependencies": {
         "isarray": {
@@ -1673,8 +1673,8 @@
       "integrity": "sha1-lYmCfx4y0iw3yCmtq9WbMkevjq8=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -1697,7 +1697,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -1706,7 +1706,7 @@
       "integrity": "sha1-CGVRN5bGswYDGFDhdVFrr4C3Km8=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "dot-case": {
@@ -1715,7 +1715,7 @@
       "integrity": "sha1-HnOCaQDeKNbeVIC8HeMdCEKwa+w=",
       "dev": true,
       "requires": {
-        "sentence-case": "1.1.3"
+        "sentence-case": "^1.1.2"
       }
     },
     "each-async": {
@@ -1724,8 +1724,8 @@
       "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
       "dev": true,
       "requires": {
-        "onetime": "1.1.0",
-        "set-immediate-shim": "1.0.1"
+        "onetime": "^1.0.0",
+        "set-immediate-shim": "^1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -1735,7 +1735,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "editorconfig": {
@@ -1744,12 +1744,12 @@
       "integrity": "sha512-j7JBoj/bpNzvoTQylfRZSc85MlLNKWQiq5y6gwKhmqD2h1eZ+tH4AXbkhEJD468gjDna/XMx2YtSkCxBRX9OGg==",
       "dev": true,
       "requires": {
-        "@types/commander": "2.12.2",
-        "@types/semver": "5.5.0",
-        "commander": "2.11.0",
-        "lru-cache": "4.1.3",
-        "semver": "5.5.0",
-        "sigmund": "1.0.1"
+        "@types/commander": "^2.11.0",
+        "@types/semver": "^5.4.0",
+        "commander": "^2.11.0",
+        "lru-cache": "^4.1.1",
+        "semver": "^5.4.1",
+        "sigmund": "^1.0.1"
       },
       "dependencies": {
         "lru-cache": {
@@ -1758,8 +1758,8 @@
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
-            "pseudomap": "1.0.2",
-            "yallist": "2.1.2"
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
           }
         },
         "semver": {
@@ -1800,7 +1800,7 @@
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.2.1"
+        "is-arrayish": "^0.2.1"
       }
     },
     "errorhandler": {
@@ -1815,8 +1815,8 @@
       "integrity": "sha1-cUGhaDZpfbq/qq7uQUlc4p9SyTk=",
       "dev": true,
       "requires": {
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "es6-iterator": "2",
+        "es6-symbol": "~3.1"
       }
     },
     "es5-shim": {
@@ -1830,9 +1830,9 @@
       "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-symbol": "^3.1"
       }
     },
     "es6-map": {
@@ -1841,12 +1841,12 @@
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
+        "es6-set": "~0.1.5",
+        "es6-symbol": "~3.1.1",
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-set": {
@@ -1855,11 +1855,11 @@
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
+        "d": "1",
+        "es5-ext": "~0.10.14",
+        "es6-iterator": "~2.0.1",
         "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
+        "event-emitter": "~0.3.5"
       }
     },
     "es6-symbol": {
@@ -1868,8 +1868,8 @@
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "es6-weak-map": {
@@ -1878,10 +1878,10 @@
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30",
-        "es6-iterator": "2.0.1",
-        "es6-symbol": "3.1.1"
+        "d": "1",
+        "es5-ext": "^0.10.14",
+        "es6-iterator": "^2.0.1",
+        "es6-symbol": "^3.1.1"
       }
     },
     "escape-html": {
@@ -1902,10 +1902,10 @@
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
       "dev": true,
       "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
+        "es6-map": "^0.1.3",
+        "es6-weak-map": "^2.0.1",
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
       }
     },
     "eslint": {
@@ -1914,41 +1914,41 @@
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
       "dev": true,
       "requires": {
-        "babel-code-frame": "6.26.0",
-        "chalk": "1.1.3",
-        "concat-stream": "1.6.0",
-        "debug": "2.6.8",
-        "doctrine": "2.0.0",
-        "escope": "3.6.0",
-        "espree": "3.5.0",
-        "esquery": "1.0.0",
-        "estraverse": "4.2.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "glob": "7.1.2",
-        "globals": "9.18.0",
-        "ignore": "3.3.5",
-        "imurmurhash": "0.1.4",
-        "inquirer": "0.12.0",
-        "is-my-json-valid": "2.16.1",
-        "is-resolvable": "1.0.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "1.2.1",
-        "progress": "1.1.8",
-        "require-uncached": "1.0.3",
-        "shelljs": "0.7.8",
-        "strip-bom": "3.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "3.8.3",
-        "text-table": "0.2.0",
-        "user-home": "2.0.0"
+        "babel-code-frame": "^6.16.0",
+        "chalk": "^1.1.3",
+        "concat-stream": "^1.5.2",
+        "debug": "^2.1.1",
+        "doctrine": "^2.0.0",
+        "escope": "^3.6.0",
+        "espree": "^3.4.0",
+        "esquery": "^1.0.0",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^2.0.0",
+        "glob": "^7.0.3",
+        "globals": "^9.14.0",
+        "ignore": "^3.2.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^0.12.0",
+        "is-my-json-valid": "^2.10.0",
+        "is-resolvable": "^1.0.0",
+        "js-yaml": "^3.5.1",
+        "json-stable-stringify": "^1.0.0",
+        "levn": "^0.3.0",
+        "lodash": "^4.0.0",
+        "mkdirp": "^0.5.0",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.1",
+        "pluralize": "^1.2.1",
+        "progress": "^1.1.8",
+        "require-uncached": "^1.0.2",
+        "shelljs": "^0.7.5",
+        "strip-bom": "^3.0.0",
+        "strip-json-comments": "~2.0.1",
+        "table": "^3.7.8",
+        "text-table": "~0.2.0",
+        "user-home": "^2.0.0"
       },
       "dependencies": {
         "argparse": {
@@ -1957,7 +1957,7 @@
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
           "dev": true,
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         },
         "esprima": {
@@ -1972,12 +1972,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "js-yaml": {
@@ -1986,8 +1986,8 @@
           "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "lodash": {
@@ -2002,7 +2002,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -2046,8 +2046,8 @@
       "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
       "dev": true,
       "requires": {
-        "acorn": "5.1.2",
-        "acorn-jsx": "3.0.1"
+        "acorn": "^5.1.1",
+        "acorn-jsx": "^3.0.0"
       }
     },
     "esprima": {
@@ -2062,7 +2062,7 @@
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0"
+        "estraverse": "^4.0.0"
       }
     },
     "esrecurse": {
@@ -2071,8 +2071,8 @@
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
       "dev": true,
       "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
+        "estraverse": "^4.1.0",
+        "object-assign": "^4.0.1"
       }
     },
     "estraverse": {
@@ -2099,8 +2099,8 @@
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
       "dev": true,
       "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.30"
+        "d": "1",
+        "es5-ext": "~0.10.14"
       }
     },
     "eventemitter2": {
@@ -2127,7 +2127,7 @@
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
       "dev": true,
       "requires": {
-        "is-posix-bracket": "0.1.1"
+        "is-posix-bracket": "^0.1.0"
       }
     },
     "expand-range": {
@@ -2136,7 +2136,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "^2.1.0"
       }
     },
     "expect.js": {
@@ -2151,36 +2151,36 @@
       "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
       "dev": true,
       "requires": {
-        "accepts": "1.3.5",
+        "accepts": "~1.3.5",
         "array-flatten": "1.1.1",
         "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "finalhandler": "1.1.1",
         "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
-        "methods": "1.1.2",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "2.0.3",
+        "proxy-addr": "~2.0.3",
         "qs": "6.5.1",
-        "range-parser": "1.2.0",
+        "range-parser": "~1.2.0",
         "safe-buffer": "5.1.1",
         "send": "0.16.2",
         "serve-static": "1.13.2",
         "setprototypeof": "1.1.0",
-        "statuses": "1.4.0",
-        "type-is": "1.6.16",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
         "utils-merge": "1.0.1",
-        "vary": "1.1.2"
+        "vary": "~1.1.2"
       },
       "dependencies": {
         "array-flatten": {
@@ -2265,7 +2265,7 @@
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "extract-zip": {
@@ -2286,9 +2286,9 @@
           "integrity": "sha1-U/fUPFHF5D+ByP3QMyHGMb5o1hE=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.0.6",
-            "typedarray": "0.0.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "~2.0.0",
+            "typedarray": "~0.0.5"
           }
         },
         "debug": {
@@ -2324,12 +2324,12 @@
           "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "0.10.31",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
           }
         }
       }
@@ -2358,7 +2358,7 @@
       "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
       "dev": true,
       "requires": {
-        "pend": "1.2.0"
+        "pend": "~1.2.0"
       }
     },
     "fg-lodash": {
@@ -2367,8 +2367,8 @@
       "integrity": "sha1-mINSU39CfaavIiEpu2OsyknmL6M=",
       "dev": true,
       "requires": {
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
+        "lodash": "^2.4.1",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
         "underscore.string": {
@@ -2385,8 +2385,8 @@
       "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "1.0.5",
-        "object-assign": "4.1.1"
+        "escape-string-regexp": "^1.0.5",
+        "object-assign": "^4.1.0"
       }
     },
     "file-entry-cache": {
@@ -2395,8 +2395,8 @@
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
       "dev": true,
       "requires": {
-        "flat-cache": "1.2.2",
-        "object-assign": "4.1.1"
+        "flat-cache": "^1.2.1",
+        "object-assign": "^4.0.1"
       }
     },
     "filename-regex": {
@@ -2411,11 +2411,11 @@
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
       "dev": true,
       "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
+        "is-number": "^2.1.0",
+        "isobject": "^2.0.0",
+        "randomatic": "^1.1.3",
+        "repeat-element": "^1.1.2",
+        "repeat-string": "^1.5.2"
       }
     },
     "finalhandler": {
@@ -2425,12 +2425,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.4.0",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "debug": {
@@ -2456,8 +2456,8 @@
       "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
       "dev": true,
       "requires": {
-        "path-exists": "2.1.0",
-        "pinkie-promise": "2.0.1"
+        "path-exists": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "findup-sync": {
@@ -2466,8 +2466,8 @@
       "integrity": "sha1-fz56l7gjksZTvwZYm9hRkOk8NoM=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "lodash": "2.4.2"
+        "glob": "~3.2.9",
+        "lodash": "~2.4.1"
       }
     },
     "finished": {
@@ -2493,10 +2493,10 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
+        "circular-json": "^0.3.1",
+        "del": "^2.0.2",
+        "graceful-fs": "^4.1.2",
+        "write": "^0.2.1"
       },
       "dependencies": {
         "graceful-fs": {
@@ -2519,7 +2519,7 @@
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
       "dev": true,
       "requires": {
-        "for-in": "1.0.2"
+        "for-in": "^1.0.1"
       }
     },
     "forever-agent": {
@@ -2534,9 +2534,9 @@
       "integrity": "sha1-rjFduaSQf6BlUCMEpm13M0de43w=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
-        "combined-stream": "1.0.5",
-        "mime-types": "2.1.17"
+        "async": "^2.0.1",
+        "combined-stream": "^1.0.5",
+        "mime-types": "^2.1.11"
       },
       "dependencies": {
         "async": {
@@ -2545,7 +2545,7 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "lodash": {
@@ -2562,7 +2562,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.3"
+        "samsam": "~1.1"
       }
     },
     "forwarded": {
@@ -2583,7 +2583,7 @@
       "integrity": "sha1-91mDufL0E75ljJPf172M5AePXNs=",
       "dev": true,
       "requires": {
-        "js-yaml": "3.11.0"
+        "js-yaml": "^3.4.6"
       },
       "dependencies": {
         "argparse": {
@@ -2592,7 +2592,7 @@
           "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
           "dev": true,
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         },
         "esprima": {
@@ -2607,8 +2607,8 @@
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         }
       }
@@ -2619,11 +2619,11 @@
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "jsonfile": "2.4.0",
-        "klaw": "1.3.1",
-        "path-is-absolute": "1.0.1",
-        "rimraf": "2.2.8"
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0",
+        "path-is-absolute": "^1.0.0",
+        "rimraf": "^2.2.8"
       },
       "dependencies": {
         "graceful-fs": {
@@ -2640,14 +2640,14 @@
       "integrity": "sha1-6x5j2niBbNzouM6xyHQxT5Hn2JI=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "globule": "0.2.0",
-        "graceful-fs": "2.0.3",
-        "js-yaml": "3.0.2",
-        "lodash": "2.4.2",
-        "mkdirp": "0.3.5",
-        "rimraf": "2.2.8",
-        "template": "0.1.8"
+        "async": "~0.2.10",
+        "globule": "~0.2.0",
+        "graceful-fs": "~2.0.3",
+        "js-yaml": "~3.0.2",
+        "lodash": "~2.4.1",
+        "mkdirp": "~0.3.5",
+        "rimraf": "~2.2.6",
+        "template": "~0.1.5"
       }
     },
     "fs.realpath": {
@@ -2662,10 +2662,10 @@
       "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "inherits": "2.0.3",
-        "mkdirp": "0.5.1",
-        "rimraf": "2.2.8"
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
       },
       "dependencies": {
         "graceful-fs": {
@@ -2697,14 +2697,14 @@
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
       "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
       }
     },
     "gaze": {
@@ -2713,7 +2713,7 @@
       "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
       "dev": true,
       "requires": {
-        "globule": "0.1.0"
+        "globule": "~0.1.0"
       },
       "dependencies": {
         "glob": {
@@ -2722,9 +2722,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
           }
         },
         "globule": {
@@ -2733,9 +2733,9 @@
           "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
           "dev": true,
           "requires": {
-            "glob": "3.1.21",
-            "lodash": "1.0.2",
-            "minimatch": "0.2.14"
+            "glob": "~3.1.21",
+            "lodash": "~1.0.1",
+            "minimatch": "~0.2.11"
           }
         },
         "graceful-fs": {
@@ -2770,7 +2770,7 @@
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "dev": true,
       "requires": {
-        "is-property": "1.0.2"
+        "is-property": "^1.0.0"
       }
     },
     "get-caller-file": {
@@ -2797,7 +2797,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -2814,8 +2814,8 @@
       "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
       "dev": true,
       "requires": {
-        "inherits": "2.0.3",
-        "minimatch": "0.3.0"
+        "inherits": "2",
+        "minimatch": "0.3"
       },
       "dependencies": {
         "minimatch": {
@@ -2824,8 +2824,8 @@
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
           "dev": true,
           "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
+            "lru-cache": "2",
+            "sigmund": "~1.0.0"
           }
         }
       }
@@ -2836,8 +2836,8 @@
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
       "dev": true,
       "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
+        "glob-parent": "^2.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "glob-parent": {
@@ -2846,7 +2846,7 @@
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
       "dev": true,
       "requires": {
-        "is-glob": "2.0.1"
+        "is-glob": "^2.0.0"
       }
     },
     "globals": {
@@ -2861,12 +2861,12 @@
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
       "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "glob": {
@@ -2875,12 +2875,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -2889,7 +2889,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -2900,9 +2900,9 @@
       "integrity": "sha1-JrZNEOHtyrYJjY/gC9K3PMoIqPs=",
       "dev": true,
       "requires": {
-        "glob": "3.2.11",
-        "lodash": "2.4.2",
-        "minimatch": "0.2.14"
+        "glob": "~3.2.7",
+        "lodash": "~2.4.1",
+        "minimatch": "~0.2.11"
       }
     },
     "gonzales-pe-sl": {
@@ -2911,7 +2911,7 @@
       "integrity": "sha1-aoaLw4BkXxQf7rBCxvl/zHG1n+Y=",
       "dev": true,
       "requires": {
-        "minimist": "1.1.3"
+        "minimist": "1.1.x"
       },
       "dependencies": {
         "minimist": {
@@ -2934,11 +2934,11 @@
       "integrity": "sha1-Oh75q2aSbGU8whUNHrW5PaODMUQ=",
       "dev": true,
       "requires": {
-        "coffee-script": "1.6.3",
-        "delims": "0.1.4",
-        "fs-utils": "0.1.11",
-        "js-yaml": "3.0.2",
-        "lodash": "2.4.2"
+        "coffee-script": "~1.6.3",
+        "delims": "~0.1.0",
+        "fs-utils": "~0.1.6",
+        "js-yaml": "~3.0.1",
+        "lodash": "~2.4.1"
       },
       "dependencies": {
         "fs-utils": {
@@ -2947,13 +2947,13 @@
           "integrity": "sha1-zsxa3MTt78xWA6Z1WEwOFAx6pTc=",
           "dev": true,
           "requires": {
-            "async": "0.2.10",
-            "globule": "0.2.0",
-            "iconv-lite": "0.2.11",
-            "js-yaml": "3.0.2",
-            "lodash": "2.4.2",
-            "mkdirp": "0.3.5",
-            "rimraf": "2.2.8"
+            "async": "~0.2.9",
+            "globule": "~0.2.0",
+            "iconv-lite": "~0.2.11",
+            "js-yaml": "~3.0.1",
+            "lodash": "~2.4.1",
+            "mkdirp": "~0.3.5",
+            "rimraf": "~2.2.6"
           }
         }
       }
@@ -2970,26 +2970,26 @@
       "integrity": "sha1-VpN81RlDJK3/bSB2MYMqnWuk5/A=",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "coffee-script": "1.3.3",
-        "colors": "0.6.2",
+        "async": "~0.1.22",
+        "coffee-script": "~1.3.3",
+        "colors": "~0.6.2",
         "dateformat": "1.0.2-1.2.3",
-        "eventemitter2": "0.4.14",
-        "exit": "0.1.2",
-        "findup-sync": "0.1.3",
-        "getobject": "0.1.0",
-        "glob": "3.1.21",
-        "grunt-legacy-log": "0.1.3",
-        "grunt-legacy-util": "0.2.0",
-        "hooker": "0.2.3",
-        "iconv-lite": "0.2.11",
-        "js-yaml": "2.0.5",
-        "lodash": "0.9.2",
-        "minimatch": "0.2.14",
-        "nopt": "1.0.10",
-        "rimraf": "2.2.8",
-        "underscore.string": "2.2.1",
-        "which": "1.0.9"
+        "eventemitter2": "~0.4.13",
+        "exit": "~0.1.1",
+        "findup-sync": "~0.1.2",
+        "getobject": "~0.1.0",
+        "glob": "~3.1.21",
+        "grunt-legacy-log": "~0.1.0",
+        "grunt-legacy-util": "~0.2.0",
+        "hooker": "~0.2.3",
+        "iconv-lite": "~0.2.11",
+        "js-yaml": "~2.0.5",
+        "lodash": "~0.9.2",
+        "minimatch": "~0.2.12",
+        "nopt": "~1.0.10",
+        "rimraf": "~2.2.8",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
       },
       "dependencies": {
         "async": {
@@ -3010,9 +3010,9 @@
           "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
           "dev": true,
           "requires": {
-            "graceful-fs": "1.2.3",
-            "inherits": "1.0.2",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~1.2.0",
+            "inherits": "1",
+            "minimatch": "~0.2.11"
           }
         },
         "graceful-fs": {
@@ -3033,8 +3033,8 @@
           "integrity": "sha1-olrmUJmZ6X3yeMZxnaEb0Gh3Q6g=",
           "dev": true,
           "requires": {
-            "argparse": "0.1.16",
-            "esprima": "1.0.4"
+            "argparse": "~ 0.1.11",
+            "esprima": "~ 1.0.2"
           }
         },
         "lodash": {
@@ -3057,12 +3057,12 @@
       "integrity": "sha1-JRZzK8e4T9juPWJwl9OyvJNAz5A=",
       "dev": true,
       "requires": {
-        "assemble-handlebars": "0.4.1",
-        "async": "0.9.2",
-        "gray-matter": "0.4.2",
-        "inflection": "1.12.0",
-        "lodash": "2.4.2",
-        "resolve-dep": "0.5.4"
+        "assemble-handlebars": "^0.4.1",
+        "async": "^0.9.0",
+        "gray-matter": "^0.4.2",
+        "inflection": "^1.3.6",
+        "lodash": "^2.4.1",
+        "resolve-dep": "^0.5.3"
       },
       "dependencies": {
         "async": {
@@ -3077,13 +3077,13 @@
           "integrity": "sha1-ZBdm/lQV0RZEHexkdpjBPWz5z3c=",
           "dev": true,
           "requires": {
-            "async": "0.6.2",
-            "globule": "0.2.0",
-            "graceful-fs": "2.0.3",
-            "js-yaml": "3.0.2",
-            "lodash": "2.4.2",
-            "mkdirp": "0.3.5",
-            "rimraf": "2.2.8"
+            "async": "~0.6.2",
+            "globule": "~0.2.0",
+            "graceful-fs": "~2.0.3",
+            "js-yaml": "~3.0.2",
+            "lodash": "~2.4.1",
+            "mkdirp": "~0.3.5",
+            "rimraf": "~2.2.6"
           },
           "dependencies": {
             "async": {
@@ -3100,11 +3100,11 @@
           "integrity": "sha1-I/GQrJhlycCtsE0xnMIw+rdZ1wg=",
           "dev": true,
           "requires": {
-            "delims": "0.1.4",
-            "fs-utils": "0.4.3",
-            "js-yaml": "3.0.2",
-            "lodash": "2.4.2",
-            "verbalize": "0.1.2"
+            "delims": "^0.1.4",
+            "fs-utils": "^0.4.3",
+            "js-yaml": "^3.0.2",
+            "lodash": "^2.4.1",
+            "verbalize": "^0.1.2"
           }
         }
       }
@@ -3121,9 +3121,9 @@
       "integrity": "sha1-XXtzt0hqzu3jdwpVtW/VdeHFqQM=",
       "dev": true,
       "requires": {
-        "bootlint": "0.14.2",
-        "chalk": "1.1.3",
-        "micromatch": "2.3.11"
+        "bootlint": "^0.14.2",
+        "chalk": "^1.1.3",
+        "micromatch": "^2.3.11"
       }
     },
     "grunt-check-dependencies": {
@@ -3132,8 +3132,8 @@
       "integrity": "sha1-9yBqOmEEGiHNJzuG46Usvul06nQ=",
       "dev": true,
       "requires": {
-        "check-dependencies": "0.7.1",
-        "lodash.clonedeep": "2.4.1"
+        "check-dependencies": "^0.7.1",
+        "lodash.clonedeep": "^2.4.1"
       }
     },
     "grunt-contrib-clean": {
@@ -3142,8 +3142,8 @@
       "integrity": "sha1-Vkq/LQN4qYOhW54/MO51tzjEBjg=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "rimraf": "2.6.2"
+        "async": "^1.5.2",
+        "rimraf": "^2.5.1"
       },
       "dependencies": {
         "async": {
@@ -3158,12 +3158,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -3172,7 +3172,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "rimraf": {
@@ -3181,7 +3181,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "7.1.2"
+            "glob": "^7.0.5"
           }
         }
       }
@@ -3192,8 +3192,8 @@
       "integrity": "sha1-lTxu/f39LBB6uchQd/LUsk0xzUk=",
       "dev": true,
       "requires": {
-        "chalk": "0.5.1",
-        "source-map": "0.3.0"
+        "chalk": "^0.5.1",
+        "source-map": "^0.3.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3214,11 +3214,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "has-ansi": {
@@ -3227,7 +3227,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "source-map": {
@@ -3236,7 +3236,7 @@
           "integrity": "sha1-hYb7mloAXltQHiHNGLbyG0V60fk=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "strip-ansi": {
@@ -3245,7 +3245,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -3262,11 +3262,11 @@
       "integrity": "sha1-H3AEPjpHOuj7eorL+SnOEE6vQyM=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "connect": "2.19.6",
-        "connect-livereload": "0.4.1",
+        "async": "~0.9.0",
+        "connect": "~2.19.5",
+        "connect-livereload": "~0.4.0",
         "open": "0.0.5",
-        "portscanner": "0.2.3"
+        "portscanner": "~0.2.3"
       },
       "dependencies": {
         "async": {
@@ -3289,10 +3289,10 @@
       "integrity": "sha1-ytHSHa7vjb8/+AFYIlVbe44p1qA=",
       "dev": true,
       "requires": {
-        "chalk": "0.5.1",
-        "csslint": "0.10.0",
-        "lodash": "2.4.2",
-        "strip-json-comments": "1.0.4"
+        "chalk": "^0.5.1",
+        "csslint": "^0.10.0",
+        "lodash": "^2.4.1",
+        "strip-json-comments": "^1.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3313,11 +3313,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "has-ansi": {
@@ -3326,7 +3326,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "strip-ansi": {
@@ -3335,7 +3335,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -3352,9 +3352,9 @@
       "integrity": "sha1-JyQfAWCohmZZ2rQNyMJ3bAHsfOI=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "clean-css": "2.1.8",
-        "maxmin": "0.1.0"
+        "chalk": "~0.4.0",
+        "clean-css": "~2.1.0",
+        "maxmin": "~0.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3369,9 +3369,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "strip-ansi": {
@@ -3388,9 +3388,9 @@
       "integrity": "sha1-y1X8owT0AbAF4hPntxizNjnL5PE=",
       "dev": true,
       "requires": {
-        "chalk": "0.5.1",
-        "html-minifier": "0.7.2",
-        "pretty-bytes": "1.0.4"
+        "chalk": "^0.5.1",
+        "html-minifier": "^0.7.0",
+        "pretty-bytes": "^1.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3411,11 +3411,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "has-ansi": {
@@ -3424,7 +3424,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "pretty-bytes": {
@@ -3433,8 +3433,8 @@
           "integrity": "sha1-CiLoIQYJrTVUL4yNXSFZr/B1HIQ=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "^4.0.1",
+            "meow": "^3.1.0"
           }
         },
         "strip-ansi": {
@@ -3443,7 +3443,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -3460,10 +3460,10 @@
       "integrity": "sha1-FfCqXo6LpCGuqYCHnuUFvHErbN4=",
       "dev": true,
       "requires": {
-        "chalk": "0.5.1",
-        "lodash": "2.4.2",
-        "maxmin": "0.2.2",
-        "uglify-js": "2.4.24"
+        "chalk": "^0.5.1",
+        "lodash": "^2.4.1",
+        "maxmin": "^0.2.0",
+        "uglify-js": "^2.4.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3484,11 +3484,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           }
         },
         "gzip-size": {
@@ -3497,8 +3497,8 @@
           "integrity": "sha1-46KhkSBf5W7jJvXCcUNd+uz7Phw=",
           "dev": true,
           "requires": {
-            "browserify-zlib": "0.1.4",
-            "concat-stream": "1.6.0"
+            "browserify-zlib": "^0.1.4",
+            "concat-stream": "^1.4.1"
           }
         },
         "has-ansi": {
@@ -3507,7 +3507,7 @@
           "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.0"
           }
         },
         "maxmin": {
@@ -3516,10 +3516,10 @@
           "integrity": "sha1-o2ztjMIuOrzRCM+3l6OktAJ1WT8=",
           "dev": true,
           "requires": {
-            "chalk": "0.5.1",
-            "figures": "1.7.0",
-            "gzip-size": "0.2.0",
-            "pretty-bytes": "0.1.2"
+            "chalk": "^0.5.0",
+            "figures": "^1.0.1",
+            "gzip-size": "^0.2.0",
+            "pretty-bytes": "^0.1.0"
           }
         },
         "strip-ansi": {
@@ -3528,7 +3528,7 @@
           "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
           "dev": true,
           "requires": {
-            "ansi-regex": "0.2.1"
+            "ansi-regex": "^0.2.1"
           }
         },
         "supports-color": {
@@ -3545,9 +3545,9 @@
       "integrity": "sha1-ZP3LolpjX1tNobbOb5DaCutuPxU=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "gaze": "0.5.2",
-        "lodash": "2.4.2",
+        "async": "~0.2.9",
+        "gaze": "~0.5.1",
+        "lodash": "~2.4.1",
         "tiny-lr-fork": "0.0.5"
       }
     },
@@ -3563,8 +3563,8 @@
       "integrity": "sha1-u3TDeQYVmc7B9mFp3vKonYYthhs=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "eslint": "3.19.0"
+        "chalk": "^1.0.0",
+        "eslint": "^3.0.0"
       }
     },
     "grunt-gh-pages": {
@@ -3574,11 +3574,11 @@
       "dev": true,
       "requires": {
         "async": "2.0.1",
-        "fs-extra": "0.30.0",
+        "fs-extra": "^0.30.0",
         "graceful-fs": "4.1.5",
         "q": "0.9.3",
         "q-io": "2.0.2",
-        "url-safe": "2.0.0"
+        "url-safe": "^2.0.0"
       },
       "dependencies": {
         "asap": {
@@ -3593,7 +3593,7 @@
           "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.8.0"
           }
         },
         "collections": {
@@ -3602,20 +3602,20 @@
           "integrity": "sha1-dlcSXoSkCGotx5f/LWltgZpyD7U=",
           "dev": true,
           "requires": {
-            "mini-map": "1.0.0",
-            "pop-arrayify": "1.0.0",
-            "pop-clear": "1.0.0",
-            "pop-clone": "1.0.1",
-            "pop-compare": "1.0.0",
-            "pop-equals": "1.0.0",
-            "pop-has": "1.0.0",
-            "pop-hash": "1.0.1",
-            "pop-iterate": "1.0.1",
-            "pop-observe": "2.0.2",
-            "pop-swap": "1.0.0",
-            "pop-zip": "1.0.0",
+            "mini-map": "^1.0.0",
+            "pop-arrayify": "^1.0.0",
+            "pop-clear": "^1.0.0",
+            "pop-clone": "^1.0.1",
+            "pop-compare": "^1.0.0",
+            "pop-equals": "^1.0.0",
+            "pop-has": "^1.0.0",
+            "pop-hash": "^1.0.0",
+            "pop-iterate": "^1.0.1",
+            "pop-observe": "^2.0.2",
+            "pop-swap": "^1.0.0",
+            "pop-zip": "^1.0.0",
             "regexp-escape": "0.0.1",
-            "weak-map": "1.0.5"
+            "weak-map": "^1.0.4"
           }
         },
         "fs-extra": {
@@ -3624,11 +3624,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.5",
-            "jsonfile": "2.4.0",
-            "klaw": "1.3.1",
-            "path-is-absolute": "1.0.1",
-            "rimraf": "2.2.8"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^2.1.0",
+            "klaw": "^1.0.0",
+            "path-is-absolute": "^1.0.0",
+            "rimraf": "^2.2.8"
           }
         },
         "graceful-fs": {
@@ -3673,8 +3673,8 @@
           "integrity": "sha1-YY1GJJfpbQb5zaMVsyXMo6JjYDg=",
           "dev": true,
           "requires": {
-            "mini-map": "1.0.0",
-            "pop-equals": "1.0.0"
+            "mini-map": "^1.0.0",
+            "pop-equals": "^1.0.0"
           }
         },
         "pop-compare": {
@@ -3689,7 +3689,7 @@
           "integrity": "sha1-kEFPj9pxo3+IHR5eOi4C7ww7fgs=",
           "dev": true,
           "requires": {
-            "mini-map": "1.0.0"
+            "mini-map": "^1.0.0"
           }
         },
         "pop-has": {
@@ -3698,7 +3698,7 @@
           "integrity": "sha1-myJrWblgq2XqsLQS3VVw3OkOZRw=",
           "dev": true,
           "requires": {
-            "pop-equals": "1.0.0"
+            "pop-equals": "^1.0.0"
           }
         },
         "pop-hash": {
@@ -3707,7 +3707,7 @@
           "integrity": "sha1-vNaUVL0vmd7SC1/Iork9a1+rRMw=",
           "dev": true,
           "requires": {
-            "weak-map": "1.0.5"
+            "weak-map": "^1.0.5"
           }
         },
         "pop-iterate": {
@@ -3722,9 +3722,9 @@
           "integrity": "sha1-WstaxvJMfG/6ssMhUbCtt0Du82M=",
           "dev": true,
           "requires": {
-            "pop-equals": "1.0.0",
-            "pop-has": "1.0.0",
-            "pop-swap": "1.0.0"
+            "pop-equals": "^1.0.0",
+            "pop-has": "^1.0.0",
+            "pop-swap": "^1.0.0"
           }
         },
         "pop-swap": {
@@ -3757,12 +3757,12 @@
           "integrity": "sha1-GTNM5KlL2r/42dMBXz07csm+O/U=",
           "dev": true,
           "requires": {
-            "collections": "2.0.3",
-            "mime": "1.3.4",
-            "mimeparse": "0.1.4",
-            "q": "2.0.3",
-            "qs": "0.6.6",
-            "url2": "1.0.4"
+            "collections": "^2.0.1",
+            "mime": "^1.2.11",
+            "mimeparse": "^0.1.4",
+            "q": "^2.0.1",
+            "qs": "^0.6.6",
+            "url2": "^1.0.1"
           },
           "dependencies": {
             "q": {
@@ -3771,9 +3771,9 @@
               "integrity": "sha1-dbjbAlWhpa+C9Yw/Oqoe/sfQ0TQ=",
               "dev": true,
               "requires": {
-                "asap": "2.0.6",
-                "pop-iterate": "1.0.1",
-                "weak-map": "1.0.5"
+                "asap": "^2.0.0",
+                "pop-iterate": "^1.0.1",
+                "weak-map": "^1.0.5"
               }
             }
           }
@@ -3839,7 +3839,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "async": {
@@ -3848,7 +3848,7 @@
           "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.10"
+            "lodash": "^4.17.10"
           }
         },
         "chalk": {
@@ -3857,9 +3857,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.4.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "lodash": {
@@ -3874,7 +3874,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         },
         "vnu-jar": {
@@ -3891,8 +3891,8 @@
       "integrity": "sha1-5MRQBth7l3X0yigRDTa722X2Gdg=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "csv": "0.3.7"
+        "chalk": "~0.4.0",
+        "csv": "~0.3.6"
       },
       "dependencies": {
         "ansi-styles": {
@@ -3907,9 +3907,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "strip-ansi": {
@@ -3926,13 +3926,13 @@
       "integrity": "sha1-a5iRfQD+Mc6fsDJTF1n6WLiRX8c=",
       "dev": true,
       "requires": {
-        "async": "0.9.2",
-        "cheerio": "0.17.0",
-        "grunt": "0.4.5",
-        "lodash": "2.4.2",
-        "mime": "1.2.11",
-        "phantomjs": "2.1.7",
-        "which": "1.0.9"
+        "async": "~0.9.0",
+        "cheerio": "~0.17.0",
+        "grunt": "~0.4.5",
+        "lodash": "~2.4.1",
+        "mime": "~1.2.11",
+        "phantomjs": "~2.1.7",
+        "which": "~1.0.5"
       },
       "dependencies": {
         "async": {
@@ -3947,11 +3947,11 @@
           "integrity": "sha1-+lrkLMYBIRM9KW0LRtmDIV9yaOo=",
           "dev": true,
           "requires": {
-            "CSSselect": "0.4.1",
-            "dom-serializer": "0.0.1",
-            "entities": "1.1.1",
-            "htmlparser2": "3.7.3",
-            "lodash": "2.4.2"
+            "CSSselect": "~0.4.0",
+            "dom-serializer": "~0.0.0",
+            "entities": "~1.1.1",
+            "htmlparser2": "~3.7.2",
+            "lodash": "~2.4.1"
           }
         },
         "domhandler": {
@@ -3960,7 +3960,7 @@
           "integrity": "sha1-Wd+dzSJ+gIs2Wuc+H2aErD2Ub8I=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0"
+            "domelementtype": "1"
           }
         },
         "domutils": {
@@ -3969,8 +3969,8 @@
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "dev": true,
           "requires": {
-            "dom-serializer": "0.0.1",
-            "domelementtype": "1.3.0"
+            "dom-serializer": "0",
+            "domelementtype": "1"
           }
         },
         "htmlparser2": {
@@ -3979,11 +3979,11 @@
           "integrity": "sha1-amTHdjfAjG8w7CqBV6UzM758sF4=",
           "dev": true,
           "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.2.1",
-            "domutils": "1.5.1",
-            "entities": "1.0.0",
-            "readable-stream": "1.1.14"
+            "domelementtype": "1",
+            "domhandler": "2.2",
+            "domutils": "1.5",
+            "entities": "1.0",
+            "readable-stream": "1.1"
           },
           "dependencies": {
             "entities": {
@@ -4008,11 +4008,11 @@
       "integrity": "sha1-7ClCboAwIa9ZAp+H0vnNczWgVTE=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "grunt-legacy-log-utils": "0.1.1",
-        "hooker": "0.2.3",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
+        "colors": "~0.6.2",
+        "grunt-legacy-log-utils": "~0.1.1",
+        "hooker": "~0.2.3",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
         "underscore.string": {
@@ -4029,9 +4029,9 @@
       "integrity": "sha1-wHBrndkGThFvNvI/5OawSGcsD34=",
       "dev": true,
       "requires": {
-        "colors": "0.6.2",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
+        "colors": "~0.6.2",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
         "underscore.string": {
@@ -4048,13 +4048,13 @@
       "integrity": "sha1-kzJIhNv343qf98Am3/RR2UqeVUs=",
       "dev": true,
       "requires": {
-        "async": "0.1.22",
-        "exit": "0.1.2",
-        "getobject": "0.1.0",
-        "hooker": "0.2.3",
-        "lodash": "0.9.2",
-        "underscore.string": "2.2.1",
-        "which": "1.0.9"
+        "async": "~0.1.22",
+        "exit": "~0.1.1",
+        "getobject": "~0.1.0",
+        "hooker": "~0.2.3",
+        "lodash": "~0.9.2",
+        "underscore.string": "~2.2.1",
+        "which": "~1.0.5"
       },
       "dependencies": {
         "async": {
@@ -4083,10 +4083,10 @@
       "integrity": "sha1-pJasEEvI6ELiaJN0nVTEkFR16Pw=",
       "dev": true,
       "requires": {
-        "eventemitter2": "0.4.14",
-        "phantomjs": "1.9.20",
-        "semver": "4.3.6",
-        "temporary": "0.0.8"
+        "eventemitter2": "^0.4.9",
+        "phantomjs": "^1.9.15",
+        "semver": "^4.3.0",
+        "temporary": "^0.0.8"
       },
       "dependencies": {
         "phantomjs": {
@@ -4095,14 +4095,14 @@
           "integrity": "sha1-RCSsog4U0lXAsIia9va4lz2hDg0=",
           "dev": true,
           "requires": {
-            "extract-zip": "1.5.0",
-            "fs-extra": "0.26.7",
-            "hasha": "2.2.0",
-            "kew": "0.7.0",
-            "progress": "1.1.8",
-            "request": "2.67.0",
-            "request-progress": "2.0.1",
-            "which": "1.2.14"
+            "extract-zip": "~1.5.0",
+            "fs-extra": "~0.26.4",
+            "hasha": "^2.2.0",
+            "kew": "~0.7.0",
+            "progress": "~1.1.8",
+            "request": "~2.67.0",
+            "request-progress": "~2.0.1",
+            "which": "~1.2.2"
           }
         },
         "which": {
@@ -4111,7 +4111,7 @@
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -4122,8 +4122,8 @@
       "integrity": "sha512-D0PVIDjaPC2UZtvBeYKT1SgSEmqxgTwcYfJu/YcLl0SjV2SAf9jJWClFMqeo1Vmp3+0mALiRcyRRAYEp+WtQBQ==",
       "dev": true,
       "requires": {
-        "junitwriter": "0.3.1",
-        "lintspaces": "0.6.2"
+        "junitwriter": "^0.3.1",
+        "lintspaces": "^0.6.2"
       }
     },
     "grunt-markdownlint": {
@@ -4132,7 +4132,7 @@
       "integrity": "sha512-+VQdbrbZ5hSexpbJS69YeUpv0bZ5fv856KA/jkbIgjHOtBEkWlu7Ieos1wg0SsQB+npwk1QF/eLPhCk+eReOyQ==",
       "dev": true,
       "requires": {
-        "markdownlint": "0.8.1"
+        "markdownlint": "^0.8.1"
       }
     },
     "grunt-mocha": {
@@ -4141,9 +4141,9 @@
       "integrity": "sha1-r1hHEvRn+yohawwEhjBh2kg44SM=",
       "dev": true,
       "requires": {
-        "grunt-lib-phantomjs": "0.7.1",
-        "lodash": "3.10.1",
-        "mocha": "1.21.5"
+        "grunt-lib-phantomjs": "^0.7.1",
+        "lodash": "^3.9.0",
+        "mocha": "^1.21.5"
       },
       "dependencies": {
         "lodash": {
@@ -4160,9 +4160,9 @@
       "integrity": "sha512-lglLcVaoOIqH0sFv7RqwUKkEFGQwnlqyAKbatxZderwZGV1nDyKHN7gZS9LUiTx1t5GOvRBx0BEalHMyVwFAIA==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.2",
-        "diff": "3.5.0",
-        "postcss": "6.0.21"
+        "chalk": "^2.1.0",
+        "diff": "^3.0.0",
+        "postcss": "^6.0.11"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4171,7 +4171,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -4180,9 +4180,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "supports-color": {
@@ -4191,7 +4191,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -4202,9 +4202,9 @@
       "integrity": "sha512-XkexnQt/9rhReNd+Y7T0n/2g5FqYOQKfi2iSlpwDqvgs7EgEaGTxNhnWzHnbW5oNRvzL9AHopBG3AgRxL0d+DA==",
       "dev": true,
       "requires": {
-        "each-async": "1.1.1",
-        "node-sass": "4.9.0",
-        "object-assign": "4.1.1"
+        "each-async": "^1.0.0",
+        "node-sass": "^4.7.2",
+        "object-assign": "^4.0.1"
       }
     },
     "grunt-sass-lint": {
@@ -4213,7 +4213,7 @@
       "integrity": "sha512-jV88yXoxFFvr4R3WVBl0uz4YBzNxXTrCJ7ZBKrYby/SjRCw2sieKPkt5tpWDcQZIj9XrKsOpKuHQn08MaECVwg==",
       "dev": true,
       "requires": {
-        "sass-lint": "1.12.1"
+        "sass-lint": "^1.12.0"
       }
     },
     "grunt-saucelabs": {
@@ -4222,12 +4222,12 @@
       "integrity": "sha1-1ogCWgVQHeysCp4SndTk9QpCAUo=",
       "dev": true,
       "requires": {
-        "colors": "1.1.2",
-        "lodash": "4.13.1",
-        "q": "1.4.1",
-        "requestretry": "1.9.1",
-        "sauce-tunnel": "2.5.0",
-        "saucelabs": "1.2.0"
+        "colors": "~1.1.2",
+        "lodash": "~4.13.1",
+        "q": "~1.4.1",
+        "requestretry": "~1.9.0",
+        "sauce-tunnel": "~2.5.0",
+        "saucelabs": "~1.2.0"
       },
       "dependencies": {
         "colors": {
@@ -4256,9 +4256,9 @@
       "integrity": "sha1-/2RzFLUTtpOSUnGQt2l9Dsx0eVg=",
       "dev": true,
       "requires": {
-        "async": "2.5.0",
-        "ramda": "0.22.1",
-        "sri-toolbox": "0.2.0"
+        "async": "^2.0.0",
+        "ramda": "^0.22.1",
+        "sri-toolbox": "^0.2.0"
       },
       "dependencies": {
         "async": {
@@ -4267,7 +4267,7 @@
           "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "lodash": {
@@ -4284,8 +4284,8 @@
       "integrity": "sha1-YzoDvHhIKg4OH5339kWBH8H7sWI=",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
-        "chalk": "1.1.3"
+        "async": "^2.0.0",
+        "chalk": "^1.0.0"
       },
       "dependencies": {
         "async": {
@@ -4294,7 +4294,7 @@
           "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
           "dev": true,
           "requires": {
-            "lodash": "4.17.4"
+            "lodash": "^4.14.0"
           }
         },
         "lodash": {
@@ -4311,7 +4311,7 @@
       "integrity": "sha1-KW1qqkw7mkmQ20K/CgutDbtgfcE=",
       "dev": true,
       "requires": {
-        "node-git-simple": "0.2.0"
+        "node-git-simple": "^0.2.0"
       }
     },
     "grunt-wget": {
@@ -4320,8 +4320,8 @@
       "integrity": "sha1-o9O9OKT0cRlGECcwJSIJyB9ABoI=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
-        "request": "2.40.0"
+        "async": "~0.2.10",
+        "request": "~2.40.0"
       },
       "dependencies": {
         "asn1": {
@@ -4351,7 +4351,7 @@
           "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
           "dev": true,
           "requires": {
-            "hoek": "0.9.1"
+            "hoek": "0.9.x"
           }
         },
         "combined-stream": {
@@ -4371,7 +4371,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "0.4.2"
+            "boom": "0.4.x"
           }
         },
         "delayed-stream": {
@@ -4394,9 +4394,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "async": "0.9.2",
-            "combined-stream": "0.0.7",
-            "mime": "1.2.11"
+            "async": "~0.9.0",
+            "combined-stream": "~0.0.4",
+            "mime": "~1.2.11"
           },
           "dependencies": {
             "async": {
@@ -4415,10 +4415,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "boom": "0.4.2",
-            "cryptiles": "0.2.2",
-            "hoek": "0.9.1",
-            "sntp": "0.2.4"
+            "boom": "0.4.x",
+            "cryptiles": "0.2.x",
+            "hoek": "0.9.x",
+            "sntp": "0.2.x"
           }
         },
         "hoek": {
@@ -4435,7 +4435,7 @@
           "optional": true,
           "requires": {
             "asn1": "0.1.11",
-            "assert-plus": "0.1.5",
+            "assert-plus": "^0.1.5",
             "ctype": "0.5.3"
           }
         },
@@ -4471,19 +4471,19 @@
           "integrity": "sha1-TdZw9pbx5uhC5mtLXoOTAaub62c=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.5.0",
-            "forever-agent": "0.5.2",
-            "form-data": "0.1.4",
+            "aws-sign2": "~0.5.0",
+            "forever-agent": "~0.5.0",
+            "form-data": "~0.1.0",
             "hawk": "1.1.1",
-            "http-signature": "0.10.1",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "1.0.2",
-            "node-uuid": "1.4.8",
-            "oauth-sign": "0.3.0",
-            "qs": "1.0.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.2.2",
-            "tunnel-agent": "0.4.3"
+            "http-signature": "~0.10.0",
+            "json-stringify-safe": "~5.0.0",
+            "mime-types": "~1.0.1",
+            "node-uuid": "~1.4.0",
+            "oauth-sign": "~0.3.0",
+            "qs": "~1.0.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": ">=0.12.0",
+            "tunnel-agent": "~0.4.0"
           }
         },
         "sntp": {
@@ -4493,7 +4493,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "hoek": "0.9.1"
+            "hoek": "0.9.x"
           }
         }
       }
@@ -4504,8 +4504,8 @@
       "integrity": "sha1-rjNIO2/IIk6DQilt4Qjvk3V/duA=",
       "dev": true,
       "requires": {
-        "concat-stream": "1.6.0",
-        "zlib-browserify": "0.0.3"
+        "concat-stream": "^1.4.1",
+        "zlib-browserify": "^0.0.3"
       }
     },
     "handlebars": {
@@ -4514,10 +4514,10 @@
       "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -4533,9 +4533,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "0.5.7",
-            "uglify-to-browserify": "1.0.2",
-            "yargs": "3.10.0"
+            "source-map": "~0.5.1",
+            "uglify-to-browserify": "~1.0.0",
+            "yargs": "~3.10.0"
           },
           "dependencies": {
             "source-map": {
@@ -4561,35 +4561,35 @@
       "integrity": "sha1-+YgLeujYkOYxoxRvAZBQAFxU7RI=",
       "dev": true,
       "requires": {
-        "arr-filter": "1.1.2",
-        "arr-flatten": "1.1.0",
-        "array-sort": "0.1.4",
-        "create-frame": "1.0.0",
-        "define-property": "0.2.5",
-        "for-in": "0.1.8",
-        "for-own": "0.1.5",
-        "get-object": "0.2.0",
-        "get-value": "2.0.6",
-        "handlebars": "4.0.10",
-        "helper-date": "0.2.3",
-        "helper-markdown": "0.2.2",
-        "helper-md": "0.2.2",
-        "html-tag": "1.0.0",
-        "index-of": "0.2.0",
-        "is-even": "0.1.2",
-        "is-glob": "3.1.0",
-        "is-number": "3.0.0",
-        "is-odd": "0.1.2",
-        "kind-of": "3.2.2",
-        "lazy-cache": "2.0.2",
-        "logging-helpers": "0.4.0",
-        "make-iterator": "0.3.1",
-        "micromatch": "2.3.11",
-        "mixin-deep": "1.2.0",
-        "normalize-path": "2.1.1",
-        "relative": "3.0.2",
-        "striptags": "2.2.1",
-        "to-gfm-code-block": "0.1.1"
+        "arr-filter": "^1.1.1",
+        "arr-flatten": "^1.0.1",
+        "array-sort": "^0.1.2",
+        "create-frame": "^1.0.0",
+        "define-property": "^0.2.5",
+        "for-in": "^0.1.6",
+        "for-own": "^0.1.4",
+        "get-object": "^0.2.0",
+        "get-value": "^2.0.6",
+        "handlebars": "^4.0.6",
+        "helper-date": "^0.2.3",
+        "helper-markdown": "^0.2.1",
+        "helper-md": "^0.2.2",
+        "html-tag": "^1.0.0",
+        "index-of": "^0.2.0",
+        "is-even": "^0.1.1",
+        "is-glob": "^3.1.0",
+        "is-number": "^3.0.0",
+        "is-odd": "^0.1.1",
+        "kind-of": "^3.1.0",
+        "lazy-cache": "^2.0.2",
+        "logging-helpers": "^0.4.0",
+        "make-iterator": "^0.3.0",
+        "micromatch": "^2.3.11",
+        "mixin-deep": "^1.1.3",
+        "normalize-path": "^2.0.1",
+        "relative": "^3.0.2",
+        "striptags": "^2.1.1",
+        "to-gfm-code-block": "^0.1.1"
       },
       "dependencies": {
         "arr-diff": {
@@ -4598,7 +4598,7 @@
           "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0"
+            "arr-flatten": "^1.0.1"
           }
         },
         "arr-filter": {
@@ -4607,7 +4607,7 @@
           "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
           "dev": true,
           "requires": {
-            "make-iterator": "1.0.0"
+            "make-iterator": "^1.0.0"
           },
           "dependencies": {
             "make-iterator": {
@@ -4616,7 +4616,7 @@
               "integrity": "sha1-V7713IXSOSO6I3ZzJNjo+PPZaUs=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.1.0"
               }
             }
           }
@@ -4633,9 +4633,9 @@
           "integrity": "sha512-BNcM+RXxndPxiZ2rd76k6nyQLRZr2/B/sdi8pQ+Joafr5AH279L40dfokSUTp8O+AaqYjXWhblBWa2st2nc4fQ==",
           "dev": true,
           "requires": {
-            "default-compare": "1.0.0",
-            "get-value": "2.0.6",
-            "kind-of": "5.0.2"
+            "default-compare": "^1.0.0",
+            "get-value": "^2.0.6",
+            "kind-of": "^5.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4664,9 +4664,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "create-frame": {
@@ -4675,10 +4675,10 @@
           "integrity": "sha1-i5XyaR4ySbYIBEPjPQutn49pdao=",
           "dev": true,
           "requires": {
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "isobject": "3.0.1",
-            "lazy-cache": "2.0.2"
+            "define-property": "^0.2.5",
+            "extend-shallow": "^2.0.1",
+            "isobject": "^3.0.0",
+            "lazy-cache": "^2.0.2"
           }
         },
         "date.js": {
@@ -4687,14 +4687,14 @@
           "integrity": "sha1-OefHx3rcdl0Qvs9JbKzTkTMtfMg=",
           "dev": true,
           "requires": {
-            "debug": "0.7.4",
-            "lodash.filter": "4.6.0",
-            "lodash.findkey": "4.6.0",
-            "lodash.foreach": "4.5.0",
-            "lodash.includes": "4.3.0",
-            "lodash.isempty": "4.4.0",
-            "lodash.partition": "4.6.0",
-            "lodash.trim": "4.5.1"
+            "debug": "~0.7.2",
+            "lodash.filter": "^4.2.0",
+            "lodash.findkey": "^4.2.0",
+            "lodash.foreach": "^4.1.0",
+            "lodash.includes": "^4.1.0",
+            "lodash.isempty": "^4.1.2",
+            "lodash.partition": "^4.2.0",
+            "lodash.trim": "^4.2.0"
           }
         },
         "debug": {
@@ -4709,7 +4709,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "0.1.6"
+            "is-descriptor": "^0.1.0"
           }
         },
         "ent": {
@@ -4724,7 +4724,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -4733,7 +4733,7 @@
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "extend-shallow": {
@@ -4742,7 +4742,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "0.1.1"
+            "is-extendable": "^0.1.0"
           }
         },
         "extglob": {
@@ -4751,7 +4751,7 @@
           "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
           "dev": true,
           "requires": {
-            "is-extglob": "1.0.0"
+            "is-extglob": "^1.0.0"
           },
           "dependencies": {
             "is-extglob": {
@@ -4774,11 +4774,11 @@
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           },
           "dependencies": {
             "is-number": {
@@ -4787,7 +4787,7 @@
               "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "isobject": {
@@ -4813,7 +4813,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           },
           "dependencies": {
             "for-in": {
@@ -4836,8 +4836,8 @@
           "integrity": "sha1-2S/31RkMZFMM2gVD2sY6PUf+jAw=",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "0.2.0"
+            "is-number": "^2.0.2",
+            "isobject": "^0.2.0"
           },
           "dependencies": {
             "is-number": {
@@ -4846,7 +4846,7 @@
               "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               }
             },
             "isobject": {
@@ -4869,8 +4869,8 @@
           "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
           "dev": true,
           "requires": {
-            "glob-parent": "2.0.0",
-            "is-glob": "2.0.1"
+            "glob-parent": "^2.0.0",
+            "is-glob": "^2.0.0"
           },
           "dependencies": {
             "is-extglob": {
@@ -4885,7 +4885,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -4896,7 +4896,7 @@
           "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           },
           "dependencies": {
             "is-extglob": {
@@ -4911,7 +4911,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -4922,10 +4922,10 @@
           "integrity": "sha1-2HDKu6BB0ynMhW2yC7jElnTj7yg=",
           "dev": true,
           "requires": {
-            "date.js": "0.3.1",
-            "extend-shallow": "2.0.1",
-            "kind-of": "3.2.2",
-            "moment": "2.18.1"
+            "date.js": "^0.3.1",
+            "extend-shallow": "^2.0.1",
+            "kind-of": "^3.1.0",
+            "moment": "^2.17.1"
           }
         },
         "helper-markdown": {
@@ -4934,9 +4934,9 @@
           "integrity": "sha1-ONt/dxhJ4wrpXJL8AhuutT8uMEA=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "mixin-deep": "1.2.0",
-            "remarkable": "1.7.1"
+            "isobject": "^2.0.0",
+            "mixin-deep": "^1.1.3",
+            "remarkable": "^1.6.0"
           },
           "dependencies": {
             "isobject": {
@@ -4956,10 +4956,10 @@
           "integrity": "sha1-wfWdflW7riM2L9ig6XFgeuxp1B8=",
           "dev": true,
           "requires": {
-            "ent": "2.2.0",
-            "extend-shallow": "2.0.1",
-            "fs-exists-sync": "0.1.0",
-            "remarkable": "1.7.1"
+            "ent": "^2.2.0",
+            "extend-shallow": "^2.0.1",
+            "fs-exists-sync": "^0.1.0",
+            "remarkable": "^1.6.2"
           }
         },
         "html-tag": {
@@ -4968,8 +4968,8 @@
           "integrity": "sha1-leVhKuyCvqko7URZX4VBRen34LU=",
           "dev": true,
           "requires": {
-            "isobject": "3.0.1",
-            "void-elements": "2.0.1"
+            "isobject": "^3.0.0",
+            "void-elements": "^2.0.1"
           }
         },
         "index-of": {
@@ -4984,7 +4984,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-data-descriptor": {
@@ -4993,7 +4993,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-descriptor": {
@@ -5002,9 +5002,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.0.2"
+            "is-accessor-descriptor": "^0.1.6",
+            "is-data-descriptor": "^0.1.4",
+            "kind-of": "^5.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -5027,7 +5027,7 @@
           "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
           "dev": true,
           "requires": {
-            "is-primitive": "2.0.0"
+            "is-primitive": "^2.0.0"
           }
         },
         "is-even": {
@@ -5036,7 +5036,7 @@
           "integrity": "sha1-4EMqc3ny0gtuu8LLEeab6q8xzWM=",
           "dev": true,
           "requires": {
-            "is-odd": "0.1.2"
+            "is-odd": "^0.1.2"
           }
         },
         "is-extendable": {
@@ -5057,7 +5057,7 @@
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
           "dev": true,
           "requires": {
-            "is-extglob": "2.1.1"
+            "is-extglob": "^2.1.0"
           }
         },
         "is-number": {
@@ -5066,7 +5066,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         },
         "is-odd": {
@@ -5075,7 +5075,7 @@
           "integrity": "sha1-vFc7XONx7yqtbm9JeZtyvvE5eKc=",
           "dev": true,
           "requires": {
-            "is-number": "3.0.0"
+            "is-number": "^3.0.0"
           }
         },
         "is-posix-bracket": {
@@ -5108,7 +5108,7 @@
           "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
           "dev": true,
           "requires": {
-            "set-getter": "0.1.0"
+            "set-getter": "^0.1.0"
           }
         },
         "lodash.filter": {
@@ -5159,7 +5159,7 @@
           "integrity": "sha1-AObVMWwjdn7BLhIA5PEsXgM+frA=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3"
+            "chalk": "^1.0.0"
           }
         },
         "make-iterator": {
@@ -5168,7 +5168,7 @@
           "integrity": "sha1-4calMrVGon8TlIoG+CUJsz25gRI=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.1.0"
           }
         },
         "micromatch": {
@@ -5177,19 +5177,19 @@
           "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
           "dev": true,
           "requires": {
-            "arr-diff": "2.0.0",
-            "array-unique": "0.2.1",
-            "braces": "1.8.5",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.3.2",
-            "filename-regex": "2.0.1",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1",
-            "kind-of": "3.2.2",
-            "normalize-path": "2.1.1",
-            "object.omit": "2.0.1",
-            "parse-glob": "3.0.4",
-            "regex-cache": "0.4.4"
+            "arr-diff": "^2.0.0",
+            "array-unique": "^0.2.1",
+            "braces": "^1.8.2",
+            "expand-brackets": "^0.1.4",
+            "extglob": "^0.3.1",
+            "filename-regex": "^2.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.1",
+            "kind-of": "^3.0.2",
+            "normalize-path": "^2.0.1",
+            "object.omit": "^2.0.0",
+            "parse-glob": "^3.0.4",
+            "regex-cache": "^0.4.2"
           },
           "dependencies": {
             "is-extglob": {
@@ -5204,7 +5204,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -5215,8 +5215,8 @@
           "integrity": "sha1-0CuMb4ttS49ZgtP9AJxJGYUcP+I=",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2",
-            "is-extendable": "0.1.1"
+            "for-in": "^1.0.2",
+            "is-extendable": "^0.1.1"
           },
           "dependencies": {
             "for-in": {
@@ -5239,8 +5239,8 @@
           "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
           "dev": true,
           "requires": {
-            "for-own": "0.1.5",
-            "is-extendable": "0.1.1"
+            "for-own": "^0.1.4",
+            "is-extendable": "^0.1.1"
           }
         },
         "parse-glob": {
@@ -5249,10 +5249,10 @@
           "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
           "dev": true,
           "requires": {
-            "glob-base": "0.3.0",
-            "is-dotfile": "1.0.3",
-            "is-extglob": "1.0.0",
-            "is-glob": "2.0.1"
+            "glob-base": "^0.3.0",
+            "is-dotfile": "^1.0.0",
+            "is-extglob": "^1.0.0",
+            "is-glob": "^2.0.0"
           },
           "dependencies": {
             "is-extglob": {
@@ -5267,7 +5267,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -5284,8 +5284,8 @@
           "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -5294,7 +5294,7 @@
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -5305,7 +5305,7 @@
           "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
           "dev": true,
           "requires": {
-            "is-equal-shallow": "0.1.3"
+            "is-equal-shallow": "^0.1.3"
           }
         },
         "relative": {
@@ -5314,7 +5314,7 @@
           "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0"
+            "isobject": "^2.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -5334,8 +5334,8 @@
           "integrity": "sha1-qspJchALZqZCpjoQIcpLrBvjv/Y=",
           "dev": true,
           "requires": {
-            "argparse": "0.1.16",
-            "autolinker": "0.15.3"
+            "argparse": "~0.1.15",
+            "autolinker": "~0.15.0"
           }
         },
         "repeat-element": {
@@ -5350,7 +5350,7 @@
           "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
           "dev": true,
           "requires": {
-            "to-object-path": "0.3.0"
+            "to-object-path": "^0.3.0"
           }
         },
         "striptags": {
@@ -5371,7 +5371,7 @@
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           }
         }
       }
@@ -5388,10 +5388,10 @@
       "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "commander": "2.11.0",
-        "is-my-json-valid": "2.16.1",
-        "pinkie-promise": "2.0.1"
+        "chalk": "^1.1.1",
+        "commander": "^2.9.0",
+        "is-my-json-valid": "^2.12.4",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "has-ansi": {
@@ -5400,7 +5400,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-color": {
@@ -5427,8 +5427,8 @@
       "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
       "dev": true,
       "requires": {
-        "is-stream": "1.1.0",
-        "pinkie-promise": "2.0.1"
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
       }
     },
     "hawk": {
@@ -5437,10 +5437,10 @@
       "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
       "dev": true,
       "requires": {
-        "boom": "2.10.1",
-        "cryptiles": "2.0.5",
-        "hoek": "2.16.3",
-        "sntp": "1.0.9"
+        "boom": "2.x.x",
+        "cryptiles": "2.x.x",
+        "hoek": "2.x.x",
+        "sntp": "1.x.x"
       }
     },
     "hoek": {
@@ -5467,12 +5467,12 @@
       "integrity": "sha1-K3lZsQUaSB5xzXxuWaZCcq+JXP0=",
       "dev": true,
       "requires": {
-        "change-case": "2.3.1",
-        "clean-css": "3.1.9",
-        "cli": "0.6.6",
-        "concat-stream": "1.4.10",
-        "relateurl": "0.2.7",
-        "uglify-js": "2.4.24"
+        "change-case": "2.3.x",
+        "clean-css": "3.1.x",
+        "cli": "0.6.x",
+        "concat-stream": "1.4.x",
+        "relateurl": "0.2.x",
+        "uglify-js": "2.4.x"
       },
       "dependencies": {
         "clean-css": {
@@ -5481,8 +5481,8 @@
           "integrity": "sha1-29BaFIvklDuzfOBnnmdsvJ9YAmY=",
           "dev": true,
           "requires": {
-            "commander": "2.6.0",
-            "source-map": "0.1.43"
+            "commander": "2.6.x",
+            "source-map": ">=0.1.43 <0.2"
           }
         },
         "commander": {
@@ -5497,9 +5497,9 @@
           "integrity": "sha1-rMO79WAsuMyYDGrIQPp9hgPj7zY=",
           "dev": true,
           "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "1.1.14",
-            "typedarray": "0.0.6"
+            "inherits": "~2.0.1",
+            "readable-stream": "~1.1.9",
+            "typedarray": "~0.0.5"
           }
         },
         "source-map": {
@@ -5508,7 +5508,7 @@
           "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -5524,11 +5524,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       },
       "dependencies": {
         "domutils": {
@@ -5537,8 +5537,8 @@
           "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
           "dev": true,
           "requires": {
-            "dom-serializer": "0.0.1",
-            "domelementtype": "1.3.0"
+            "dom-serializer": "0",
+            "domelementtype": "1"
           }
         },
         "entities": {
@@ -5555,10 +5555,10 @@
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-signature": {
@@ -5567,9 +5567,9 @@
       "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
       "dev": true,
       "requires": {
-        "assert-plus": "0.2.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.13.1"
+        "assert-plus": "^0.2.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-proxy-agent": {
@@ -5578,9 +5578,9 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true,
       "requires": {
-        "agent-base": "2.1.1",
-        "debug": "2.6.8",
-        "extend": "3.0.1"
+        "agent-base": "2",
+        "debug": "2",
+        "extend": "3"
       }
     },
     "iconv-lite": {
@@ -5613,7 +5613,7 @@
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
       "dev": true,
       "requires": {
-        "repeating": "2.0.1"
+        "repeating": "^2.0.0"
       }
     },
     "inflection": {
@@ -5628,8 +5628,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -5650,19 +5650,19 @@
       "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "1.4.0",
-        "ansi-regex": "2.1.1",
-        "chalk": "1.1.3",
-        "cli-cursor": "1.0.2",
-        "cli-width": "2.2.0",
-        "figures": "1.7.0",
-        "lodash": "4.17.4",
-        "readline2": "1.0.1",
-        "run-async": "0.1.0",
-        "rx-lite": "3.1.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "through": "2.3.8"
+        "ansi-escapes": "^1.1.0",
+        "ansi-regex": "^2.0.0",
+        "chalk": "^1.0.0",
+        "cli-cursor": "^1.0.1",
+        "cli-width": "^2.0.0",
+        "figures": "^1.3.5",
+        "lodash": "^4.3.0",
+        "readline2": "^1.0.1",
+        "run-async": "^0.1.0",
+        "rx-lite": "^3.1.2",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.0",
+        "through": "^2.3.6"
       },
       "dependencies": {
         "lodash": {
@@ -5709,7 +5709,7 @@
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
       "dev": true,
       "requires": {
-        "builtin-modules": "1.1.1"
+        "builtin-modules": "^1.0.0"
       }
     },
     "is-dotfile": {
@@ -5724,7 +5724,7 @@
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
       "dev": true,
       "requires": {
-        "is-primitive": "2.0.0"
+        "is-primitive": "^2.0.0"
       }
     },
     "is-extendable": {
@@ -5745,7 +5745,7 @@
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-fullwidth-code-point": {
@@ -5754,7 +5754,7 @@
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "dev": true,
       "requires": {
-        "number-is-nan": "1.0.1"
+        "number-is-nan": "^1.0.0"
       }
     },
     "is-glob": {
@@ -5763,7 +5763,7 @@
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
       "dev": true,
       "requires": {
-        "is-extglob": "1.0.0"
+        "is-extglob": "^1.0.0"
       }
     },
     "is-lower-case": {
@@ -5772,7 +5772,7 @@
       "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.0"
       }
     },
     "is-my-json-valid": {
@@ -5781,10 +5781,10 @@
       "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
       "dev": true,
       "requires": {
-        "generate-function": "2.0.0",
-        "generate-object-property": "1.2.0",
-        "jsonpointer": "4.0.1",
-        "xtend": "4.0.1"
+        "generate-function": "^2.0.0",
+        "generate-object-property": "^1.1.0",
+        "jsonpointer": "^4.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "is-number": {
@@ -5793,7 +5793,7 @@
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2"
+        "kind-of": "^3.0.2"
       }
     },
     "is-path-cwd": {
@@ -5808,7 +5808,7 @@
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
       "dev": true,
       "requires": {
-        "is-path-inside": "1.0.0"
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -5817,7 +5817,7 @@
       "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
       "dev": true,
       "requires": {
-        "path-is-inside": "1.0.2"
+        "path-is-inside": "^1.0.1"
       }
     },
     "is-posix-bracket": {
@@ -5844,7 +5844,7 @@
       "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
       "dev": true,
       "requires": {
-        "tryit": "1.0.3"
+        "tryit": "^1.0.1"
       }
     },
     "is-stream": {
@@ -5865,7 +5865,7 @@
       "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
       "dev": true,
       "requires": {
-        "upper-case": "1.1.3"
+        "upper-case": "^1.1.0"
       }
     },
     "is-utf8": {
@@ -5943,7 +5943,7 @@
       "resolved": "https://registry.npmjs.org/jquery-validation/-/jquery-validation-1.17.0.tgz",
       "integrity": "sha512-XddiAwhGdWhcIJ+W3ri3KG8uTPMua4TPYuUIC8/E7lOyqdScG5xHuy9YishlKc0c/lIQai77EX7hxMdTSYCEjA==",
       "requires": {
-        "jquery": "2.2.4"
+        "jquery": "^1.7 || ^2.0 || ^3.1"
       }
     },
     "js-base64": {
@@ -5964,8 +5964,8 @@
       "integrity": "sha1-mTeGX46Jel6JTnPCxc8uibMut3E=",
       "dev": true,
       "requires": {
-        "argparse": "0.1.16",
-        "esprima": "1.0.4"
+        "argparse": "~ 0.1.11",
+        "esprima": "~ 1.0.2"
       }
     },
     "jsbn": {
@@ -5987,7 +5987,7 @@
       "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
       "dev": true,
       "requires": {
-        "jsonify": "0.0.0"
+        "jsonify": "~0.0.0"
       }
     },
     "json-stringify-safe": {
@@ -6002,7 +6002,7 @@
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.6"
       },
       "dependencies": {
         "graceful-fs": {
@@ -6064,8 +6064,8 @@
           "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
           "dev": true,
           "requires": {
-            "get-stdin": "4.0.1",
-            "meow": "3.7.0"
+            "get-stdin": "*",
+            "meow": "*"
           }
         },
         "minimist": {
@@ -6097,7 +6097,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.5"
+        "is-buffer": "^1.1.5"
       }
     },
     "klaw": {
@@ -6106,7 +6106,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11"
+        "graceful-fs": "^4.1.9"
       },
       "dependencies": {
         "graceful-fs": {
@@ -6136,7 +6136,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "1.0.0"
+        "invert-kv": "^1.0.0"
       }
     },
     "levn": {
@@ -6145,8 +6145,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "linkify-it": {
@@ -6155,7 +6155,7 @@
       "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
       "dev": true,
       "requires": {
-        "uc.micro": "1.0.5"
+        "uc.micro": "^1.0.1"
       }
     },
     "lintspaces": {
@@ -6164,9 +6164,9 @@
       "integrity": "sha512-2WBNDTbVXtR+EFljfzMjjhbLHrlAfusQmznOigX2v+FnnnwyV03ZgwyuTkLJvba7E2Yy02vR60/hurpM6nRjJQ==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.6.0",
-        "editorconfig": "0.15.0",
-        "rc": "1.2.8"
+        "deep-extend": "^0.6.0",
+        "editorconfig": "^0.15.0",
+        "rc": "^1.2.8"
       }
     },
     "load-grunt-tasks": {
@@ -6175,10 +6175,10 @@
       "integrity": "sha1-ByhWEYD9IP+KaSdQWFL8WKrqDIg=",
       "dev": true,
       "requires": {
-        "arrify": "1.0.1",
-        "multimatch": "2.1.0",
-        "pkg-up": "1.0.0",
-        "resolve-pkg": "0.1.0"
+        "arrify": "^1.0.0",
+        "multimatch": "^2.0.0",
+        "pkg-up": "^1.0.0",
+        "resolve-pkg": "^0.1.0"
       }
     },
     "load-json-file": {
@@ -6187,11 +6187,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "2.2.0",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "strip-bom": "2.0.0"
+        "graceful-fs": "^4.1.2",
+        "parse-json": "^2.2.0",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0",
+        "strip-bom": "^2.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -6208,7 +6208,7 @@
       "integrity": "sha1-kjCzfsBOVpADBgvFiVHj7VCNWU8=",
       "dev": true,
       "requires": {
-        "find-pkg": "0.1.2"
+        "find-pkg": "^0.1.0"
       },
       "dependencies": {
         "expand-tilde": {
@@ -6217,7 +6217,7 @@
           "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "^1.0.1"
           }
         },
         "find-file-up": {
@@ -6226,8 +6226,8 @@
           "integrity": "sha1-z2gJG8+fMApA2kEbN9pczlovvqA=",
           "dev": true,
           "requires": {
-            "fs-exists-sync": "0.1.0",
-            "resolve-dir": "0.1.1"
+            "fs-exists-sync": "^0.1.0",
+            "resolve-dir": "^0.1.0"
           }
         },
         "find-pkg": {
@@ -6236,7 +6236,7 @@
           "integrity": "sha1-G9wiwG42NlUy4qJIBGhUuXiNpVc=",
           "dev": true,
           "requires": {
-            "find-file-up": "0.1.3"
+            "find-file-up": "^0.1.2"
           }
         },
         "fs-exists-sync": {
@@ -6251,8 +6251,8 @@
           "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
           "dev": true,
           "requires": {
-            "global-prefix": "0.1.5",
-            "is-windows": "0.2.0"
+            "global-prefix": "^0.1.4",
+            "is-windows": "^0.2.0"
           }
         },
         "global-prefix": {
@@ -6261,10 +6261,10 @@
           "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "1.0.1",
-            "ini": "1.3.4",
-            "is-windows": "0.2.0",
-            "which": "1.3.0"
+            "homedir-polyfill": "^1.0.0",
+            "ini": "^1.3.4",
+            "is-windows": "^0.2.0",
+            "which": "^1.2.12"
           }
         },
         "homedir-polyfill": {
@@ -6273,7 +6273,7 @@
           "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
           "dev": true,
           "requires": {
-            "parse-passwd": "1.0.0"
+            "parse-passwd": "^1.0.0"
           }
         },
         "ini": {
@@ -6300,8 +6300,8 @@
           "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
           "dev": true,
           "requires": {
-            "expand-tilde": "1.2.2",
-            "global-modules": "0.2.3"
+            "expand-tilde": "^1.2.2",
+            "global-modules": "^0.2.3"
           }
         },
         "which": {
@@ -6310,7 +6310,7 @@
           "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -6333,10 +6333,10 @@
       "integrity": "sha1-6UC5690nwyfgqNqxtVkWxTQelXU=",
       "dev": true,
       "requires": {
-        "lodash._basecreate": "2.4.1",
-        "lodash._setbinddata": "2.4.1",
-        "lodash._slice": "2.4.1",
-        "lodash.isobject": "2.4.1"
+        "lodash._basecreate": "~2.4.1",
+        "lodash._setbinddata": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
       }
     },
     "lodash._baseclone": {
@@ -6345,14 +6345,14 @@
       "integrity": "sha1-MPgj5X4X43NdODvWK2Czh1Q7QYY=",
       "dev": true,
       "requires": {
-        "lodash._getarray": "2.4.1",
-        "lodash._releasearray": "2.4.1",
-        "lodash._slice": "2.4.1",
-        "lodash.assign": "2.4.1",
-        "lodash.foreach": "2.4.1",
-        "lodash.forown": "2.4.1",
-        "lodash.isarray": "2.4.1",
-        "lodash.isobject": "2.4.1"
+        "lodash._getarray": "~2.4.1",
+        "lodash._releasearray": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.assign": "~2.4.1",
+        "lodash.foreach": "~2.4.1",
+        "lodash.forown": "~2.4.1",
+        "lodash.isarray": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
       }
     },
     "lodash._basecreate": {
@@ -6361,9 +6361,9 @@
       "integrity": "sha1-+Ob1tXip405UEXm1a47uv0oofgg=",
       "dev": true,
       "requires": {
-        "lodash._isnative": "2.4.1",
-        "lodash.isobject": "2.4.1",
-        "lodash.noop": "2.4.1"
+        "lodash._isnative": "~2.4.1",
+        "lodash.isobject": "~2.4.1",
+        "lodash.noop": "~2.4.1"
       }
     },
     "lodash._basecreatecallback": {
@@ -6372,10 +6372,10 @@
       "integrity": "sha1-fQsmdknLKeehOdAQO3wR+uhOSFE=",
       "dev": true,
       "requires": {
-        "lodash._setbinddata": "2.4.1",
-        "lodash.bind": "2.4.1",
-        "lodash.identity": "2.4.1",
-        "lodash.support": "2.4.1"
+        "lodash._setbinddata": "~2.4.1",
+        "lodash.bind": "~2.4.1",
+        "lodash.identity": "~2.4.1",
+        "lodash.support": "~2.4.1"
       }
     },
     "lodash._basecreatewrapper": {
@@ -6384,10 +6384,10 @@
       "integrity": "sha1-TTHy595+E0+/KAN2K4FQsyUZZm8=",
       "dev": true,
       "requires": {
-        "lodash._basecreate": "2.4.1",
-        "lodash._setbinddata": "2.4.1",
-        "lodash._slice": "2.4.1",
-        "lodash.isobject": "2.4.1"
+        "lodash._basecreate": "~2.4.1",
+        "lodash._setbinddata": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
       }
     },
     "lodash._createwrapper": {
@@ -6396,10 +6396,10 @@
       "integrity": "sha1-UdaVeXPaTtVW43KQ2MGhjFPeFgc=",
       "dev": true,
       "requires": {
-        "lodash._basebind": "2.4.1",
-        "lodash._basecreatewrapper": "2.4.1",
-        "lodash._slice": "2.4.1",
-        "lodash.isfunction": "2.4.1"
+        "lodash._basebind": "~2.4.1",
+        "lodash._basecreatewrapper": "~2.4.1",
+        "lodash._slice": "~2.4.1",
+        "lodash.isfunction": "~2.4.1"
       }
     },
     "lodash._getarray": {
@@ -6408,7 +6408,7 @@
       "integrity": "sha1-+vH3+BD6mFolHCGHQESBCUg55e4=",
       "dev": true,
       "requires": {
-        "lodash._arraypool": "2.4.1"
+        "lodash._arraypool": "~2.4.1"
       }
     },
     "lodash._isnative": {
@@ -6435,8 +6435,8 @@
       "integrity": "sha1-phOWMNdtFTawfdyAliiJsIL2pkE=",
       "dev": true,
       "requires": {
-        "lodash._arraypool": "2.4.1",
-        "lodash._maxpoolsize": "2.4.1"
+        "lodash._arraypool": "~2.4.1",
+        "lodash._maxpoolsize": "~2.4.1"
       }
     },
     "lodash._setbinddata": {
@@ -6445,8 +6445,8 @@
       "integrity": "sha1-98IAzRuS7yNrOZ7s9zxkjReqlNI=",
       "dev": true,
       "requires": {
-        "lodash._isnative": "2.4.1",
-        "lodash.noop": "2.4.1"
+        "lodash._isnative": "~2.4.1",
+        "lodash.noop": "~2.4.1"
       }
     },
     "lodash._shimkeys": {
@@ -6455,7 +6455,7 @@
       "integrity": "sha1-bpzJZm/wgfC1psl4uD4kLmlJ0gM=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "lodash._slice": {
@@ -6470,9 +6470,9 @@
       "integrity": "sha1-hMOVlt1xGBqXsGUpE6fJZ15Jsao=",
       "dev": true,
       "requires": {
-        "lodash._basecreatecallback": "2.4.1",
-        "lodash._objecttypes": "2.4.1",
-        "lodash.keys": "2.4.1"
+        "lodash._basecreatecallback": "~2.4.1",
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
       }
     },
     "lodash.bind": {
@@ -6481,8 +6481,8 @@
       "integrity": "sha1-XRn6AFyMTSNvr0dCx7eh/Kvikmc=",
       "dev": true,
       "requires": {
-        "lodash._createwrapper": "2.4.1",
-        "lodash._slice": "2.4.1"
+        "lodash._createwrapper": "~2.4.1",
+        "lodash._slice": "~2.4.1"
       }
     },
     "lodash.capitalize": {
@@ -6497,8 +6497,8 @@
       "integrity": "sha1-8pIDtAsS/uCkXTYxZIJZvrq8eGg=",
       "dev": true,
       "requires": {
-        "lodash._baseclone": "2.4.1",
-        "lodash._basecreatecallback": "2.4.1"
+        "lodash._baseclone": "~2.4.1",
+        "lodash._basecreatecallback": "~2.4.1"
       }
     },
     "lodash.foreach": {
@@ -6507,8 +6507,8 @@
       "integrity": "sha1-/j/Do0yGyUyrb5UiVgKCdB4BYwk=",
       "dev": true,
       "requires": {
-        "lodash._basecreatecallback": "2.4.1",
-        "lodash.forown": "2.4.1"
+        "lodash._basecreatecallback": "~2.4.1",
+        "lodash.forown": "~2.4.1"
       }
     },
     "lodash.forown": {
@@ -6517,9 +6517,9 @@
       "integrity": "sha1-eLQer+FAX6lmRZ6kGT/VAtCEUks=",
       "dev": true,
       "requires": {
-        "lodash._basecreatecallback": "2.4.1",
-        "lodash._objecttypes": "2.4.1",
-        "lodash.keys": "2.4.1"
+        "lodash._basecreatecallback": "~2.4.1",
+        "lodash._objecttypes": "~2.4.1",
+        "lodash.keys": "~2.4.1"
       }
     },
     "lodash.identity": {
@@ -6534,7 +6534,7 @@
       "integrity": "sha1-tSoybB9i9tfac6MdVAHfbvRPD6E=",
       "dev": true,
       "requires": {
-        "lodash._isnative": "2.4.1"
+        "lodash._isnative": "~2.4.1"
       }
     },
     "lodash.isfunction": {
@@ -6549,7 +6549,7 @@
       "integrity": "sha1-Wi5H/mmVPx7mMafrof5k0tBlWPU=",
       "dev": true,
       "requires": {
-        "lodash._objecttypes": "2.4.1"
+        "lodash._objecttypes": "~2.4.1"
       }
     },
     "lodash.kebabcase": {
@@ -6564,9 +6564,9 @@
       "integrity": "sha1-SN6kbfj/djKxDXBrissmWR4rNyc=",
       "dev": true,
       "requires": {
-        "lodash._isnative": "2.4.1",
-        "lodash._shimkeys": "2.4.1",
-        "lodash.isobject": "2.4.1"
+        "lodash._isnative": "~2.4.1",
+        "lodash._shimkeys": "~2.4.1",
+        "lodash.isobject": "~2.4.1"
       }
     },
     "lodash.mergewith": {
@@ -6587,7 +6587,7 @@
       "integrity": "sha1-Mg4LZwMWc8KNeiu12eAzGkUkBRU=",
       "dev": true,
       "requires": {
-        "lodash._isnative": "2.4.1"
+        "lodash._isnative": "~2.4.1"
       }
     },
     "lolex": {
@@ -6608,8 +6608,8 @@
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
       "dev": true,
       "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
+        "currently-unhandled": "^0.4.1",
+        "signal-exit": "^3.0.0"
       }
     },
     "lower-case": {
@@ -6624,7 +6624,7 @@
       "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.2"
       }
     },
     "lru-cache": {
@@ -6632,6 +6632,10 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
       "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
       "dev": true
+    },
+    "magnific-popup": {
+      "version": "git+https://github.com/wet-boew/Magnific-Popup.git#4a2964f4ea087258631323fec6fe4494c7fe0079",
+      "from": "git+https://github.com/wet-boew/Magnific-Popup.git#1.0.0+keyboard_trap_fix"
     },
     "map-obj": {
       "version": "1.0.1",
@@ -6645,11 +6649,11 @@
       "integrity": "sha512-CzzqSSNkFRUf9vlWvhK1awpJreMRqdCrBvZ8DIoDWTOkESMIF741UPAhuAmbyWmdiFPA6WARNhnu2M6Nrhwa+A==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "entities": "1.1.1",
-        "linkify-it": "2.0.3",
-        "mdurl": "1.0.1",
-        "uc.micro": "1.0.5"
+        "argparse": "^1.0.7",
+        "entities": "~1.1.1",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
       },
       "dependencies": {
         "argparse": {
@@ -6658,7 +6662,7 @@
           "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
           "dev": true,
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         }
       }
@@ -6683,9 +6687,9 @@
       "integrity": "sha1-ldgcUonjqdMPf8fcVZwCTlAwydA=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0",
-        "gzip-size": "0.1.1",
-        "pretty-bytes": "0.1.2"
+        "chalk": "^0.4.0",
+        "gzip-size": "^0.1.0",
+        "pretty-bytes": "^0.1.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -6700,9 +6704,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "strip-ansi": {
@@ -6731,16 +6735,16 @@
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
       "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
+        "camelcase-keys": "^2.0.0",
+        "decamelize": "^1.1.2",
+        "loud-rejection": "^1.0.0",
+        "map-obj": "^1.0.1",
+        "minimist": "^1.1.3",
+        "normalize-package-data": "^2.3.4",
+        "object-assign": "^4.0.1",
+        "read-pkg-up": "^1.0.1",
+        "redent": "^1.0.0",
+        "trim-newlines": "^1.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -6811,19 +6815,19 @@
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
       "dev": true,
       "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
+        "arr-diff": "^2.0.0",
+        "array-unique": "^0.2.1",
+        "braces": "^1.8.2",
+        "expand-brackets": "^0.1.4",
+        "extglob": "^0.3.1",
+        "filename-regex": "^2.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.1",
+        "kind-of": "^3.0.2",
+        "normalize-path": "^2.0.1",
+        "object.omit": "^2.0.0",
+        "parse-glob": "^3.0.4",
+        "regex-cache": "^0.4.2"
       }
     },
     "mime": {
@@ -6844,7 +6848,7 @@
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "dev": true,
       "requires": {
-        "mime-db": "1.30.0"
+        "mime-db": "~1.30.0"
       }
     },
     "minimatch": {
@@ -6853,8 +6857,8 @@
       "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
       "dev": true,
       "requires": {
-        "lru-cache": "2.7.3",
-        "sigmund": "1.0.1"
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
       }
     },
     "minimist": {
@@ -6918,9 +6922,9 @@
           "integrity": "sha1-4xPusknHr/qlxHUoaw4RW1mDlGc=",
           "dev": true,
           "requires": {
-            "graceful-fs": "2.0.3",
-            "inherits": "2.0.3",
-            "minimatch": "0.2.14"
+            "graceful-fs": "~2.0.0",
+            "inherits": "2",
+            "minimatch": "~0.2.11"
           }
         },
         "minimist": {
@@ -6952,11 +6956,11 @@
       "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
       "dev": true,
       "requires": {
-        "basic-auth": "2.0.0",
+        "basic-auth": "~2.0.0",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
+        "depd": "~1.1.1",
+        "on-finished": "~2.3.0",
+        "on-headers": "~1.0.1"
       },
       "dependencies": {
         "debug": {
@@ -6988,10 +6992,10 @@
       "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
       "dev": true,
       "requires": {
-        "array-differ": "1.0.0",
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "minimatch": "3.0.4"
+        "array-differ": "^1.0.0",
+        "array-union": "^1.0.1",
+        "arrify": "^1.0.0",
+        "minimatch": "^3.0.0"
       },
       "dependencies": {
         "minimatch": {
@@ -7000,7 +7004,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -7011,8 +7015,8 @@
       "integrity": "sha1-veITAdrSlChuFVsrYHEMauBK5k8=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14",
-        "stream-counter": "0.2.0"
+        "readable-stream": "~1.1.9",
+        "stream-counter": "~0.2.0"
       }
     },
     "mute-stream": {
@@ -7045,7 +7049,7 @@
       "integrity": "sha1-JP48OYN69be5U8aI4kLz98C50Qo=",
       "dev": true,
       "requires": {
-        "q": "1.5.0"
+        "q": "^1.0.1"
       },
       "dependencies": {
         "q": {
@@ -7062,19 +7066,19 @@
       "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
       "dev": true,
       "requires": {
-        "fstream": "1.0.11",
-        "glob": "7.1.2",
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "npmlog": "4.1.2",
-        "osenv": "0.0.3",
-        "request": "2.67.0",
-        "rimraf": "2.2.8",
-        "semver": "5.3.0",
-        "tar": "2.2.1",
-        "which": "1.0.9"
+        "fstream": "^1.0.0",
+        "glob": "^7.0.3",
+        "graceful-fs": "^4.1.2",
+        "minimatch": "^3.0.2",
+        "mkdirp": "^0.5.0",
+        "nopt": "2 || 3",
+        "npmlog": "0 || 1 || 2 || 3 || 4",
+        "osenv": "0",
+        "request": "2",
+        "rimraf": "2",
+        "semver": "~5.3.0",
+        "tar": "^2.0.0",
+        "which": "1"
       },
       "dependencies": {
         "glob": {
@@ -7083,12 +7087,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "graceful-fs": {
@@ -7103,7 +7107,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -7127,7 +7131,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.0"
+            "abbrev": "1"
           }
         },
         "semver": {
@@ -7144,25 +7148,25 @@
       "integrity": "sha512-QFHfrZl6lqRU3csypwviz2XLgGNOoWQbo2GOvtsfQqOfL4cy1BtWnhx/XUeAO9LT3ahBzSRXcEO6DdvAH9DzSg==",
       "dev": true,
       "requires": {
-        "async-foreach": "0.1.3",
-        "chalk": "1.1.3",
-        "cross-spawn": "3.0.1",
-        "gaze": "1.1.2",
-        "get-stdin": "4.0.1",
-        "glob": "7.1.2",
-        "in-publish": "2.0.0",
-        "lodash.assign": "4.2.0",
-        "lodash.clonedeep": "4.5.0",
-        "lodash.mergewith": "4.6.1",
-        "meow": "3.7.0",
-        "mkdirp": "0.5.1",
-        "nan": "2.10.0",
-        "node-gyp": "3.6.2",
-        "npmlog": "4.1.2",
-        "request": "2.79.0",
-        "sass-graph": "2.2.4",
-        "stdout-stream": "1.4.0",
-        "true-case-path": "1.0.2"
+        "async-foreach": "^0.1.3",
+        "chalk": "^1.1.1",
+        "cross-spawn": "^3.0.0",
+        "gaze": "^1.0.0",
+        "get-stdin": "^4.0.1",
+        "glob": "^7.0.3",
+        "in-publish": "^2.0.0",
+        "lodash.assign": "^4.2.0",
+        "lodash.clonedeep": "^4.3.2",
+        "lodash.mergewith": "^4.6.0",
+        "meow": "^3.7.0",
+        "mkdirp": "^0.5.1",
+        "nan": "^2.10.0",
+        "node-gyp": "^3.3.1",
+        "npmlog": "^4.0.0",
+        "request": "~2.79.0",
+        "sass-graph": "^2.2.4",
+        "stdout-stream": "^1.4.0",
+        "true-case-path": "^1.0.2"
       },
       "dependencies": {
         "form-data": {
@@ -7171,9 +7175,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "gaze": {
@@ -7182,7 +7186,7 @@
           "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
           "dev": true,
           "requires": {
-            "globule": "1.2.0"
+            "globule": "^1.0.0"
           }
         },
         "glob": {
@@ -7191,12 +7195,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globule": {
@@ -7205,9 +7209,9 @@
           "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "lodash": "4.17.10",
-            "minimatch": "3.0.4"
+            "glob": "~7.1.1",
+            "lodash": "~4.17.4",
+            "minimatch": "~3.0.2"
           }
         },
         "lodash": {
@@ -7234,7 +7238,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -7264,26 +7268,26 @@
           "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.11.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "2.0.6",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "qs": "6.3.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.4.3",
-            "uuid": "3.2.1"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1",
+            "uuid": "^3.0.0"
           }
         },
         "tough-cookie": {
@@ -7292,7 +7296,7 @@
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "uuid": {
@@ -7315,7 +7319,7 @@
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.0"
+        "abbrev": "1"
       }
     },
     "noptify": {
@@ -7324,7 +7328,7 @@
       "integrity": "sha1-WPZUpz2XU98MUdlobckhBKZ/S7s=",
       "dev": true,
       "requires": {
-        "nopt": "2.0.0"
+        "nopt": "~2.0.0"
       },
       "dependencies": {
         "nopt": {
@@ -7333,7 +7337,7 @@
           "integrity": "sha1-ynQW8gpeP5w7hhgPlilfo9C1Lg0=",
           "dev": true,
           "requires": {
-            "abbrev": "1.1.0"
+            "abbrev": "1"
           }
         }
       }
@@ -7344,10 +7348,10 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "4.3.6",
-        "validate-npm-package-license": "3.0.1"
+        "hosted-git-info": "^2.1.4",
+        "is-builtin-module": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
       }
     },
     "normalize-path": {
@@ -7356,7 +7360,7 @@
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
       "dev": true,
       "requires": {
-        "remove-trailing-separator": "1.1.0"
+        "remove-trailing-separator": "^1.0.1"
       },
       "dependencies": {
         "remove-trailing-separator": {
@@ -7379,10 +7383,10 @@
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
       "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
       }
     },
     "nth-check": {
@@ -7391,7 +7395,7 @@
       "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
       "dev": true,
       "requires": {
-        "boolbase": "1.0.0"
+        "boolbase": "~1.0.0"
       }
     },
     "num2fraction": {
@@ -7424,8 +7428,8 @@
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
       "dev": true,
       "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
+        "for-own": "^0.1.4",
+        "is-extendable": "^0.1.1"
       }
     },
     "on-finished": {
@@ -7449,7 +7453,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "onetime": {
@@ -7470,8 +7474,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.2"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       }
     },
     "optionator": {
@@ -7480,12 +7484,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       },
       "dependencies": {
         "wordwrap": {
@@ -7508,7 +7512,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "1.0.0"
+        "lcid": "^1.0.0"
       }
     },
     "osenv": {
@@ -7535,7 +7539,7 @@
       "integrity": "sha1-3LCRpDwlm5Io8cNB57akTqC/l0M=",
       "dev": true,
       "requires": {
-        "sentence-case": "1.1.3"
+        "sentence-case": "^1.1.2"
       }
     },
     "parse-glob": {
@@ -7544,10 +7548,10 @@
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
       "dev": true,
       "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
+        "glob-base": "^0.3.0",
+        "is-dotfile": "^1.0.0",
+        "is-extglob": "^1.0.0",
+        "is-glob": "^2.0.0"
       }
     },
     "parse-json": {
@@ -7556,7 +7560,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "^1.2.0"
       }
     },
     "parse-ms": {
@@ -7583,8 +7587,8 @@
       "integrity": "sha1-Pl1kogBDgwp8STRMLXS0G+DJyZs=",
       "dev": true,
       "requires": {
-        "camel-case": "1.2.2",
-        "upper-case-first": "1.1.2"
+        "camel-case": "^1.1.1",
+        "upper-case-first": "^1.1.0"
       }
     },
     "path-case": {
@@ -7593,7 +7597,7 @@
       "integrity": "sha1-UM5roNO+090LXCqcRVNpdDRAlRQ=",
       "dev": true,
       "requires": {
-        "sentence-case": "1.1.3"
+        "sentence-case": "^1.1.2"
       }
     },
     "path-exists": {
@@ -7602,7 +7606,7 @@
       "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
       "dev": true,
       "requires": {
-        "pinkie-promise": "2.0.1"
+        "pinkie-promise": "^2.0.0"
       }
     },
     "path-is-absolute": {
@@ -7635,9 +7639,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "4.1.11",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
+        "graceful-fs": "^4.1.2",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
       },
       "dependencies": {
         "graceful-fs": {
@@ -7672,14 +7676,14 @@
       "integrity": "sha1-xpEPZ5NcNyhbYRQyn8LyfV8+MTQ=",
       "dev": true,
       "requires": {
-        "extract-zip": "1.5.0",
-        "fs-extra": "0.26.7",
-        "hasha": "2.2.0",
-        "kew": "0.7.0",
-        "progress": "1.1.8",
-        "request": "2.67.0",
-        "request-progress": "2.0.1",
-        "which": "1.2.14"
+        "extract-zip": "~1.5.0",
+        "fs-extra": "~0.26.4",
+        "hasha": "^2.2.0",
+        "kew": "~0.7.0",
+        "progress": "~1.1.8",
+        "request": "~2.67.0",
+        "request-progress": "~2.0.1",
+        "which": "~1.2.2"
       },
       "dependencies": {
         "which": {
@@ -7688,7 +7692,7 @@
           "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -7711,7 +7715,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "2.0.4"
+        "pinkie": "^2.0.0"
       }
     },
     "pkg-up": {
@@ -7720,7 +7724,7 @@
       "integrity": "sha1-Pgj7RhUlxEIWJKM7n35tCvWwWiY=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2"
+        "find-up": "^1.0.0"
       }
     },
     "plur": {
@@ -7758,9 +7762,9 @@
       "integrity": "sha512-y/bKfbQz2Nn/QBC08bwvYUxEFOVGfPIUOTsJ2CK5inzlXW9SdYR1x4pEsG9blRAF/PX+wRNdOah+gx/hv4q7dw==",
       "dev": true,
       "requires": {
-        "chalk": "2.3.2",
-        "source-map": "0.6.1",
-        "supports-color": "5.3.0"
+        "chalk": "^2.3.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^5.3.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -7769,7 +7773,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1"
+            "color-convert": "^1.9.0"
           }
         },
         "chalk": {
@@ -7778,9 +7782,9 @@
           "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.3.0"
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
           }
         },
         "source-map": {
@@ -7795,7 +7799,7 @@
           "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -7830,9 +7834,9 @@
       "integrity": "sha1-QlfCVt8/sLRR1q/6qwIYhBJpgdw=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2",
-        "parse-ms": "1.0.1",
-        "plur": "1.0.0"
+        "is-finite": "^1.0.1",
+        "parse-ms": "^1.0.0",
+        "plur": "^1.0.0"
       }
     },
     "process-nextick-args": {
@@ -7861,7 +7865,7 @@
       "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
       "dev": true,
       "requires": {
-        "forwarded": "0.1.2",
+        "forwarded": "~0.1.2",
         "ipaddr.js": "1.6.0"
       }
     },
@@ -7895,8 +7899,8 @@
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "^3.0.0",
+        "kind-of": "^4.0.0"
       },
       "dependencies": {
         "is-number": {
@@ -7905,7 +7909,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -7914,7 +7918,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -7925,7 +7929,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "1.1.5"
+            "is-buffer": "^1.1.5"
           }
         }
       }
@@ -7963,7 +7967,7 @@
             "depd": "1.1.1",
             "inherits": "2.0.3",
             "setprototypeof": "1.0.3",
-            "statuses": "1.5.0"
+            "statuses": ">= 1.3.1 < 2"
           }
         },
         "iconv-lite": {
@@ -7986,10 +7990,10 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
       },
       "dependencies": {
         "minimist": {
@@ -8012,9 +8016,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "1.1.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "1.1.0"
+        "load-json-file": "^1.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^1.0.0"
       }
     },
     "read-pkg-up": {
@@ -8023,8 +8027,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "1.1.2",
-        "read-pkg": "1.1.0"
+        "find-up": "^1.0.0",
+        "read-pkg": "^1.0.0"
       }
     },
     "readable-stream": {
@@ -8033,10 +8037,10 @@
       "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
       "dev": true,
       "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
         "isarray": "0.0.1",
-        "string_decoder": "0.10.31"
+        "string_decoder": "~0.10.x"
       }
     },
     "readline2": {
@@ -8045,8 +8049,8 @@
       "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
         "mute-stream": "0.0.5"
       }
     },
@@ -8056,7 +8060,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.4.0"
+        "resolve": "^1.1.6"
       }
     },
     "redent": {
@@ -8065,8 +8069,8 @@
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
       "dev": true,
       "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
+        "indent-string": "^2.1.0",
+        "strip-indent": "^1.0.1"
       }
     },
     "regex-cache": {
@@ -8075,7 +8079,7 @@
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "requires": {
-        "is-equal-shallow": "0.1.3"
+        "is-equal-shallow": "^0.1.3"
       }
     },
     "relateurl": {
@@ -8102,7 +8106,7 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "dev": true,
       "requires": {
-        "is-finite": "1.0.2"
+        "is-finite": "^1.0.0"
       }
     },
     "request": {
@@ -8111,26 +8115,26 @@
       "integrity": "sha1-ivdHgOK/EeoK6aqWXBHxGv0nJ0I=",
       "dev": true,
       "requires": {
-        "aws-sign2": "0.6.0",
-        "bl": "1.0.3",
-        "caseless": "0.11.0",
-        "combined-stream": "1.0.5",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "1.0.1",
-        "har-validator": "2.0.6",
-        "hawk": "3.1.3",
-        "http-signature": "1.1.1",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.17",
-        "node-uuid": "1.4.8",
-        "oauth-sign": "0.8.2",
-        "qs": "5.2.1",
-        "stringstream": "0.0.5",
-        "tough-cookie": "2.2.2",
-        "tunnel-agent": "0.4.3"
+        "aws-sign2": "~0.6.0",
+        "bl": "~1.0.0",
+        "caseless": "~0.11.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.0",
+        "forever-agent": "~0.6.1",
+        "form-data": "~1.0.0-rc3",
+        "har-validator": "~2.0.2",
+        "hawk": "~3.1.0",
+        "http-signature": "~1.1.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.7",
+        "node-uuid": "~1.4.7",
+        "oauth-sign": "~0.8.0",
+        "qs": "~5.2.0",
+        "stringstream": "~0.0.4",
+        "tough-cookie": "~2.2.0",
+        "tunnel-agent": "~0.4.1"
       },
       "dependencies": {
         "qs": {
@@ -8147,7 +8151,7 @@
       "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
       "dev": true,
       "requires": {
-        "throttleit": "1.0.0"
+        "throttleit": "^1.0.0"
       }
     },
     "requestretry": {
@@ -8156,10 +8160,10 @@
       "integrity": "sha1-CioATq8hGWnEzCz+vz/p5XuSx04=",
       "dev": true,
       "requires": {
-        "extend": "3.0.1",
+        "extend": "^3.0.0",
         "fg-lodash": "0.0.2",
-        "request": "2.81.0",
-        "when": "3.7.8"
+        "request": "^2.74.x",
+        "when": "~3.7.5"
       },
       "dependencies": {
         "caseless": {
@@ -8174,9 +8178,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "har-validator": {
@@ -8185,8 +8189,8 @@
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "qs": {
@@ -8201,28 +8205,28 @@
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "tough-cookie": {
@@ -8231,7 +8235,7 @@
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -8240,7 +8244,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "uuid": {
@@ -8269,8 +8273,8 @@
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
       "dev": true,
       "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
+        "caller-path": "^0.1.0",
+        "resolve-from": "^1.0.0"
       }
     },
     "resolve": {
@@ -8279,7 +8283,7 @@
       "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
       "dev": true,
       "requires": {
-        "path-parse": "1.0.5"
+        "path-parse": "^1.0.5"
       }
     },
     "resolve-dep": {
@@ -8288,14 +8292,14 @@
       "integrity": "sha1-L1LSAjz+guw/GY1K8ry2SSXSdU8=",
       "dev": true,
       "requires": {
-        "arrayify-compact": "0.1.0",
-        "cwd": "0.3.7",
-        "extend-shallow": "0.2.0",
-        "globby": "1.2.0",
-        "load-pkg": "3.0.1",
-        "lookup-path": "0.3.1",
-        "micromatch": "1.6.2",
-        "resolve": "1.4.0"
+        "arrayify-compact": "^0.1.0",
+        "cwd": "^0.3.7",
+        "extend-shallow": "^0.2.0",
+        "globby": "^1.1.0",
+        "load-pkg": "^3.0.1",
+        "lookup-path": "^0.3.0",
+        "micromatch": "^1.2.2",
+        "resolve": "^1.0.0"
       },
       "dependencies": {
         "ansi": {
@@ -8316,7 +8320,7 @@
           "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
           "dev": true,
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         },
         "arr-diff": {
@@ -8325,8 +8329,8 @@
           "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
           "dev": true,
           "requires": {
-            "arr-flatten": "1.1.0",
-            "array-slice": "0.2.3"
+            "arr-flatten": "^1.0.1",
+            "array-slice": "^0.2.3"
           }
         },
         "arr-flatten": {
@@ -8359,7 +8363,7 @@
           "integrity": "sha1-uG302tz8I2pKQE8CR5QLf3OzYT4=",
           "dev": true,
           "requires": {
-            "array-flatten": "2.1.1"
+            "array-flatten": ">= 0.0.2"
           }
         },
         "async": {
@@ -8386,13 +8390,13 @@
           "integrity": "sha1-hxPRaOC87Hy73z8JPDT7USPofkk=",
           "dev": true,
           "requires": {
-            "ansi": "0.3.1",
-            "benchmark": "1.0.0",
-            "chalk": "1.1.3",
-            "extend-shallow": "1.1.4",
-            "file-reader": "1.1.1",
-            "for-own": "0.1.5",
-            "has-values": "0.1.4"
+            "ansi": "^0.3.0",
+            "benchmark": "^1.0.0",
+            "chalk": "^1.0.0",
+            "extend-shallow": "^1.1.2",
+            "file-reader": "^1.0.0",
+            "for-own": "^0.1.3",
+            "has-values": "^0.1.2"
           },
           "dependencies": {
             "chalk": {
@@ -8401,11 +8405,11 @@
               "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
               "dev": true,
               "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
               }
             },
             "extend-shallow": {
@@ -8414,7 +8418,7 @@
               "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
               "dev": true,
               "requires": {
-                "kind-of": "1.1.0"
+                "kind-of": "^1.1.0"
               }
             }
           }
@@ -8425,9 +8429,9 @@
           "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
           "dev": true,
           "requires": {
-            "expand-range": "1.8.2",
-            "preserve": "0.2.0",
-            "repeat-element": "1.1.2"
+            "expand-range": "^1.8.1",
+            "preserve": "^0.2.0",
+            "repeat-element": "^1.1.2"
           }
         },
         "chalk": {
@@ -8436,11 +8440,11 @@
           "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.1.0",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "0.1.0",
-            "strip-ansi": "0.3.0",
-            "supports-color": "0.2.0"
+            "ansi-styles": "^1.1.0",
+            "escape-string-regexp": "^1.0.0",
+            "has-ansi": "^0.1.0",
+            "strip-ansi": "^0.3.0",
+            "supports-color": "^0.2.0"
           },
           "dependencies": {
             "ansi-styles": {
@@ -8455,7 +8459,7 @@
               "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
               "dev": true,
               "requires": {
-                "ansi-regex": "0.2.1"
+                "ansi-regex": "^0.2.0"
               }
             },
             "strip-ansi": {
@@ -8464,7 +8468,7 @@
               "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
               "dev": true,
               "requires": {
-                "ansi-regex": "0.2.1"
+                "ansi-regex": "^0.2.1"
               }
             },
             "supports-color": {
@@ -8499,7 +8503,7 @@
           "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
           "dev": true,
           "requires": {
-            "is-posix-bracket": "0.1.1"
+            "is-posix-bracket": "^0.1.0"
           }
         },
         "expand-range": {
@@ -8508,7 +8512,7 @@
           "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
           "dev": true,
           "requires": {
-            "fill-range": "2.2.3"
+            "fill-range": "^2.1.0"
           }
         },
         "expand-tilde": {
@@ -8517,7 +8521,7 @@
           "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
           "dev": true,
           "requires": {
-            "os-homedir": "1.0.2"
+            "os-homedir": "^1.0.1"
           }
         },
         "extend-shallow": {
@@ -8526,7 +8530,7 @@
           "integrity": "sha1-DJignyfYPLQ++vztrIydFJ3rWZw=",
           "dev": true,
           "requires": {
-            "array-slice": "0.2.3"
+            "array-slice": "^0.2.2"
           }
         },
         "extglob": {
@@ -8535,7 +8539,7 @@
           "integrity": "sha1-MWtr7G4bM1cxOMoEyh48sJNm8Nc=",
           "dev": true,
           "requires": {
-            "micromatch": "1.6.2"
+            "micromatch": "^1.2.2"
           }
         },
         "file-reader": {
@@ -8544,11 +8548,11 @@
           "integrity": "sha1-OD0TG0p9WMd+w1Nm3Nrb1HV96NY=",
           "dev": true,
           "requires": {
-            "camel-case": "1.2.2",
-            "extend-shallow": "2.0.1",
-            "lazy-cache": "1.0.4",
-            "map-files": "0.8.2",
-            "read-yaml": "1.1.0"
+            "camel-case": "^1.2.2",
+            "extend-shallow": "^2.0.1",
+            "lazy-cache": "^1.0.4",
+            "map-files": "^0.8.0",
+            "read-yaml": "^1.0.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -8557,7 +8561,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -8574,11 +8578,11 @@
           "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
           "dev": true,
           "requires": {
-            "is-number": "2.1.0",
-            "isobject": "2.1.0",
-            "randomatic": "1.1.7",
-            "repeat-element": "1.1.2",
-            "repeat-string": "1.6.1"
+            "is-number": "^2.1.0",
+            "isobject": "^2.0.0",
+            "randomatic": "^1.1.3",
+            "repeat-element": "^1.1.2",
+            "repeat-string": "^1.5.2"
           }
         },
         "for-in": {
@@ -8593,7 +8597,7 @@
           "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
           "dev": true,
           "requires": {
-            "for-in": "1.0.2"
+            "for-in": "^1.0.1"
           }
         },
         "fs-exists-sync": {
@@ -8608,10 +8612,10 @@
           "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "2.0.10",
-            "once": "1.4.0"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
           }
         },
         "glob-base": {
@@ -8620,8 +8624,8 @@
           "integrity": "sha1-87LcQGRnztJWfxlldFD7jgNvjG0=",
           "dev": true,
           "requires": {
-            "glob-parent": "1.3.0",
-            "is-glob": "1.1.3"
+            "glob-parent": "^1.2.0",
+            "is-glob": "^1.1.1"
           }
         },
         "glob-parent": {
@@ -8630,7 +8634,7 @@
           "integrity": "sha1-lx7dgW7V21hwW1gHlkemTQrveWg=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.0"
           },
           "dependencies": {
             "is-glob": {
@@ -8639,7 +8643,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -8656,8 +8660,8 @@
           "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
           "dev": true,
           "requires": {
-            "global-prefix": "0.1.5",
-            "is-windows": "0.2.0"
+            "global-prefix": "^0.1.4",
+            "is-windows": "^0.2.0"
           }
         },
         "global-prefix": {
@@ -8666,10 +8670,10 @@
           "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "1.0.1",
-            "ini": "1.3.4",
-            "is-windows": "0.2.0",
-            "which": "1.3.0"
+            "homedir-polyfill": "^1.0.0",
+            "ini": "^1.3.4",
+            "is-windows": "^0.2.0",
+            "which": "^1.2.12"
           }
         },
         "globby": {
@@ -8678,10 +8682,10 @@
           "integrity": "sha1-x8l60cxvhZSBHaHrgpBqhSukfaQ=",
           "dev": true,
           "requires": {
-            "array-union": "1.0.2",
-            "async": "0.9.2",
-            "glob": "4.5.3",
-            "object-assign": "2.1.1"
+            "array-union": "^1.0.1",
+            "async": "^0.9.0",
+            "glob": "^4.4.0",
+            "object-assign": "^2.0.0"
           }
         },
         "has-glob": {
@@ -8690,7 +8694,7 @@
           "integrity": "sha1-omHEwqbGZ+DHe3AKfyl8Oe86pYk=",
           "dev": true,
           "requires": {
-            "is-glob": "2.0.1"
+            "is-glob": "^2.0.1"
           },
           "dependencies": {
             "is-glob": {
@@ -8699,7 +8703,7 @@
               "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
               "dev": true,
               "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
               }
             }
           }
@@ -8716,7 +8720,7 @@
           "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
           "dev": true,
           "requires": {
-            "parse-passwd": "1.0.0"
+            "parse-passwd": "^1.0.0"
           }
         },
         "ini": {
@@ -8731,8 +8735,8 @@
           "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
           "dev": true,
           "requires": {
-            "is-relative": "0.2.1",
-            "is-windows": "0.2.0"
+            "is-relative": "^0.2.1",
+            "is-windows": "^0.2.0"
           }
         },
         "is-extendable": {
@@ -8759,7 +8763,7 @@
           "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -8768,7 +8772,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -8785,7 +8789,7 @@
           "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
           "dev": true,
           "requires": {
-            "is-unc-path": "0.1.2"
+            "is-unc-path": "^0.1.1"
           }
         },
         "is-unc-path": {
@@ -8794,7 +8798,7 @@
           "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
           "dev": true,
           "requires": {
-            "unc-path-regex": "0.1.2"
+            "unc-path-regex": "^0.1.0"
           }
         },
         "is-valid-glob": {
@@ -8830,8 +8834,8 @@
           "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "kind-of": {
@@ -8846,8 +8850,8 @@
           "integrity": "sha1-pO8kEK4yZpr3AMTLfhsBCVCc8rg=",
           "dev": true,
           "requires": {
-            "debug": "2.6.8",
-            "is-absolute": "0.2.6"
+            "debug": "^2.2.0",
+            "is-absolute": "^0.2.3"
           }
         },
         "map-files": {
@@ -8856,10 +8860,10 @@
           "integrity": "sha1-wb8wAX7l9ZSPJZdAdqOvllOXg4E=",
           "dev": true,
           "requires": {
-            "isobject": "2.1.0",
-            "lazy-cache": "1.0.4",
-            "matched": "0.4.4",
-            "vinyl": "1.2.0"
+            "isobject": "^2.0.0",
+            "lazy-cache": "^1.0.4",
+            "matched": "^0.4.1",
+            "vinyl": "^1.1.1"
           }
         },
         "matched": {
@@ -8868,15 +8872,15 @@
           "integrity": "sha1-Vte36xgDPwz5vFLrIJD6x9weifo=",
           "dev": true,
           "requires": {
-            "arr-union": "3.1.0",
-            "async-array-reduce": "0.2.1",
-            "extend-shallow": "2.0.1",
-            "fs-exists-sync": "0.1.0",
-            "glob": "7.1.2",
-            "has-glob": "0.1.1",
-            "is-valid-glob": "0.3.0",
-            "lazy-cache": "2.0.2",
-            "resolve-dir": "0.1.1"
+            "arr-union": "^3.1.0",
+            "async-array-reduce": "^0.2.0",
+            "extend-shallow": "^2.0.1",
+            "fs-exists-sync": "^0.1.0",
+            "glob": "^7.0.5",
+            "has-glob": "^0.1.1",
+            "is-valid-glob": "^0.3.0",
+            "lazy-cache": "^2.0.1",
+            "resolve-dir": "^0.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -8885,7 +8889,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             },
             "glob": {
@@ -8894,12 +8898,12 @@
               "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
               "dev": true,
               "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
               }
             },
             "lazy-cache": {
@@ -8908,7 +8912,7 @@
               "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
               "dev": true,
               "requires": {
-                "set-getter": "0.1.0"
+                "set-getter": "^0.1.0"
               }
             },
             "minimatch": {
@@ -8917,7 +8921,7 @@
               "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
               "dev": true,
               "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
               }
             }
           }
@@ -8928,17 +8932,17 @@
           "integrity": "sha1-OPq0cHaqzs5urXfvOEcjkve0v7k=",
           "dev": true,
           "requires": {
-            "arr-diff": "1.1.0",
-            "braces": "1.8.5",
-            "debug": "2.6.8",
-            "expand-brackets": "0.1.5",
-            "extglob": "0.2.0",
-            "filename-regex": "2.0.1",
-            "is-glob": "1.1.3",
-            "kind-of": "1.1.0",
-            "object.omit": "0.2.1",
-            "parse-glob": "2.1.1",
-            "regex-cache": "0.3.0"
+            "arr-diff": "^1.0.1",
+            "braces": "^1.7.0",
+            "debug": "^2.1.2",
+            "expand-brackets": "^0.1.1",
+            "extglob": "^0.2.0",
+            "filename-regex": "^2.0.0",
+            "is-glob": "^1.1.1",
+            "kind-of": "^1.1.0",
+            "object.omit": "^0.2.1",
+            "parse-glob": "^2.1.1",
+            "regex-cache": "^0.3.0"
           }
         },
         "minimatch": {
@@ -8947,7 +8951,7 @@
           "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.0.0"
           }
         },
         "object-assign": {
@@ -8962,8 +8966,8 @@
           "integrity": "sha1-ypr2Yx32iD/mG65034Kk+8nfLpI=",
           "dev": true,
           "requires": {
-            "for-own": "0.1.5",
-            "isobject": "0.2.0"
+            "for-own": "^0.1.1",
+            "isobject": "^0.2.0"
           },
           "dependencies": {
             "isobject": {
@@ -8980,9 +8984,9 @@
           "integrity": "sha1-WxNouudnoisTWitQBGs09O75B/Y=",
           "dev": true,
           "requires": {
-            "glob-base": "0.1.1",
-            "glob-path-regex": "1.0.0",
-            "is-glob": "1.1.3"
+            "glob-base": "^0.1.0",
+            "glob-path-regex": "^1.0.0",
+            "is-glob": "^1.1.0"
           }
         },
         "parse-passwd": {
@@ -9003,8 +9007,8 @@
           "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
           "dev": true,
           "requires": {
-            "is-number": "3.0.0",
-            "kind-of": "4.0.0"
+            "is-number": "^3.0.0",
+            "kind-of": "^4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -9013,7 +9017,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -9022,7 +9026,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "1.1.5"
+                    "is-buffer": "^1.1.5"
                   }
                 }
               }
@@ -9033,7 +9037,7 @@
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -9044,8 +9048,8 @@
           "integrity": "sha1-DSc6wMlb6SIw3A1MTE9biWCjNtY=",
           "dev": true,
           "requires": {
-            "extend-shallow": "2.0.1",
-            "js-yaml": "3.10.0"
+            "extend-shallow": "^2.0.1",
+            "js-yaml": "^3.8.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -9054,7 +9058,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
               }
             }
           }
@@ -9065,10 +9069,10 @@
           "integrity": "sha1-PqA2YnF5ECv7GiNkqyZ5oPMpZMA=",
           "dev": true,
           "requires": {
-            "benchmarked": "0.1.5",
-            "chalk": "0.5.1",
-            "micromatch": "1.6.2",
-            "to-key": "1.0.0"
+            "benchmarked": "^0.1.3",
+            "chalk": "^0.5.1",
+            "micromatch": "^1.2.2",
+            "to-key": "^1.0.0"
           }
         },
         "repeat-element": {
@@ -9089,8 +9093,8 @@
           "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
           "dev": true,
           "requires": {
-            "expand-tilde": "1.2.2",
-            "global-modules": "0.2.3"
+            "expand-tilde": "^1.2.2",
+            "global-modules": "^0.2.3"
           }
         },
         "set-getter": {
@@ -9099,7 +9103,7 @@
           "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
           "dev": true,
           "requires": {
-            "to-object-path": "0.3.0"
+            "to-object-path": "^0.3.0"
           }
         },
         "to-key": {
@@ -9108,9 +9112,9 @@
           "integrity": "sha1-I5D8drsqo/VnWZhcp2O7RRV4nyo=",
           "dev": true,
           "requires": {
-            "arr-map": "1.0.0",
-            "for-in": "0.1.8",
-            "kind-of": "1.1.0"
+            "arr-map": "^1.0.0",
+            "for-in": "^0.1.3",
+            "kind-of": "^1.1.0"
           },
           "dependencies": {
             "for-in": {
@@ -9127,7 +9131,7 @@
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
-            "kind-of": "3.2.2"
+            "kind-of": "^3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9136,7 +9140,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
               }
             }
           }
@@ -9153,8 +9157,8 @@
           "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
           "dev": true,
           "requires": {
-            "clone": "1.0.2",
-            "clone-stats": "0.0.1",
+            "clone": "^1.0.0",
+            "clone-stats": "^0.0.1",
             "replace-ext": "0.0.1"
           }
         },
@@ -9164,7 +9168,7 @@
           "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
-            "isexe": "2.0.0"
+            "isexe": "^2.0.0"
           }
         }
       }
@@ -9181,7 +9185,7 @@
       "integrity": "sha1-AsyZNBDik2livZcWahsHfalyVTE=",
       "dev": true,
       "requires": {
-        "resolve-from": "2.0.0"
+        "resolve-from": "^2.0.0"
       },
       "dependencies": {
         "resolve-from": {
@@ -9215,8 +9219,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "1.1.1",
-        "onetime": "1.1.0"
+        "exit-hook": "^1.0.0",
+        "onetime": "^1.0.0"
       }
     },
     "right-align": {
@@ -9226,7 +9230,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -9247,7 +9251,7 @@
       "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
       "dev": true,
       "requires": {
-        "once": "1.4.0"
+        "once": "^1.3.0"
       }
     },
     "rx-lite": {
@@ -9274,10 +9278,10 @@
       "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "lodash": "4.17.10",
-        "scss-tokenizer": "0.2.3",
-        "yargs": "7.1.0"
+        "glob": "^7.0.0",
+        "lodash": "^4.0.0",
+        "scss-tokenizer": "^0.2.3",
+        "yargs": "^7.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -9292,9 +9296,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "glob": {
@@ -9303,12 +9307,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "lodash": {
@@ -9323,7 +9327,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "yargs": {
@@ -9332,19 +9336,19 @@
           "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
           "dev": true,
           "requires": {
-            "camelcase": "3.0.0",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "get-caller-file": "1.0.2",
-            "os-locale": "1.4.0",
-            "read-pkg-up": "1.0.1",
-            "require-directory": "2.1.1",
-            "require-main-filename": "1.0.1",
-            "set-blocking": "2.0.0",
-            "string-width": "1.0.2",
-            "which-module": "1.0.0",
-            "y18n": "3.2.1",
-            "yargs-parser": "5.0.0"
+            "camelcase": "^3.0.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^1.4.0",
+            "read-pkg-up": "^1.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^1.0.2",
+            "which-module": "^1.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^5.0.0"
           }
         }
       }
@@ -9355,20 +9359,20 @@
       "integrity": "sha1-Yw9pwhaqIGuCMvsqqQe98zNrbYM=",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
-        "eslint": "2.13.1",
+        "commander": "^2.8.1",
+        "eslint": "^2.7.0",
         "front-matter": "2.1.2",
-        "fs-extra": "3.0.1",
-        "glob": "7.1.2",
-        "globule": "1.2.0",
-        "gonzales-pe-sl": "4.2.3",
-        "js-yaml": "3.11.0",
-        "known-css-properties": "0.3.0",
-        "lodash.capitalize": "4.2.1",
-        "lodash.kebabcase": "4.1.1",
-        "merge": "1.2.0",
-        "path-is-absolute": "1.0.1",
-        "util": "0.10.3"
+        "fs-extra": "^3.0.1",
+        "glob": "^7.0.0",
+        "globule": "^1.0.0",
+        "gonzales-pe-sl": "^4.2.3",
+        "js-yaml": "^3.5.4",
+        "known-css-properties": "^0.3.0",
+        "lodash.capitalize": "^4.1.0",
+        "lodash.kebabcase": "^4.0.0",
+        "merge": "^1.2.0",
+        "path-is-absolute": "^1.0.0",
+        "util": "^0.10.3"
       },
       "dependencies": {
         "argparse": {
@@ -9377,7 +9381,7 @@
           "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
           "dev": true,
           "requires": {
-            "sprintf-js": "1.0.3"
+            "sprintf-js": "~1.0.2"
           }
         },
         "doctrine": {
@@ -9386,8 +9390,8 @@
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
           "dev": true,
           "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
           }
         },
         "eslint": {
@@ -9396,39 +9400,39 @@
           "integrity": "sha1-5MyPoPAJ+4KaquI4VaKTYL4fbBE=",
           "dev": true,
           "requires": {
-            "chalk": "1.1.3",
-            "concat-stream": "1.6.0",
-            "debug": "2.6.8",
-            "doctrine": "1.5.0",
-            "es6-map": "0.1.5",
-            "escope": "3.6.0",
-            "espree": "3.5.0",
-            "estraverse": "4.2.0",
-            "esutils": "2.0.2",
-            "file-entry-cache": "1.3.1",
-            "glob": "7.1.2",
-            "globals": "9.18.0",
-            "ignore": "3.3.5",
-            "imurmurhash": "0.1.4",
-            "inquirer": "0.12.0",
-            "is-my-json-valid": "2.16.1",
-            "is-resolvable": "1.0.0",
-            "js-yaml": "3.11.0",
-            "json-stable-stringify": "1.0.1",
-            "levn": "0.3.0",
-            "lodash": "4.17.10",
-            "mkdirp": "0.5.1",
-            "optionator": "0.8.2",
-            "path-is-absolute": "1.0.1",
-            "path-is-inside": "1.0.2",
-            "pluralize": "1.2.1",
-            "progress": "1.1.8",
-            "require-uncached": "1.0.3",
-            "shelljs": "0.6.1",
-            "strip-json-comments": "1.0.4",
-            "table": "3.8.3",
-            "text-table": "0.2.0",
-            "user-home": "2.0.0"
+            "chalk": "^1.1.3",
+            "concat-stream": "^1.4.6",
+            "debug": "^2.1.1",
+            "doctrine": "^1.2.2",
+            "es6-map": "^0.1.3",
+            "escope": "^3.6.0",
+            "espree": "^3.1.6",
+            "estraverse": "^4.2.0",
+            "esutils": "^2.0.2",
+            "file-entry-cache": "^1.1.1",
+            "glob": "^7.0.3",
+            "globals": "^9.2.0",
+            "ignore": "^3.1.2",
+            "imurmurhash": "^0.1.4",
+            "inquirer": "^0.12.0",
+            "is-my-json-valid": "^2.10.0",
+            "is-resolvable": "^1.0.0",
+            "js-yaml": "^3.5.1",
+            "json-stable-stringify": "^1.0.0",
+            "levn": "^0.3.0",
+            "lodash": "^4.0.0",
+            "mkdirp": "^0.5.0",
+            "optionator": "^0.8.1",
+            "path-is-absolute": "^1.0.0",
+            "path-is-inside": "^1.0.1",
+            "pluralize": "^1.2.1",
+            "progress": "^1.1.8",
+            "require-uncached": "^1.0.2",
+            "shelljs": "^0.6.0",
+            "strip-json-comments": "~1.0.1",
+            "table": "^3.7.8",
+            "text-table": "~0.2.0",
+            "user-home": "^2.0.0"
           }
         },
         "esprima": {
@@ -9443,8 +9447,8 @@
           "integrity": "sha1-RMYepgeuS+nBQC9B9EJwy/4zT/g=",
           "dev": true,
           "requires": {
-            "flat-cache": "1.2.2",
-            "object-assign": "4.1.1"
+            "flat-cache": "^1.2.1",
+            "object-assign": "^4.0.1"
           }
         },
         "fs-extra": {
@@ -9453,9 +9457,9 @@
           "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11",
-            "jsonfile": "3.0.1",
-            "universalify": "0.1.1"
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^3.0.0",
+            "universalify": "^0.1.0"
           }
         },
         "glob": {
@@ -9464,12 +9468,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "globule": {
@@ -9478,9 +9482,9 @@
           "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
           "dev": true,
           "requires": {
-            "glob": "7.1.2",
-            "lodash": "4.17.10",
-            "minimatch": "3.0.4"
+            "glob": "~7.1.1",
+            "lodash": "~4.17.4",
+            "minimatch": "~3.0.2"
           }
         },
         "graceful-fs": {
@@ -9501,8 +9505,8 @@
           "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
           "dev": true,
           "requires": {
-            "argparse": "1.0.10",
-            "esprima": "4.0.0"
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "jsonfile": {
@@ -9511,7 +9515,7 @@
           "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
           "dev": true,
           "requires": {
-            "graceful-fs": "4.1.11"
+            "graceful-fs": "^4.1.6"
           }
         },
         "lodash": {
@@ -9526,7 +9530,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -9558,9 +9562,9 @@
       "integrity": "sha1-DuTE/5tH4BPosHLL+sSVt/7Y6Os=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "request": "2.81.0",
-        "split": "1.0.1"
+        "chalk": "^1.1.3",
+        "request": "^2.72.0",
+        "split": "^1.0.0"
       },
       "dependencies": {
         "caseless": {
@@ -9575,9 +9579,9 @@
           "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.17"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "har-validator": {
@@ -9586,8 +9590,8 @@
           "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "qs": {
@@ -9602,28 +9606,28 @@
           "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.17",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
           }
         },
         "tough-cookie": {
@@ -9632,7 +9636,7 @@
           "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "requires": {
-            "punycode": "1.4.1"
+            "punycode": "^1.4.1"
           }
         },
         "tunnel-agent": {
@@ -9641,7 +9645,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "^5.0.1"
           }
         },
         "uuid": {
@@ -9658,7 +9662,7 @@
       "integrity": "sha1-XoBHazbaG0LRDzlwfprypTsD2Io=",
       "dev": true,
       "requires": {
-        "https-proxy-agent": "1.0.0"
+        "https-proxy-agent": "^1.0.0"
       }
     },
     "scmp": {
@@ -9673,8 +9677,8 @@
       "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
       "dev": true,
       "requires": {
-        "js-base64": "2.4.3",
-        "source-map": "0.4.4"
+        "js-base64": "^2.1.8",
+        "source-map": "^0.4.2"
       }
     },
     "semver": {
@@ -9690,18 +9694,18 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "destroy": "1.0.4",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "etag": "1.8.1",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
         "fresh": "0.5.2",
-        "http-errors": "1.6.3",
+        "http-errors": "~1.6.2",
         "mime": "1.4.1",
         "ms": "2.0.0",
-        "on-finished": "2.3.0",
-        "range-parser": "1.2.0",
-        "statuses": "1.4.0"
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
       },
       "dependencies": {
         "debug": {
@@ -9733,7 +9737,7 @@
       "integrity": "sha1-gDSq/CFFdy06vhUJqkLJ4QQtwTk=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4"
+        "lower-case": "^1.1.1"
       }
     },
     "serve-favicon": {
@@ -9769,7 +9773,7 @@
           "integrity": "sha1-krHbDU89tHsFMN9uFa6X21FNwvg=",
           "dev": true,
           "requires": {
-            "mime": "1.2.11",
+            "mime": "~1.2.11",
             "negotiator": "0.4.6"
           }
         },
@@ -9793,9 +9797,9 @@
       "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "parseurl": "1.3.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
         "send": "0.16.2"
       }
     },
@@ -9823,9 +9827,9 @@
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
       "dev": true,
       "requires": {
-        "glob": "7.1.2",
-        "interpret": "1.0.4",
-        "rechoir": "0.6.2"
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
       },
       "dependencies": {
         "glob": {
@@ -9834,12 +9838,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -9848,7 +9852,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -9873,7 +9877,7 @@
       "requires": {
         "formatio": "1.1.1",
         "lolex": "1.1.0",
-        "util": "0.10.3"
+        "util": ">=0.10.3 <1"
       }
     },
     "slice-ansi": {
@@ -9888,7 +9892,7 @@
       "integrity": "sha1-DC8l4wUVjZoY09l3BmGH/vilpmo=",
       "dev": true,
       "requires": {
-        "sentence-case": "1.1.3"
+        "sentence-case": "^1.1.2"
       }
     },
     "sntp": {
@@ -9897,7 +9901,7 @@
       "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
       "dev": true,
       "requires": {
-        "hoek": "2.16.3"
+        "hoek": "2.x.x"
       }
     },
     "source-map": {
@@ -9906,7 +9910,7 @@
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
       "dev": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "spdx-correct": {
@@ -9915,7 +9919,7 @@
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
       "dev": true,
       "requires": {
-        "spdx-license-ids": "1.2.2"
+        "spdx-license-ids": "^1.0.2"
       }
     },
     "spdx-expression-parse": {
@@ -9936,7 +9940,7 @@
       "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
       "dev": true,
       "requires": {
-        "through": "2.3.8"
+        "through": "2"
       }
     },
     "sprintf-js": {
@@ -9957,14 +9961,14 @@
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
       "dev": true,
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -9987,7 +9991,7 @@
       "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
       "dev": true,
       "requires": {
-        "readable-stream": "2.3.6"
+        "readable-stream": "^2.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -10008,13 +10012,13 @@
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
           }
         },
         "string_decoder": {
@@ -10023,7 +10027,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "5.1.1"
+            "safe-buffer": "~5.1.0"
           }
         }
       }
@@ -10034,7 +10038,7 @@
       "integrity": "sha1-3tJmVWMZyLDiIoErnPOyb6fZR94=",
       "dev": true,
       "requires": {
-        "readable-stream": "1.1.14"
+        "readable-stream": "~1.1.8"
       }
     },
     "string-width": {
@@ -10043,9 +10047,9 @@
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "dev": true,
       "requires": {
-        "code-point-at": "1.1.0",
-        "is-fullwidth-code-point": "1.0.0",
-        "strip-ansi": "3.0.1"
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
       }
     },
     "string_decoder": {
@@ -10066,7 +10070,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "strip-bom": {
@@ -10075,7 +10079,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "0.2.1"
+        "is-utf8": "^0.2.0"
       }
     },
     "strip-indent": {
@@ -10084,7 +10088,7 @@
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
       "dev": true,
       "requires": {
-        "get-stdin": "4.0.1"
+        "get-stdin": "^4.0.1"
       }
     },
     "strip-json-comments": {
@@ -10105,8 +10109,8 @@
       "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
       "dev": true,
       "requires": {
-        "lower-case": "1.1.4",
-        "upper-case": "1.1.3"
+        "lower-case": "^1.1.1",
+        "upper-case": "^1.1.1"
       }
     },
     "table": {
@@ -10115,12 +10119,12 @@
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
       "dev": true,
       "requires": {
-        "ajv": "4.11.8",
-        "ajv-keywords": "1.5.1",
-        "chalk": "1.1.3",
-        "lodash": "4.17.4",
+        "ajv": "^4.7.0",
+        "ajv-keywords": "^1.0.0",
+        "chalk": "^1.1.1",
+        "lodash": "^4.0.0",
         "slice-ansi": "0.0.4",
-        "string-width": "2.1.1"
+        "string-width": "^2.0.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -10147,8 +10151,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -10157,7 +10161,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "3.0.0"
+            "ansi-regex": "^3.0.0"
           }
         }
       }
@@ -10168,9 +10172,9 @@
       "integrity": "sha1-ZMz6S37PSgBgAH5hcW1CR4FnFjc=",
       "dev": true,
       "requires": {
-        "deep-equal": "0.0.0",
-        "defined": "0.0.0",
-        "jsonify": "0.0.0"
+        "deep-equal": "~0.0.0",
+        "defined": "~0.0.0",
+        "jsonify": "~0.0.0"
       }
     },
     "tar": {
@@ -10179,9 +10183,9 @@
       "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
       "dev": true,
       "requires": {
-        "block-stream": "0.0.9",
-        "fstream": "1.0.11",
-        "inherits": "2.0.3"
+        "block-stream": "*",
+        "fstream": "^1.0.2",
+        "inherits": "2"
       }
     },
     "template": {
@@ -10190,10 +10194,10 @@
       "integrity": "sha1-F8rA7noO/1jda48Y6msFoHEXT8I=",
       "dev": true,
       "requires": {
-        "delims": "0.1.4",
-        "fs-utils": "0.4.3",
-        "lodash": "2.4.2",
-        "underscore.string": "2.3.3"
+        "delims": "~0.1.4",
+        "fs-utils": "~0.4.1",
+        "lodash": "~2.4.1",
+        "underscore.string": "~2.3.3"
       },
       "dependencies": {
         "async": {
@@ -10208,13 +10212,13 @@
           "integrity": "sha1-ZBdm/lQV0RZEHexkdpjBPWz5z3c=",
           "dev": true,
           "requires": {
-            "async": "0.6.2",
-            "globule": "0.2.0",
-            "graceful-fs": "2.0.3",
-            "js-yaml": "3.0.2",
-            "lodash": "2.4.2",
-            "mkdirp": "0.3.5",
-            "rimraf": "2.2.8"
+            "async": "~0.6.2",
+            "globule": "~0.2.0",
+            "graceful-fs": "~2.0.3",
+            "js-yaml": "~3.0.2",
+            "lodash": "~2.4.1",
+            "mkdirp": "~0.3.5",
+            "rimraf": "~2.2.6"
           }
         },
         "underscore.string": {
@@ -10231,7 +10235,7 @@
       "integrity": "sha1-oYqYHSi6jKNgJ/s8MFOMPst0CsA=",
       "dev": true,
       "requires": {
-        "package": "1.0.1"
+        "package": ">= 1.0.0 < 1.2.0"
       }
     },
     "text-table": {
@@ -10258,13 +10262,13 @@
       "integrity": "sha1-T+QF411tnhtr87eYg1WFdGudm9Y=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "date-time": "1.1.0",
-        "figures": "1.7.0",
-        "hooker": "0.2.3",
-        "number-is-nan": "1.0.1",
-        "pretty-ms": "2.1.0",
-        "text-table": "0.2.0"
+        "chalk": "^1.0.0",
+        "date-time": "^1.0.0",
+        "figures": "^1.0.0",
+        "hooker": "^0.2.3",
+        "number-is-nan": "^1.0.0",
+        "pretty-ms": "^2.1.0",
+        "text-table": "^0.2.0"
       }
     },
     "time-zone": {
@@ -10279,10 +10283,10 @@
       "integrity": "sha1-Hpnh4qhGm3NquX2X7vqYxx927Qo=",
       "dev": true,
       "requires": {
-        "debug": "0.7.4",
-        "faye-websocket": "0.4.4",
-        "noptify": "0.0.3",
-        "qs": "0.5.6"
+        "debug": "~0.7.0",
+        "faye-websocket": "~0.4.3",
+        "noptify": "~0.0.3",
+        "qs": "~0.5.2"
       },
       "dependencies": {
         "debug": {
@@ -10305,8 +10309,8 @@
       "integrity": "sha1-+uSmrlRr+iLQg6DuqRCkDRLtT1o=",
       "dev": true,
       "requires": {
-        "sentence-case": "1.1.3",
-        "upper-case": "1.1.3"
+        "sentence-case": "^1.1.1",
+        "upper-case": "^1.0.3"
       }
     },
     "tough-cookie": {
@@ -10327,7 +10331,7 @@
       "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
       "dev": true,
       "requires": {
-        "glob": "6.0.4"
+        "glob": "^6.0.4"
       },
       "dependencies": {
         "glob": {
@@ -10336,11 +10340,11 @@
           "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimatch": {
@@ -10349,7 +10353,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.8"
+            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -10379,7 +10383,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-is": {
@@ -10389,7 +10393,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       },
       "dependencies": {
         "mime-db": {
@@ -10404,7 +10408,7 @@
           "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
           "dev": true,
           "requires": {
-            "mime-db": "1.33.0"
+            "mime-db": "~1.33.0"
           }
         }
       }
@@ -10427,10 +10431,10 @@
       "integrity": "sha1-+tV1XB4Vd2WLsG/5q25UjJW+vW4=",
       "dev": true,
       "requires": {
-        "async": "0.2.10",
+        "async": "~0.2.6",
         "source-map": "0.1.34",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.5.4"
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.5.4"
       },
       "dependencies": {
         "source-map": {
@@ -10439,7 +10443,7 @@
           "integrity": "sha1-p8/omux7FoLDsZjQrPtH19CQVms=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         },
         "yargs": {
@@ -10448,8 +10452,8 @@
           "integrity": "sha1-2K/49mXpTDS9JZvevRv68N3TU2E=",
           "dev": true,
           "requires": {
-            "camelcase": "1.2.1",
-            "decamelize": "1.2.0",
+            "camelcase": "^1.0.2",
+            "decamelize": "^1.0.0",
             "window-size": "0.1.0",
             "wordwrap": "0.0.2"
           }
@@ -10509,7 +10513,7 @@
       "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
       "dev": true,
       "requires": {
-        "upper-case": "1.1.3"
+        "upper-case": "^1.1.1"
       }
     },
     "user-home": {
@@ -10518,7 +10522,7 @@
       "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
       "dev": true,
       "requires": {
-        "os-homedir": "1.0.2"
+        "os-homedir": "^1.0.0"
       }
     },
     "util": {
@@ -10556,8 +10560,8 @@
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
       "dev": true,
       "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
+        "spdx-correct": "~1.0.0",
+        "spdx-expression-parse": "~1.0.0"
       }
     },
     "vary": {
@@ -10572,7 +10576,7 @@
       "integrity": "sha1-Fl/aRkAzFUj46ZCx1+FDletyAgc=",
       "dev": true,
       "requires": {
-        "chalk": "0.4.0"
+        "chalk": "~0.4.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -10587,9 +10591,9 @@
           "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
-            "ansi-styles": "1.0.0",
-            "has-color": "0.1.7",
-            "strip-ansi": "0.1.1"
+            "ansi-styles": "~1.0.0",
+            "has-color": "~0.1.0",
+            "strip-ansi": "~0.1.0"
           }
         },
         "strip-ansi": {
@@ -10606,9 +10610,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       },
       "dependencies": {
         "assert-plus": {
@@ -10655,7 +10659,7 @@
       "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2"
+        "string-width": "^1.0.2"
       }
     },
     "window-size": {
@@ -10676,8 +10680,8 @@
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
       }
     },
     "wrappy": {
@@ -10692,7 +10696,7 @@
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
       "dev": true,
       "requires": {
-        "mkdirp": "0.5.1"
+        "mkdirp": "^0.5.1"
       },
       "dependencies": {
         "minimist": {
@@ -10718,7 +10722,7 @@
       "integrity": "sha1-+Rb20Q1F3BcbG+Lm5nP7bgzDXQo=",
       "dev": true,
       "requires": {
-        "lodash": "3.5.0"
+        "lodash": "~3.5.0"
       },
       "dependencies": {
         "lodash": {
@@ -10754,9 +10758,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     },
@@ -10766,7 +10770,7 @@
       "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
       "dev": true,
       "requires": {
-        "camelcase": "3.0.0"
+        "camelcase": "^3.0.0"
       },
       "dependencies": {
         "camelcase": {
@@ -10783,7 +10787,7 @@
       "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
       "dev": true,
       "requires": {
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "~1.0.1"
       }
     },
     "zlib-browserify": {
@@ -10792,7 +10796,7 @@
       "integrity": "sha1-JAzNv9AgP6hCsTDe77FBQSLIzFA=",
       "dev": true,
       "requires": {
-        "tape": "0.2.2"
+        "tape": "~0.2.2"
       }
     }
   }


### PR DESCRIPTION
Specific changes:
* Changed "requires" fields to use version ranges derived from each dependency's package.json file.
* Added entry for "magnific-popup" (was previously missing).

Notes:
* The latest versions of node.js come with npm 6.4.1. So all newer versions of node.js expect the new style.
* Running npm install in older versions of npm will reconvert the Git working tree's package-lock.json file to the older style.