### PR TITLE
Multimedia Youtube player - YT event workaround when open in a modal

### DIFF
--- a/src/plugins/multimedia/multimedia-youtube-en.hbs
+++ b/src/plugins/multimedia/multimedia-youtube-en.hbs
@@ -45,3 +45,42 @@
 		</details>
 	</section>
 </div>
+
+<h2>Youtube video in a lightbox</h2>
+
+<p><a class="wb-lbx lbx-modal lbx-iframe" href="#video-youtube">Open the video</a></p>
+<section id="video-youtube" class="mfp-hide modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h3>Youtube video in a lightbox</h3>
+	</header>
+	<div class="modal-body">
+		<figure class="wb-mltmd" data-wb-mltmd='{"shareUrl": "http://www.youtube.com/watch?v=9znKJqnFuuY"}'>
+			<video title="Suspect">
+				<source type="video/youtube" src="http://www.youtube.com/watch?v=9znKJqnFuuY" />
+			</video>
+			<figcaption>
+				<p>Suspect (<a href="http://healthycanadians.gc.ca/video/suspect-eng.php#trans">Transcript</a>)</p>
+			</figcaption>
+		</figure>
+	</div>
+</section>
+
+<details>
+	<summary>View code</summary>
+	<pre><code>&lt;p&gt;&lt;a class="wb-lbx lbx-modal lbx-iframe" href="#video-youtube"&gt;Open the video&lt;/a&gt;&lt;/p&gt;
+&lt;section id="video-youtube" class="mfp-hide modal-dialog modal-content overlay-def"&gt;
+	&lt;header class="modal-header"&gt;
+		&lt;h3&gt;Youtube video in a lightbox&lt;/h3&gt;
+	&lt;/header&gt;
+	&lt;div class="modal-body"&gt;
+		&lt;figure class="wb-mltmd" data-wb-mltmd='{"shareUrl": "http://www.youtube.com/watch?v=9znKJqnFuuY"}'&gt;
+			&lt;video title="Suspect"&gt;
+				&lt;source type="video/youtube" src="http://www.youtube.com/watch?v=9znKJqnFuuY" /&gt;
+			&lt;/video&gt;
+			&lt;figcaption&gt;
+				&lt;p&gt;Suspect (&lt;a href="http://healthycanadians.gc.ca/video/suspect-eng.php#trans"&gt;Transcript&lt;/a&gt;)&lt;/p&gt;
+			&lt;/figcaption&gt;
+		&lt;/figure&gt;
+	&lt;/div&gt;
+&lt;/section&gt;</code></pre>
+</details>

--- a/src/plugins/multimedia/multimedia-youtube-fr.hbs
+++ b/src/plugins/multimedia/multimedia-youtube-fr.hbs
@@ -44,3 +44,42 @@
 		</details>
 	</section>
 </div>
