### PR TITLE
Footnotes: update hidden text for WCAG 2.1 best practice compliance

### DIFF
--- a/site/pages/docs/ref/footnotes/footnotes-en.hbs
+++ b/site/pages/docs/ref/footnotes/footnotes-en.hbs
@@ -6,14 +6,14 @@
 	"categoryfile": "plugins",
 	"description": "Provides a consistent, accessible way of handling footnotes across websites.",
 	"altLangPrefix": "footnotes",
-	"dateModified": "2016-06-10"
+	"dateModified": "2016-01-21"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
 
 <section>
 	<h2>Purpose</h2>
-	<p>This plugin allows developers to easily embed footnotes into their Web pages, and helps to achieve WCAG 2.0 compliance when providing such footnotes.</p>
+	<p>This plugin allows developers to easily embed footnotes into their Web pages, and helps to achieve WCAG 2.1 compliance when providing such footnotes.</p>
 </section>
 
 <section>
@@ -60,14 +60,14 @@
 		<section>
 			<h4>Link to a Footnote</h4>
 			<p>Use the following code as a basis to link to a particular footnote.</p>
-			<pre><code>&lt;sup id="fn1-rf"&gt;&lt;a class="fn-lnk" href="#fn1"&gt;&lt;span class="wb-inv"&gt;Footnote &lt;/span&gt;1&lt;/a&gt;&lt;/sup&gt;</code></pre>
+			<pre><code>&lt;sup id="fn1-rf"&gt;&lt;a class="fn-lnk" href="#fn1"&gt;1&lt;span class="wb-inv"&gt; (footnote)&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;</code></pre>
 			<p><strong>Note:</strong> The ID attributes of links to a multi-referenced footnote should contain a hyphen and a number just after the indicator (e.g. <code>id="fn2-1-rf"</code>, <code>id="fn2-2-rf"</code>, <code>id="fn2-3-rf"</code>, etc) to make it possible to programmatically distinguish one referrer link from another.</p>
 		</section>
 
 		<section>
 			<h4>Link to Multiple Footnotes</h4>
 			<p>Use the following code as a basis to consecutively link to multiple footnotes.</p>
