### PR TITLE
Release notes: Fixed issues in 4.0.28-4.0.29 pages.

### DIFF
--- a/site/pages/docs/versions/v4.0/v4.0.28-en.hbs
+++ b/site/pages/docs/versions/v4.0/v4.0.28-en.hbs
@@ -4,7 +4,7 @@
 	"language": "en",
 	"description": "v4.0.28.x release notes - Version history - Web Experience Toolkit (WET)",
 	"altLangPrefix": "v4.0.28",
-	"dateModified": "2018-04-27"
+	"dateModified": "2018-10-30"
 }
 ---
 <p>Version 4.0.28.1</p>
@@ -22,66 +22,74 @@
 
 <section>
 	<h2>What's New</h2>
-	<h3 id="v4.0.28.1">Version 4.0.28.1</h3>
-	<ul>
-		<li>Fix an issue that was preventing the form validation WET feature to initiate</li>
-	</ul>
+	<section>
+		<h3 id="v4.0.28.1">Version 4.0.28.1</h3>
+		<ul>
+			<li>Fix an issue that was preventing the form validation WET feature to initiate</li>
+		</ul>
+	</section>
 
-	<h3>Version 4.0.28</h3>
-	<ul>
-		<li>Minor - markup change for SVGs images
-			<ul>
-				<li><a href="http://wet-boew.github.io/wet-boew-documentation/decision/1.html">Design decision 1 - Use SVG with <code>img</code> element instead of <code>object</code></a></li>
-			</ul>
-		</li>
-		<li>Minor - Datepicker polyfill - Date initialisation patch when minimal date are larger than today date</li>
-		<li>Minor - Charts - Added floating label to pie charts</li>
-		<li>WET developer - Major - Build script update
-			<ul>
-				<li>WET developer may need to delete npm caching with the local "node_modules" and "lib" folder before to run "script/setup" in order to sucessfully build.</li>
-			</ul>
-		</li>
-	</ul>
+	<section>
+		<h3>Version 4.0.28</h3>
+		<ul>
+			<li>Minor - markup change for SVGs images
+				<ul>
+					<li><a href="http://wet-boew.github.io/wet-boew-documentation/decision/1.html">Design decision 1 - Use SVG with <code>img</code> element instead of <code>object</code></a></li>
+				</ul>
+			</li>
+			<li>Minor - Datepicker polyfill - Date initialisation patch when minimal date are larger than today date</li>
+			<li>Minor - Charts - Added floating label to pie charts</li>
+			<li>WET developer - Major - Build script update
+				<ul>
+					<li>WET developer may need to delete npm caching with the local "node_modules" and "lib" folder before to run "script/setup" in order to sucessfully build.</li>
+				</ul>
+			</li>
+		</ul>
 
-	<p>Canada.ca (GCWeb):</p>
-	<ul>
-		<li>Minor - markup change for SVGs images
-			<ul>
-				<li><a href="http://wet-boew.github.io/wet-boew-documentation/decision/1.html">Design decision 1 - Use SVG with <code>img</code> element instead of <code>object</code></a></li>
-			</ul>
-		</li>
-		<li>Minor - Departement features - Add one titles example</li>
-		<li>Minor - Departement features - Markup change</li>
-		<li>Minor - Removed GC priorities</li>
-		<li>Minor - Improved markup for arms length footer</li>
-		<li>Minor - Mega menu content update</li>
-		<li>Information - Added a deprecated testing page</li>
-		<li>WET developer - Major - Build script update
-			<ul>
-				<li>WET developer may need to delete npm caching with the local "node_modules" and "lib" folder before to run "script/setup" in order to sucessfully build.</li>
-			</ul>
-		</li>
-	</ul>
-	<h3>The following theme were abandoned:</h3>
-	<ul>
-		<li>Base</li>
-		<li>Government of Canada Web Usability</li>
-		<li>Government of Canada Intranet</li>
-		<li>Open Government Platform (OGPL)</li>
-	</ul>
-	<p>If you are interested to have one of those themes above to be released with WET 4.0.28, please join the discussion on Github on the <a href="https://github.com/wet-boew/wet-boew/issues/8366">issue #8366</a>.</p>
-	<h3>Browser supported:</h3>
-	<ul>
-		<li>Chrome 65</li>
-		<li>Chrome 66</li>
-		<li>Safari 11.1</li>
-		<li>Firefox 59</li>
-		<li>Firefox 58</li>
-		<li>Firefox ESR - 52.7.3</li>
-		<li>IE 11</li>
-		<li>Edge 16</li>
-	</ul>
-	<p>As per <a href="http://wet-boew.github.io/wet-boew-documentation/decision/2.html">Design decision 2: Browser supported</a></p>
+		<p>Canada.ca (GCWeb):</p>
+		<ul>
+			<li>Minor - markup change for SVGs images
+				<ul>
+					<li><a href="http://wet-boew.github.io/wet-boew-documentation/decision/1.html">Design decision 1 - Use SVG with <code>img</code> element instead of <code>object</code></a></li>
+				</ul>
+			</li>
+			<li>Minor - Departement features - Add one titles example</li>
+			<li>Minor - Departement features - Markup change</li>
+			<li>Minor - Removed GC priorities</li>
+			<li>Minor - Improved markup for arms length footer</li>
+			<li>Minor - Mega menu content update</li>
+			<li>Information - Added a deprecated testing page</li>
+			<li>WET developer - Major - Build script update
+				<ul>
+					<li>WET developer may need to delete npm caching with the local "node_modules" and "lib" folder before to run "script/setup" in order to sucessfully build.</li>
+				</ul>
+			</li>
+		</ul>
+	</section>
+	<section>
+		<h3>The following theme were abandoned:</h3>
+		<ul>
+			<li>Base</li>
+			<li>Government of Canada Web Usability</li>
+			<li>Government of Canada Intranet</li>
+			<li>Open Government Platform (OGPL)</li>
+		</ul>
+		<p>If you are interested to have one of those themes above to be released with WET 4.0.28, please join the discussion on Github on the <a href="https://github.com/wet-boew/wet-boew/issues/8366">issue #8366</a>.</p>
+	</section>
+	<section>
+		<h3>Browser supported:</h3>
+		<ul>
+			<li>Chrome 65</li>
+			<li>Chrome 66</li>
+			<li>Safari 11.1</li>
+			<li>Firefox 59</li>
+			<li>Firefox 58</li>
+			<li>Firefox ESR - 52.7.3</li>
+			<li>IE 11</li>
+			<li>Edge 16</li>
+		</ul>
+		<p>As per <a href="http://wet-boew.github.io/wet-boew-documentation/decision/2.html">Design decision 2: Browser supported</a></p>
+	</section>
 </section>
 
 <section>
@@ -101,48 +109,50 @@
 		<li><a href="https://github.com/phurinaix">@phurinaix</a>: 1 commit</li>
 		<li><a href="https://github.com/bsouster">@bsouster</a>: 1 commit</li>
 	</ul>
