### PR TITLE
Boostrap overrides: Fix solid abbreviation underlines

### DIFF
--- a/src/base/bootstrap-overrides/_base.scss
+++ b/src/base/bootstrap-overrides/_base.scss
@@ -217,6 +217,27 @@ a {
 }
 
 /*
+ *	Abbreviations with title attributes
+ *	Workaround for abbreviations with titles using solid underlines in IE11/Edge in Bootstrap 3.4.0 (via normalize.css 4.0.1-8.0.1):
+ *	- Use a dotted underline in browsers that support it (e.g. Firefox, Chrome, etc...)
+ *	- Fallback on a dotted bottom border in browsers that don't support it (e.g. IE11, Edge, etc...)
+ *	Source: https://github.com/necolas/normalize.css/pull/738#issuecomment-387549760
+ *	Created by: @mattbrundage
+ */
+
+abbr[title] {
+	border-bottom: 1px dotted;
+	text-decoration: none;
+}
+
+@supports (text-decoration: underline dotted) {
+	abbr[title] {
+		border-bottom: 0;
+		text-decoration: underline dotted;
+	}
+}
+
+/*
  *	Override the design of alerts and labels
  */
 


### PR DESCRIPTION
In Bootstrap 3.4.0 (via normalize.css 4.0.1-8.0.1), abbreviations with title attributes use "text-decoration: underline dotted;" to create a dotted underline effect in modern browsers.

"text-decoration: underline" is used as a fallback for older browsers such as IE11 and Edge... which causes them to render affected abbreviations with solid underlines. That isn't desirable since they end up looking too much like links.

This commit adjusts WET's CSS to continue using "text-decoration: underline dotted;" for abbreviations in browsers that support it and fallback on "border-bottom: 1px dotted;" in ones that don't.

It's a port of https://github.com/necolas/normalize.css/pull/738#issuecomment-387549760 (created by @mattbrundage).