-			<pre><code>&lt;sup id="fn2-rf"&gt;&lt;a class="fn-lnk" href="#fn2"&gt;&lt;span class="wb-inv"&gt;Footnote &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id="fn3-rf"&gt;&lt;a class="fn-lnk" href="#fn3"&gt;&lt;span class="wb-inv"&gt;Footnote &lt;/span&gt;3&lt;/a&gt;&lt;/sup&gt;</code></pre>
+			<pre><code>&lt;sup id="fn2-rf"&gt;&lt;a class="fn-lnk" href="#fn2"&gt;2&lt;span class="wb-inv"&gt; (footnote)&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id="fn3-rf"&gt;&lt;a class="fn-lnk" href="#fn3"&gt;3&lt;span class="wb-inv"&gt; (footnote)&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;</code></pre>
 			<p><strong>Note:</strong> Non-breaking spaces (i.e. <code>&amp;#160;</code>) should be used to separate each link.</p>
 		</section>
 	</section>
@@ -95,7 +95,7 @@
 			<pre><code>&lt;dt&gt;Footnote 1&lt;/dt&gt;
 &lt;dd id="fn1"&gt;
 	&lt;p&gt;Example of a standard footnote.&lt;/p&gt;
-	&lt;p class="fn-rtn"&gt;&lt;a href="#fn1-rf"&gt;&lt;span class="wb-inv"&gt;Return to footnote &lt;/span&gt;1&lt;span class="wb-inv"&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+	&lt;p class="fn-rtn"&gt;&lt;a href="#fn1-rf"&gt;1&lt;span class="wb-inv"&gt;, return to footnote referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;/dd&gt;</code></pre>
 		</section>
 
@@ -106,7 +106,7 @@
 			<pre><code>&lt;dt&gt;Footnote 2&lt;/dt&gt;
 &lt;dd id="fn2"&gt;
 	&lt;p&gt;Example of a footnote being referenced by multiple pieces of content.&lt;/p&gt;
-	&lt;p class="fn-rtn"&gt;&lt;a href="#fn2-1-rf"&gt;&lt;span class="wb-inv"&gt;Return to &lt;span&gt;first&lt;/span&gt; footnote &lt;/span&gt;2&lt;span class="wb-inv"&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+	&lt;p class="fn-rtn"&gt;&lt;a href="#fn2-1-rf"&gt;2&lt;span class="wb-inv"&gt;, return to <span>first</span> footnote referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;/dd&gt;</code></pre>
 
 			<p><strong>Note 1:</strong> The <code>href</code> attributes of return links in multi-referenced footnotes should always contain "-1" after the footnote indicator (e.g. <code>href="#fn2-1-rf"</code>).</p>
@@ -122,7 +122,7 @@
 	&lt;p&gt;Example of a footnote containing multiple paragraphs (first paragraph).&lt;/p&gt;
 	&lt;p&gt;Example of a footnote containing multiple paragraphs (second paragraph).&lt;/p&gt;
 	&lt;p&gt;Example of a footnote containing multiple paragraphs (third paragraph).&lt;/p&gt;
-	&lt;p class="fn-rtn"&gt;&lt;a href="#fn3-rf"&gt;&lt;span class="wb-inv"&gt;Return to footnote &lt;/span&gt;3&lt;span class="wb-inv"&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+	&lt;p class="fn-rtn"&gt;&lt;a href="#fn3-rf"&gt;3&lt;span class="wb-inv"&gt;, return to footnote referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;/dd&gt;</code></pre>
 		</section>
 	</section>

--- a/site/pages/docs/ref/footnotes/footnotes-fr.hbs
+++ b/site/pages/docs/ref/footnotes/footnotes-fr.hbs
@@ -6,14 +6,14 @@
 	"categoryfile": "plugins",
 	"description": "Une méthode cohérente et facile d’accès pour répertorier les notes de bas de page.",
 	"altLangPrefix": "footnotes",
-	"dateModified": "2016-06-10"
+	"dateModified": "2019-01-21"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
 
 <section>
 	<h2>But</h2>
-	<p>Ce plugiciel permet aux développeurs d’intégrer facilement des notes de bas de page dans leurs pages Web et facilite la conformité à WCAG 2.0 lors de l’intégration de ces notes de bas de page.</p>
+	<p>Ce plugiciel permet aux développeurs d’intégrer facilement des notes de bas de page dans leurs pages Web et facilite la conformité à WCAG 2.1 lors de l’intégration de ces notes de bas de page.</p>
 </section>
 
 <div lang="en">
@@ -68,7 +68,7 @@
 	<section>
 		<h4>Lien vers une note de bas de page</h4>
 		<p>Utiliser le code suivant pour rechercher le lien vers une note de bas de page particulière.</p>
-		<pre><code>&lt;sup id="fn1-rf"&gt;&lt;a class="fn-lnk" href="#fn1"&gt;&lt;span class="wb-inv"&gt;Note de bas de page &lt;/span&gt;1&lt;/a&gt;&lt;/sup&gt;</code></pre>
+		<pre><code>&lt;sup id="fn1-rf"&gt;&lt;a class="fn-lnk" href="#fn1"&gt;1&lt;span class="wb-inv"&gt;, note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;</code></pre>
 
 		<p><strong>Remarque&#160;:</strong> Les attributs ID des liens vers une note de bas de page multiréférentielle devraient contenir un trait d'union et un numéro placée juste après l’indicateur (par exemple&#160;: <code>id="fn2-1-rf"</code>, <code>id="fn2-2-rf"</code>, <code>id="fn2-3-rf"</code>, etc.) afin de pouvoir faire, à l’aide d’un programme, la distinction entre les liens de référence.</p>
 	</section>
@@ -78,7 +78,7 @@
 		<p><strong>Needs translation</strong></p>
 		<h4>Link to Multiple Footnotes</h4>
 		<p>Use the following code as a basis to consecutively link to multiple footnotes.</p>
-		<pre><code>&lt;sup id="fn2-rf"&gt;&lt;a class="fn-lnk" href="#fn2"&gt;&lt;span class="wb-inv"&gt;Note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id="fn3-rf"&gt;&lt;a class="fn-lnk" href="#fn3"&gt;&lt;span class="wb-inv"&gt;Note de bas de page &lt;/span&gt;3&lt;/a&gt;&lt;/sup&gt;</code></pre>
+		<pre><code>&lt;sup id="fn2-rf"&gt;&lt;a class="fn-lnk" href="#fn2"&gt;2&lt;span class="wb-inv"&gt;, note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id="fn3-rf"&gt;&lt;a class="fn-lnk" href="#fn3"&gt;3&lt;span class="wb-inv"&gt;, note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;</code></pre>
 
 		<p><strong>Note:</strong> Non-breaking spaces (i.e. <code>&amp;#160;</code>) should be used to separate each link.</p>
 	</section>
@@ -107,7 +107,7 @@
 			<pre><code>&lt;dt&gt;Note de bas de page 1&lt;/dt&gt;
 &lt;dd id="fn1"&gt;
 	&lt;p&gt;Exemple de note de bas de page standard.&lt;/p&gt;
-	&lt;p class="fn-rtn"&gt;&lt;a href="#fn1-rf"&gt;&lt;span class="wb-inv"&gt;Retour à la référence de la note de bas de page &lt;/span&gt;1&lt;/a&gt;&lt;/p&gt;
+	&lt;p class="fn-rtn"&gt;&lt;a href="#fn1-rf"&gt;1&lt;span class="wb-inv"&gt;, retour à la référence de la note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;/dd&gt;</code></pre>
 		</section>
 
@@ -118,7 +118,7 @@
 			<pre><code>&lt;dt&gt;Note de bas de page 2&lt;/dt&gt;
 &lt;dd id="fn2"&gt;
 	&lt;p&gt;Exemple de note de bas de page qui comporte de nombreux liens.&lt;/p&gt;
-	&lt;p class="fn-rtn"&gt;&lt;a href="#fn2-1-rf"&gt;&lt;span class="wb-inv"&gt;Retour à la &lt;span&gt;première&lt;/span&gt; référence de la note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/p&gt;
+	&lt;p class="fn-rtn"&gt;&lt;a href="#fn2-1-rf"&gt;2&lt;span class="wb-inv"&gt;, retour à la &lt;span&gt;première&lt;/span&gt; référence de la note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;/dd&gt;</code></pre>
 
 			<p><strong>Remarque&#160;:</strong> Les attributs <code>href</code> des liens retour dans des notes de bas de page multiréférentielles devraient toujours contenir «&#160;-1&#160;» après l’indicateur de la note de bas de page (p. ex. <code>href="#fn2-1-rf"</code>).</p>
@@ -134,7 +134,7 @@
 	&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (premier paragraphe).&lt;/p&gt;
 	&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).&lt;/p&gt;
 	&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).&lt;/p&gt;
