### PR TITLE
Build: Update Bootstrap to 3.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -666,9 +666,9 @@
       }
     },
     "bootstrap-sass": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
-      "integrity": "sha1-ZZbHq0D2Y3OTMjqwvIDQZPxjBJg="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.4.1.tgz",
+      "integrity": "sha512-p5rxsK/IyEDQm2CwiHxxUi0MZZtvVFbhWmyMOt4lLkA4bujDA1TGoKT0i1FKIWiugAdP+kK8T5KMDFIKQCLYIA=="
     },
     "bower-config": {
       "version": "0.5.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "bootstrap-sass": "^3.3.7",
+    "bootstrap-sass": "3.4.1",
     "code-prettify": "^0.1.0",
     "datatables": "1.10.13",
     "es5-shim": "2.3.0",


### PR DESCRIPTION
Package.json previously contained "^3.3.7". Package-lock.json contained "3.4.1".

That arrangement caused npm install to install 3.3.7 for WET's build system (since package-lock.json takes priority in this context).

But other WET themes (like GCWeb) were resolving to 3.4.1. For example, when setting up GCWeb's build system, wet-boew is used as a dependency. Due to the behaviour described in npm/npm#19458, npm dependencies rely on their package.json files instead of their package-lock.json files.

This commit updates WET's Bootstrap dependency to be exactly 3.4.1 and removes the ^ from package.json. That should make WET's Bootstrap version consistent with its themes and prevent future Bootstrap version mismatches between them.