+
+<h2>Vidéo Youtube dans une fenêtre modale (lightbox)</h2>
+
+<p><a class="wb-lbx lbx-modal lbx-iframe" href="#video-youtube">Ouvrir le vidéo</a></p>
+<section id="video-youtube" class="mfp-hide modal-dialog modal-content overlay-def">
+	<header class="modal-header">
+		<h3>Vidéo Youtube dans une fenêtre modale (lightbox)</h3>
+	</header>
+	<div class="modal-body">
+		<figure class="wb-mltmd" data-wb-mltmd='{"shareUrl": "http://www.youtube.com/watch?v=LLg-UsTr7us"}'>
+			<video title="Suspect">
+				<source type="video/youtube" src="http://www.youtube.com/watch?v=LLg-UsTr7us" />
+			</video>
+			<figcaption>
+				<p>Suspect (<a href="http://canadiensensante.gc.ca/video/suspect-fra.php#trans">Transcription</a>)</p>
+			</figcaption>
+		</figure>
+	</div>
+</section>
+
+<details>
+	<summary>View code</summary>
+	<pre><code>&lt;p&gt;&lt;a class="wb-lbx lbx-modal lbx-iframe" href="#video-youtube"&gt;Ouvrir le vidéo&lt;/a&gt;&lt;/p&gt;
+&lt;section id="video-youtube" class="mfp-hide modal-dialog modal-content overlay-def"&gt;
+	&lt;header class="modal-header"&gt;
+		&lt;h3&gt;Vidéo Youtube dans une fenêtre modale (lightbox)&lt;/h3&gt;
+	&lt;/header&gt;
+	&lt;div class="modal-body"&gt;
+		&lt;figure class="wb-mltmd" data-wb-mltmd='{"shareUrl": "http://www.youtube.com/watch?v=LLg-UsTr7us"}'&gt;
+			&lt;video title="Suspect"&gt;
+				&lt;source type="video/youtube" src="http://www.youtube.com/watch?v=LLg-UsTr7us" /&gt;
+			&lt;/video&gt;
+			&lt;figcaption&gt;
+				&lt;p&gt;Suspect (&lt;a href="http://canadiensensante.gc.ca/video/suspect-fra.php#trans"&gt;Transcription&lt;/a&gt;)&lt;/p&gt;
+			&lt;/figcaption&gt;
+		&lt;/figure&gt;
+	&lt;/div&gt;
+&lt;/section&gt;</code></pre>
+</details>

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -718,7 +718,7 @@ $document.on( youtubeEvent, selector, function( event, data ) {
 			var elm = evt.currentTarget,
 				ds = elm.dataset;
 
-			// Do nothing on the first load and add a flag to indicate it is loaded a second times
+			// Do nothing on the first load and add a flag to indicate it is loaded a second time
 			if ( ds.L1 ) {
 				ds.L2 = true;
 			} else {

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -66,7 +66,7 @@ var componentName = "wb-mltmd",
 				// the issue is when the iFrame is moved, it reloads and then it doesn't emit the right event to
 				// adjust the WET multimedia controller to represent its current state.
 				//
-				// This need to be executed only once that is why it is in the i18nText conditional
+				// This needs to be executed only once, that is why it is in the i18nText conditional
 				window.addEventListener( "message", function( e ) {
 					var data, frames, i, i_len, i_cache;
 

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -64,7 +64,7 @@ var componentName = "wb-mltmd",
 				// YT workaround for when played inside a modal dialog, like with lightbox
 				//
 				// the issue is when the iFrame is moved, it reloads and then it doesn't emit the right event to
-				// adjust the WET multimedia controler to represent it's current state.
+				// adjust the WET multimedia controller to represent its current state.
 				//
 				// This need to be executed only once that is why it is in the i18nText conditional
 				window.addEventListener( "message", function( e ) {

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -711,7 +711,7 @@ $document.on( youtubeEvent, selector, function( event, data ) {
 		data.ytPlayer = ytPlayer;
 
 		// Detect if the YT player reloads, like when magnific Popup show the modal, because it moves the iframe
-		// and then the iframe get refreshed and reloaded. So the issue is the iframe stop to emit the event
+		// and then the iframe gets refreshed and reloaded. So the issue is that the iframe stops emitting the event
 		// needed to adjust the multimedia player controler, like the "onStateChange" event.
 		$media.on( "load", function( evt ) {
 

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -710,7 +710,7 @@ $document.on( youtubeEvent, selector, function( event, data ) {
 		data.media = $media;
 		data.ytPlayer = ytPlayer;
 
-		// Detect if the YTplayer re-load like when magnific Popup show the modal because it move the iframe
+		// Detect if the YT player reloads, like when magnific Popup show the modal, because it moves the iframe
 		// and then the iframe get refreshed and reloaded. So the issue is the iframe stop to emit the event
 		// needed to adjust the multimedia player controler, like the "onStateChange" event.
 		$media.on( "load", function( evt ) {

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -77,7 +77,7 @@ var componentName = "wb-mltmd",
 						// Only for a specific YT message
 						if ( data.event && data.event === "infoDelivery" && data.info && data.info.playerState ) {
 
-							// Find the iFrame and evaluate if it need to be repost
+							// Find the iFrame and evaluate if it needs to be reposted
 							frames = document.getElementsByTagName( "iframe" );
 
 							i_len = frames.length;

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -63,7 +63,7 @@ var componentName = "wb-mltmd",
 
 				// YT workaround for when played inside a modal dialog, like with lightbox
 				//
-				// the issue is when the iFrame is moved, it reload and then it don't emit the right event to
+				// the issue is when the iFrame is moved, it reloads and then it doesn't emit the right event to
 				// adjust the WET multimedia controler to represent it's current state.
 				//
 				// This need to be executed only once that is why it is in the i18nText conditional


### PR DESCRIPTION
Working example: http://universallabs.org/wet/labs/multimedia-yt/demos/multimedia/multimedia-youtube-en.html

fix #7828, #8232