-	<h3>List of commits</h3>
-	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/40277dc7fa42d5872b118070df9950496a0ccaea">4.0.27 release notes</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/d48d117e6596708d84b31ef74f11145671535828">Updated files for the v4.0.27 maintenance release</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ffdc0263ee0c941dffc4f1aa0e81f6ade0139e15">Updated the build version to v4.0.28-development</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/991663878fde50b95a6c632f579ae61c7a253a3f">build: Update Selenium browsers for vendor support</a> - <span>@nschonni</span>, <time>2018-01-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/fdbc8ef5fc5fda0d1e42ad293617367856e059c9">Revert "Revert "Bower to npm""</a> - <span>@nschonni</span>, <time>2018-01-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/5182d363fd3f3428259476b410f9d84056c439fb">Remove unnecessary timer event</a> - <span>@Pacoup</span>, <time>2018-01-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/26d20f55e2225af547358858327ba91d0290ab62">Date init patch</a> - <span>@thekodester</span>, <time>2018-01-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e29270ba7d0c9ef95edf6e8cf5e1b5b285fe0ee6">Do not block collapsible component init on whole document</a> - <span>@Pacoup</span>, <time>2018-01-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ccecec09a62f683e4a977fb8683e8452a8209fed">Fix typo</a> - <span>@jkshapiro</span>, <time>2018-01-19</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/4709d0e4a335428464dcf387c76df538cbf74b4f">Build - Remove copying docs folder for MathJax</a> - <span>@duboisp</span>, <time>2018-02-08</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/f3e19b4f7fc77098d39cb8dd38916c58ac6aa54d">Splash page: Fixed SVG logo's relative path.</a> - <span>@EricDunsworth</span>, <time>2018-02-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/1136cdb0261b204c973d24d8647eb5620fb92357">Overlay/Lightbox: Removed unused "hdrClose" and "ftrClose" IDs.</a> - <span>@EricDunsworth</span>, <time>2018-02-13</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2a0ce56783a33c7c6776109c1f6f17f3754a43d7">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2ef8f6633f367c4c50bcd20110980b040a8d48c2">Multimedia player: Replace all single quotes in video titles that get re-used for the share widget.</a> - <span>@EricDunsworth</span>, <time>2018-02-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/63124df8dc438933be56f20eb0ec1da765eb2706">LightBox / dependency loading/executing racing issue</a> - <span>@StdGit</span>, <time>2018-02-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/442202ca3c7008550aea9e5c53c9974e54f52d08">Added prepare script to allow themes to use WET core via npm</a> - <span>@LaurentGoderre</span>, <time>2018-02-22</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/915b5ecff76e063df8cba626f0d275d3d7339b69">Typo - wetsites-fr.hbs - Change http to https in some links</a> - <span>@peterparkers</span>, <time>2018-02-22</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/edb66b82631aa901bafc682673dcb82f8b21403c">Typo - wetsites-en.hbs - Change http to https in some links</a> - <span>@peterparkers</span>, <time>2018-02-22</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/6b0f86beb810c355dd790c80e4166da70232ffcd">Fixed tasks not loading when installed in a theme</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/d58a14050556b3b5282360533a9bd56e05d27cb8">Fixed tasks not loading when installed in a theme</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/01258d38064f62cbca7b0e71768ce59ef203da12">Update package.json</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/1d364271d0cd573cf1964711e37b5e32edc235d3">Updated the prepare script to avoid a double installation of dependencies</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/1dd35f21ea6f5c3fe3bbce613997e761e2fde65d">Fixed the WET npm as a package installed in themes</a> - <span>@LaurentGoderre</span>, <time>2018-03-01</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/354ee44dc914fca2ca27ffafe32ade0b0fe7091a">Cleanup the gitignore and add an npmignore</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/0a87c82faaa833992a7f722488d28c6d00f6e3b9">Added SASS includePath to resolve npm dependencies</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/6474f34ac9ef8d85bab6e9dbefd40a6d3620d407">Fix jQuery and MathJax version references</a> - <span>@LaurentGoderre</span>, <time>2018-03-09</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ff8c1c5e916712542a57037215f2d51b44befff6">Site - Add wet-boew-documentation to home page, move the release notice and add link to a developer build</a> - <span>@duboisp</span>, <time>2018-03-13</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/5fe83b74fcd56e92a494c41426dc294638d96623">Edit http link in CONTRIBUTING.md (#8233)</a> - <span>@phurinaix</span>, <time>2018-03-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/4d24da7c04d33a4d47e8623f123a19a2b86d50f9">build: bump grunt-sass for latest build</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/aba47c2b1587439947b31b8c7905036f1fbdee17">css: Remove IE &lt; 11 and Android 2</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/eead92e746c757325803d0a71440ba3f0d5890f3">css: Move min Firefox to ESR</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/1be1a52ff08d9727cbcc901dab3f90d466fe3841">build: convert grunt-autoprefixer to grunt-postcss</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/d3b3b7bb42f95c5ba68d51ff0848ef2413c7a836">chore: Fix NPM files</a> - <span>@nschonni</span>, <time>2018-04-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/73fcc3e11a432cb878aedccf1a9ebf283aea4156">Charts - Improving pie charts labels</a> - <span>@bsouster</span>, <time>2018-04-10</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ace2903e72395404028032ee8daa6837cae7de45">Update i18n.csv</a> - <span>@duboisp</span>, <time>2018-04-10</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/a15195e8098aff580ab8f6d4f386a5be4a74edbb">Build: Updated grunt-contrib-clean to version ~1.1.0.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e4e2e03325aec435cf2be4f4eda7f36a2ef253cf">Multimedia player/Carousel: Fixed broken links/captions in media player samples.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/255560b1bf442300ac41ee8e2693b9a94ee72003">Form validation - Add test ready</a> - @duboisp, <time>2018-04-20</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/58eb144bb0bc32b47e7776df0388c7051bccbccd">Country content - Fix geolocation request url</a> - @duboisp, <time>2018-04-22</time></li>
-	</ul>
+	<section>
+		<h3>List of commits</h3>
+		<ul>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/40277dc7fa42d5872b118070df9950496a0ccaea">4.0.27 release notes</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/d48d117e6596708d84b31ef74f11145671535828">Updated files for the v4.0.27 maintenance release</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/ffdc0263ee0c941dffc4f1aa0e81f6ade0139e15">Updated the build version to v4.0.28-development</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/991663878fde50b95a6c632f579ae61c7a253a3f">build: Update Selenium browsers for vendor support</a> - <span>@nschonni</span>, <time>2018-01-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/fdbc8ef5fc5fda0d1e42ad293617367856e059c9">Revert "Revert "Bower to npm""</a> - <span>@nschonni</span>, <time>2018-01-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/5182d363fd3f3428259476b410f9d84056c439fb">Remove unnecessary timer event</a> - <span>@Pacoup</span>, <time>2018-01-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/26d20f55e2225af547358858327ba91d0290ab62">Date init patch</a> - <span>@thekodester</span>, <time>2018-01-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/e29270ba7d0c9ef95edf6e8cf5e1b5b285fe0ee6">Do not block collapsible component init on whole document</a> - <span>@Pacoup</span>, <time>2018-01-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/ccecec09a62f683e4a977fb8683e8452a8209fed">Fix typo</a> - <span>@jkshapiro</span>, <time>2018-01-19</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/4709d0e4a335428464dcf387c76df538cbf74b4f">Build - Remove copying docs folder for MathJax</a> - <span>@duboisp</span>, <time>2018-02-08</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/f3e19b4f7fc77098d39cb8dd38916c58ac6aa54d">Splash page: Fixed SVG logo's relative path.</a> - <span>@EricDunsworth</span>, <time>2018-02-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/1136cdb0261b204c973d24d8647eb5620fb92357">Overlay/Lightbox: Removed unused "hdrClose" and "ftrClose" IDs.</a> - <span>@EricDunsworth</span>, <time>2018-02-13</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/2a0ce56783a33c7c6776109c1f6f17f3754a43d7">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/2ef8f6633f367c4c50bcd20110980b040a8d48c2">Multimedia player: Replace all single quotes in video titles that get re-used for the share widget.</a> - <span>@EricDunsworth</span>, <time>2018-02-15</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/63124df8dc438933be56f20eb0ec1da765eb2706">LightBox / dependency loading/executing racing issue</a> - <span>@StdGit</span>, <time>2018-02-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/442202ca3c7008550aea9e5c53c9974e54f52d08">Added prepare script to allow themes to use WET core via npm</a> - <span>@LaurentGoderre</span>, <time>2018-02-22</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/915b5ecff76e063df8cba626f0d275d3d7339b69">Typo - wetsites-fr.hbs - Change http to https in some links</a> - <span>@peterparkers</span>, <time>2018-02-22</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/edb66b82631aa901bafc682673dcb82f8b21403c">Typo - wetsites-en.hbs - Change http to https in some links</a> - <span>@peterparkers</span>, <time>2018-02-22</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/6b0f86beb810c355dd790c80e4166da70232ffcd">Fixed tasks not loading when installed in a theme</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/d58a14050556b3b5282360533a9bd56e05d27cb8">Fixed tasks not loading when installed in a theme</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/01258d38064f62cbca7b0e71768ce59ef203da12">Update package.json</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/1d364271d0cd573cf1964711e37b5e32edc235d3">Updated the prepare script to avoid a double installation of dependencies</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/1dd35f21ea6f5c3fe3bbce613997e761e2fde65d">Fixed the WET npm as a package installed in themes</a> - <span>@LaurentGoderre</span>, <time>2018-03-01</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/354ee44dc914fca2ca27ffafe32ade0b0fe7091a">Cleanup the gitignore and add an npmignore</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/0a87c82faaa833992a7f722488d28c6d00f6e3b9">Added SASS includePath to resolve npm dependencies</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/6474f34ac9ef8d85bab6e9dbefd40a6d3620d407">Fix jQuery and MathJax version references</a> - <span>@LaurentGoderre</span>, <time>2018-03-09</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/ff8c1c5e916712542a57037215f2d51b44befff6">Site - Add wet-boew-documentation to home page, move the release notice and add link to a developer build</a> - <span>@duboisp</span>, <time>2018-03-13</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/5fe83b74fcd56e92a494c41426dc294638d96623">Edit http link in CONTRIBUTING.md (#8233)</a> - <span>@phurinaix</span>, <time>2018-03-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/4d24da7c04d33a4d47e8623f123a19a2b86d50f9">build: bump grunt-sass for latest build</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/aba47c2b1587439947b31b8c7905036f1fbdee17">css: Remove IE &lt; 11 and Android 2</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/eead92e746c757325803d0a71440ba3f0d5890f3">css: Move min Firefox to ESR</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/1be1a52ff08d9727cbcc901dab3f90d466fe3841">build: convert grunt-autoprefixer to grunt-postcss</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/d3b3b7bb42f95c5ba68d51ff0848ef2413c7a836">chore: Fix NPM files</a> - <span>@nschonni</span>, <time>2018-04-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/73fcc3e11a432cb878aedccf1a9ebf283aea4156">Charts - Improving pie charts labels</a> - <span>@bsouster</span>, <time>2018-04-10</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/ace2903e72395404028032ee8daa6837cae7de45">Update i18n.csv</a> - <span>@duboisp</span>, <time>2018-04-10</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/a15195e8098aff580ab8f6d4f386a5be4a74edbb">Build: Updated grunt-contrib-clean to version ~1.1.0.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/e4e2e03325aec435cf2be4f4eda7f36a2ef253cf">Multimedia player/Carousel: Fixed broken links/captions in media player samples.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/255560b1bf442300ac41ee8e2693b9a94ee72003">Form validation - Add test ready</a> - @duboisp, <time>2018-04-20</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/58eb144bb0bc32b47e7776df0388c7051bccbccd">Country content - Fix geolocation request url</a> - @duboisp, <time>2018-04-22</time></li>
+		</ul>
+	</section>
 </section>
 
 <section>
@@ -155,70 +165,78 @@
 		<li><a href="https://github.com/LaurentGoderre">@LaurentGoderre</a>: 2 commits</li>
 		<li><a href="https://github.com/lucas-hay">@lucas-hay</a>: 2 commits</li>
 	</ul>
-	<h3>List of commits</h3>
-	<ul>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/af7bc1ac3977fdd7badd2bace7f0d3a5274239ca">Updated files for the v4.0.27 maintenance release</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/50b438ba0011c901064f7e89bac28eddc5769b7d">Updated the build version to v4.0.28-development</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/59e0c1c8be0d51740667efe1bff565dd7d2f358e">Replace bower with npm</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/0a0ce03afa2ec0f0482f02f6b830378290b0179c">Departement features - Add one tile example and markup improvement</a> - <span>@duboisp</span>, <time>2018-03-02</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/6415befd2d1a91050ff84309741b86a026f9bbdd">Fixed the jQuery version references</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/05274ec69cbfd64a856e2e0e0139c45c67d2ce39">Report a problem - Remove privacy statement and enforce the new markup</a> - <span>@duboisp</span>, <time>2018-03-21</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/1e4dd1c14ac5bbb512641dbe99770f1bd9e4b03a">Remove GC priorities and improved arms length footer</a> - <span>@duboisp</span>, <time>2018-03-21</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/ff8dc73eab75335b9b9d9bf998b87782c979d9d4">update - mega-menu item</a> - <span>@thangle2013</span>, <time>2018-03-28</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/6a56f078d18ae124501bbec10c51efb197b8ad7d">megamenu-benefits-finder-update</a> - <span>@thangle2013</span>, <time>2018-04-05</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/eb0e603fa55eec923575c578d7ea62b205a30a74">Build - fix dependencies for data-JSON</a> - <span>@duboisp</span>, <time>2018-04-10</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/cd1ae832b82c307de6abcc2827d7b6a978844543">Revert "Datalist JSON suggestion - initial commit"</a> - <span>@duboisp</span>, <time>2018-04-18</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/a3e6b59d860bcf11efbdbc7a0f922eaf57fd53a6">Build: Updated grunt-contrib-clean to version ~1.1.0.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/d17bf110cee9a9e616e24153cf1794f74ac62b7a">Build - Added Sub-resource basic integrity generation</a> - <span>@duboisp</span>, <time>2018-04-23</time></li>
-	</ul>
+	<section>
+		<h3>List of commits</h3>
+		<ul>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/af7bc1ac3977fdd7badd2bace7f0d3a5274239ca">Updated files for the v4.0.27 maintenance release</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/50b438ba0011c901064f7e89bac28eddc5769b7d">Updated the build version to v4.0.28-development</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/59e0c1c8be0d51740667efe1bff565dd7d2f358e">Replace bower with npm</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/0a0ce03afa2ec0f0482f02f6b830378290b0179c">Departement features - Add one tile example and markup improvement</a> - <span>@duboisp</span>, <time>2018-03-02</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/6415befd2d1a91050ff84309741b86a026f9bbdd">Fixed the jQuery version references</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/05274ec69cbfd64a856e2e0e0139c45c67d2ce39">Report a problem - Remove privacy statement and enforce the new markup</a> - <span>@duboisp</span>, <time>2018-03-21</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/1e4dd1c14ac5bbb512641dbe99770f1bd9e4b03a">Remove GC priorities and improved arms length footer</a> - <span>@duboisp</span>, <time>2018-03-21</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/ff8dc73eab75335b9b9d9bf998b87782c979d9d4">update - mega-menu item</a> - <span>@thangle2013</span>, <time>2018-03-28</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/6a56f078d18ae124501bbec10c51efb197b8ad7d">megamenu-benefits-finder-update</a> - <span>@thangle2013</span>, <time>2018-04-05</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/eb0e603fa55eec923575c578d7ea62b205a30a74">Build - fix dependencies for data-JSON</a> - <span>@duboisp</span>, <time>2018-04-10</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/cd1ae832b82c307de6abcc2827d7b6a978844543">Revert "Datalist JSON suggestion - initial commit"</a> - <span>@duboisp</span>, <time>2018-04-18</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/a3e6b59d860bcf11efbdbc7a0f922eaf57fd53a6">Build: Updated grunt-contrib-clean to version ~1.1.0.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/d17bf110cee9a9e616e24153cf1794f74ac62b7a">Build - Added Sub-resource basic integrity generation</a> - <span>@duboisp</span>, <time>2018-04-23</time></li>
+		</ul>
+	</section>
 </section>
 
 <section>
 	<h2>v4.0.28.1 details</h2>
 	<p><strong>Number of commits:</strong> 1</p>
 
-	<h3>List of commits</h3>
-	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/9093ab44ad2d66b4d4eeda699a616a0c37b762b7">Form validation - Fix testReady major issue</a> - <span>@duboisp</span>, <time>2018-04-27</time></li>
-	</ul>
+	<section>
+		<h3>List of commits</h3>
+		<ul>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/9093ab44ad2d66b4d4eeda699a616a0c37b762b7">Form validation - Fix testReady major issue</a> - <span>@duboisp</span>, <time>2018-04-27</time></li>
+		</ul>
+	</section>
 </section>
 
 <section>
 	<h2 id="sri">Subresource integrity (SRI)</h2>
 	<p><a href="https://www.w3.org/TR/SRI/">SRI</a> provide a method to protect website delivery. The following information are the hash for key resource in WET and GCWeb.</p>
 
-	<h3>v4.0.28.1</h3>
-	<dl>
-		<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
-		<dd>sha256-W6CzUu6JitSJY/awKY6lyauDQa0IWXBTVjtxq3SpctA= sha512-oNEAH27TChN3HFV2ni+Xt2ZdS7NANHvMRFNky1lUqPsgYNBmC8wi2QaFIKlRKcp+6hPQKDNKix8umA2OfIRoxA==</dd>
-		<dt><code>GCWeb/css/theme.min.css</code></dt>
-		<dd>sha256-pQ+6VomndRUojeRLzarl8eU/m/UahNwxikiY4kZi07I= sha512-Ew4mh/42v30LSF6Ukwct4IdsgzQy692g8rZVKOnnVfSAKKnUMa+K+8DDO2gOVZ43jeizI5niztMcX7frC3hI7A==</dd>
-		<dt><code>GCWeb/js/theme.min.js</code></dt>
-		<dd>sha256-e/lB+Xz0k6XYvac+g+u3l2FbsvoaLIYdCo7l9jFDF+g= sha512-Iff1dyKW1izYivZIiJYY2pccIsDvlrPuulsuq4tONeiWltc3N+VJ4PR/95lZ3f660xF4QqAPdovVexJVnYG68A==</dd>
-	</dl>
-	<p>Get all hash (JSON format):</p>
-	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28.1/wet-boew/payload.json">WET-BOEW</a></li>
-		<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.28.1-gcweb/GCWeb/payload.json">GCWeb theme</a></li>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28.1/theme-wet-boew/payload.json">WET-BOEW theme</a></li>
-	</ul>
+	<section>
+		<h3>v4.0.28.1</h3>
+		<dl>
+			<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
+			<dd>sha256-W6CzUu6JitSJY/awKY6lyauDQa0IWXBTVjtxq3SpctA= sha512-oNEAH27TChN3HFV2ni+Xt2ZdS7NANHvMRFNky1lUqPsgYNBmC8wi2QaFIKlRKcp+6hPQKDNKix8umA2OfIRoxA==</dd>
+			<dt><code>GCWeb/css/theme.min.css</code></dt>
+			<dd>sha256-pQ+6VomndRUojeRLzarl8eU/m/UahNwxikiY4kZi07I= sha512-Ew4mh/42v30LSF6Ukwct4IdsgzQy692g8rZVKOnnVfSAKKnUMa+K+8DDO2gOVZ43jeizI5niztMcX7frC3hI7A==</dd>
+			<dt><code>GCWeb/js/theme.min.js</code></dt>
+			<dd>sha256-e/lB+Xz0k6XYvac+g+u3l2FbsvoaLIYdCo7l9jFDF+g= sha512-Iff1dyKW1izYivZIiJYY2pccIsDvlrPuulsuq4tONeiWltc3N+VJ4PR/95lZ3f660xF4QqAPdovVexJVnYG68A==</dd>
+		</dl>
+		<p>Get all hash (JSON format):</p>
+		<ul>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28.1/wet-boew/payload.json">WET-BOEW</a></li>
+			<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.28.1-gcweb/GCWeb/payload.json">GCWeb theme</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28.1/theme-wet-boew/payload.json">WET-BOEW theme</a></li>
+		</ul>
+	</section>
 
-	<h3>v4.0.28</h3>
-	<dl>
-		<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
-		<dd>sha256-Sv7zmMeu3pyom8vBljYLKbIT0mPtH938C9aiY+vM270= sha512-/uqNTSqhBGKI/4O+iEfvhj/HmDC7sKx7Ui91HYes3u/mOhlA1bCzu6UgBStXDLvzTEbvLEMsEWcwQscZ1LIXUA==</dd>
-		<dt><code>GCWeb/css/theme.min.css</code></dt>
-		<dd>sha256-avMS175xBhGsJPv3ovrFldfgmkV9xiKtXb3AREeAs88= sha512-IUpmszkQ0oasj2i2KDf/Gl8eoLxwXhRfGmmz1O5Ve8IaCiKaTt+/Nfe/5Up988lvoorIIduGtQt2tuyxWebxhA==</dd>
-		<dt><code>GCWeb/js/theme.min.js</code></dt>
-		<dd>sha256-Uv0fzXl0qj6+VTKtU/o9XtyFDtJoSjv0zY4ocGRVRoI= sha512-gAsn3Dq/oOR7zwfnmwqml008xlE++XGmV5WT75u/xOY9YckZjXC1cOSKNdbdjMxa6isiJQmz3ZdLpUMQNi+DAA==</dd>
-	</dl>
-	<p>Get all hash (JSON format):</p>
-	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28/wet-boew/payload.json">WET-BOEW</a></li>
-		<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.28-gcweb/GCWeb/payload.json">GCWeb theme</a></li>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28/theme-wet-boew/payload.json">WET-BOEW theme</a></li>
-	</ul>
+	<section>
+		<h3>v4.0.28</h3>
+		<dl>
+			<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
+			<dd>sha256-Sv7zmMeu3pyom8vBljYLKbIT0mPtH938C9aiY+vM270= sha512-/uqNTSqhBGKI/4O+iEfvhj/HmDC7sKx7Ui91HYes3u/mOhlA1bCzu6UgBStXDLvzTEbvLEMsEWcwQscZ1LIXUA==</dd>
+			<dt><code>GCWeb/css/theme.min.css</code></dt>
+			<dd>sha256-avMS175xBhGsJPv3ovrFldfgmkV9xiKtXb3AREeAs88= sha512-IUpmszkQ0oasj2i2KDf/Gl8eoLxwXhRfGmmz1O5Ve8IaCiKaTt+/Nfe/5Up988lvoorIIduGtQt2tuyxWebxhA==</dd>
+			<dt><code>GCWeb/js/theme.min.js</code></dt>
+			<dd>sha256-Uv0fzXl0qj6+VTKtU/o9XtyFDtJoSjv0zY4ocGRVRoI= sha512-gAsn3Dq/oOR7zwfnmwqml008xlE++XGmV5WT75u/xOY9YckZjXC1cOSKNdbdjMxa6isiJQmz3ZdLpUMQNi+DAA==</dd>
+		</dl>
+		<p>Get all hash (JSON format):</p>
+		<ul>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28/wet-boew/payload.json">WET-BOEW</a></li>
+			<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.28-gcweb/GCWeb/payload.json">GCWeb theme</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28/theme-wet-boew/payload.json">WET-BOEW theme</a></li>
+		</ul>
+	</section>
 </section>

--- a/site/pages/docs/versions/v4.0/v4.0.28-fr.hbs
+++ b/site/pages/docs/versions/v4.0/v4.0.28-fr.hbs
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"description": "v4.0.28.x - Notes de version - Historique des versions - Boîte à outils de l'expérience Web (BOEW)",
 	"altLangPrefix": "v4.0.28",
-	"dateModified": "2018-04-27"
+	"dateModified": "2018-10-30"
 }
 ---
 <p>Version 4.0.28.1</p>
@@ -20,65 +20,73 @@
 
 <section>
 	<h2>Quoi de neuf?</h2>
-	<h3 id="v4.0.28.1">Version 4.0.28.1</h3>
-	<ul>
-		<li>Réparation d'un problème qui empêchait la fonctionnalité BOEW pour effectuer la validation de formulaire de démarrer.</li>
-	</ul>
+	<section>
+		<h3 id="v4.0.28.1">Version 4.0.28.1</h3>
+		<ul>
+			<li>Réparation d'un problème qui empêchait la fonctionnalité BOEW pour effectuer la validation de formulaire de démarrer.</li>
+		</ul>
+	</section>
 
-	<h3>Version 4.0.28</h3>
-	<ul>
-		<li>Mineur - Changement dans le balisage des images SVG
-			<ul>
-				<li><a href="http://wet-boew.github.io/wet-boew-documentation/decision/1.html" hreflang="en">Décision de conception 1 - Utilidation des SVG avec l'élément <code>img</code> plutôt que l'élément <code>object</code></a> (en anglais)</li>
-			</ul>
-		</li>
-		<li>Mineur - Datepicker polyfill - La date d'initialisation a été ajusté lorsque la date minimale est plus grande que la date actuelle</li>
-		<li>Mineur - Graphique - Ajout d'étiquettes pour les graphiques sectoriel</li>
-		<li>Développeur de la BOEW - Majeur - Changement dans le script de compilation
-			<ul>
-				<li>Les développeur de la BOEW devrons peut-être supprimer le cache de npm ainsi que les répertoires "node_modules" et "lib" avant d'exécuter "script/setup" pour être capable de compiler avec succès.</li>
-			</ul>
-		</li>
-	</ul>
-	<p>Canada.ca (GCWeb):</p>
-	<ul>
-		<li>Mineur - Changement dans le balisage des images SVG
-			<ul>
-				<li><a href="http://wet-boew.github.io/wet-boew-documentation/decision/1.html" hreflang="en">Décision de conception 1 - Utilidation des SVG avec l'élément <code>img</code> plutôt que l'élément <code>object</code></a> (en anglais)</li>
-			</ul>
-		</li>
-		<li>Mineur - Section en vedette - Ajout d'un exemple avec un item</li>
-		<li>Mineur - Section en vedette - Changement de balisage</li>
-		<li>Mineur - Les priorités du GC a été enlevé</li>
-		<li>Mineur - Amélioration du balisage pour l'image de marque d'oganisme indépendant</li>
-		<li>Mineur - Mise à jour du méga menu</li>
-		<li>Information - Ajout d'un page pour la mise à l'essaie de balisage maintenant déconseillé</li>
-		<li>Développeur de la BOEW - Majeur - Changement dans le script de compilation
-			<ul>
-				<li>Les développeur de la BOEW devrons peut-être supprimer le cache de npm ainsi que les répertoires "node_modules" et "lib" avant d'exécuter "script/setup" pour être capable de compiler avec succès.</li>
-			</ul>
-		</li>
-	</ul>
-	<h3>Les thèmes suivant ont été abandonné:</h3>
-	<ul>
-		<li>Base</li>
-		<li>Facilité d’emploi Web du gouvernement du Canada</li>
-		<li>Gouvernement du Canada pour les sites intranet</li>
-		<li>Plate-forme de gouvernement ouvert (PGO)</li>
-	</ul>
-	<p>Si vous estes intéressé d'avoir un de ces thèmes ci-dessus publié avec la version 4.0.28 de la BOEW, veuillez joindre la discussion sur Github via le <a href="https://github.com/wet-boew/wet-boew/issues/8366">billet #8366</a>.</p>
-	<h3>Fureteur supporté:</h3>
-	<ul>
-		<li>Chrome 65</li>
-		<li>Chrome 66</li>
-		<li>Safari 11.1</li>
-		<li>Firefox 59</li>
-		<li>Firefox 58</li>
-		<li>Firefox ESR - 52.7.3</li>
-		<li>IE 11</li>
-		<li>Edge 16</li>
-	</ul>
-	<p class="mrgn-bttm-xl">Tel que défini par la <a href="http://wet-boew.github.io/wet-boew-documentation/decision/2.html" hreflang="en">Décision de conception 2: Fureteur supporté</a> (en anglais)</p>
+	<section>
+		<h3>Version 4.0.28</h3>
+		<ul>
+			<li>Mineur - Changement dans le balisage des images SVG
+				<ul>
+					<li><a href="http://wet-boew.github.io/wet-boew-documentation/decision/1.html" hreflang="en">Décision de conception 1 - Utilidation des SVG avec l'élément <code>img</code> plutôt que l'élément <code>object</code></a> (en anglais)</li>
+				</ul>
+			</li>
+			<li>Mineur - Datepicker polyfill - La date d'initialisation a été ajusté lorsque la date minimale est plus grande que la date actuelle</li>
+			<li>Mineur - Graphique - Ajout d'étiquettes pour les graphiques sectoriel</li>
+			<li>Développeur de la BOEW - Majeur - Changement dans le script de compilation
+				<ul>
+					<li>Les développeur de la BOEW devrons peut-être supprimer le cache de npm ainsi que les répertoires "node_modules" et "lib" avant d'exécuter "script/setup" pour être capable de compiler avec succès.</li>
+				</ul>
+			</li>
+		</ul>
+		<p>Canada.ca (GCWeb):</p>
+		<ul>
+			<li>Mineur - Changement dans le balisage des images SVG
+				<ul>
+					<li><a href="http://wet-boew.github.io/wet-boew-documentation/decision/1.html" hreflang="en">Décision de conception 1 - Utilidation des SVG avec l'élément <code>img</code> plutôt que l'élément <code>object</code></a> (en anglais)</li>
+				</ul>
+			</li>
+			<li>Mineur - Section en vedette - Ajout d'un exemple avec un item</li>
+			<li>Mineur - Section en vedette - Changement de balisage</li>
+			<li>Mineur - Les priorités du GC a été enlevé</li>
+			<li>Mineur - Amélioration du balisage pour l'image de marque d'oganisme indépendant</li>
+			<li>Mineur - Mise à jour du méga menu</li>
+			<li>Information - Ajout d'un page pour la mise à l'essaie de balisage maintenant déconseillé</li>
+			<li>Développeur de la BOEW - Majeur - Changement dans le script de compilation
+				<ul>
+					<li>Les développeur de la BOEW devrons peut-être supprimer le cache de npm ainsi que les répertoires "node_modules" et "lib" avant d'exécuter "script/setup" pour être capable de compiler avec succès.</li>
+				</ul>
+			</li>
+		</ul>
+	</section>
+	<section>
+		<h3>Les thèmes suivant ont été abandonné:</h3>
+		<ul>
+			<li>Base</li>
+			<li>Facilité d’emploi Web du gouvernement du Canada</li>
+			<li>Gouvernement du Canada pour les sites intranet</li>
+			<li>Plate-forme de gouvernement ouvert (PGO)</li>
+		</ul>
+		<p>Si vous estes intéressé d'avoir un de ces thèmes ci-dessus publié avec la version 4.0.28 de la BOEW, veuillez joindre la discussion sur Github via le <a href="https://github.com/wet-boew/wet-boew/issues/8366">billet #8366</a>.</p>
+	</section>
+	<section>
+		<h3>Fureteur supporté:</h3>
+		<ul>
+			<li>Chrome 65</li>
+			<li>Chrome 66</li>
+			<li>Safari 11.1</li>
+			<li>Firefox 59</li>
+			<li>Firefox 58</li>
+			<li>Firefox ESR - 52.7.3</li>
+			<li>IE 11</li>
+			<li>Edge 16</li>
+		</ul>
+		<p class="mrgn-bttm-xl">Tel que défini par la <a href="http://wet-boew.github.io/wet-boew-documentation/decision/2.html" hreflang="en">Décision de conception 2: Fureteur supporté</a> (en anglais)</p>
+	</section>
 </section>
 
 <section>
@@ -99,48 +107,50 @@
 		<li><a href="https://github.com/bsouster">@bsouster</a>: 1 contribution</li>
 	</ul>
 
-	<h3>Liste des contributions</h3>
-	<ul lang="en">
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/40277dc7fa42d5872b118070df9950496a0ccaea">4.0.27 release notes</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/d48d117e6596708d84b31ef74f11145671535828">Updated files for the v4.0.27 maintenance release</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ffdc0263ee0c941dffc4f1aa0e81f6ade0139e15">Updated the build version to v4.0.28-development</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/991663878fde50b95a6c632f579ae61c7a253a3f">build: Update Selenium browsers for vendor support</a> - <span>@nschonni</span>, <time>2018-01-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/fdbc8ef5fc5fda0d1e42ad293617367856e059c9">Revert "Revert "Bower to npm""</a> - <span>@nschonni</span>, <time>2018-01-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/5182d363fd3f3428259476b410f9d84056c439fb">Remove unnecessary timer event</a> - <span>@Pacoup</span>, <time>2018-01-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/26d20f55e2225af547358858327ba91d0290ab62">Date init patch</a> - <span>@thekodester</span>, <time>2018-01-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e29270ba7d0c9ef95edf6e8cf5e1b5b285fe0ee6">Do not block collapsible component init on whole document</a> - <span>@Pacoup</span>, <time>2018-01-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ccecec09a62f683e4a977fb8683e8452a8209fed">Fix typo</a> - <span>@jkshapiro</span>, <time>2018-01-19</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/4709d0e4a335428464dcf387c76df538cbf74b4f">Build - Remove copying docs folder for MathJax</a> - <span>@duboisp</span>, <time>2018-02-08</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/f3e19b4f7fc77098d39cb8dd38916c58ac6aa54d">Splash page: Fixed SVG logo's relative path.</a> - <span>@EricDunsworth</span>, <time>2018-02-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/1136cdb0261b204c973d24d8647eb5620fb92357">Overlay/Lightbox: Removed unused "hdrClose" and "ftrClose" IDs.</a> - <span>@EricDunsworth</span>, <time>2018-02-13</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2a0ce56783a33c7c6776109c1f6f17f3754a43d7">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2ef8f6633f367c4c50bcd20110980b040a8d48c2">Multimedia player: Replace all single quotes in video titles that get re-used for the share widget.</a> - <span>@EricDunsworth</span>, <time>2018-02-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/63124df8dc438933be56f20eb0ec1da765eb2706">LightBox / dependency loading/executing racing issue</a> - <span>@StdGit</span>, <time>2018-02-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/442202ca3c7008550aea9e5c53c9974e54f52d08">Added prepare script to allow themes to use WET core via npm</a> - <span>@LaurentGoderre</span>, <time>2018-02-22</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/915b5ecff76e063df8cba626f0d275d3d7339b69">Typo - wetsites-fr.hbs - Change http to https in some links</a> - <span>@peterparkers</span>, <time>2018-02-22</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/edb66b82631aa901bafc682673dcb82f8b21403c">Typo - wetsites-en.hbs - Change http to https in some links</a> - <span>@peterparkers</span>, <time>2018-02-22</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/6b0f86beb810c355dd790c80e4166da70232ffcd">Fixed tasks not loading when installed in a theme</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/d58a14050556b3b5282360533a9bd56e05d27cb8">Fixed tasks not loading when installed in a theme</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/01258d38064f62cbca7b0e71768ce59ef203da12">Update package.json</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/1d364271d0cd573cf1964711e37b5e32edc235d3">Updated the prepare script to avoid a double installation of dependencies</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/1dd35f21ea6f5c3fe3bbce613997e761e2fde65d">Fixed the WET npm as a package installed in themes</a> - <span>@LaurentGoderre</span>, <time>2018-03-01</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/354ee44dc914fca2ca27ffafe32ade0b0fe7091a">Cleanup the gitignore and add an npmignore</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/0a87c82faaa833992a7f722488d28c6d00f6e3b9">Added SASS includePath to resolve npm dependencies</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/6474f34ac9ef8d85bab6e9dbefd40a6d3620d407">Fix jQuery and MathJax version references</a> - <span>@LaurentGoderre</span>, <time>2018-03-09</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ff8c1c5e916712542a57037215f2d51b44befff6">Site - Add wet-boew-documentation to home page, move the release notice and add link to a developer build</a> - <span>@duboisp</span>, <time>2018-03-13</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/5fe83b74fcd56e92a494c41426dc294638d96623">Edit http link in CONTRIBUTING.md (#8233)</a> - <span>@phurinaix</span>, <time>2018-03-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/4d24da7c04d33a4d47e8623f123a19a2b86d50f9">build: bump grunt-sass for latest build</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/aba47c2b1587439947b31b8c7905036f1fbdee17">css: Remove IE &lt; 11 and Android 2</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/eead92e746c757325803d0a71440ba3f0d5890f3">css: Move min Firefox to ESR</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/1be1a52ff08d9727cbcc901dab3f90d466fe3841">build: convert grunt-autoprefixer to grunt-postcss</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/d3b3b7bb42f95c5ba68d51ff0848ef2413c7a836">chore: Fix NPM files</a> - <span>@nschonni</span>, <time>2018-04-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/73fcc3e11a432cb878aedccf1a9ebf283aea4156">Charts - Improving pie charts labels</a> - <span>@bsouster</span>, <time>2018-04-10</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ace2903e72395404028032ee8daa6837cae7de45">Update i18n.csv</a> - <span>@duboisp</span>, <time>2018-04-10</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/a15195e8098aff580ab8f6d4f386a5be4a74edbb">Build: Updated grunt-contrib-clean to version ~1.1.0.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e4e2e03325aec435cf2be4f4eda7f36a2ef253cf">Multimedia player/Carousel: Fixed broken links/captions in media player samples.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/255560b1bf442300ac41ee8e2693b9a94ee72003">Form validation - Add test ready</a> - @duboisp, <time>2018-04-20</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/58eb144bb0bc32b47e7776df0388c7051bccbccd">Country content - Fix geolocation request url</a> - @duboisp, <time>2018-04-22</time></li>
-	</ul>
+	<section>
+		<h3>Liste des contributions</h3>
+		<ul lang="en">
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/40277dc7fa42d5872b118070df9950496a0ccaea">4.0.27 release notes</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/d48d117e6596708d84b31ef74f11145671535828">Updated files for the v4.0.27 maintenance release</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/ffdc0263ee0c941dffc4f1aa0e81f6ade0139e15">Updated the build version to v4.0.28-development</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/991663878fde50b95a6c632f579ae61c7a253a3f">build: Update Selenium browsers for vendor support</a> - <span>@nschonni</span>, <time>2018-01-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/fdbc8ef5fc5fda0d1e42ad293617367856e059c9">Revert "Revert "Bower to npm""</a> - <span>@nschonni</span>, <time>2018-01-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/5182d363fd3f3428259476b410f9d84056c439fb">Remove unnecessary timer event</a> - <span>@Pacoup</span>, <time>2018-01-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/26d20f55e2225af547358858327ba91d0290ab62">Date init patch</a> - <span>@thekodester</span>, <time>2018-01-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/e29270ba7d0c9ef95edf6e8cf5e1b5b285fe0ee6">Do not block collapsible component init on whole document</a> - <span>@Pacoup</span>, <time>2018-01-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/ccecec09a62f683e4a977fb8683e8452a8209fed">Fix typo</a> - <span>@jkshapiro</span>, <time>2018-01-19</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/4709d0e4a335428464dcf387c76df538cbf74b4f">Build - Remove copying docs folder for MathJax</a> - <span>@duboisp</span>, <time>2018-02-08</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/f3e19b4f7fc77098d39cb8dd38916c58ac6aa54d">Splash page: Fixed SVG logo's relative path.</a> - <span>@EricDunsworth</span>, <time>2018-02-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/1136cdb0261b204c973d24d8647eb5620fb92357">Overlay/Lightbox: Removed unused "hdrClose" and "ftrClose" IDs.</a> - <span>@EricDunsworth</span>, <time>2018-02-13</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/2a0ce56783a33c7c6776109c1f6f17f3754a43d7">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/2ef8f6633f367c4c50bcd20110980b040a8d48c2">Multimedia player: Replace all single quotes in video titles that get re-used for the share widget.</a> - <span>@EricDunsworth</span>, <time>2018-02-15</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/63124df8dc438933be56f20eb0ec1da765eb2706">LightBox / dependency loading/executing racing issue</a> - <span>@StdGit</span>, <time>2018-02-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/442202ca3c7008550aea9e5c53c9974e54f52d08">Added prepare script to allow themes to use WET core via npm</a> - <span>@LaurentGoderre</span>, <time>2018-02-22</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/915b5ecff76e063df8cba626f0d275d3d7339b69">Typo - wetsites-fr.hbs - Change http to https in some links</a> - <span>@peterparkers</span>, <time>2018-02-22</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/edb66b82631aa901bafc682673dcb82f8b21403c">Typo - wetsites-en.hbs - Change http to https in some links</a> - <span>@peterparkers</span>, <time>2018-02-22</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/6b0f86beb810c355dd790c80e4166da70232ffcd">Fixed tasks not loading when installed in a theme</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/d58a14050556b3b5282360533a9bd56e05d27cb8">Fixed tasks not loading when installed in a theme</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/01258d38064f62cbca7b0e71768ce59ef203da12">Update package.json</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/1d364271d0cd573cf1964711e37b5e32edc235d3">Updated the prepare script to avoid a double installation of dependencies</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/1dd35f21ea6f5c3fe3bbce613997e761e2fde65d">Fixed the WET npm as a package installed in themes</a> - <span>@LaurentGoderre</span>, <time>2018-03-01</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/354ee44dc914fca2ca27ffafe32ade0b0fe7091a">Cleanup the gitignore and add an npmignore</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/0a87c82faaa833992a7f722488d28c6d00f6e3b9">Added SASS includePath to resolve npm dependencies</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/6474f34ac9ef8d85bab6e9dbefd40a6d3620d407">Fix jQuery and MathJax version references</a> - <span>@LaurentGoderre</span>, <time>2018-03-09</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/ff8c1c5e916712542a57037215f2d51b44befff6">Site - Add wet-boew-documentation to home page, move the release notice and add link to a developer build</a> - <span>@duboisp</span>, <time>2018-03-13</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/5fe83b74fcd56e92a494c41426dc294638d96623">Edit http link in CONTRIBUTING.md (#8233)</a> - <span>@phurinaix</span>, <time>2018-03-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/4d24da7c04d33a4d47e8623f123a19a2b86d50f9">build: bump grunt-sass for latest build</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/aba47c2b1587439947b31b8c7905036f1fbdee17">css: Remove IE &lt; 11 and Android 2</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/eead92e746c757325803d0a71440ba3f0d5890f3">css: Move min Firefox to ESR</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/1be1a52ff08d9727cbcc901dab3f90d466fe3841">build: convert grunt-autoprefixer to grunt-postcss</a> - <span>@nschonni</span>, <time>2018-04-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/d3b3b7bb42f95c5ba68d51ff0848ef2413c7a836">chore: Fix NPM files</a> - <span>@nschonni</span>, <time>2018-04-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/73fcc3e11a432cb878aedccf1a9ebf283aea4156">Charts - Improving pie charts labels</a> - <span>@bsouster</span>, <time>2018-04-10</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/ace2903e72395404028032ee8daa6837cae7de45">Update i18n.csv</a> - <span>@duboisp</span>, <time>2018-04-10</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/a15195e8098aff580ab8f6d4f386a5be4a74edbb">Build: Updated grunt-contrib-clean to version ~1.1.0.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/e4e2e03325aec435cf2be4f4eda7f36a2ef253cf">Multimedia player/Carousel: Fixed broken links/captions in media player samples.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/255560b1bf442300ac41ee8e2693b9a94ee72003">Form validation - Add test ready</a> - @duboisp, <time>2018-04-20</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/58eb144bb0bc32b47e7776df0388c7051bccbccd">Country content - Fix geolocation request url</a> - @duboisp, <time>2018-04-22</time></li>
+		</ul>
+	</section>
 </section>
 
 <section>
@@ -154,70 +164,78 @@
 		<li><a href="https://github.com/lucas-hay">@lucas-hay</a>: 2 contributions</li>
 	</ul>
 
-	<h3>Liste des contributions</h3>
-	<ul lang="en">
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/af7bc1ac3977fdd7badd2bace7f0d3a5274239ca">Updated files for the v4.0.27 maintenance release</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/50b438ba0011c901064f7e89bac28eddc5769b7d">Updated the build version to v4.0.28-development</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/59e0c1c8be0d51740667efe1bff565dd7d2f358e">Replace bower with npm</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/0a0ce03afa2ec0f0482f02f6b830378290b0179c">Departement features - Add one tile example and markup improvement</a> - <span>@duboisp</span>, <time>2018-03-02</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/6415befd2d1a91050ff84309741b86a026f9bbdd">Fixed the jQuery version references</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/05274ec69cbfd64a856e2e0e0139c45c67d2ce39">Report a problem - Remove privacy statement and enforce the new markup</a> - <span>@duboisp</span>, <time>2018-03-21</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/1e4dd1c14ac5bbb512641dbe99770f1bd9e4b03a">Remove GC priorities and improved arms length footer</a> - <span>@duboisp</span>, <time>2018-03-21</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/ff8dc73eab75335b9b9d9bf998b87782c979d9d4">update - mega-menu item</a> - <span>@thangle2013</span>, <time>2018-03-28</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/6a56f078d18ae124501bbec10c51efb197b8ad7d">megamenu-benefits-finder-update</a> - <span>@thangle2013</span>, <time>2018-04-05</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/eb0e603fa55eec923575c578d7ea62b205a30a74">Build - fix dependencies for data-JSON</a> - <span>@duboisp</span>, <time>2018-04-10</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/cd1ae832b82c307de6abcc2827d7b6a978844543">Revert "Datalist JSON suggestion - initial commit"</a> - <span>@duboisp</span>, <time>2018-04-18</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/a3e6b59d860bcf11efbdbc7a0f922eaf57fd53a6">Build: Updated grunt-contrib-clean to version ~1.1.0.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
-		<li><a href="https://github.com/wet-boew/GCWeb/commit/d17bf110cee9a9e616e24153cf1794f74ac62b7a">Build - Added Sub-resource basic integrity generation</a> - <span>@duboisp</span>, <time>2018-04-23</time></li>
-	</ul>
+	<section>
+		<h3>Liste des contributions</h3>
+		<ul lang="en">
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/af7bc1ac3977fdd7badd2bace7f0d3a5274239ca">Updated files for the v4.0.27 maintenance release</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/50b438ba0011c901064f7e89bac28eddc5769b7d">Updated the build version to v4.0.28-development</a> - <span>@lucas-hay</span>, <time>2017-12-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/2f0ad4c055c171d4403b8d6a2a869bbd58a7826f">Theme: Reference SVG logos with img element instead of object.</a> - <span>@EricDunsworth</span>, <time>2018-02-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/59e0c1c8be0d51740667efe1bff565dd7d2f358e">Replace bower with npm</a> - <span>@LaurentGoderre</span>, <time>2018-02-28</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/0a0ce03afa2ec0f0482f02f6b830378290b0179c">Departement features - Add one tile example and markup improvement</a> - <span>@duboisp</span>, <time>2018-03-02</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/6415befd2d1a91050ff84309741b86a026f9bbdd">Fixed the jQuery version references</a> - <span>@LaurentGoderre</span>, <time>2018-03-07</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/05274ec69cbfd64a856e2e0e0139c45c67d2ce39">Report a problem - Remove privacy statement and enforce the new markup</a> - <span>@duboisp</span>, <time>2018-03-21</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/1e4dd1c14ac5bbb512641dbe99770f1bd9e4b03a">Remove GC priorities and improved arms length footer</a> - <span>@duboisp</span>, <time>2018-03-21</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/ff8dc73eab75335b9b9d9bf998b87782c979d9d4">update - mega-menu item</a> - <span>@thangle2013</span>, <time>2018-03-28</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/6a56f078d18ae124501bbec10c51efb197b8ad7d">megamenu-benefits-finder-update</a> - <span>@thangle2013</span>, <time>2018-04-05</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/eb0e603fa55eec923575c578d7ea62b205a30a74">Build - fix dependencies for data-JSON</a> - <span>@duboisp</span>, <time>2018-04-10</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/cd1ae832b82c307de6abcc2827d7b6a978844543">Revert "Datalist JSON suggestion - initial commit"</a> - <span>@duboisp</span>, <time>2018-04-18</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/a3e6b59d860bcf11efbdbc7a0f922eaf57fd53a6">Build: Updated grunt-contrib-clean to version ~1.1.0.</a> - <span>@EricDunsworth</span>, <time>2018-04-18</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/d17bf110cee9a9e616e24153cf1794f74ac62b7a">Build - Added Sub-resource basic integrity generation</a> - <span>@duboisp</span>, <time>2018-04-23</time></li>
+		</ul>
+	</section>
 </section>
 
 <section>
 	<h2>v4.0.28.1 - Détails</h2>
 	<p><strong>Nombre de contributionss:</strong> 1</p>
 
-	<h3>Liste des contributions</h3>
-	<ul lang="en">
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/9093ab44ad2d66b4d4eeda699a616a0c37b762b7">Form validation - Fix testReady major issue</a> - <span>@duboisp</span>, <time>2018-04-27</time></li>
-	</ul>
+	<section>
+		<h3>Liste des contributions</h3>
+		<ul lang="en">
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/9093ab44ad2d66b4d4eeda699a616a0c37b762b7">Form validation - Fix testReady major issue</a> - <span>@duboisp</span>, <time>2018-04-27</time></li>
+		</ul>
+	</section>
 </section>
 
 <section>
 	<h2 id="sri">Intégrité des sous-ressource (SRI)</h2>
 	<p>Le <a href="https://www.w3.org/TR/SRI/" hreflang="en">SRI</a> (en anglais) est une méthode qui permet de protéger le transfère des resources d'un site web. Ci-dessous vous avez les condensés numériques pour les ressource clef de la BOEW et de GCWeb.</p>
 
-	<h3>v4.0.28.1</h3>
-	<dl>
-		<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
-		<dd>sha256-W6CzUu6JitSJY/awKY6lyauDQa0IWXBTVjtxq3SpctA= sha512-oNEAH27TChN3HFV2ni+Xt2ZdS7NANHvMRFNky1lUqPsgYNBmC8wi2QaFIKlRKcp+6hPQKDNKix8umA2OfIRoxA==</dd>
-		<dt><code>GCWeb/css/theme.min.css</code></dt>
-		<dd>sha256-pQ+6VomndRUojeRLzarl8eU/m/UahNwxikiY4kZi07I= sha512-Ew4mh/42v30LSF6Ukwct4IdsgzQy692g8rZVKOnnVfSAKKnUMa+K+8DDO2gOVZ43jeizI5niztMcX7frC3hI7A==</dd>
-		<dt><code>GCWeb/js/theme.min.js</code></dt>
-		<dd>sha256-e/lB+Xz0k6XYvac+g+u3l2FbsvoaLIYdCo7l9jFDF+g= sha512-Iff1dyKW1izYivZIiJYY2pccIsDvlrPuulsuq4tONeiWltc3N+VJ4PR/95lZ3f660xF4QqAPdovVexJVnYG68A==</dd>
-	</dl>
-	<p>Obtenez tous les condensés numériques (en format JSON):</p>
-	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28.1/wet-boew/payload.json">WET-BOEW</a></li>
-		<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.28.1-gcweb/GCWeb/payload.json">Thème GCWeb</a></li>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28.1/theme-wet-boew/payload.json">Thème WET-BOEW</a></li>
-	</ul>
+	<section>
+		<h3>v4.0.28.1</h3>
+		<dl>
+			<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
+			<dd>sha256-W6CzUu6JitSJY/awKY6lyauDQa0IWXBTVjtxq3SpctA= sha512-oNEAH27TChN3HFV2ni+Xt2ZdS7NANHvMRFNky1lUqPsgYNBmC8wi2QaFIKlRKcp+6hPQKDNKix8umA2OfIRoxA==</dd>
+			<dt><code>GCWeb/css/theme.min.css</code></dt>
+			<dd>sha256-pQ+6VomndRUojeRLzarl8eU/m/UahNwxikiY4kZi07I= sha512-Ew4mh/42v30LSF6Ukwct4IdsgzQy692g8rZVKOnnVfSAKKnUMa+K+8DDO2gOVZ43jeizI5niztMcX7frC3hI7A==</dd>
+			<dt><code>GCWeb/js/theme.min.js</code></dt>
+			<dd>sha256-e/lB+Xz0k6XYvac+g+u3l2FbsvoaLIYdCo7l9jFDF+g= sha512-Iff1dyKW1izYivZIiJYY2pccIsDvlrPuulsuq4tONeiWltc3N+VJ4PR/95lZ3f660xF4QqAPdovVexJVnYG68A==</dd>
+		</dl>
+		<p>Obtenez tous les condensés numériques (en format JSON):</p>
+		<ul>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28.1/wet-boew/payload.json">WET-BOEW</a></li>
+			<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.28.1-gcweb/GCWeb/payload.json">Thème GCWeb</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28.1/theme-wet-boew/payload.json">Thème WET-BOEW</a></li>
+		</ul>
+	</section>
 
-	<h3>v4.0.28</h3>
-	<dl>
-		<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
-		<dd>sha256-Sv7zmMeu3pyom8vBljYLKbIT0mPtH938C9aiY+vM270= sha512-/uqNTSqhBGKI/4O+iEfvhj/HmDC7sKx7Ui91HYes3u/mOhlA1bCzu6UgBStXDLvzTEbvLEMsEWcwQscZ1LIXUA==</dd>
-		<dt><code>GCWeb/css/theme.min.css</code></dt>
-		<dd>sha256-avMS175xBhGsJPv3ovrFldfgmkV9xiKtXb3AREeAs88= sha512-IUpmszkQ0oasj2i2KDf/Gl8eoLxwXhRfGmmz1O5Ve8IaCiKaTt+/Nfe/5Up988lvoorIIduGtQt2tuyxWebxhA==</dd>
-		<dt><code>GCWeb/js/theme.min.js</code></dt>
-		<dd>sha256-Uv0fzXl0qj6+VTKtU/o9XtyFDtJoSjv0zY4ocGRVRoI= sha512-gAsn3Dq/oOR7zwfnmwqml008xlE++XGmV5WT75u/xOY9YckZjXC1cOSKNdbdjMxa6isiJQmz3ZdLpUMQNi+DAA==</dd>
-	</dl>
-	<p>Obtenez tous les condensés numériques (en format JSON):</p>
-	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28/wet-boew/payload.json">WET-BOEW</a></li>
-		<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.28-gcweb/GCWeb/payload.json">Thème GCWeb</a></li>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28/theme-wet-boew/payload.json">Thème WET-BOEW</a></li>
-	</ul>
+	<section>
+		<h3>v4.0.28</h3>
+		<dl>
+			<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
+			<dd>sha256-Sv7zmMeu3pyom8vBljYLKbIT0mPtH938C9aiY+vM270= sha512-/uqNTSqhBGKI/4O+iEfvhj/HmDC7sKx7Ui91HYes3u/mOhlA1bCzu6UgBStXDLvzTEbvLEMsEWcwQscZ1LIXUA==</dd>
+			<dt><code>GCWeb/css/theme.min.css</code></dt>
+			<dd>sha256-avMS175xBhGsJPv3ovrFldfgmkV9xiKtXb3AREeAs88= sha512-IUpmszkQ0oasj2i2KDf/Gl8eoLxwXhRfGmmz1O5Ve8IaCiKaTt+/Nfe/5Up988lvoorIIduGtQt2tuyxWebxhA==</dd>
+			<dt><code>GCWeb/js/theme.min.js</code></dt>
+			<dd>sha256-Uv0fzXl0qj6+VTKtU/o9XtyFDtJoSjv0zY4ocGRVRoI= sha512-gAsn3Dq/oOR7zwfnmwqml008xlE++XGmV5WT75u/xOY9YckZjXC1cOSKNdbdjMxa6isiJQmz3ZdLpUMQNi+DAA==</dd>
+		</dl>
+		<p>Obtenez tous les condensés numériques (en format JSON):</p>
+		<ul>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28/wet-boew/payload.json">WET-BOEW</a></li>
+			<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.28-gcweb/GCWeb/payload.json">Thème GCWeb</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.28/theme-wet-boew/payload.json">Thème WET-BOEW</a></li>
+		</ul>
+	</section>
 </section>

--- a/site/pages/docs/versions/v4.0/v4.0.29-en.hbs
+++ b/site/pages/docs/versions/v4.0/v4.0.29-en.hbs
@@ -4,7 +4,7 @@
 	"language": "en",
 	"description": "v4.0.29 release notes - Version history - Web Experience Toolkit (WET)",
 	"altLangPrefix": "v4.0.29",
-	"dateModified": "2018-09-19"
+	"dateModified": "2018-10-30"
 }
 ---
 <p>Version 4.0.29</p>
@@ -17,103 +17,108 @@
 
 <section>
 	<h2>What's New</h2>
-	<h3>Version 4.0.29</h3>
 
-	<ul>
-		<li>Minor - Filter - Add support to interpret spaces as boolean operator (and, or)</li>
-		<li>Minor - Charts - Add a possiblity to bypass the data cell value</li>
-		<li>Minor - Add checklist for mobile accessbility tests</li>
-		<li>Informational template - Minor - markup change for sign on off template, see <a href="https://github.com/wet-boew/wet-boew/pull/8382">PR 8382</a>.
-			<ul>
-				<li>The <code>&lt;p class="btn"&gt;</code> was changed by <code>&lt;span class="mrgn-rght-tp"&gt;</code></li>
-			</ul>
-		</li>
-		<li>Minor (Major for IE &lt; 9) - Bump jQuery to final 1.x and 2.x release
-			<ul>
-				<li>A markup change is required for those still supporting IE &lt; 9, see <a href="https://github.com/wet-boew/wet-boew/pull/8371">PR 8371</a>. IE 10 and bellow are not supported by this release of WET.</li>
-			</ul>
-		</li>
-		<li>Minor - Feeds - Add support for xhtml title in an Atom feed</li>
+	<section>
+		<h3>Version 4.0.29</h3>
 
-		<li>WET developer - Major - Build script update
-			<ul>
-				<li>Introduction of lint spacing checker, indentation must be done through tabs spacing character.</li>
-				<li>Version bump for various nodeJS dependency.</li>
-				<li>WET developer may need to delete npm caching with the local "node_modules" and "lib" folder before to run "script/setup" in order to sucessfully build.</li>
-			</ul>
-		</li>
+		<ul>
+			<li>Minor - Filter - Add support to interpret spaces as boolean operator (and, or)</li>
+			<li>Minor - Charts - Add a possiblity to bypass the data cell value</li>
+			<li>Minor - Add checklist for mobile accessbility tests</li>
+			<li>Informational template - Minor - markup change for sign on off template, see <a href="https://github.com/wet-boew/wet-boew/pull/8382">PR 8382</a>.
+				<ul>
+					<li>The <code>&lt;p class="btn"&gt;</code> was changed by <code>&lt;span class="mrgn-rght-tp"&gt;</code></li>
+				</ul>
+			</li>
+			<li>Minor (Major for IE &lt; 9) - Bump jQuery to final 1.x and 2.x release
+				<ul>
+					<li>A markup change is required for those still supporting IE &lt; 9, see <a href="https://github.com/wet-boew/wet-boew/pull/8371">PR 8371</a>. IE 10 and bellow are not supported by this release of WET.</li>
+				</ul>
+			</li>
+			<li>Minor - Feeds - Add support for xhtml title in an Atom feed</li>
 
-		<li>Accessiblity patch fixes:
-			<ul>
-				<li>Mobile menu - Use case where there is no close button</li>
-				<li>Menu - Keyboard navigation for sub-submenus</li>
-				<li>Session timeout - Empty text link</li>
-				<li>Menu - Focus styling on menu items with no submenu</li>
-				<li>Menu - Background color issue in Basic HTML mode</li>
-				<li>Accordion (Toggle) - Keyboard navigation</li>
-				<li>Tabs - Keyboard navigation</li>
-				<li>Details - Added outline on focus</li>
-				<li>Mega menu - Keyboard navigation (<a href="https://github.com/wet-boew/wet-boew/issues/8361">#8382</a>, <a href="https://github.com/wet-boew/gcweb/issues/1335">GCWeb #1335</a>)</li>
-			</ul>
-		</li>
-	</ul>
+			<li>WET developer - Major - Build script update
+				<ul>
+					<li>Introduction of lint spacing checker, indentation must be done through tabs spacing character.</li>
+					<li>Version bump for various nodeJS dependency.</li>
+					<li>WET developer may need to delete npm caching with the local "node_modules" and "lib" folder before to run "script/setup" in order to sucessfully build.</li>
+				</ul>
+			</li>
 
-	<p>Recommended markup change (Minor)</p>
-	<ul>
-		<li>Page template - Update jQuery library version
-			<ul>
-				<li>In the bottom of the page: <code>&lt;script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"&gt;&lt;/script&gt;</code></li>
-				<li>In the top of the page in the IE 9 conditional: <code>&lt;script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.js"&gt;&lt;/script&gt;</code></li>
-			</ul>
-		</li>
-	</ul>
+			<li>Accessiblity patch fixes:
+				<ul>
+					<li>Mobile menu - Use case where there is no close button</li>
+					<li>Menu - Keyboard navigation for sub-submenus</li>
+					<li>Session timeout - Empty text link</li>
+					<li>Menu - Focus styling on menu items with no submenu</li>
+					<li>Menu - Background color issue in Basic HTML mode</li>
+					<li>Accordion (Toggle) - Keyboard navigation</li>
+					<li>Tabs - Keyboard navigation</li>
+					<li>Details - Added outline on focus</li>
+					<li>Mega menu - Keyboard navigation (<a href="https://github.com/wet-boew/wet-boew/issues/8361">#8382</a>, <a href="https://github.com/wet-boew/gcweb/issues/1335">GCWeb #1335</a>)</li>
+				</ul>
+			</li>
+		</ul>
 
-	<p>Canada.ca (GCWeb):</p>
+		<p>Recommended markup change (Minor)</p>
+		<ul>
+			<li>Page template - Update jQuery library version
+				<ul>
+					<li>In the bottom of the page: <code>&lt;script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"&gt;&lt;/script&gt;</code></li>
+					<li>In the top of the page in the IE 9 conditional: <code>&lt;script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.js"&gt;&lt;/script&gt;</code></li>
+				</ul>
+			</li>
+		</ul>
 
-	<ul>
-		<li>Minor - Removed IE &lt; 11 CSS prefix</li>
-		<li>Minor (Major for IE &lt; 9) - Bump jQuery to final 1.x and 2.x release</li>
-		<li>Minor - Prevent the impression of "Report a problem" button</li>
-		<li>Minor - Reviewed the markup for the minister page - See <a href="https://github.com/wet-boew/GCWeb/pull/1365">#1365</a>
-			<ul>
-				<li>Removed the CSS class <code>.h5</code> for the "Contact information" title - <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-en.hbs#L29">Line 29</a></li>
-				<li>Use of <code>&lt;strong&gt;</code> element to emphasis the word "Telephone" and "Email" in the contact information section. <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-en.hbs#L32-L33">Line 32 to 33</a>.</li>
-				<li>Latest news items, the item description have better semantic markup - <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-en.hbs#L52-L53">Line 52-53</a></li>
-				<li>Markup for items in the gallery was reviewed. As per bootlint: <a href="https://github.com/twbs/bootlint/wiki/E013">E013 (row children must be columns)</a>; <a href="https://github.com/twbs/bootlint/wiki/E014">E014 (column parent must be a row)</a>.</li>
-			</ul>
-		</li>
-		<li>Minor - Reviewed the markup for the local navigation index - See <a href="https://github.com/wet-boew/GCWeb/pull/1365">#1365</a>
-			<ul>
-				<li>Removed the clearfix after the section "Services and information". Right before <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/localnav/index-en.hbs#L51">Line 51</a></li>
-				<li>Added the CSS class <code>whtwedo</code> for the section "What we are doing". <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/localnav/index-en.hbs#L56">Line 56</a></li>
-			</ul>
-		</li>
-		<li>Minor - Field flow - Add ifNone action configuration</li>
-		<li>Minor - Url mapping - Convert "+" symbol in space character</li>
-		<li>Major - Mega menu content update</li>
-		<li>Minor - Fixed top margin for topic page</li>
-		<li>Minor - Add partial long index page</li>
-		<li>Major - Redesign on GCWeb main page</li>
-		<li>Minor - Remove of <code>pagetag</code> CSS class. It impact the following template:
-			<ul>
-				<li>Departments and agencies</li>
-				<li>Topic</li>
-			</ul>
-		</li>
-	</ul>
-	<h3>Browser supported:</h3>
-	<p>As per the rule defined by <a href="http://wet-boew.github.io/wet-boew-documentation/decision/2.html">Design decision 2: Browser supported</a></p>
-	<ul>
-		<li>Chrome 69</li>
-		<li>Chrome 68</li>
-		<li>Safari 11.2</li>
-		<li>Firefox 62</li>
-		<li>Firefox 61</li>
-		<li>Firefox ESR - 52.8.0</li>
-		<li>Firefox ESR - 6052.7.3</li>
-		<li>IE 11</li>
-		<li>Edge 17</li>
-	</ul>
+		<p>Canada.ca (GCWeb):</p>
+
+		<ul>
+			<li>Minor - Removed IE &lt; 11 CSS prefix</li>
+			<li>Minor (Major for IE &lt; 9) - Bump jQuery to final 1.x and 2.x release</li>
+			<li>Minor - Prevent the impression of "Report a problem" button</li>
+			<li>Minor - Reviewed the markup for the minister page - See <a href="https://github.com/wet-boew/GCWeb/pull/1365">#1365</a>
+				<ul>
+					<li>Removed the CSS class <code>.h5</code> for the "Contact information" title - <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-en.hbs#L29">Line 29</a></li>
+					<li>Use of <code>&lt;strong&gt;</code> element to emphasis the word "Telephone" and "Email" in the contact information section. <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-en.hbs#L32-L33">Line 32 to 33</a>.</li>
+					<li>Latest news items, the item description have better semantic markup - <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-en.hbs#L52-L53">Line 52-53</a></li>
+					<li>Markup for items in the gallery was reviewed. As per bootlint: <a href="https://github.com/twbs/bootlint/wiki/E013">E013 (row children must be columns)</a>; <a href="https://github.com/twbs/bootlint/wiki/E014">E014 (column parent must be a row)</a>.</li>
+				</ul>
+			</li>
+			<li>Minor - Reviewed the markup for the local navigation index - See <a href="https://github.com/wet-boew/GCWeb/pull/1365">#1365</a>
+				<ul>
+					<li>Removed the clearfix after the section "Services and information". Right before <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/localnav/index-en.hbs#L51">Line 51</a></li>
+					<li>Added the CSS class <code>whtwedo</code> for the section "What we are doing". <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/localnav/index-en.hbs#L56">Line 56</a></li>
+				</ul>
+			</li>
+			<li>Minor - Field flow - Add ifNone action configuration</li>
+			<li>Minor - Url mapping - Convert "+" symbol in space character</li>
+			<li>Major - Mega menu content update</li>
+			<li>Minor - Fixed top margin for topic page</li>
+			<li>Minor - Add partial long index page</li>
+			<li>Major - Redesign on GCWeb main page</li>
+			<li>Minor - Remove of <code>pagetag</code> CSS class. It impact the following template:
+				<ul>
+					<li>Departments and agencies</li>
+					<li>Topic</li>
+				</ul>
+			</li>
+		</ul>
+	</section>
+	<section>
+		<h3>Browser supported:</h3>
+		<p>As per the rule defined by <a href="http://wet-boew.github.io/wet-boew-documentation/decision/2.html">Design decision 2: Browser supported</a></p>
+		<ul>
+			<li>Chrome 69</li>
+			<li>Chrome 68</li>
+			<li>Safari 11.2</li>
+			<li>Firefox 62</li>
+			<li>Firefox 61</li>
+			<li>Firefox ESR - 52.8.0</li>
+			<li>Firefox ESR - 6052.7.3</li>
+			<li>IE 11</li>
+			<li>Edge 17</li>
+		</ul>
+	</section>
 </section>
 
 <section>
@@ -132,61 +137,63 @@
 		<li><a href="https://github.com/waterandsewerbill2">waterandsewerbill2</a>: 1 commit</li>
 	</ul>
 
-	<h3>List of commits</h3>
-	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/fdb02f0">Updated the build version to v4.0.29-development and minor fix to v4.0.28 release notes.</a> - Pierre Dubois, <time>2018-04-23</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/3eae25c">feat(form-valid): Bump jQuery Validation to 1.17.0</a> - Nick Schonning, <time>2018-04-26</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/01c0ab0">build(markdownlint): Add grunt-markdownlint</a> - Nick Schonning, <time>2018-04-26</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/38c3c32">feat(bootstrap): Bump Bootstrap to 3.3.7</a> - Nick Schonning, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/86932bb">chore: Fix Glyphicons copyright banner</a> - Nick Schonning, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/b10e1e1">build: Bump grunt-sass-lint</a> - Nick Schonning, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/9093ab4">Form validation - Fix testReady major issue</a> - Pierre Dubois, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/6c641ed">4.0.28.1 release notes</a> - Pierre Dubois, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/4c7627c">Feeds: Allows correct xhtml feeds title parsing</a> - Philippe T. Simard, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/eb6b5d1">Release v4.0.28.1 - Update change log and SRI hash for GCWeb theme</a> - Pierre Dubois, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/537b186">build(bootlint): Bump grunt-bootlinto to 0.10.2 and fix errors</a> - Nick Schonning, <time>2018-04-30</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e82880d">feat(jquery): Bump jQuery to 2.2.4</a> - Nick Schonning, <time>2018-05-03</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/dc1f19f">feat(jQuery): Bump old IE jQuery to 1.12.4</a> - Nick Schonning, <time>2018-05-03</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/3723cfe">Site: Removed metadata comments from page templates.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/f5854da">build: Update node-sass dep for Node 10 support</a> - Nick Schonning, <time>2018-05-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/704e626">Theme: Restored "signed in as" text's original visual layout in a bootlint-friendly manner.</a> - Eric Dunsworth, <time>2018-05-17</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/b96b0c8">menu - Fix for GCweb issue #1335 (#8395)</a> - Zachary Zucco, <time>2018-05-23</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/1ea01b9">Grid - col-XX-auto - Fix an overflow issue</a> - Pierre Dubois, <time>2018-05-24</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/77a90b4">Details Polyfill - Added Outline on Focus (#8403)</a> - Zachary Zucco, <time>2018-06-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/c11cc7e">Tabbed Interface: Remove tabindex attr on details</a> - Jules Kuehn, <time>2018-06-19</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/3b3c080">Toggle accordion remains keyboard focusable after collapsing all items</a> - Jules Kuehn, <time>2018-06-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/42d0b2a">Toggle accordion: Removed (now) misleading comment</a> - Jules Kuehn, <time>2018-06-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/702eadd">Editorial - Update info on WET themes that is currently supported</a> - Pierre Dubois, <time>2018-07-09</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/77f72ce">table validator - added label to textarea</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/cb45a30">table validator - radio button group missing labels and layout improvements</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/4e477c4">Checklist for mobile accessibility tests</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e2eefbe">Charts - Bypass the data cell value on table parsing</a> - Pierre Dubois, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2ec3222">menu - Added background colour to menubar in Basic HTML mode (#8410)</a> - Zachary Zucco, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/9fb6aed">Menu: Focus styling on menu items with no submenu (#8417)</a> - Jules Kuehn, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/16c108e">Table validator - Fix bootlint error E019 and E020</a> - Pierre Dubois, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2d51939">Docs: Double and single quotes</a> - Jules Kuehn, <time>2018-07-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/143e720">chore: EditorConfig tabs -> tab (#8446)</a> - Nick Schonning, <time>2018-07-24</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/a4d242d">EditorConfig: Added global JSON/KML/CSV overrides.</a> - Eric Dunsworth, <time>2018-07-26</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/a3a0fd9">Session Timeout: Empty link with no text  Issue #7945</a> - Ducharme, <time>2018-07-26</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/be71815">Menu: Close nested submenus on menuClose</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/801dbf0">Menu: Define keycodes as 'constant' variables</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/efb03ba">Menu: Enter or spacebar follow link and close menu (including for in-page links)</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/35ce1cd">Menu: Spacebar opens or closes menu; behaves same as enter key</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/d9a805e">Menu: Prevent double handling of enter or spacebar by details.js polyfill</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/75b9e8e">Menu: Also select nested submenu items by letter</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/29eb9d6">Menu: Remove unneeded conditional</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/7386eb2">Menu: Prevent handling of keyup events (Firefox)</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/758dcdc">EditorConfig: Added .*/sitemenureplace/unset overrides and removed KML one.</a> - Eric Dunsworth, <time>2018-08-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/787ff30">Build: Added lintspaces task to check for .editorconfig compliance.</a> - Eric Dunsworth, <time>2018-08-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/49cc3d7">Filter: Add additional functionality to search (AND and OR)</a> - Neil Mispelaar, <time>2018-08-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/71bbe6e">Repo: Corrected files to comply with .editorconfig rules.</a> - Eric Dunsworth, <time>2018-08-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/54dd690">Table parser: Removed unused variables.</a> - Eric Dunsworth, <time>2018-08-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/a490b30">Build: Exempted docker env from lintspaces task.</a> - Eric Dunsworth, <time>2018-08-17</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/8de4859">Fix #8241 Data Ajax: data-wb-ajax: cdn menu</a> - Stéphane Ducharme, <time>2018-08-20</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/31135cd">Documentation: Typos in Charts</a> - waterandsewerbill2, <time>2018-09-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ffa59c0">Charts doc - Replicated updates to French and fix the merge conflit</a> - Pierre Dubois, <time>2018-09-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e79729c">WET v4.0.29 - Release notes</a> - Pierre Dubois, <time>2018-09-17</time></li>
-	</ul>
+	<section>
+		<h3>List of commits</h3>
+		<ul>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/fdb02f0">Updated the build version to v4.0.29-development and minor fix to v4.0.28 release notes.</a> - Pierre Dubois, <time>2018-04-23</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/3eae25c">feat(form-valid): Bump jQuery Validation to 1.17.0</a> - Nick Schonning, <time>2018-04-26</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/01c0ab0">build(markdownlint): Add grunt-markdownlint</a> - Nick Schonning, <time>2018-04-26</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/38c3c32">feat(bootstrap): Bump Bootstrap to 3.3.7</a> - Nick Schonning, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/86932bb">chore: Fix Glyphicons copyright banner</a> - Nick Schonning, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/b10e1e1">build: Bump grunt-sass-lint</a> - Nick Schonning, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/9093ab4">Form validation - Fix testReady major issue</a> - Pierre Dubois, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/6c641ed">4.0.28.1 release notes</a> - Pierre Dubois, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/4c7627c">Feeds: Allows correct xhtml feeds title parsing</a> - Philippe T. Simard, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/eb6b5d1">Release v4.0.28.1 - Update change log and SRI hash for GCWeb theme</a> - Pierre Dubois, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/537b186">build(bootlint): Bump grunt-bootlinto to 0.10.2 and fix errors</a> - Nick Schonning, <time>2018-04-30</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/e82880d">feat(jquery): Bump jQuery to 2.2.4</a> - Nick Schonning, <time>2018-05-03</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/dc1f19f">feat(jQuery): Bump old IE jQuery to 1.12.4</a> - Nick Schonning, <time>2018-05-03</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/3723cfe">Site: Removed metadata comments from page templates.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/f5854da">build: Update node-sass dep for Node 10 support</a> - Nick Schonning, <time>2018-05-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/704e626">Theme: Restored "signed in as" text's original visual layout in a bootlint-friendly manner.</a> - Eric Dunsworth, <time>2018-05-17</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/b96b0c8">menu - Fix for GCweb issue #1335 (#8395)</a> - Zachary Zucco, <time>2018-05-23</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/1ea01b9">Grid - col-XX-auto - Fix an overflow issue</a> - Pierre Dubois, <time>2018-05-24</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/77a90b4">Details Polyfill - Added Outline on Focus (#8403)</a> - Zachary Zucco, <time>2018-06-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/c11cc7e">Tabbed Interface: Remove tabindex attr on details</a> - Jules Kuehn, <time>2018-06-19</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/3b3c080">Toggle accordion remains keyboard focusable after collapsing all items</a> - Jules Kuehn, <time>2018-06-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/42d0b2a">Toggle accordion: Removed (now) misleading comment</a> - Jules Kuehn, <time>2018-06-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/702eadd">Editorial - Update info on WET themes that is currently supported</a> - Pierre Dubois, <time>2018-07-09</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/77f72ce">table validator - added label to textarea</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/cb45a30">table validator - radio button group missing labels and layout improvements</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/4e477c4">Checklist for mobile accessibility tests</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/e2eefbe">Charts - Bypass the data cell value on table parsing</a> - Pierre Dubois, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/2ec3222">menu - Added background colour to menubar in Basic HTML mode (#8410)</a> - Zachary Zucco, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/9fb6aed">Menu: Focus styling on menu items with no submenu (#8417)</a> - Jules Kuehn, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/16c108e">Table validator - Fix bootlint error E019 and E020</a> - Pierre Dubois, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/2d51939">Docs: Double and single quotes</a> - Jules Kuehn, <time>2018-07-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/143e720">chore: EditorConfig tabs -> tab (#8446)</a> - Nick Schonning, <time>2018-07-24</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/a4d242d">EditorConfig: Added global JSON/KML/CSV overrides.</a> - Eric Dunsworth, <time>2018-07-26</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/a3a0fd9">Session Timeout: Empty link with no text  Issue #7945</a> - Ducharme, <time>2018-07-26</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/be71815">Menu: Close nested submenus on menuClose</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/801dbf0">Menu: Define keycodes as 'constant' variables</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/efb03ba">Menu: Enter or spacebar follow link and close menu (including for in-page links)</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/35ce1cd">Menu: Spacebar opens or closes menu; behaves same as enter key</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/d9a805e">Menu: Prevent double handling of enter or spacebar by details.js polyfill</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/75b9e8e">Menu: Also select nested submenu items by letter</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/29eb9d6">Menu: Remove unneeded conditional</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/7386eb2">Menu: Prevent handling of keyup events (Firefox)</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/758dcdc">EditorConfig: Added .*/sitemenureplace/unset overrides and removed KML one.</a> - Eric Dunsworth, <time>2018-08-07</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/787ff30">Build: Added lintspaces task to check for .editorconfig compliance.</a> - Eric Dunsworth, <time>2018-08-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/49cc3d7">Filter: Add additional functionality to search (AND and OR)</a> - Neil Mispelaar, <time>2018-08-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/71bbe6e">Repo: Corrected files to comply with .editorconfig rules.</a> - Eric Dunsworth, <time>2018-08-15</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/54dd690">Table parser: Removed unused variables.</a> - Eric Dunsworth, <time>2018-08-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/a490b30">Build: Exempted docker env from lintspaces task.</a> - Eric Dunsworth, <time>2018-08-17</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/8de4859">Fix #8241 Data Ajax: data-wb-ajax: cdn menu</a> - Stéphane Ducharme, <time>2018-08-20</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/31135cd">Documentation: Typos in Charts</a> - waterandsewerbill2, <time>2018-09-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/ffa59c0">Charts doc - Replicated updates to French and fix the merge conflit</a> - Pierre Dubois, <time>2018-09-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/e79729c">WET v4.0.29 - Release notes</a> - Pierre Dubois, <time>2018-09-17</time></li>
+		</ul>
+	</section>
 </section>
 
 <section>
@@ -202,35 +209,37 @@
 		<li><a href="https://github.com/therealolivergross">Oliver Gross (@therealolivergross)</a>: 1 commit</li>
 		<li><a href="https://github.com/steve-h">Steve Hume (@steve-h)</a>: 1 commit</li>
 	</ul>
-	<h3>List of commits</h3>
-	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/7de5a26">chore: Add missing lock file updates</a> - Nick Schonning, <time>2018-04-23</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/26f6ed3">Updated the build version to v4.0.29-development</a> - Pierre Dubois, <time>2018-04-23</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/74c09e7">Build: Updated version to 4.0.29-development in package-lock.json.</a> - Eric Dunsworth, <time>2018-05-03</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/bd35d9d">Build: Autoprefix to PostCSS conversion</a> - Eric Dunsworth, <time>2018-05-04</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ed579b2">Site: Removed metadata comments from server message page templates.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/58c950a">Theme: Removed orphaned images.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/f5bbbdf">build: Update hardcoded oldIE jQuery version</a> - Nick Schonning, <time>2018-05-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/5d4947e">Theme: Hid expanded report a problem dropdowns when printing.</a> - Eric Dunsworth, <time>2018-05-22</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/f849528">Fix part of #1305: addresses the pull right classes</a> - Neil Mispelaar, <time>2018-06-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/3628cd0">Fix part of #1305: address items on the Ministerial page template</a> - Neil Mispelaar, <time>2018-06-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2eff1a3">Fieldflow - Add ifNone default action</a> - Pierre Dubois, <time>2018-06-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/17d13b3">Fieldflow - Add "query" action on form submission</a> - Pierre Dubois, <time>2018-06-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/45d709a">URL mapping - Convert "+" symbol in space</a> - Pierre Dubois, <time>2018-06-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/3b098bc">Add link to GCWU institution template</a> - Pierre Dubois, <time>2018-06-08</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/973454c">update-megamenu-health</a> - Thang Le, <time>2018-06-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e491bef">Topic tmpl - Fix top margin for the decorative image</a> - Pierre Dubois, <time>2018-06-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/8502083">Add long index template</a> - Ilya Pak, <time>2018-06-28</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/85de2c4">update links to https to sites with https</a> - steve-h, <time>2018-06-29</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2cccecf">mega-menu-update-bsd-4675</a> - Oliver Gross, <time>2018-07-04</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/527c9dd">updated 11-07-2018</a> - Ilya Pak, <time>2018-07-11 09:57:33</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e646379">Redesing of GCWeb home page</a> - Pierre Dubois, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/f19242e">Theme: Removed leftover references to to the "pagetag" class/property.</a> - Eric Dunsworth, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/a80443a">chore: EditorConfig tabs -> tab</a> - Nick Schonning, <time>2018-07-23</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/0db5fd5">update-megamenu-text-BSD4949</a> - Thang Le, <time>2018-08-09</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/b357315">megamenu-update-BSD-5062</a> - Thang Le, <time>2018-08-09</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ce90c33">BSD-5217-updateText</a> - Thang Le, <time>2018-08-17</time></li>
-	</ul>
+	<section>
+		<h3>List of commits</h3>
+		<ul>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/7de5a26">chore: Add missing lock file updates</a> - Nick Schonning, <time>2018-04-23</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/26f6ed3">Updated the build version to v4.0.29-development</a> - Pierre Dubois, <time>2018-04-23</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/74c09e7">Build: Updated version to 4.0.29-development in package-lock.json.</a> - Eric Dunsworth, <time>2018-05-03</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/bd35d9d">Build: Autoprefix to PostCSS conversion</a> - Eric Dunsworth, <time>2018-05-04</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/ed579b2">Site: Removed metadata comments from server message page templates.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/58c950a">Theme: Removed orphaned images.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/f5bbbdf">build: Update hardcoded oldIE jQuery version</a> - Nick Schonning, <time>2018-05-16</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/5d4947e">Theme: Hid expanded report a problem dropdowns when printing.</a> - Eric Dunsworth, <time>2018-05-22</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/f849528">Fix part of #1305: addresses the pull right classes</a> - Neil Mispelaar, <time>2018-06-05</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/3628cd0">Fix part of #1305: address items on the Ministerial page template</a> - Neil Mispelaar, <time>2018-06-05</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/2eff1a3">Fieldflow - Add ifNone default action</a> - Pierre Dubois, <time>2018-06-07</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/17d13b3">Fieldflow - Add "query" action on form submission</a> - Pierre Dubois, <time>2018-06-07</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/45d709a">URL mapping - Convert "+" symbol in space</a> - Pierre Dubois, <time>2018-06-07</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/3b098bc">Add link to GCWU institution template</a> - Pierre Dubois, <time>2018-06-08</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/973454c">update-megamenu-health</a> - Thang Le, <time>2018-06-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/e491bef">Topic tmpl - Fix top margin for the decorative image</a> - Pierre Dubois, <time>2018-06-15</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/8502083">Add long index template</a> - Ilya Pak, <time>2018-06-28</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/85de2c4">update links to https to sites with https</a> - steve-h, <time>2018-06-29</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/2cccecf">mega-menu-update-bsd-4675</a> - Oliver Gross, <time>2018-07-04</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/527c9dd">updated 11-07-2018</a> - Ilya Pak, <time>2018-07-11 09:57:33</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/e646379">Redesing of GCWeb home page</a> - Pierre Dubois, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/f19242e">Theme: Removed leftover references to to the "pagetag" class/property.</a> - Eric Dunsworth, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/a80443a">chore: EditorConfig tabs -> tab</a> - Nick Schonning, <time>2018-07-23</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/0db5fd5">update-megamenu-text-BSD4949</a> - Thang Le, <time>2018-08-09</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/b357315">megamenu-update-BSD-5062</a> - Thang Le, <time>2018-08-09</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/ce90c33">BSD-5217-updateText</a> - Thang Le, <time>2018-08-17</time></li>
+		</ul>
+	</section>
 </section>
 
 
@@ -238,19 +247,21 @@
 	<h2 id="sri">Subresource integrity (SRI)</h2>
 	<p><a href="https://www.w3.org/TR/SRI/">SRI</a> provide a method to protect website delivery. The following information are the hash for key resource in WET and GCWeb.</p>
 
-	<h3>v4.0.29</h3>
-	<dl>
-		<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
-		<dd>sha256-XCV8JwSxVtIYcrO3tgo95hPBkZwMZQimvalfBfN0ya4= sha512-wfEtVBdJzQLLxzuBa+GbI5gck/7UM0YeRFWMFJNNSYf9Cw4sg9TDCM6PEpCvIxMBXrcADCpyES4ofkeTDtWK5g==</dd>
-		<dt><code>GCWeb/css/theme.min.css</code></dt>
-		<dd>sha256-AGYfOGvA2TR53g8OJQWEHip5R1swHSkE8Ue6HTabfGM= sha512-kt+KBWqeRxOcQWlOGymUeGEbzL5raaHmVVWDDr3icSldNEivIhRHLfuOSRLIfJ/QT1dPfdTIuDOc0l89f9oBag==</dd>
-		<dt><code>GCWeb/js/theme.min.js</code></dt>
-		<dd>sha256-iDg0VG7uKTKMi4Ux5pzT9RmgtslErUVGvNNalnE8UQI= sha512-2cAoesVhTuii2q5jGh+7scPBec+Yln7O4pctgEV+rrzolITIr4GHI5ksq697PGe/k+MMQaeoVitSho8vK/KzRA==</dd>
-	</dl>
-	<p>Get all hash (JSON format):</p>
-	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.29/wet-boew/payload.json">WET-BOEW</a></li>
-		<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.29-gcweb/GCWeb/payload.json">GCWeb theme</a></li>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.29/theme-wet-boew/payload.json">WET-BOEW theme</a></li>
-	</ul>
+	<section>
+		<h3>v4.0.29</h3>
+		<dl>
+			<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
+			<dd>sha256-XCV8JwSxVtIYcrO3tgo95hPBkZwMZQimvalfBfN0ya4= sha512-wfEtVBdJzQLLxzuBa+GbI5gck/7UM0YeRFWMFJNNSYf9Cw4sg9TDCM6PEpCvIxMBXrcADCpyES4ofkeTDtWK5g==</dd>
+			<dt><code>GCWeb/css/theme.min.css</code></dt>
+			<dd>sha256-AGYfOGvA2TR53g8OJQWEHip5R1swHSkE8Ue6HTabfGM= sha512-kt+KBWqeRxOcQWlOGymUeGEbzL5raaHmVVWDDr3icSldNEivIhRHLfuOSRLIfJ/QT1dPfdTIuDOc0l89f9oBag==</dd>
+			<dt><code>GCWeb/js/theme.min.js</code></dt>
+			<dd>sha256-iDg0VG7uKTKMi4Ux5pzT9RmgtslErUVGvNNalnE8UQI= sha512-2cAoesVhTuii2q5jGh+7scPBec+Yln7O4pctgEV+rrzolITIr4GHI5ksq697PGe/k+MMQaeoVitSho8vK/KzRA==</dd>
+		</dl>
+		<p>Get all hash (JSON format):</p>
+		<ul>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.29/wet-boew/payload.json">WET-BOEW</a></li>
+			<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.29-gcweb/GCWeb/payload.json">GCWeb theme</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.29/theme-wet-boew/payload.json">WET-BOEW theme</a></li>
+		</ul>
+	</section>
 </section>

--- a/site/pages/docs/versions/v4.0/v4.0.29-fr.hbs
+++ b/site/pages/docs/versions/v4.0/v4.0.29-fr.hbs
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"description": "v4.0.29 - Notes de version - Historique des versions - Boîte à outils de l'expérience Web (BOEW)",
 	"altLangPrefix": "v4.0.29",
-	"dateModified": "2018-09-19"
+	"dateModified": "2018-10-30"
 }
 ---
 <p>Version 4.0.29</p>
@@ -13,106 +13,112 @@
 	<li><a href="../dwnld-fr.html#v4029">Téléchargements</a></li>
 </ul>
 
+<div class="wb-prettify all-pre"></div>
+
 <section>
 	<h2>Quoi de neuf?</h2>
-	<h3>Version 4.0.29</h3>
-	<h3>Version 4.0.28</h3>
 
-	<ul>
-		<li>Mineur - Filtre - Ajout de l'interprétation des espaces comme un opérateur booléan (et, ou)</li>
-		<li>Mineur - Graphique - Ajout d'une configuration possible pour contourner la valeur de la cellule de donnée</li>
-		<li>Mineur - Ajout d'une liste de vérification pour l'accessibilité sur des appareils mobile</li>
-		<li>Information gababrit - Mineur - Changement dans le balisage du gabarit pour le gabarit de connexion, voir <a href="https://github.com/wet-boew/wet-boew/pull/8382" hreflang="en">PR 8382</a>.
-			<ul>
-				<li>L'élément <code>&lt;p class="btn"&gt;</code> a été modifié par <code>&lt;span class="mrgn-rght-tp"&gt;</code></li>
-			</ul>
-		</li>
-		<li>Mineur  (Majeur pour IE &lt; 9) - Mise à jour vers la dernière version de jQuery 1.x et 2.x
-			<ul>
-				<li>Des changements dans le balisage est requis pour ceux qui doivent supporter IE &lt; 9, voir <a hreflang="en" href="https://github.com/wet-boew/wet-boew/pull/8371">PR 8371</a>. IE 10 ainsi que les versions précédentes ne sont pas supportées par cette version de la BOEW.</li>
-			</ul>
-		</li>
-		<li>Mineur - Flux - Ajout du support pour des titre en format XHTML definie dans un flux Atom</li>
+	<section>
+		<h3>Version 4.0.29</h3>
 
-		<li>Développeur BOEW - Majeur - Modification du script de compilation
-			<ul>
-				<li>Introduction d'une vérification automatisé des espaces, l'indentation doit être maintenant faire à l'aide de charactère de tabulation.</li>
-				<li>Mise à jour de quelques version pour les dépendances de nodeJS.</li>
-				<li>Les développeur de la BOEW devrons peut-être supprimer le cache de npm ainsi que les répertoires "node_modules" et "lib" avant d'exécuter "script/setup" pour être capable de compiler avec succès.</li>
-			</ul>
-		</li>
+		<ul>
+			<li>Mineur - Filtre - Ajout de l'interprétation des espaces comme un opérateur booléan (et, ou)</li>
+			<li>Mineur - Graphique - Ajout d'une configuration possible pour contourner la valeur de la cellule de donnée</li>
+			<li>Mineur - Ajout d'une liste de vérification pour l'accessibilité sur des appareils mobile</li>
+			<li>Information gababrit - Mineur - Changement dans le balisage du gabarit pour le gabarit de connexion, voir <a href="https://github.com/wet-boew/wet-boew/pull/8382" hreflang="en">PR 8382</a>.
+				<ul>
+					<li>L'élément <code>&lt;p class="btn"&gt;</code> a été modifié par <code>&lt;span class="mrgn-rght-tp"&gt;</code></li>
+				</ul>
+			</li>
+			<li>Mineur  (Majeur pour IE &lt; 9) - Mise à jour vers la dernière version de jQuery 1.x et 2.x
+				<ul>
+					<li>Des changements dans le balisage est requis pour ceux qui doivent supporter IE &lt; 9, voir <a hreflang="en" href="https://github.com/wet-boew/wet-boew/pull/8371">PR 8371</a>. IE 10 ainsi que les versions précédentes ne sont pas supportées par cette version de la BOEW.</li>
+				</ul>
+			</li>
+			<li>Mineur - Flux - Ajout du support pour des titre en format XHTML definie dans un flux Atom</li>
 
-		<li>Correctif d'accessibilité:
-			<ul>
-				<li>Menu mobile - Cas d'utilisation d'où qu'il n'y a aucun bouton de fermeture</li>
-				<li>Menu - Navigation par clavier pour les sous-sous-menus</li>
-				<li>Expiration de session - Texte de lien vide</li>
-				<li>Menu - Style pour la cible sur un item de menu qui n'a pas de sous menu</li>
-				<li>Menu - Couleur d'arrière plan en mode HTML simplifié</li>
-				<li>Accordéon (Basculer) - Navigation par clavier</li>
-				<li>Onglet - Navigation par clavier</li>
-				<li>Détails - Ajout d'un contour lors du ciblage</li>
-				<li>Mega menu - Navigation par clavier (<a hreflang="en" href="https://github.com/wet-boew/wet-boew/issues/8361">#8382</a>, <a href="https://github.com/wet-boew/gcweb/issues/1335" hreflang="en">GCWeb #1335</a>)</li>
-			</ul>
-		</li>
-	</ul>
+			<li>Développeur BOEW - Majeur - Modification du script de compilation
+				<ul>
+					<li>Introduction d'une vérification automatisé des espaces, l'indentation doit être maintenant faire à l'aide de charactère de tabulation.</li>
+					<li>Mise à jour de quelques version pour les dépendances de nodeJS.</li>
+					<li>Les développeur de la BOEW devrons peut-être supprimer le cache de npm ainsi que les répertoires "node_modules" et "lib" avant d'exécuter "script/setup" pour être capable de compiler avec succès.</li>
+				</ul>
+			</li>
 
-	<p>Recommendation de mise à jour de balisage (Mineur)</p>
-	<ul>
-		<li>Gabarit de page - Mise à jour de la version de jQuery
-			<ul>
-				<li>En bas de la page: <code>&lt;script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"&gt;&lt;/script&gt;</code></li>
-				<li>En haut de la page à l'intérieur des balises conditionnel IE 9: <code>&lt;script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.js"&gt;&lt;/script&gt;</code></li>
-			</ul>
-		</li>
-	</ul>
+			<li>Correctif d'accessibilité:
+				<ul>
+					<li>Menu mobile - Cas d'utilisation d'où qu'il n'y a aucun bouton de fermeture</li>
+					<li>Menu - Navigation par clavier pour les sous-sous-menus</li>
+					<li>Expiration de session - Texte de lien vide</li>
+					<li>Menu - Style pour la cible sur un item de menu qui n'a pas de sous menu</li>
+					<li>Menu - Couleur d'arrière plan en mode HTML simplifié</li>
+					<li>Accordéon (Basculer) - Navigation par clavier</li>
+					<li>Onglet - Navigation par clavier</li>
+					<li>Détails - Ajout d'un contour lors du ciblage</li>
+					<li>Mega menu - Navigation par clavier (<a hreflang="en" href="https://github.com/wet-boew/wet-boew/issues/8361">#8382</a>, <a href="https://github.com/wet-boew/gcweb/issues/1335" hreflang="en">GCWeb #1335</a>)</li>
+				</ul>
+			</li>
+		</ul>
 
-	<p>Canada.ca (GCWeb):</p>
+		<p>Recommendation de mise à jour de balisage (Mineur)</p>
+		<ul>
+			<li>Gabarit de page - Mise à jour de la version de jQuery
+				<ul>
+					<li>En bas de la page: <code>&lt;script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.js"&gt;&lt;/script&gt;</code></li>
+					<li>En haut de la page à l'intérieur des balises conditionnel IE 9: <code>&lt;script src="http://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.js"&gt;&lt;/script&gt;</code></li>
+				</ul>
+			</li>
+		</ul>
 
-	<ul>
-		<li>Mineur - Retrait des préfix CSS IE &lt; 11</li>
-		<li>Mineur (Majeur pour IE &lt; 9) - Mise à jour vers la dernière version de jQuery 1.x et 2.x</li>
-		<li>Mineur - Prévention de l'impression du bouton "Signaler un problème sur cette page"</li>
-		<li>Mineur - Revision du balisage pour le profile ministériel - voir <a hreflang="en" href="https://github.com/wet-boew/GCWeb/pull/1365">#1365</a>
-			<ul>
-				<li>Retrait des classes CSS <code>.h5</code> pour la section titré "Coordonnées" - <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-fr.hbs#L29">Ligne 29</a></li>
-				<li>Utilisation de l'élément <code>&lt;strong&gt;</code> pour mettre en évidence les mots "Téléphone" et "Courriel" dans la section coordonnées. <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-fr.hbs#L32-L33">Ligne 32 à 33</a>.</li>
-				<li>Les dernières nouvelles, le balisage utilisé pour la description associé utilise une meilleur sémentique - <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-fr.hbs#L52-L53">Ligne 52 à 53</a></li>
-				<li>Le balisage pour les items de la galleries a été revues. Tel que définie par bootlint: <a hreflang="en" href="https://github.com/twbs/bootlint/wiki/E013">E013 (Les enfants des lignes doivent être des colonnes)</a>; <a hreflang="en" lang="en" href="https://github.com/twbs/bootlint/wiki/E014">E014 (Le parent d'une colonne doit être une ligne)</a>.</li>
-			</ul>
-		</li>
-		<li>Mineur - Revision du balisage pour l'index de navigation locale - Voir <a hreflang="en" href="https://github.com/wet-boew/GCWeb/pull/1365">#1365</a>
-			<ul>
-				<li>Retrait du <span lang="en">clearfix</span> après la section "Services et information". Juste avant <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/localnav/index-fr.hbs#L51">Ligne 51</a></li>
-				<li>Ajout de la classe CSS <code>whtwedo</code> pour la section "En demande". <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/localnav/index-fr.hbs#L56">Ligne 56</a></li>
-			</ul>
-		</li>
-		<li>Mineur - Déroulement de champs - Ajout d'une action configurable si aucun <code>ifNone</code> choix n'est fait.</li>
-		<li>Mineur - Corespondance d'URL - Conversion du symbole "+" en un caractère d'espacement</li>
-		<li>Majeur - Mise à jour du contenu pour le mega menu</li>
-		<li>Mineur - Correctif de l'espacement en haut (<span lang="en">top margin</span>) pour la page des sujets</li>
-		<li>Mineur - Ajout partiel de la page de long index</li>
-		<li>Majeur - Revision considérable de la page d'accueil de GCWeb</li>
-		<li>Mineur - Retrait de la classe CSS <code>pagetag</code>. Ceci à un effet pour les gabarits suivant:
-			<ul>
-				<li>Département et agence</li>
-				<li>Sujet</li>
-			</ul>
-		</li>
-	</ul>
-	<h3>Fureteur supporté</h3>
-	<p>Tel que défini par la <a hreflang="en" href="http://wet-boew.github.io/wet-boew-documentation/decision/2.html">Décision de conception 2: Fureteur supporté</a> (en anglais)</p>
-	<ul>
-		<li>Chrome 69</li>
-		<li>Chrome 68</li>
-		<li>Safari 11.2</li>
-		<li>Firefox 62</li>
-		<li>Firefox 61</li>
-		<li>Firefox ESR - 52.8.0</li>
-		<li>Firefox ESR - 6052.7.3</li>
-		<li>IE 11</li>
-		<li>Edge 17</li>
-	</ul>
+		<p>Canada.ca (GCWeb):</p>
+
+		<ul>
+			<li>Mineur - Retrait des préfix CSS IE &lt; 11</li>
+			<li>Mineur (Majeur pour IE &lt; 9) - Mise à jour vers la dernière version de jQuery 1.x et 2.x</li>
+			<li>Mineur - Prévention de l'impression du bouton "Signaler un problème sur cette page"</li>
+			<li>Mineur - Revision du balisage pour le profile ministériel - voir <a hreflang="en" href="https://github.com/wet-boew/GCWeb/pull/1365">#1365</a>
+				<ul>
+					<li>Retrait des classes CSS <code>.h5</code> pour la section titré "Coordonnées" - <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-fr.hbs#L29">Ligne 29</a></li>
+					<li>Utilisation de l'élément <code>&lt;strong&gt;</code> pour mettre en évidence les mots "Téléphone" et "Courriel" dans la section coordonnées. <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-fr.hbs#L32-L33">Ligne 32 à 33</a>.</li>
+					<li>Les dernières nouvelles, le balisage utilisé pour la description associé utilise une meilleur sémentique - <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/ministerial-fr.hbs#L52-L53">Ligne 52 à 53</a></li>
+					<li>Le balisage pour les items de la galleries a été revues. Tel que définie par bootlint: <a hreflang="en" href="https://github.com/twbs/bootlint/wiki/E013">E013 (Les enfants des lignes doivent être des colonnes)</a>; <a hreflang="en" lang="en" href="https://github.com/twbs/bootlint/wiki/E014">E014 (Le parent d'une colonne doit être une ligne)</a>.</li>
+				</ul>
+			</li>
+			<li>Mineur - Revision du balisage pour l'index de navigation locale - Voir <a hreflang="en" href="https://github.com/wet-boew/GCWeb/pull/1365">#1365</a>
+				<ul>
+					<li>Retrait du <span lang="en">clearfix</span> après la section "Services et information". Juste avant <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/localnav/index-fr.hbs#L51">Ligne 51</a></li>
+					<li>Ajout de la classe CSS <code>whtwedo</code> pour la section "En demande". <a href="https://github.com/wet-boew/GCWeb/blob/master/site/pages/localnav/index-fr.hbs#L56">Ligne 56</a></li>
+				</ul>
+			</li>
+			<li>Mineur - Déroulement de champs - Ajout d'une action configurable si aucun <code>ifNone</code> choix n'est fait.</li>
+			<li>Mineur - Corespondance d'URL - Conversion du symbole "+" en un caractère d'espacement</li>
+			<li>Majeur - Mise à jour du contenu pour le mega menu</li>
+			<li>Mineur - Correctif de l'espacement en haut (<span lang="en">top margin</span>) pour la page des sujets</li>
+			<li>Mineur - Ajout partiel de la page de long index</li>
+			<li>Majeur - Revision considérable de la page d'accueil de GCWeb</li>
+			<li>Mineur - Retrait de la classe CSS <code>pagetag</code>. Ceci à un effet pour les gabarits suivant:
+				<ul>
+					<li>Département et agence</li>
+					<li>Sujet</li>
+				</ul>
+			</li>
+		</ul>
+	</section>
+	<section>
+		<h3>Fureteur supporté</h3>
+		<p>Tel que défini par la <a hreflang="en" href="http://wet-boew.github.io/wet-boew-documentation/decision/2.html">Décision de conception 2: Fureteur supporté</a> (en anglais)</p>
+		<ul>
+			<li>Chrome 69</li>
+			<li>Chrome 68</li>
+			<li>Safari 11.2</li>
+			<li>Firefox 62</li>
+			<li>Firefox 61</li>
+			<li>Firefox ESR - 52.8.0</li>
+			<li>Firefox ESR - 6052.7.3</li>
+			<li>IE 11</li>
+			<li>Edge 17</li>
+		</ul>
+	</section>
 </section>
 
 <section>
@@ -131,61 +137,63 @@
 		<li><a href="https://github.com/waterandsewerbill2">waterandsewerbill2</a>: 1 contribution</li>
 	</ul>
 
-	<h3>Liste des contributions</h3>
-	<ul lang="en">
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/fdb02f0">Updated the build version to v4.0.29-development and minor fix to v4.0.28 release notes.</a> - Pierre Dubois, <time>2018-04-23</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/3eae25c">feat(form-valid): Bump jQuery Validation to 1.17.0</a> - Nick Schonning, <time>2018-04-26</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/01c0ab0">build(markdownlint): Add grunt-markdownlint</a> - Nick Schonning, <time>2018-04-26</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/38c3c32">feat(bootstrap): Bump Bootstrap to 3.3.7</a> - Nick Schonning, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/86932bb">chore: Fix Glyphicons copyright banner</a> - Nick Schonning, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/b10e1e1">build: Bump grunt-sass-lint</a> - Nick Schonning, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/9093ab4">Form validation - Fix testReady major issue</a> - Pierre Dubois, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/6c641ed">4.0.28.1 release notes</a> - Pierre Dubois, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/4c7627c">Feeds: Allows correct xhtml feeds title parsing</a> - Philippe T. Simard, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/eb6b5d1">Release v4.0.28.1 - Update change log and SRI hash for GCWeb theme</a> - Pierre Dubois, <time>2018-04-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/537b186">build(bootlint): Bump grunt-bootlinto to 0.10.2 and fix errors</a> - Nick Schonning, <time>2018-04-30</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e82880d">feat(jquery): Bump jQuery to 2.2.4</a> - Nick Schonning, <time>2018-05-03</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/dc1f19f">feat(jQuery): Bump old IE jQuery to 1.12.4</a> - Nick Schonning, <time>2018-05-03</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/3723cfe">Site: Removed metadata comments from page templates.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/f5854da">build: Update node-sass dep for Node 10 support</a> - Nick Schonning, <time>2018-05-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/704e626">Theme: Restored "signed in as" text's original visual layout in a bootlint-friendly manner.</a> - Eric Dunsworth, <time>2018-05-17</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/b96b0c8">menu - Fix for GCweb issue #1335 (#8395)</a> - Zachary Zucco, <time>2018-05-23</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/1ea01b9">Grid - col-XX-auto - Fix an overflow issue</a> - Pierre Dubois, <time>2018-05-24</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/77a90b4">Details Polyfill - Added Outline on Focus (#8403)</a> - Zachary Zucco, <time>2018-06-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/c11cc7e">Tabbed Interface: Remove tabindex attr on details</a> - Jules Kuehn, <time>2018-06-19</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/3b3c080">Toggle accordion remains keyboard focusable after collapsing all items</a> - Jules Kuehn, <time>2018-06-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/42d0b2a">Toggle accordion: Removed (now) misleading comment</a> - Jules Kuehn, <time>2018-06-27</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/702eadd">Editorial - Update info on WET themes that is currently supported</a> - Pierre Dubois, <time>2018-07-09</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/77f72ce">table validator - added label to textarea</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/cb45a30">table validator - radio button group missing labels and layout improvements</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/4e477c4">Checklist for mobile accessibility tests</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e2eefbe">Charts - Bypass the data cell value on table parsing</a> - Pierre Dubois, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2ec3222">menu - Added background colour to menubar in Basic HTML mode (#8410)</a> - Zachary Zucco, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/9fb6aed">Menu: Focus styling on menu items with no submenu (#8417)</a> - Jules Kuehn, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/16c108e">Table validator - Fix bootlint error E019 and E020</a> - Pierre Dubois, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2d51939">Docs: Double and single quotes</a> - Jules Kuehn, <time>2018-07-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/143e720">chore: EditorConfig tabs -> tab (#8446)</a> - Nick Schonning, <time>2018-07-24</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/a4d242d">EditorConfig: Added global JSON/KML/CSV overrides.</a> - Eric Dunsworth, <time>2018-07-26</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/a3a0fd9">Session Timeout: Empty link with no text  Issue #7945</a> - Ducharme, <time>2018-07-26</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/be71815">Menu: Close nested submenus on menuClose</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/801dbf0">Menu: Define keycodes as 'constant' variables</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/efb03ba">Menu: Enter or spacebar follow link and close menu (including for in-page links)</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/35ce1cd">Menu: Spacebar opens or closes menu; behaves same as enter key</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/d9a805e">Menu: Prevent double handling of enter or spacebar by details.js polyfill</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/75b9e8e">Menu: Also select nested submenu items by letter</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/29eb9d6">Menu: Remove unneeded conditional</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/7386eb2">Menu: Prevent handling of keyup events (Firefox)</a> - Jules Kuehn, <time>2018-08-06</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/758dcdc">EditorConfig: Added .*/sitemenureplace/unset overrides and removed KML one.</a> - Eric Dunsworth, <time>2018-08-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/787ff30">Build: Added lintspaces task to check for .editorconfig compliance.</a> - Eric Dunsworth, <time>2018-08-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/49cc3d7">Filter: Add additional functionality to search (AND and OR)</a> - Neil Mispelaar, <time>2018-08-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/71bbe6e">Repo: Corrected files to comply with .editorconfig rules.</a> - Eric Dunsworth, <time>2018-08-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/54dd690">Table parser: Removed unused variables.</a> - Eric Dunsworth, <time>2018-08-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/a490b30">Build: Exempted docker env from lintspaces task.</a> - Eric Dunsworth, <time>2018-08-17</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/8de4859">Fix #8241 Data Ajax: data-wb-ajax: cdn menu</a> - Stéphane Ducharme, <time>2018-08-20</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/31135cd">Documentation: Typos in Charts</a> - waterandsewerbill2, <time>2018-09-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ffa59c0">Charts doc - Replicated updates to French and fix the merge conflit</a> - Pierre Dubois, <time>2018-09-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e79729c">WET v4.0.29 - Release notes</a> - Pierre Dubois, <time>2018-09-17</time></li>
-	</ul>
+	<section>
+		<h3>Liste des contributions</h3>
+		<ul lang="en">
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/fdb02f0">Updated the build version to v4.0.29-development and minor fix to v4.0.28 release notes.</a> - Pierre Dubois, <time>2018-04-23</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/3eae25c">feat(form-valid): Bump jQuery Validation to 1.17.0</a> - Nick Schonning, <time>2018-04-26</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/01c0ab0">build(markdownlint): Add grunt-markdownlint</a> - Nick Schonning, <time>2018-04-26</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/38c3c32">feat(bootstrap): Bump Bootstrap to 3.3.7</a> - Nick Schonning, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/86932bb">chore: Fix Glyphicons copyright banner</a> - Nick Schonning, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/b10e1e1">build: Bump grunt-sass-lint</a> - Nick Schonning, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/9093ab4">Form validation - Fix testReady major issue</a> - Pierre Dubois, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/6c641ed">4.0.28.1 release notes</a> - Pierre Dubois, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/4c7627c">Feeds: Allows correct xhtml feeds title parsing</a> - Philippe T. Simard, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/eb6b5d1">Release v4.0.28.1 - Update change log and SRI hash for GCWeb theme</a> - Pierre Dubois, <time>2018-04-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/537b186">build(bootlint): Bump grunt-bootlinto to 0.10.2 and fix errors</a> - Nick Schonning, <time>2018-04-30</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/e82880d">feat(jquery): Bump jQuery to 2.2.4</a> - Nick Schonning, <time>2018-05-03</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/dc1f19f">feat(jQuery): Bump old IE jQuery to 1.12.4</a> - Nick Schonning, <time>2018-05-03</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/3723cfe">Site: Removed metadata comments from page templates.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/f5854da">build: Update node-sass dep for Node 10 support</a> - Nick Schonning, <time>2018-05-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/704e626">Theme: Restored "signed in as" text's original visual layout in a bootlint-friendly manner.</a> - Eric Dunsworth, <time>2018-05-17</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/b96b0c8">menu - Fix for GCweb issue #1335 (#8395)</a> - Zachary Zucco, <time>2018-05-23</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/1ea01b9">Grid - col-XX-auto - Fix an overflow issue</a> - Pierre Dubois, <time>2018-05-24</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/77a90b4">Details Polyfill - Added Outline on Focus (#8403)</a> - Zachary Zucco, <time>2018-06-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/c11cc7e">Tabbed Interface: Remove tabindex attr on details</a> - Jules Kuehn, <time>2018-06-19</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/3b3c080">Toggle accordion remains keyboard focusable after collapsing all items</a> - Jules Kuehn, <time>2018-06-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/42d0b2a">Toggle accordion: Removed (now) misleading comment</a> - Jules Kuehn, <time>2018-06-27</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/702eadd">Editorial - Update info on WET themes that is currently supported</a> - Pierre Dubois, <time>2018-07-09</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/77f72ce">table validator - added label to textarea</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/cb45a30">table validator - radio button group missing labels and layout improvements</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/4e477c4">Checklist for mobile accessibility tests</a> - Armagan Tekdoner, <time>2018-07-10</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/e2eefbe">Charts - Bypass the data cell value on table parsing</a> - Pierre Dubois, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/2ec3222">menu - Added background colour to menubar in Basic HTML mode (#8410)</a> - Zachary Zucco, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/9fb6aed">Menu: Focus styling on menu items with no submenu (#8417)</a> - Jules Kuehn, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/16c108e">Table validator - Fix bootlint error E019 and E020</a> - Pierre Dubois, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/2d51939">Docs: Double and single quotes</a> - Jules Kuehn, <time>2018-07-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/143e720">chore: EditorConfig tabs -> tab (#8446)</a> - Nick Schonning, <time>2018-07-24</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/a4d242d">EditorConfig: Added global JSON/KML/CSV overrides.</a> - Eric Dunsworth, <time>2018-07-26</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/a3a0fd9">Session Timeout: Empty link with no text  Issue #7945</a> - Ducharme, <time>2018-07-26</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/be71815">Menu: Close nested submenus on menuClose</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/801dbf0">Menu: Define keycodes as 'constant' variables</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/efb03ba">Menu: Enter or spacebar follow link and close menu (including for in-page links)</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/35ce1cd">Menu: Spacebar opens or closes menu; behaves same as enter key</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/d9a805e">Menu: Prevent double handling of enter or spacebar by details.js polyfill</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/75b9e8e">Menu: Also select nested submenu items by letter</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/29eb9d6">Menu: Remove unneeded conditional</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/7386eb2">Menu: Prevent handling of keyup events (Firefox)</a> - Jules Kuehn, <time>2018-08-06</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/758dcdc">EditorConfig: Added .*/sitemenureplace/unset overrides and removed KML one.</a> - Eric Dunsworth, <time>2018-08-07</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/787ff30">Build: Added lintspaces task to check for .editorconfig compliance.</a> - Eric Dunsworth, <time>2018-08-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/49cc3d7">Filter: Add additional functionality to search (AND and OR)</a> - Neil Mispelaar, <time>2018-08-14</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/71bbe6e">Repo: Corrected files to comply with .editorconfig rules.</a> - Eric Dunsworth, <time>2018-08-15</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/54dd690">Table parser: Removed unused variables.</a> - Eric Dunsworth, <time>2018-08-16</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/a490b30">Build: Exempted docker env from lintspaces task.</a> - Eric Dunsworth, <time>2018-08-17</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/8de4859">Fix #8241 Data Ajax: data-wb-ajax: cdn menu</a> - Stéphane Ducharme, <time>2018-08-20</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/31135cd">Documentation: Typos in Charts</a> - waterandsewerbill2, <time>2018-09-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/ffa59c0">Charts doc - Replicated updates to French and fix the merge conflit</a> - Pierre Dubois, <time>2018-09-05</time></li>
+			<li><a href="https://github.com/wet-boew/wet-boew/commit/e79729c">WET v4.0.29 - Release notes</a> - Pierre Dubois, <time>2018-09-17</time></li>
+		</ul>
+	</section>
 </section>
 
 <section>
@@ -201,54 +209,58 @@
 		<li><a href="https://github.com/therealolivergross">Oliver Gross (@therealolivergross)</a>: 1 contribution</li>
 		<li><a href="https://github.com/steve-h">Steve Hume (@steve-h)</a>: 1 contribution</li>
 	</ul>
-	<h3>Liste des contributionss</h3>
-	<ul lang="en">
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/7de5a26">chore: Add missing lock file updates</a> - Nick Schonning, <time>2018-04-23</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/26f6ed3">Updated the build version to v4.0.29-development</a> - Pierre Dubois, <time>2018-04-23</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/74c09e7">Build: Updated version to 4.0.29-development in package-lock.json.</a> - Eric Dunsworth, <time>2018-05-03</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/bd35d9d">Build: Autoprefix to PostCSS conversion</a> - Eric Dunsworth, <time>2018-05-04</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ed579b2">Site: Removed metadata comments from server message page templates.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/58c950a">Theme: Removed orphaned images.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/f5bbbdf">build: Update hardcoded oldIE jQuery version</a> - Nick Schonning, <time>2018-05-16</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/5d4947e">Theme: Hid expanded report a problem dropdowns when printing.</a> - Eric Dunsworth, <time>2018-05-22</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/f849528">Fix part of #1305: addresses the pull right classes</a> - Neil Mispelaar, <time>2018-06-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/3628cd0">Fix part of #1305: address items on the Ministerial page template</a> - Neil Mispelaar, <time>2018-06-05</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2eff1a3">Fieldflow - Add ifNone default action</a> - Pierre Dubois, <time>2018-06-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/17d13b3">Fieldflow - Add "query" action on form submission</a> - Pierre Dubois, <time>2018-06-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/45d709a">URL mapping - Convert "+" symbol in space</a> - Pierre Dubois, <time>2018-06-07</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/3b098bc">Add link to GCWU institution template</a> - Pierre Dubois, <time>2018-06-08</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/973454c">update-megamenu-health</a> - Thang Le, <time>2018-06-14</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e491bef">Topic tmpl - Fix top margin for the decorative image</a> - Pierre Dubois, <time>2018-06-15</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/8502083">Add long index template</a> - Ilya Pak, <time>2018-06-28</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/85de2c4">update links to https to sites with https</a> - steve-h, <time>2018-06-29</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/2cccecf">mega-menu-update-bsd-4675</a> - Oliver Gross, <time>2018-07-04</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/527c9dd">updated 11-07-2018</a> - Ilya Pak, <time>2018-07-11 09:57:33</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/e646379">Redesing of GCWeb home page</a> - Pierre Dubois, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/f19242e">Theme: Removed leftover references to to the "pagetag" class/property.</a> - Eric Dunsworth, <time>2018-07-12</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/a80443a">chore: EditorConfig tabs -> tab</a> - Nick Schonning, <time>2018-07-23</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/0db5fd5">update-megamenu-text-BSD4949</a> - Thang Le, <time>2018-08-09</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/b357315">megamenu-update-BSD-5062</a> - Thang Le, <time>2018-08-09</time></li>
-		<li><a href="https://github.com/wet-boew/wet-boew/commit/ce90c33">BSD-5217-updateText</a> - Thang Le, <time>2018-08-17</time></li>
-	</ul>
+	<section>
+		<h3>Liste des contributionss</h3>
+		<ul lang="en">
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/7de5a26">chore: Add missing lock file updates</a> - Nick Schonning, <time>2018-04-23</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/26f6ed3">Updated the build version to v4.0.29-development</a> - Pierre Dubois, <time>2018-04-23</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/74c09e7">Build: Updated version to 4.0.29-development in package-lock.json.</a> - Eric Dunsworth, <time>2018-05-03</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/bd35d9d">Build: Autoprefix to PostCSS conversion</a> - Eric Dunsworth, <time>2018-05-04</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/ed579b2">Site: Removed metadata comments from server message page templates.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/58c950a">Theme: Removed orphaned images.</a> - Eric Dunsworth, <time>2018-05-15</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/f5bbbdf">build: Update hardcoded oldIE jQuery version</a> - Nick Schonning, <time>2018-05-16</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/5d4947e">Theme: Hid expanded report a problem dropdowns when printing.</a> - Eric Dunsworth, <time>2018-05-22</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/f849528">Fix part of #1305: addresses the pull right classes</a> - Neil Mispelaar, <time>2018-06-05</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/3628cd0">Fix part of #1305: address items on the Ministerial page template</a> - Neil Mispelaar, <time>2018-06-05</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/2eff1a3">Fieldflow - Add ifNone default action</a> - Pierre Dubois, <time>2018-06-07</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/17d13b3">Fieldflow - Add "query" action on form submission</a> - Pierre Dubois, <time>2018-06-07</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/45d709a">URL mapping - Convert "+" symbol in space</a> - Pierre Dubois, <time>2018-06-07</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/3b098bc">Add link to GCWU institution template</a> - Pierre Dubois, <time>2018-06-08</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/973454c">update-megamenu-health</a> - Thang Le, <time>2018-06-14</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/e491bef">Topic tmpl - Fix top margin for the decorative image</a> - Pierre Dubois, <time>2018-06-15</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/8502083">Add long index template</a> - Ilya Pak, <time>2018-06-28</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/85de2c4">update links to https to sites with https</a> - steve-h, <time>2018-06-29</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/2cccecf">mega-menu-update-bsd-4675</a> - Oliver Gross, <time>2018-07-04</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/527c9dd">updated 11-07-2018</a> - Ilya Pak, <time>2018-07-11 09:57:33</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/e646379">Redesing of GCWeb home page</a> - Pierre Dubois, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/f19242e">Theme: Removed leftover references to to the "pagetag" class/property.</a> - Eric Dunsworth, <time>2018-07-12</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/a80443a">chore: EditorConfig tabs -> tab</a> - Nick Schonning, <time>2018-07-23</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/0db5fd5">update-megamenu-text-BSD4949</a> - Thang Le, <time>2018-08-09</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/b357315">megamenu-update-BSD-5062</a> - Thang Le, <time>2018-08-09</time></li>
+			<li><a href="https://github.com/wet-boew/GCWeb/commit/ce90c33">BSD-5217-updateText</a> - Thang Le, <time>2018-08-17</time></li>
+		</ul>
+	</section>
 </section>
 
 <section>
 	<h2 id="sri">Intégrité des sous-ressource (SRI)</h2>
 	<p>Le <a href="https://www.w3.org/TR/SRI/" hreflang="en">SRI</a> (en anglais) est une méthode qui permet de protéger le transfère des resources d'un site web. Ci-dessous vous avez les condensés numériques pour les ressource clef de la BOEW et de GCWeb.</p>
 
-	<h3>v4.0.28.1</h3>
-	<dl>
-		<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
-		<dd>sha256-XCV8JwSxVtIYcrO3tgo95hPBkZwMZQimvalfBfN0ya4= sha512-wfEtVBdJzQLLxzuBa+GbI5gck/7UM0YeRFWMFJNNSYf9Cw4sg9TDCM6PEpCvIxMBXrcADCpyES4ofkeTDtWK5g==</dd>
-		<dt><code>GCWeb/css/theme.min.css</code></dt>
-		<dd>sha256-AGYfOGvA2TR53g8OJQWEHip5R1swHSkE8Ue6HTabfGM= sha512-kt+KBWqeRxOcQWlOGymUeGEbzL5raaHmVVWDDr3icSldNEivIhRHLfuOSRLIfJ/QT1dPfdTIuDOc0l89f9oBag==</dd>
-		<dt><code>GCWeb/js/theme.min.js</code></dt>
-		<dd>sha256-iDg0VG7uKTKMi4Ux5pzT9RmgtslErUVGvNNalnE8UQI= sha512-2cAoesVhTuii2q5jGh+7scPBec+Yln7O4pctgEV+rrzolITIr4GHI5ksq697PGe/k+MMQaeoVitSho8vK/KzRA==</dd>
-	</dl>
-	<p>Obtenez tous les condensés numériques (en format JSON):</p>
-	<ul>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.29/wet-boew/payload.json">WET-BOEW</a></li>
-		<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.29-gcweb/GCWeb/payload.json">Thème GCWeb</a></li>
-		<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.29/theme-wet-boew/payload.json">Thème WET-BOEW</a></li>
-	</ul>
+	<section>
+		<h3>v4.0.28.1</h3>
+		<dl>
+			<dt><code>wet-boew/js/wet-boew.min.js</code></dt>
+			<dd>sha256-XCV8JwSxVtIYcrO3tgo95hPBkZwMZQimvalfBfN0ya4= sha512-wfEtVBdJzQLLxzuBa+GbI5gck/7UM0YeRFWMFJNNSYf9Cw4sg9TDCM6PEpCvIxMBXrcADCpyES4ofkeTDtWK5g==</dd>
+			<dt><code>GCWeb/css/theme.min.css</code></dt>
+			<dd>sha256-AGYfOGvA2TR53g8OJQWEHip5R1swHSkE8Ue6HTabfGM= sha512-kt+KBWqeRxOcQWlOGymUeGEbzL5raaHmVVWDDr3icSldNEivIhRHLfuOSRLIfJ/QT1dPfdTIuDOc0l89f9oBag==</dd>
+			<dt><code>GCWeb/js/theme.min.js</code></dt>
+			<dd>sha256-iDg0VG7uKTKMi4Ux5pzT9RmgtslErUVGvNNalnE8UQI= sha512-2cAoesVhTuii2q5jGh+7scPBec+Yln7O4pctgEV+rrzolITIr4GHI5ksq697PGe/k+MMQaeoVitSho8vK/KzRA==</dd>
+		</dl>
+		<p>Obtenez tous les condensés numériques (en format JSON):</p>
+		<ul>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.29/wet-boew/payload.json">WET-BOEW</a></li>
+			<li><a href="https://github.com/wet-boew/themes-dist/blob/v4.0.29-gcweb/GCWeb/payload.json">Thème GCWeb</a></li>
+			<li><a href="https://github.com/wet-boew/wet-boew-dist/blob/v4.0.29/theme-wet-boew/payload.json">Thème WET-BOEW</a></li>
+		</ul>
+	</section>
 </section>


### PR DESCRIPTION
* All
  * Added section elements around H3 headings and their associated content.
* 4.0.29:
  * Fixed GCWeb 4.0.29 commit links.
  * Removed leftover "4.0.28" heading from French version. Fixes #8503.
  * Added prettify all plugin to French version (for consistency with English variant).