-	&lt;p class="fn-rtn"&gt;&lt;a href="#fn3-rf"&gt;&lt;span class="wb-inv"&gt;Retour à la référence de la note de bas de page &lt;/span&gt;3&lt;/a&gt;&lt;/p&gt;
+	&lt;p class="fn-rtn"&gt;&lt;a href="#fn3-rf"&gt;3&lt;span class="wb-inv"&gt;, retour à la référence de la note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 &lt;/dd&gt;</code></pre>
 		</section>
 	</section>

--- a/src/plugins/footnotes/footnotes-en.hbs
+++ b/src/plugins/footnotes/footnotes-en.hbs
@@ -12,24 +12,24 @@
 ---
 <section>
 	<h2>Purpose</h2>
-	<p>The purpose of the Footnotes plugin is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the <a href="#fn">Footnotes</a> section. Supporting CSS is used to lay out the footnotes and hide navigational aids<sup id="fn1-rf"><a class="fn-lnk" href="#fn1"><span class="wb-inv">Footnote </span>1</a></sup>.</p>
+	<p>The purpose of the Footnotes plugin is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the <a href="#fn">Footnotes</a> section. Supporting CSS is used to lay out the footnotes and hide navigational aids<sup id="fn1-rf"><a class="fn-lnk" href="#fn1">1<span class="wb-inv"> (footnote)</span></a></sup>.</p>
 </section>
 
 <section>
 	<h2>Benefits</h2>
 	<ul>
-		<li>Conforms to WCAG 2.0 AA<sup id="fn2-1-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
+		<li>Conforms to WCAG 2.1 AA<sup id="fn2-1-rf"><a class="fn-lnk" href="#fn2">2<span class="wb-inv"> (footnote)</span></a></sup></li>
 		<li>Progressive enhancement approach</li>
