### PR TITLE
Forms: Add autocomplete attributes

### DIFF
--- a/site/pages/docs/ref/formvalid/formvalid-en.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-en.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Provides generic validation and error message handling for Web forms.",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2018-07-04"
+	"dateModified": "2019-07-29"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -53,7 +53,7 @@
 &lt;/label&gt;</code></pre>
 		</li>
 		<li>Add <code>required="required"</code> to each mandatory form field
-			<pre><code>&lt;input id="fname1" name="fname1" type="text" required="required" /&gt;</code></pre>
+			<pre><code>&lt;input id="fname1" name="fname1" type="text" autocomplete="given-name" required="required" /&gt;</code></pre>
 		</li>
 		<li><p><strong>Optional: </strong>For input fields, add one of these <a href="#SpecializedValidation">options</a> for specialized validation.</p></li>
 		<li><strong>Optional: </strong>For ASP validators add the following attributes to enable the <a href="#MergeSCE">Merge Server-Client errors functionality</a>

--- a/site/pages/docs/ref/formvalid/formvalid-fr.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-fr.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Effectue la validation de formulaires Web selon un ensemble de règles de base avant qu'ils soient soumis.",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2018-07-04"
+	"dateModified": "2019-07-29"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -56,7 +56,7 @@
 &lt;/label&gt;</code></pre>
 		</li>
 		<li>Add <code>required="required"</code> to each mandatory form field
-			<pre><code>&lt;input id="fname1" name="fname1" type="text" required="required" /&gt;</code></pre>
+			<pre><code>&lt;input id="fname1" name="fname1" type="text" autocomplete="given-name" required="required" /&gt;</code></pre>
 		</li>
 		<li><p><strong>Optional: </strong>For input fields, add one of these <a href="#SpecializedValidation">options</a> for specialized validation.</p></li>
 		<li><strong>Optional: </strong>For ASP validators add the following attributes to enable the <a href="#MergeSCE">Merge Server-Client errors functionality</a>

--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2018-07-04"
+	"dateModified": "2019-07-29"
 }
 ---
 
@@ -32,7 +32,7 @@
 				<legend>Contact information</legend>
 				<div class="form-group">
 					<label for="title1" class="required"><span class="field-name">Title</span> <strong class="required">(required)</strong></label>
-					<select class="form-control" id="title1" name="title1" required="required">
+					<select class="form-control" id="title1" name="title1" autocomplete="honorific-prefix" required="required">
 						<option label="Select a title"></option>
 						<option value="dr">Dr.</option>
 						<option value="esq">Esq.</option>
@@ -47,7 +47,7 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="title1" class="required"&gt;&lt;span class="field-name"&gt;Title&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
-			&lt;select class="form-control" id="title1" name="title1" required="required"&gt;
+			&lt;select class="form-control" id="title1" name="title1" autocomplete="honorific-prefix" required="required"&gt;
 				&lt;option label="Select a title"&gt;&lt;/option&gt;
 				&lt;option value="dr"&gt;Dr.&lt;/option&gt;
 				&lt;option value="esq"&gt;Esq.&lt;/option&gt;
@@ -59,7 +59,7 @@
 
 				<div class="form-group">
 					<label for="fname1" class="required"><span class="field-name">First name</span> <strong class="required">(required)</strong></label>
-					<input class="form-control" id="fname1" name="fname1" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" />
+					<input class="form-control" id="fname1" name="fname1" type="text" autocomplete="given-name" required="required" pattern=".{2,}" data-rule-minlength="2" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
@@ -68,13 +68,13 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="fname1" class="required"&gt;&lt;span class="field-name"&gt;First name&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="fname1" name="fname1" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
+			&lt;input class="form-control" id="fname1" name="fname1" type="text" autocomplete="given-name" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
 					<label for="lname1" class="required"><span class="field-name">Last name</span> <strong class="required">(required)</strong></label>
-					<input class="form-control" id="lname1" name="lname1" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" />
+					<input class="form-control" id="lname1" name="lname1" type="text" autocomplete="family-name" required="required" pattern=".{2,}" data-rule-minlength="2" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
@@ -83,13 +83,13 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="lname1" class="required"&gt;&lt;span class="field-name"&gt;Last name&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="lname1" name="lname1" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
+			&lt;input class="form-control" id="lname1" name="lname1" type="text" autocomplete="family-name" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
 					<label for="tel1" class="required"><span class="field-name">Telephone number (including area code)</span> <strong class="required">(required)</strong></label>
