### PR TITLE
Table validator: Updated HTML spec link.

### DIFF
--- a/src/other/tablevalidator/demo/tablevalidator.js
+++ b/src/other/tablevalidator/demo/tablevalidator.js
@@ -89,7 +89,7 @@ var componentName = "wb-tblvalidator",
 		"colgroupsummary-techniques.html", /* 10 */
 		"colheader-description-techniques.html", /* 11 */
 		"layoutcell-techniques.html", /* 12 */
-		"http:/*www.w3.org/TR/html5/spec.html" ], /* 13 */
+		"https://html.spec.whatwg.org/multipage/tables.html#tables" ], /* 13 */
 	techniqueName = [
 		"Defining a Key Cell", /* 1 */
 		"Defining a Data Row Group in a Data Table", /* 2 */
@@ -103,7 +103,7 @@ var componentName = "wb-tblvalidator",
 		"Summaries a Data Column Group in a Data Table", /* 10 */
 		"Describing a Column Header Cell in a Data Table", /* 11 */
 		"Defining a Layout Cell in a Data Table", /* 12 */
-		"HTML5 Specification" ]; /* 13 */
+		"HTML Standard: Tabular data" ]; /* 13 */
 
 // Prevent any form to submit
 $document.on( "submit", formSelector, function( ) {


### PR DESCRIPTION
The W3C HTML5 specification link that can potentially show up as a warning in validation results was malformed and pointed to a decommissioned page.

This commit updates the link's title to "HTML Standard: Tabular data" and changes its destination to that section in the WHATWG's HTML spec.