-		<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
+		<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2">2<span class="wb-inv"> (footnote)</span></a></sup></li>
 		<li>Support for English and French</li>
-		<li>Configurable layout and design<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Footnote </span>3</a></sup></li>
+		<li>Configurable layout and design<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2">2<span class="wb-inv"> (footnote)</span></a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3">3<span class="wb-inv"> (footnote)</span></a></sup></li>
 	</ul>
 </section>
 
 <section>
 	<h2>Recommended usage</h2>
 	<ul>
-		<li>Implementing footnotes in Web pages<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Footnote </span>*</a></sup></li>
+		<li>Implementing footnotes in Web pages<sup id="fn*-rf"><a class="fn-lnk" href="#fn*">*<span class="wb-inv"> (footnote)</span></a></sup></li>
 	</ul>
 </section>
 
@@ -39,24 +39,24 @@
 		<dt>Footnote 1</dt>
 		<dd id="fn1">
 			<p>Example of a standard footnote.</p>
-			<p class="fn-rtn"><a href="#fn1-rf"><span class="wb-inv">Return to footnote </span>1<span class="wb-inv"> referrer</span></a></p>
+			<p class="fn-rtn"><a href="#fn1-rf">1<span class="wb-inv">, return to footnote referrer</span></a></p>
 		</dd>
 		<dt>Footnote 2</dt>
 		<dd id="fn2">
 			<p>Example of a footnote being referenced by multiple pieces of content.</p>
-			<p class="fn-rtn"><a href="#fn2-1-rf"><span class="wb-inv">Return to <span>first</span> footnote </span>2<span class="wb-inv"> referrer</span></a></p>
+			<p class="fn-rtn"><a href="#fn2-1-rf">2<span class="wb-inv">, return to footnote referrer</span></a></p>
 		</dd>
 		<dt>Footnote 3</dt>
 		<dd id="fn3">
 			<p>Example of a footnote containing multiple paragraphs (first paragraph).</p>
 			<p>Example of a footnote containing multiple paragraphs (second paragraph).</p>
 			<p>Example of a footnote containing multiple paragraphs (third paragraph).</p>
-			<p class="fn-rtn"><a href="#fn3-rf"><span class="wb-inv">Return to footnote </span>3<span class="wb-inv"> referrer</span></a></p>
+			<p class="fn-rtn"><a href="#fn3-rf">3<span class="wb-inv">, return to footnote referrer</span></a></p>
 		</dd>
 		<dt>Footnote *</dt>
 		<dd id="fn*">
 			<p>Example of a standard footnote, denoted by a symbol.</p>
-			<p class="fn-rtn"><a href="#fn*-rf"><span class="wb-inv">Return to footnote </span>*<span class="wb-inv"> referrer</span></a></p>
+			<p class="fn-rtn"><a href="#fn*-rf">*<span class="wb-inv">, return to footnote referrer</span></a></p>
 		</dd>
 	</dl>
 </aside>
@@ -65,24 +65,24 @@
 	<h2>Code</h2>
 	<pre><code>&lt;section&gt;
 	&lt;h2&gt;Purpose&lt;/h2&gt;
-	&lt;p&gt;The purpose of the Footnotes plugin is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the &lt;a href=&quot;#fn&quot;&gt;Footnotes&lt;/a&gt; section. Supporting CSS is used to lay out the footnotes and hide navigational aids&lt;sup id=&quot;fn1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn1&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;1&lt;/a&gt;&lt;/sup&gt;.&lt;/p&gt;
+	&lt;p&gt;The purpose of the Footnotes plugin is to implement a consistent, accessible way of handling footnotes across Government of Canada web sites. The main concept behind this solution is to place footnotes in a definition list, within a dedicated section. An example of this can be found in the &lt;a href=&quot;#fn&quot;&gt;Footnotes&lt;/a&gt; section. Supporting CSS is used to lay out the footnotes and hide navigational aids&lt;sup id=&quot;fn1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn1&quot;&gt;1&lt;span class=&quot;wb-inv&quot;&gt; (footnote)&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;.&lt;/p&gt;
 &lt;/section&gt;
 
 &lt;section&gt;
 	&lt;h2&gt;Benefits&lt;/h2&gt;
 	&lt;ul&gt;