-					<input class="form-control" id="tel1" name="tel1" type="tel" required="required" data-rule-phoneUS="true" />
+					<input class="form-control" id="tel1" name="tel1" type="tel" autocomplete="tel" required="required" data-rule-phoneUS="true" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
@@ -98,13 +98,13 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="tel1" class="required"&gt;&lt;span class="field-name"&gt;Telephone number&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="tel1" name="tel1" type="tel" required="required" data-rule-phoneUS="true" /&gt;
+			&lt;input class="form-control" id="tel1" name="tel1" type="tel" autocomplete="tel" required="required" data-rule-phoneUS="true" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
 					<label for="pcodeca1" class="required"><span class="field-name">Postal code (Canada)</span> <strong class="required">(required)</strong></label>
-					<input class="form-control" id="pcodeca1" name="pcodeca1" type="text" size="7" maxlength="7" required="required" data-rule-postalCodeCA="true" />
+					<input class="form-control" id="pcodeca1" name="pcodeca1" type="text" autocomplete="postal-code" size="7" maxlength="7" required="required" data-rule-postalCodeCA="true" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
@@ -113,13 +113,13 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="pcodeca1" class="required"&gt;&lt;span class="field-name"&gt;Postal code&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="pcodeca1" name="pcodeca1" type="text" size="7" maxlength="7" required="required" data-rule-postalCodeCA="true" /&gt;
+			&lt;input class="form-control" id="pcodeca1" name="pcodeca1" type="text" autocomplete="postal-code" size="7" maxlength="7" required="required" data-rule-postalCodeCA="true" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
 					<label for="email1"><span class="field-name">Email address</span> (yourname@domain.com)</label>
