### PR TITLE
CSS - Ensure input field value don't overflow with text-zoom at 200%

### DIFF
--- a/src/base/bootstrap-overrides/_base.scss
+++ b/src/base/bootstrap-overrides/_base.scss
@@ -578,6 +578,10 @@ blockquote {
  *  height:37px; rule of Bootstrap was overwritten by height: auto; first
  *  then a min-height specified, in order to address the issue #8492. July 2019.
  */
+input[type=button], input[type=reset], input[type=submit] {
+	height: auto;
+	min-height: 37px;
+}
 .form-control {
 	height: auto;
 	max-width: 100%;

--- a/src/base/bootstrap-overrides/_base.scss
+++ b/src/base/bootstrap-overrides/_base.scss
@@ -575,9 +575,13 @@ blockquote {
  *	Default should be representative of the expected length of input.
  *	Full width should be only for cases when the expected length of input is
  *	greater than the available width.
+ *  height:37px; rule of Bootstrap was overwritten by height: auto; first
+ *  then a min-height specified, in order to address the issue #8492. July 2019.
  */
 .form-control {
+	height: auto;
 	max-width: 100%;
+	min-height: 37px;
 	width: auto;
 }
 


### PR DESCRIPTION
I have applied the fixes previously pointed out to overwrite the existing rules and they worked. Tested IE11, Microsoft Edge 42, Firefox 57 (using zoom text only), and Chrome 75.

fix #8492