-		&lt;li&gt;Conforms to WCAG 2.0 AA&lt;sup id=&quot;fn2-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Conforms to WCAG 2.1 AA&lt;sup id=&quot;fn2-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;2&lt;span class=&quot;wb-inv&quot;&gt; (footnote)&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;li&gt;Progressive enhancement approach&lt;/li&gt;
-		&lt;li&gt;Support for Firefox, Opera, Safari, Chrome, and IE 7+&lt;sup id=&quot;fn2-2-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Support for Firefox, Opera, Safari, Chrome, and IE 7+&lt;sup id=&quot;fn2-2-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;2&lt;span class=&quot;wb-inv&quot;&gt; (footnote)&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;li&gt;Support for English and French&lt;/li&gt;
-		&lt;li&gt;Configurable layout and design&lt;sup id=&quot;fn2-3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id=&quot;fn3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn3&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;3&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Configurable layout and design&lt;sup id=&quot;fn2-3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;2&lt;span class=&quot;wb-inv&quot;&gt; (footnote)&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id=&quot;fn3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn3&quot;&gt;3&lt;span class=&quot;wb-inv&quot;&gt; (footnote)&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/section&gt;
 
 &lt;section&gt;
 	&lt;h2&gt;Recommended usage&lt;/h2&gt;
 	&lt;ul&gt;
-		&lt;li&gt;Implementing footnotes in Web pages&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Implementing footnotes in Web pages&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;*&lt;span class=&quot;wb-inv&quot;&gt; (footnote)&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/section&gt;
 
@@ -92,25 +92,32 @@
 		&lt;dt&gt;Footnote 1&lt;/dt&gt;
 		&lt;dd id=&quot;fn1&quot;&gt;
 			&lt;p&gt;Example of a standard footnote.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;1&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn1-rf&quot;&gt;1&lt;span class=&quot;wb-inv&quot;&gt;, return to footnote referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Footnote 2&lt;/dt&gt;
 		&lt;dd id=&quot;fn2&quot;&gt;
 			&lt;p&gt;Example of a footnote being referenced by multiple pieces of content.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn2-1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to &lt;span&gt;first&lt;/span&gt; footnote &lt;/span&gt;2&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn2-1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to &lt;span&gt;first&lt;/span&gt; footnote &lt;/span&gt;2&lt;span class=&quot;wb-inv&quot;&gt;, return to footnote referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Footnote 3&lt;/dt&gt;
 		&lt;dd id=&quot;fn3&quot;&gt;
 			&lt;p&gt;Example of a footnote containing multiple paragraphs (first paragraph).&lt;/p&gt;
 			&lt;p&gt;Example of a footnote containing multiple paragraphs (second paragraph).&lt;/p&gt;
 			&lt;p&gt;Example of a footnote containing multiple paragraphs (third paragraph).&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn3-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;3&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn3-rf&quot;&gt;3&lt;span class=&quot;wb-inv&quot;&gt;, return to footnote referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Footnote *&lt;/dt&gt;
 		&lt;dd id=&quot;fn*&quot;&gt;
 			&lt;p&gt;Example of a standard footnote, denoted by a symbol.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn*-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;*&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn*-rf&quot;&gt;*&lt;span class=&quot;wb-inv&quot;&gt;, return to footnote referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 	&lt;/dl&gt;
 &lt;/aside&gt;</code></pre>
+</section>
+
+<section>
+	<h2>Changelog</h2>
+	<ul>
+		<li><strong>2019/01/21:</strong> Updated hidden text patterns to include visual text first in link text, as per <a href="https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html">WCAG 2.1 SC 2.5.3 Label in Name</a> best practice.</li>
+	</ul>
 </section>

--- a/src/plugins/footnotes/footnotes-fr.hbs
+++ b/src/plugins/footnotes/footnotes-fr.hbs
@@ -7,29 +7,29 @@
 	"tag": "footnotes",
 	"parentdir": "footnotes",
 	"altLangPrefix": "footnotes",
-	"dateModified": "2016-06-10"
+	"dateModified": "2019-01-21"
 }
 ---
 <section>
 	<h2>But</h2>