-					<input class="form-control" id="email1" name="email1" type="email" />
+					<input class="form-control" id="email1" name="email1" type="email" autocomplete="email" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
@@ -128,13 +128,13 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="email1"&gt;&lt;span class="field-name"&gt;Email address&lt;/span&gt; (yourname@domain.com)&lt;/label&gt;
-			&lt;input class="form-control" id="email1" name="email1" type="email" /&gt;
+			&lt;input class="form-control" id="email1" name="email1" type="email" autocomplete="email" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
 					<label for="url1"><span class="field-name">Website URL (https://www.url.com)</span></label>
-					<input class="form-control" id="url1" name="url1" type="url" />
+					<input class="form-control" id="url1" name="url1" type="url" autocomplete="url" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
@@ -143,7 +143,7 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="url1"&gt;&lt;span class="field-name"&gt;Website URL (https://www.url.com)&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="url1" name="url1" type="url" /&gt;
+			&lt;input class="form-control" id="url1" name="url1" type="url" autocomplete="url" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
@@ -332,9 +332,9 @@
 
 				<div class="form-group">
 					<label for="password1"><span class="field-name">Password</span> (between 5 and 10 characters)</label>
-					<input class="form-control" id="password1" name="password1" type="password" maxlength="10" size="10" pattern=".{5,10}" data-rule-rangelength="[5,10]" />
+					<input class="form-control" id="password1" name="password1" type="password" autocomplete="new-password" maxlength="10" size="10" pattern=".{5,10}" data-rule-rangelength="[5,10]" />
 					<label for="passwordconfirm"><span class="field-name">Confirm your password</span></label>
-					<input class="form-control" id="passwordconfirm" name="passwordconfirm" type="password" maxlength="10" size="10" data-rule-equalTo="#password1" />
+					<input class="form-control" id="passwordconfirm" name="passwordconfirm" type="password" autocomplete="new-password" maxlength="10" size="10" data-rule-equalTo="#password1" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
@@ -343,9 +343,9 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="password1"&gt;&lt;span class="field-name"&gt;Password&lt;/span&gt; (between 5 and 10 characters)&lt;/label&gt;
-			&lt;input class="form-control" id="password1" name="password1" type="password" maxlength="10" size="10" pattern=".{5,10}" data-rule-rangelength="[5,10]" /&gt;
+			&lt;input class="form-control" id="password1" name="password1" type="password" autocomplete="new-password" maxlength="10" size="10" pattern=".{5,10}" data-rule-rangelength="[5,10]" /&gt;
 			&lt;label for="passwordconfirm"&gt;&lt;span class="field-name"&gt;Confirm your password&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="passwordconfirm" name="passwordconfirm" type="password" maxlength="10" size="10" data-rule-equalTo="#password1" /&gt;
+			&lt;input class="form-control" id="passwordconfirm" name="passwordconfirm" type="password" autocomplete="new-password" maxlength="10" size="10" data-rule-equalTo="#password1" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 			</fieldset>

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -8,7 +8,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2018-07-04"
+	"dateModified": "2019-07-29"
 }
 ---
 
@@ -33,7 +33,7 @@
 				<legend>Coordonnées</legend>
 				<div class="form-group">
 					<label for="title1" class="required"><span class="field-name">Titre</span> <strong class="required">(obligatoire)</strong></label>
-					<select class="form-control" id="title1" name="title1" required="required">
+					<select class="form-control" id="title1" name="title1" autocomplete="honorific-prefix" required="required">
 						<option label="Sélectionner un titre"></option>
 						<option value="dr">D. Ph.</option>
 						<option value="esq">Me</option>
@@ -48,7 +48,7 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="title1" class="required"&gt;&lt;span class="field-name"&gt;Titre&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
-			&lt;select class="form-control" id="title1" name="title1" required="required"&gt;
+			&lt;select class="form-control" id="title1" name="title1" autocomplete="honorific-prefix" required="required"&gt;
 				&lt;option label="Sélectionner un titre"&gt;&lt;/option&gt;
 				&lt;option value="dr"&gt;D. Ph.&lt;/option&gt;
 				&lt;option value="esq"&gt;Me&lt;/option&gt;
@@ -60,7 +60,7 @@
 
 				<div class="form-group">
 					<label for="fname" class="required"><span class="field-name">Prénom</span> <strong class="required">(obligatoire)</strong></label>
-					<input class="form-control" id="fname" name="fname" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" />
+					<input class="form-control" id="fname" name="fname" type="text" autocomplete="given-name" required="required" pattern=".{2,}" data-rule-minlength="2" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Visualiser le code</summary>
@@ -69,13 +69,13 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="fname" class="required"&gt;&lt;span class="field-name"&gt;Prénom&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="fname" name="fname" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
+			&lt;input class="form-control" id="fname" name="fname" type="text" autocomplete="given-name" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
 					<label for="lname" class="required"><span class="field-name">Nom de famille</span> <strong class="required">(obligatoire)</strong></label>
-					<input class="form-control" id="lname" name="lname" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" />
+					<input class="form-control" id="lname" name="lname" type="text" autocomplete="family-name" required="required" pattern=".{2,}" data-rule-minlength="2" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Visualiser le code</summary>
@@ -84,13 +84,13 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="lname" class="required"&gt;&lt;span class="field-name"&gt;Nom de famille&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="lname" name="lname" type="text" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
+			&lt;input class="form-control" id="lname" name="lname" type="text" autocomplete="family-name" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
 					<label for="tel1" class="required"><span class="field-name">Numéro de téléphone</span> <strong class="required">(obligatoire)</strong></label>
-					<input class="form-control" id="tel1" name="tel1" type="tel" required="required" data-rule-phoneUS="true" />
+					<input class="form-control" id="tel1" name="tel1" type="tel" autocomplete="tel" required="required" data-rule-phoneUS="true" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Visualiser le code</summary>
@@ -99,13 +99,13 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="tel1" class="required"&gt;&lt;span class="field-name"&gt;Numéro de téléphone (avec l'indicatif régional)&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="tel1" name="tel1" type="tel" required="required" data-rule-phoneUS="true" /&gt;
+			&lt;input class="form-control" id="tel1" name="tel1" type="tel" autocomplete="tel" required="required" data-rule-phoneUS="true" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
 					<label for="pcodeca1" class="required"><span class="field-name">Code postal (Canada)</span> <strong class="required">(obligatoire)</strong></label>
-					<input class="form-control" id="pcodeca1" name="pcodeca1" type="text" size="7" maxlength="7" required="required" data-rule-postalCodeCA="true" />
+					<input class="form-control" id="pcodeca1" name="pcodeca1" type="text" autocomplete="postal-code" size="7" maxlength="7" required="required" data-rule-postalCodeCA="true" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
@@ -114,13 +114,13 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="pcodeca1" class="required"&gt;&lt;span class="field-name"&gt;Code postal&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="pcodeca1" name="pcodeca1" type="text" required="required" data-rule-postalCodeCA="true" /&gt;
+			&lt;input class="form-control" id="pcodeca1" name="pcodeca1" type="text" autocomplete="postal-code" required="required" data-rule-postalCodeCA="true" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
 					<label for="email1"><span class="field-name">Adresse électronique</span> (votrenom@domaine.com)</label>
-					<input class="form-control" id="email1" name="email1" type="email" />
+					<input class="form-control" id="email1" name="email1" type="email" autocomplete="email" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Visualiser le code</summary>
@@ -129,13 +129,13 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="email1"&gt;&lt;span class="field-name"&gt;Adresse électronique&lt;/span&gt; (votrenom@domaine.com)&lt;/label&gt;
-			&lt;input class="form-control" id="email1" name="email1" type="email" /&gt;
+			&lt;input class="form-control" id="email1" name="email1" type="email" autocomplete="email" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
 					<label for="url1"><span class="field-name">URL du site Web (https://www.url.com)</span></label>
-					<input class="form-control" id="url1" name="url1" type="url" />
+					<input class="form-control" id="url1" name="url1" type="url" autocomplete="url" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Visualiser le code</summary>
@@ -144,7 +144,7 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="url1"&gt;&lt;span class="field-name"&gt;URL du site Web (https://www.url.com)&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="url1" name="url1" type="url" /&gt;
+			&lt;input class="form-control" id="url1" name="url1" type="url" autocomplete="url" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
@@ -333,9 +333,9 @@
 
 				<div class="form-group">
 					<label for="password1"><span class="field-name">Mot de passe</span> (entre 5 et 10 caractères)</label>
-					<input class="form-control" id="password1" name="password1" type="password" maxlength="10" size="10" pattern=".{5,10}" data-rule-rangelength="[5,10]" />
+					<input class="form-control" id="password1" name="password1" type="password" autocomplete="new-password" maxlength="10" size="10" pattern=".{5,10}" data-rule-rangelength="[5,10]" />
 					<label for="passwordconfirm"><span class="field-name">Confirmez votre mot de passe</span></label>
-					<input class="form-control" id="passwordconfirm" name="passwordconfirm" type="password" maxlength="10" size="10" data-rule-equalTo="#password1" />
+					<input class="form-control" id="passwordconfirm" name="passwordconfirm" type="password" autocomplete="new-password" maxlength="10" size="10" data-rule-equalTo="#password1" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Visualiser le code</summary>
@@ -344,9 +344,9 @@
 		...
 		&lt;div class="form-group"&gt;
 			&lt;label for="password1"&gt;&lt;span class="field-name"&gt;Mot de passe&lt;/span&gt; (entre 5 et 10 caractères)&lt;/label&gt;
-			&lt;input class="form-control" id="password1" name="password1" type="password" maxlength="10" size="10" pattern=".{5,10}" data-rule-rangelength="[5,10]" /&gt;
+			&lt;input class="form-control" id="password1" name="password1" type="password" autocomplete="new-password" maxlength="10" size="10" pattern=".{5,10}" data-rule-rangelength="[5,10]" /&gt;
 			&lt;label for="passwordconfirm"&gt;&lt;span class="field-name"&gt;Confirmez votre mot de passe&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="passwordconfirm" name="passwordconfirm" type="password" maxlength="10" size="10" data-rule-equalTo="#password1" /&gt;
+			&lt;input class="form-control" id="passwordconfirm" name="passwordconfirm" type="password" autocomplete="new-password" maxlength="10" size="10" data-rule-equalTo="#password1" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 			</fieldset>

--- a/src/polyfills/datalist/datalist-en.hbs
+++ b/src/polyfills/datalist/datalist-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "datalist",
 	"parentdir": "datalist",
 	"altLangPrefix": "datalist",
-	"dateModified": "2014-08-06"
+	"dateModified": "2019-07-29"
 }
 ---
 <section>
@@ -20,7 +20,7 @@
 	<form action="#" method="get">
 		<div class="form-group">
 			<label for="city">City</label>
-			<input class="form-control" type="text" id="city" name="city" list="suggestions" />
+			<input class="form-control" type="text" autocomplete="address-level2" id="city" name="city" list="suggestions" />
 		</div>
 		<datalist id="suggestions">
 			<!--[if lte IE 9]><select><![endif]-->

--- a/src/polyfills/datalist/datalist-fr.hbs
+++ b/src/polyfills/datalist/datalist-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "datalist",
 	"parentdir": "datalist",
 	"altLangPrefix": "datalist",
-	"dateModified": "2014-08-06"
+	"dateModified": "2019-07-29"
 }
 ---
 <section>
@@ -20,7 +20,7 @@
 	<form action="#" method="get">
 		<div class="form-group">
 			<label for="city">Ville</label>
-			<input class="form-control" type="text" id="city" name="city" list="suggestions">
+			<input class="form-control" type="text" autocomplete="address-level2" id="city" name="city" list="suggestions">
 		</div>
 		<datalist id="suggestions">
 			<!--[if lte IE 9]><select><![endif]-->


### PR DESCRIPTION
Improves compliance with WCAG 2.1 Success Criterion 1.3.5 ("Identify Input Purpose").

**Note:** Didn't add anything to the "Merge Server-Client Errors" page's "Beneficiary name" field since I wasn't sure about what kinds of corresponding changes would need to be made to [wet-boew/asp.net-formvalid-serverside](https://github.com/wet-boew/asp.net-formvalid-serverside).