### PR TITLE
Toggle plugin: multiple details toggle fix

### DIFF
--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -370,6 +370,16 @@ var componentName = "wb-toggle",
 		} else if ( !selector ) {
 			return $link.data( componentName + "-state" ) || data.stateOff;
 
+		// When toggling multiple <details> elements, state is "off" if any are collapsed
+		} else if ( selector === "details" && !type ) {
+			var anyCollapsed = false;
+			getElements( $link, data ).each( function() {
+				if ( !$( this ).attr( "open" ) ) {
+					anyCollapsed = true;
+				}
+			} );
+			return anyCollapsed ? data.stateOff : data.stateOn;
+
 		// Get the current on/off state of the elements specified by the selector and parent
 		} else if ( states.hasOwnProperty( selector ) ) {
 			return states[ selector ].hasOwnProperty( parent ) ?


### PR DESCRIPTION
Resolves issue #8647

Changes behaviour **only** for toggling multiple detail/summary elements.

1. Toggle will expand all items if any are collapsed.
2. Toggle will collapse all items if and only if all are expanded.