-	<p>Le plugiciel Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section <a href="#fn">Notes de bas de page</a>. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation<sup id="fn1-rf"><a class="fn-lnk" href="#fn1"><span class="wb-inv">Note de bas de page </span>1</a></sup>.</p>
+	<p>Le plugiciel Notes de bas de page vise à mettre en place une méthode cohérente et facile d’accès pour répertorier les notes de bas de page dans l’ensemble des sites Web du gouvernement canadien. L’idée force qui sous-tend cette solution consiste à classer les notes de bas de page dans une liste de définitions à l’intérieur d’une section spécifique. Un exemple de ceci peut être trouvé dans la section <a href="#fn">Notes de bas de page</a>. Des styles CSS servent à disposer les notes de bas de page et à dissimuler les aides à la navigation<sup id="fn1-rf"><a class="fn-lnk" href="#fn1">1<span class="wb-inv">, note de bas de page</span></a></sup>.</p>
 </section>
 
 <section>
 	<h2>Avantages</h2>
 	<ul>
-		<li>Conformes à WCAG 2.0 AA<sup id="fn2-1-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
+		<li>Conformes à WCAG 2.1 AA<sup id="fn2-1-rf"><a class="fn-lnk" href="#fn2">2<span class="wb-inv">, note de bas de page</span></a></sup></li>
 		<li>Approche d'amélioration progressive</li>
-		<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
+		<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2">2<span class="wb-inv">, note de bas de page</span></a></sup></li>
 		<li>Soutien pour l'anglais et le français</li>
-		<li>Mise en page et conception configurable<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Note de bas de page </span>3</a></sup></li>
+		<li>Mise en page et conception configurable<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2">2<span class="wb-inv">, note de bas de page</span></a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3">3<span class="wb-inv">, note de bas de page</span></a></sup></li>
 	</ul>
 </section>
 
 <section>
 	<h2>Utilisation recommandée</h2>
 		<ul>
-			<li>Exécuter les notes de bas de page dans les pages Web<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Note de bas de page </span>*</a></sup></li>
+			<li>Exécuter les notes de bas de page dans les pages Web<sup id="fn*-rf"><a class="fn-lnk" href="#fn*">*<span class="wb-inv">, note de bas de page</span></a></sup></li>
 		</ul>
 </section>
 
@@ -39,24 +39,24 @@
 		<dt>Note de bas de page 1</dt>
 		<dd id="fn1">
 			<p>Exemple de note de bas de page standard.</p>
-			<p class="fn-rtn"><a href="#fn1-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>1</a></p>
+			<p class="fn-rtn"><a href="#fn1-rf">1<span class="wb-inv">, retour à la référence de la note de bas de page</span></a></p>
 		</dd>
 		<dt>Note de bas de page 2</dt>
 		<dd id="fn2">
 			<p>Exemple de note de bas de page qui comporte de nombreux liens.</p>
-			<p class="fn-rtn"><a href="#fn2-1-rf"><span class="wb-inv">Retour à la <span>première</span> référence de la note de bas de page </span>2</a></p>
+			<p class="fn-rtn"><a href="#fn2-1-rf">2<span class="wb-inv">, retour à la <span>première</span> référence de la note de bas de page</span></a></p>
 		</dd>
 		<dt>Note de bas de page 3</dt>
 		<dd id="fn3">
 			<p>Exemple de note de bas de page qui compte plusieurs paragraphes (premier paragraphe).</p>
 			<p>Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).</p>
 			<p>Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).</p>
-			<p class="fn-rtn"><a href="#fn3-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>3</a></p>
+			<p class="fn-rtn"><a href="#fn3-rf">3<span class="wb-inv">, retour à la référence de la note de bas de page</span></a></p>
 		</dd>
 		<dt>Note de bas de page *</dt>
 		<dd id="fn*">
 			<p>Exemple de note de bas de page standard, représentée par un symbole.</p>
-			<p class="fn-rtn"><a href="#fn*-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>*</a></p>
+			<p class="fn-rtn"><a href="#fn*-rf">*<span class="wb-inv">, retour à la référence de la note de bas de page</span></a></p>
 		</dd>
 	</dl>
 </aside>
@@ -71,18 +71,18 @@
 &lt;section&gt;
 	&lt;h2&gt;Avantages&lt;/h2&gt;
 	&lt;ul&gt;
-		&lt;li&gt;Conformes à WCAG 2.0 AA&lt;sup id=&quot;fn2-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Conformes à WCAG 2.0 AA&lt;sup id=&quot;fn2-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;2&lt;span class=&quot;wb-inv&quot;&gt;, note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;li&gt;Approche d'amélioration progressive&lt;/li&gt;
-		&lt;li&gt;Soutien pour Firefox, Opera, Safari, Chrome et IE 7+&lt;sup id=&quot;fn2-2-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Soutien pour Firefox, Opera, Safari, Chrome et IE 7+&lt;sup id=&quot;fn2-2-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;2&lt;span class=&quot;wb-inv&quot;&gt;, note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;li&gt;Soutien pour l'anglais et le français&lt;/li&gt;
-		&lt;li&gt;Mise en page et conception configurable&lt;sup id=&quot;fn2-3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id=&quot;fn3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn3&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;3&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Mise en page et conception configurable&lt;sup id=&quot;fn2-3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;2&lt;span class=&quot;wb-inv&quot;&gt;, note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id=&quot;fn3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn3&quot;&gt;3&lt;span class=&quot;wb-inv&quot;&gt;, note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/section&gt;
 
 &lt;section&gt;
 	&lt;h2&gt;Utilisation recommandée&lt;/h2&gt;
 		&lt;ul&gt;
-			&lt;li&gt;Exécuter les notes de bas de page dans les pages Web&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+			&lt;li&gt;Exécuter les notes de bas de page dans les pages Web&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;*&lt;span class=&quot;wb-inv&quot;&gt;, note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;/ul&gt;
 &lt;/section&gt;
 
@@ -92,25 +92,35 @@
 		&lt;dt&gt;Note de bas de page 1&lt;/dt&gt;
 		&lt;dd id=&quot;fn1&quot;&gt;
 			&lt;p&gt;Exemple de note de bas de page standard.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la référence de la note de bas de page &lt;/span&gt;1&lt;/a&gt;&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn1-rf&quot;&gt;1&lt;span class=&quot;wb-inv&quot;&gt;, retour à la référence de la note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Note de bas de page 2&lt;/dt&gt;
 		&lt;dd id=&quot;fn2&quot;&gt;
 			&lt;p&gt;Exemple de note de bas de page qui comporte de nombreux liens.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn2-1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la &lt;span&gt;première&lt;/span&gt; référence de la note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn2-1-rf&quot;&gt;2&lt;span class=&quot;wb-inv&quot;&gt;, retour à la &lt;span&gt;première&lt;/span&gt; référence de la note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Note de bas de page 3&lt;/dt&gt;
 		&lt;dd id=&quot;fn3&quot;&gt;
 			&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (premier paragraphe).&lt;/p&gt;
 			&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).&lt;/p&gt;
 			&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn3-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la référence de la note de bas de page &lt;/span&gt;3&lt;/a&gt;&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn3-rf&quot;&gt;3&lt;span class=&quot;wb-inv&quot;&gt;, retour à la référence de la note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Note de bas de page *&lt;/dt&gt;
 		&lt;dd id=&quot;fn*&quot;&gt;
 			&lt;p&gt;Exemple de note de bas de page standard, représentée par un symbole.&lt;/p&gt;
-			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn*-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la référence de la note de bas de page &lt;/span&gt;*&lt;/a&gt;&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn*-rf&quot;&gt;*&lt;span class=&quot;wb-inv&quot;&gt;, retour à la référence de la note de bas de page&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 	&lt;/dl&gt;
 &lt;/aside&gt;</code></pre>
 </section>
+
+<div lang="en">
+<section>
+	<p><strong>Needs translation</strong></p>
+	<h2>Changelog</h2>
+	<ul>
+		<li><strong>2019/01/21:</strong> Updated hidden text patterns to include visual text first in link text, as per <a href="https://www.w3.org/WAI/WCAG21/Understanding/label-in-name.html">WCAG 2.1 SC 2.5.3 Label in Name</a> best practice.</li>
+	</ul>
+</section>
+</div>


### PR DESCRIPTION
WCAG 2.1 SC 2.5.3 Label in Name establishes a best practice of having
hidden text come after visible text in link or label text for better
compatibility with voice control software.

Resolves issue #8528 