### PR TITLE
Web Accessibility Assessment Methodology: Cover WCAG 2.1

### DIFF
--- a/site/pages/docs/ref/wamethod/wamethod-en.hbs
+++ b/site/pages/docs/ref/wamethod/wamethod-en.hbs
@@ -4,22 +4,22 @@
 	"language": "en",
 	"category": "Other",
 	"categoryfile": "other",
-	"description": "Provides an assessment methodology that assists with measuring conformance to the Web Content Accessibility Guidelines (WCAG) 2.0 Level A, AA and AAA Success Criteria.",
+	"description": "Provides an assessment methodology that assists with measuring conformance to the Web Content Accessibility Guidelines (WCAG) 2.1 Level A, AA and AAA Success Criteria.",
 	"altLangPrefix": "wamethod",
-	"dateModified": "2014-02-19"
+	"dateModified": "2019-08-05"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
 
 <section>
 	<h2>Purpose</h2>
-	<p>Provides an assessment methodology that assists with measuring conformance to the Web Content Accessibility Guidelines (WCAG) 2.0 Level A, AA, and AAA Success Criteria.</p>
+	<p>Provides an assessment methodology that assists with measuring conformance to the Web Content Accessibility Guidelines (WCAG) 2.1 Level A, AA, and AAA Success Criteria.</p>
 </section>
 
 <section>
 	<h2>Use when</h2>
 	<ul>
-		<li>Assessing conformance to the the Web Content Accessibility Guidelines (WCAG) 2.0 Level A, AA, and AAA Success Criteria.</li>
+		<li>Assessing conformance to the the Web Content Accessibility Guidelines (WCAG) 2.1 Level A, AA, and AAA Success Criteria.</li>
 	</ul>
 </section>
 

--- a/site/pages/docs/ref/wamethod/wamethod-fr.hbs
+++ b/site/pages/docs/ref/wamethod/wamethod-fr.hbs
@@ -4,16 +4,16 @@
 	"language": "fr",
 	"category": "Autre",
 	"categoryfile": "other",
-	"description": "Offre une méthodologie d’évaluation qui permet de mesurer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.0 pour les critères de succès de niveau A, AA et AAA.",
+	"description": "Offre une méthodologie d’évaluation qui permet de mesurer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.1 pour les critères de succès de niveau A, AA et AAA.",
 	"altLangPrefix": "wamethod",
-	"dateModified": "2014-08-15"
+	"dateModified": "2019-08-05"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
 
 <section>
 	<h2>But</h2>
-	<p>Offre une méthodologie d’évaluation qui permet de mesurer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.0 pour les critères de succès de niveau A, AA et AAA.</p>
+	<p>Offre une méthodologie d’évaluation qui permet de mesurer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.1 pour les critères de succès de niveau A, AA et AAA.</p>
 </section>
 
 <div lang="en">
@@ -21,7 +21,7 @@
 <section>
 	<h2>Utiliser afin</h2>
 	<ul>
-		<li>D'évaluer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.0 pour les critères de succès de niveau A, AA et AAA.</li>
+		<li>D'évaluer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.1 pour les critères de succès de niveau A, AA et AAA.</li>
 	</ul>
 </section>
 

--- a/src/other/wamethod/demo/wamethod.js
+++ b/src/other/wamethod/demo/wamethod.js
@@ -35,7 +35,7 @@ var componentName = "wb-wamethod",
 	rsltAAA = document.getElementById( "rsltAAA" ),
 	percAAA = document.getElementById( "percAAA" ),
 	aaaIncluded = rsltAAA !== null,
-	successCriteriaDivideBy = aaaIncluded ? 0.61 : 0.38,
+	successCriteriaDivideBy = aaaIncluded ? 0.78 : 0.50,
 
 	/**
 	 * @method init
@@ -82,13 +82,13 @@ $document.on( "change", selector + " input", function() {
 	// Update number of Success Criteria evaluated and passed
 	$summaryTd.attr( "aria-busy", "true" );
 	rsltA.innerHTML = aPassed;
-	percA.innerHTML = Math.round( aPassed / 0.25 );
+	percA.innerHTML = Math.round( aPassed / 0.30 );
 	rsltAA.innerHTML = aaPassed;
-	percAA.innerHTML = Math.round( aaPassed / 0.13 );
+	percAA.innerHTML = Math.round( aaPassed / 0.20 );
 	naTotal.innerHTML = naChecked;
 	if ( aaaIncluded ) {
 		rsltAAA.innerHTML = aaaPassed;
-		percAAA.innerHTML = Math.round( aaaPassed / 0.23 );
+		percAAA.innerHTML = Math.round( aaaPassed / 0.28 );
 	}
 	evalTotal.innerHTML = aEvaluated + aaEvaluated + aaaEvaluated;
 	percEvalTotal.innerHTML = Math.round( ( aEvaluated + aaEvaluated + aaaEvaluated ) / successCriteriaDivideBy );

--- a/src/other/wamethod/wamethod-AA-en.hbs
+++ b/src/other/wamethod/wamethod-AA-en.hbs
@@ -3,24 +3,24 @@
 	"title": "Web Accessibility Assessment Methodology (Level AA)",
 	"language": "en",
 	"category": "Other",
-	"description": "Provides an assessment methodology that assists with measuring conformance to the Web Content Accessibility Guidelines (WCAG) 2.0 Level A, and AA Success Criteria.",
+	"description": "Provides an assessment methodology that assists with measuring conformance to the Web Content Accessibility Guidelines (WCAG) 2.1 Level A, and AA Success Criteria.",
 	"tag": "wamethod",
 	"parentdir": "wamethod",
 	"altLangPrefix": "wamethod-AA",
 	"css": ["demo/wamethod"],
 	"js": ["demo/wamethod"],
-	"dateModified": "2014-04-07"
+	"dateModified": "2019-08-05"
 }
 ---
 <section>
 	<h2>Purpose:</h2>
-	<p>Assist with measuring conformance to the <a href="https://www.w3.org/TR/WCAG20/" rel="external">Web Content Accessibility Guidelines (WCAG)&#160;2.0</a> Level&#160;A and Level&#160;AA <a href="#success">Success Criteria</a></p>.
+	<p>Assist with measuring conformance to the <a href="https://www.w3.org/TR/WCAG21/" rel="external">Web Content Accessibility Guidelines (WCAG)&#160;2.1</a> Level&#160;A and Level&#160;AA <a href="#success">Success Criteria</a></p>.
 </section>
 
 <nav role="navigation">
 	<h2>Table of Contents</h2>
 	<ul>
-		<li><a href="#wcag"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.0 Success Criteria Checklist</a>
+		<li><a href="#wcag"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.1 Success Criteria Checklist</a>
 			<ul>
 				<li><a href="#wcag1">Principle: Perceivable</a></li>
 				<li><a href="#wcag2">Principle: Operable</a></li>
@@ -33,9 +33,9 @@
 	</ul>
 </nav>
 
-<p>The following are required for a <a href="#webpagedef">Web page</a> to satisfy a <abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.0 Success Criterion:</p>
+<p>The following are required for a <a href="#webpagedef">Web page</a> to satisfy a <abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.1 Success Criterion:</p>
 <ol>
-	<li>Web page successfully avoids each <a href="https://www.w3.org/TR/WCAG20-TECHS/failures.html" rel="external">common failure</a> of the Success Criterion.</li>
+	<li>Web page successfully avoids each <a href="https://www.w3.org/WAI/WCAG21/Techniques/#failures" rel="external">common failure</a> of the Success Criterion.</li>
 	<li>Web page successfully implements <a href="#sufftech">sufficient techniques</a> or combinations of sufficient techniques for the Success Criterion that are:
 		<ol>
 			<li>Specific to each applicable situation; and</li>
@@ -45,15 +45,15 @@
 </ol>
 
 <section class="wb-wamethod">
-	<h2 id="wcag"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.0 Success Criteria Checklist (12&#160;Guidelines, 38&#160;Success Criteria)</h2>
+	<h2 id="wcag"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.1 Success Criteria Checklist (13&#160;Guidelines, 50&#160;Success Criteria)</h2>
 	<section>
 		<h3 id="wcag1"><b>Principle:</b> Perceivable</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g1"><b>Guideline 1.1 Text Alternatives:</b> Provide text alternatives for any non-text content so that it can be changed into other forms people need, such as large print, braille, speech, symbols or simpler language.</h4>
+			<h4 id="g11"><b>Guideline 1.1 Text Alternatives:</b> Provide text alternatives for any non-text content so that it can be changed into other forms people need, such as large print, braille, speech, symbols or simpler language.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#text-equiv-all" rel="external" aria-describedby="g1">1.1.1 Non-text content (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#text-equiv-all" rel="external" aria-describedby="g11">1.1.1 Non-text content (Level&#160;A)</a></legend>
 						<input id="ap111" type="radio" name="sc111" value="pass"><label for="ap111">Pass</label>
 						<input id="af111" type="radio" name="sc111" value="fail"><label for="af111">Fail</label>
 						<input id="an111" type="radio" name="sc111" value="na"><label for="an111"><abbr title="Not applicable">N/A</abbr></label>
@@ -62,11 +62,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g2"><b>Guideline 1.2 Time-based Media:</b> Provide alternatives for time-based media.</h4>
+			<h4 id="g12"><b>Guideline 1.2 Time-based Media:</b> Provide alternatives for time-based media.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt" rel="external" aria-describedby="g2">1.2.1 Audio-only and Video-only (Prerecorded) (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt" rel="external" aria-describedby="g12">1.2.1 Audio-only and Video-only (Prerecorded) (Level&#160;A)</a></legend>
 						<input id="ap121" type="radio" name="sc121" value="pass"><label for="ap121">Pass</label>
 						<input id="af121" type="radio" name="sc121" value="fail"><label for="af121">Fail</label>
 						<input id="an121" type="radio" name="sc121" value="na"><label for="an121"><abbr title="Not applicable">N/A</abbr></label>
@@ -74,7 +74,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions" rel="external" aria-describedby="g2">1.2.2 Captions (Prerecorded) (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions" rel="external" aria-describedby="g12">1.2.2 Captions (Prerecorded) (Level&#160;A)</a></legend>
 						<input id="ap122" type="radio" name="sc122" value="pass"><label for="ap122">Pass</label>
 						<input id="af122" type="radio" name="sc122" value="fail"><label for="af122">Fail</label>
 						<input id="an122" type="radio" name="sc122" value="na"><label for="an122"><abbr title="Not applicable">N/A</abbr></label>
@@ -82,7 +82,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc" rel="external" aria-describedby="g2">1.2.3 Audio Description or Media Alternative (Prerecorded) (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc" rel="external" aria-describedby="g12">1.2.3 Audio Description or Media Alternative (Prerecorded) (Level&#160;A)</a></legend>
 						<input id="ap123" type="radio" name="sc123" value="pass"><label for="ap123">Pass</label>
 						<input id="af123" type="radio" name="sc123" value="fail"><label for="af123">Fail</label>
 						<input id="an123" type="radio" name="sc123" value="na"><label for="an123"><abbr title="Not applicable">N/A</abbr></label>
@@ -90,7 +90,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions" rel="external" aria-describedby="g2">1.2.4 Captions (Live) (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions" rel="external" aria-describedby="g12">1.2.4 Captions (Live) (Level&#160;AA)</a></legend>
 						<input id="aap124" type="radio" name="sc124" value="pass"><label for="aap124">Pass</label>
 						<input id="aaf124" type="radio" name="sc124" value="fail"><label for="aaf124">Fail</label>
 						<input id="aan124" type="radio" name="sc124" value="na"><label for="aan124"><abbr title="Not applicable">N/A</abbr></label>
@@ -98,7 +98,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only" rel="external" aria-describedby="g2">1.2.5 Audio Description (Prerecorded) (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only" rel="external" aria-describedby="g12">1.2.5 Audio Description (Prerecorded) (Level&#160;AA)</a></legend>
 						<input id="aap125" type="radio" name="sc125" value="pass"><label for="aap125">Pass</label>
 						<input id="aaf125" type="radio" name="sc125" value="fail"><label for="aaf125">Fail</label>
 						<input id="aan125" type="radio" name="sc125" value="na"><label for="aan125"><abbr title="Not applicable">N/A</abbr></label>
@@ -107,11 +107,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g3"><b>Guideline 1.3 Adaptable:</b> Create content that can be presented in different ways (for example simpler layout) without losing information or structure.</h4>
+			<h4 id="g13"><b>Guideline 1.3 Adaptable:</b> Create content that can be presented in different ways (for example simpler layout) without losing information or structure.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic" rel="external" aria-describedby="g3">1.3.1 Info and Relationships (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic" rel="external" aria-describedby="g13">1.3.1 Info and Relationships (Level&#160;A)</a></legend>
 						<input id="ap131" type="radio" name="sc131" value="pass"><label for="ap131">Pass</label>
 						<input id="af131" type="radio" name="sc131" value="fail"><label for="af131">Fail</label>
 						<input id="an131" type="radio" name="sc131" value="na"><label for="an131"><abbr title="Not applicable">N/A</abbr></label>
@@ -119,7 +119,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence" rel="external" aria-describedby="g3">1.3.2 Meaningful Sequence (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence" rel="external" aria-describedby="g13">1.3.2 Meaningful Sequence (Level&#160;A)</a></legend>
 						<input id="ap132" type="radio" name="sc132" value="pass"><label for="ap132">Pass</label>
 						<input id="af132" type="radio" name="sc132" value="fail"><label for="af132">Fail</label>
 						<input id="an132" type="radio" name="sc132" value="na"><label for="an132"><abbr title="Not applicable">N/A</abbr></label>
@@ -127,20 +127,36 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding" rel="external" aria-describedby="g3">1.3.3 Sensory Characteristics (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding" rel="external" aria-describedby="g13">1.3.3 Sensory Characteristics (Level&#160;A)</a></legend>
 						<input id="ap133" type="radio" name="sc133" value="pass"><label for="ap133">Pass</label>
 						<input id="af133" type="radio" name="sc133" value="fail"><label for="af133">Fail</label>
 						<input id="an133" type="radio" name="sc133" value="na"><label for="an133"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#orientation" rel="external" aria-describedby="g13">1.3.4 Orientation (Level&#160;AA)</a></legend>
+						<input id="aap134" type="radio" name="sc134" value="pass"><label for="aap134">Pass</label>
+						<input id="aaf134" type="radio" name="sc134" value="fail"><label for="aaf134">Fail</label>
+						<input id="aan134" type="radio" name="sc134" value="na"><label for="aan134"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#identify-input-purpose" rel="external" aria-describedby="g13">1.3.5 Identify Input Purpose (Level&#160;AA)</a></legend>
+						<input id="aap135" type="radio" name="sc135" value="pass"><label for="aap135">Pass</label>
+						<input id="aaf135" type="radio" name="sc135" value="fail"><label for="aaf135">Fail</label>
+						<input id="aan135" type="radio" name="sc135" value="na"><label for="aan135"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g4"><b>Guideline 1.4 Distinguishable:</b> Make it easier for users to see and hear content including separating foreground from background.</h4>
+			<h4 id="g14"><b>Guideline 1.4 Distinguishable:</b> Make it easier for users to see and hear content including separating foreground from background.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color" rel="external" aria-describedby="g4">1.4.1 Use of Color (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color" rel="external" aria-describedby="g14">1.4.1 Use of Color (Level&#160;A)</a></legend>
 						<input id="ap141" type="radio" name="sc141" value="pass"><label for="ap141">Pass</label>
 						<input id="af141" type="radio" name="sc141" value="fail"><label for="af141">Fail</label>
 						<input id="an141" type="radio" name="sc141" value="na"><label for="an141"><abbr title="Not applicable">N/A</abbr></label>
@@ -148,7 +164,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio" rel="external" aria-describedby="g4">1.4.2 Audio Control (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio" rel="external" aria-describedby="g14">1.4.2 Audio Control (Level&#160;A)</a></legend>
 						<input id="ap142" type="radio" name="sc142" value="pass"><label for="ap142">Pass</label>
 						<input id="af142" type="radio" name="sc142" value="fail"><label for="af142">Fail</label>
 						<input id="an142" type="radio" name="sc142" value="na"><label for="an142"><abbr title="Not applicable">N/A</abbr></label>
@@ -156,7 +172,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast" rel="external" aria-describedby="g4">1.4.3 Contrast (Minimum) (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast" rel="external" aria-describedby="g14">1.4.3 Contrast (Minimum) (Level&#160;AA)</a></legend>
 						<input id="aap143" type="radio" name="sc143" value="pass"><label for="aap143">Pass</label>
 						<input id="aaf143" type="radio" name="sc143" value="fail"><label for="aaf143">Fail</label>
 						<input id="aan143" type="radio" name="sc143" value="na"><label for="aan143"><abbr title="Not applicable">N/A</abbr></label>
@@ -164,7 +180,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale" rel="external" aria-describedby="g4">1.4.4 Resize text (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale" rel="external" aria-describedby="g14">1.4.4 Resize text (Level&#160;AA)</a></legend>
 						<input id="aap144" type="radio" name="sc144" value="pass"><label for="aap144">Pass</label>
 						<input id="aaf144" type="radio" name="sc144" value="fail"><label for="aaf144">Fail</label>
 						<input id="aan144" type="radio" name="sc144" value="na"><label for="aan144"><abbr title="Not applicable">N/A</abbr></label>
@@ -172,10 +188,42 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation" rel="external" aria-describedby="g4">1.4.5 Images of Text (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation" rel="external" aria-describedby="g14">1.4.5 Images of Text (Level&#160;AA)</a></legend>
 						<input id="aap145" type="radio" name="sc145" value="pass"><label for="aap145">Pass</label>
 						<input id="aaf145" type="radio" name="sc145" value="fail"><label for="aaf145">Fail</label>
 						<input id="aan145" type="radio" name="sc145" value="na"><label for="aan145"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#reflow" rel="external" aria-describedby="g14">1.4.10 Reflow (Level&#160;AA)</a></legend>
+						<input id="aap1410" type="radio" name="sc1410" value="pass"><label for="aap1410">Pass</label>
+						<input id="aaf1410" type="radio" name="sc1410" value="fail"><label for="aaf1410">Fail</label>
+						<input id="aan1410" type="radio" name="sc1410" value="na"><label for="aan1410"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#non-text-contrast" rel="external" aria-describedby="g14">1.4.11 Non-Text Contrast (Level&#160;AA)</a></legend>
+						<input id="aap1411" type="radio" name="sc1411" value="pass"><label for="aap1411">Pass</label>
+						<input id="aaf1411" type="radio" name="sc1411" value="fail"><label for="aaf1411">Fail</label>
+						<input id="aan1411" type="radio" name="sc1411" value="na"><label for="aan1411"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#text-spacing" rel="external" aria-describedby="g14">1.4.12 Text Spacing (Level&#160;AA)</a></legend>
+						<input id="aap1412" type="radio" name="sc1412" value="pass"><label for="aap1412">Pass</label>
+						<input id="aaf1412" type="radio" name="sc1412" value="fail"><label for="aaf1412">Fail</label>
+						<input id="aan1412" type="radio" name="sc1412" value="na"><label for="aan1412"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus" rel="external" aria-describedby="g14">1.4.13 Content on Hover or Focus (Level&#160;AA)</a></legend>
+						<input id="aap1413" type="radio" name="sc1413" value="pass"><label for="aap1413">Pass</label>
+						<input id="aaf1413" type="radio" name="sc1413" value="fail"><label for="aaf1413">Fail</label>
+						<input id="aan1413" type="radio" name="sc1413" value="na"><label for="aan1413"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -185,11 +233,11 @@
 	<section>
 		<h3 id="wcag2"><b>Principle:</b> Operable</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g5"><b>Guideline 2.1 Keyboard Accessible:</b> Make all functionality available from a keyboard.</h4>
+			<h4 id="g21"><b>Guideline 2.1 Keyboard Accessible:</b> Make all functionality available from a keyboard.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable" rel="external" aria-describedby="g5">2.1.1 Keyboard (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable" rel="external" aria-describedby="g21">2.1.1 Keyboard (Level&#160;A)</a></legend>
 						<input id="ap211" type="radio" name="sc211" value="pass"><label for="ap211">Pass</label>
 						<input id="af211" type="radio" name="sc211" value="fail"><label for="af211">Fail</label>
 						<input id="an211" type="radio" name="sc211" value="na"><label for="an211"><abbr title="Not applicable">N/A</abbr></label>
@@ -197,20 +245,28 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping" rel="external" aria-describedby="g5">2.1.2 No Keyboard Trap (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping" rel="external" aria-describedby="g21">2.1.2 No Keyboard Trap (Level&#160;A)</a></legend>
 						<input id="ap212" type="radio" name="sc212" value="pass"><label for="ap212">Pass</label>
 						<input id="af212" type="radio" name="sc212" value="fail"><label for="af212">Fail</label>
 						<input id="an212" type="radio" name="sc212" value="na"><label for="an212"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#character-key-shortcuts" rel="external" aria-describedby="g21">2.1.4 Character Key Shortcuts (Level&#160;A)</a></legend>
+						<input id="ap214" type="radio" name="sc214" value="pass"><label for="ap214">Pass</label>
+						<input id="af214" type="radio" name="sc214" value="fail"><label for="af214">Fail</label>
+						<input id="an214" type="radio" name="sc214" value="na"><label for="an214"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g6"><b>Guideline 2.2 Enough Time:</b> Provide users enough time to read and use content.</h4>
+			<h4 id="g22"><b>Guideline 2.2 Enough Time:</b> Provide users enough time to read and use content.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors" rel="external" aria-describedby="g6">2.2.1 Timing Adjustable (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors" rel="external" aria-describedby="g22">2.2.1 Timing Adjustable (Level&#160;A)</a></legend>
 						<input id="ap221" type="radio" name="sc221" value="pass"><label for="ap221">Pass</label>
 						<input id="af221" type="radio" name="sc221" value="fail"><label for="af221">Fail</label>
 						<input id="an221" type="radio" name="sc221" value="na"><label for="an221"><abbr title="Not applicable">N/A</abbr></label>
@@ -218,7 +274,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-pause" rel="external" aria-describedby="g6">2.2.2 Pause, Stop, Hide (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-pause" rel="external" aria-describedby="g22">2.2.2 Pause, Stop, Hide (Level&#160;A)</a></legend>
 						<input id="ap222" type="radio" name="sc222" value="pass"><label for="ap222">Pass</label>
 						<input id="af222" type="radio" name="sc222" value="fail"><label for="af222">Fail</label>
 						<input id="an222" type="radio" name="sc222" value="na"><label for="an222"><abbr title="Not applicable">N/A</abbr></label>
@@ -227,11 +283,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g7"><b>Guideline 2.3 Seizures:</b> Do not design content in a way that is known to cause seizures.</h4>
+			<h4 id="g23"><b>Guideline 2.3 Seizures:</b> Do not design content in a way that is known to cause seizures.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate" rel="external" aria-describedby="g7">2.3.1 Three Flashes or Below Threshold (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate" rel="external" aria-describedby="g23">2.3.1 Three Flashes or Below Threshold (Level&#160;A)</a></legend>
 						<input id="ap231" type="radio" name="sc231" value="pass"><label for="ap231">Pass</label>
 						<input id="af231" type="radio" name="sc231" value="fail"><label for="af231">Fail</label>
 						<input id="an231" type="radio" name="sc231" value="na"><label for="an231"><abbr title="Not applicable">N/A</abbr></label>
@@ -240,11 +296,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g8"><b>Guideline 2.4 Navigable:</b> Provide ways to help users navigate, find content, and determine where they are.</h4>
+			<h4 id="g24"><b>Guideline 2.4 Navigable:</b> Provide ways to help users navigate, find content, and determine where they are.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip" rel="external" aria-describedby="g8">2.4.1 Bypass Blocks (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip" rel="external" aria-describedby="g24">2.4.1 Bypass Blocks (Level&#160;A)</a></legend>
 						<input id="ap241" type="radio" name="sc241" value="pass"><label for="ap241">Pass</label>
 						<input id="af241" type="radio" name="sc241" value="fail"><label for="af241">Fail</label>
 						<input id="an241" type="radio" name="sc241" value="na"><label for="an241"><abbr title="Not applicable">N/A</abbr></label>
@@ -252,7 +308,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title" rel="external" aria-describedby="g8">2.4.2 Page Titled (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title" rel="external" aria-describedby="g24">2.4.2 Page Titled (Level&#160;A)</a></legend>
 						<input id="ap242" type="radio" name="sc242" value="pass"><label for="ap242">Pass</label>
 						<input id="af242" type="radio" name="sc242" value="fail"><label for="af242">Fail</label>
 						<input id="an242" type="radio" name="sc242" value="na"><label for="an242"><abbr title="Not applicable">N/A</abbr></label>
@@ -260,7 +316,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order" rel="external" aria-describedby="g8">2.4.3 Focus Order (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order" rel="external" aria-describedby="g24">2.4.3 Focus Order (Level&#160;A)</a></legend>
 						<input id="ap243" type="radio" name="sc243" value="pass"><label for="ap243">Pass</label>
 						<input id="af243" type="radio" name="sc243" value="fail"><label for="af243">Fail</label>
 						<input id="an243" type="radio" name="sc243" value="na"><label for="an243"><abbr title="Not applicable">N/A</abbr></label>
@@ -268,7 +324,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs" rel="external" aria-describedby="g8">2.4.4 Link Purpose (In Context) (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs" rel="external" aria-describedby="g24">2.4.4 Link Purpose (In Context) (Level&#160;A)</a></legend>
 						<input id="ap244" type="radio" name="sc244" value="pass"><label for="ap244">Pass</label>
 						<input id="af244" type="radio" name="sc244" value="fail"><label for="af244">Fail</label>
 						<input id="an244" type="radio" name="sc244" value="na"><label for="an244"><abbr title="Not applicable">N/A</abbr></label>
@@ -276,7 +332,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc" rel="external" aria-describedby="g8">2.4.5 Multiple ways (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc" rel="external" aria-describedby="g24">2.4.5 Multiple ways (Level&#160;AA)</a></legend>
 						<input id="aap245" type="radio" name="sc245" value="pass"><label for="aap245">Pass</label>
 						<input id="aaf245" type="radio" name="sc245" value="fail"><label for="aaf245">Fail</label>
 						<input id="aan245" type="radio" name="sc245" value="na"><label for="aan245"><abbr title="Not applicable">N/A</abbr></label>
@@ -284,7 +340,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive" rel="external" aria-describedby="g8">2.4.6 Headings and Labels (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive" rel="external" aria-describedby="g24">2.4.6 Headings and Labels (Level&#160;AA)</a></legend>
 						<input id="aap246" type="radio" name="sc246" value="pass"><label for="aap246">Pass</label>
 						<input id="aaf246" type="radio" name="sc246" value="fail"><label for="aaf246">Fail</label>
 						<input id="aan246" type="radio" name="sc246" value="na"><label for="aan246"><abbr title="Not applicable">N/A</abbr></label>
@@ -292,10 +348,47 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible" rel="external" aria-describedby="g8">2.4.7 Focus Visible (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible" rel="external" aria-describedby="g24">2.4.7 Focus Visible (Level&#160;AA)</a></legend>
 						<input id="aap247" type="radio" name="sc247" value="pass"><label for="aap247">Pass</label>
 						<input id="aaf247" type="radio" name="sc247" value="fail"><label for="aaf247">Fail</label>
 						<input id="aan247" type="radio" name="sc247" value="na"><label for="aan247"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+			</ol>
+		</section>
+		<section class="mrgn-tp-lg">
+			<h4 id="g25"><b>Guideline 2.5 Input Modalities:</b> Make it easier for users to operate functionality through various inputs beyond keyboard.</h4>
+			<ol>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#pointer-gestures" rel="external" aria-describedby="g25">2.5.1 Pointer Gestures (Level&#160;A)</a></legend>
+						<input id="ap251" type="radio" name="sc251" value="pass"><label for="ap251">Pass</label>
+						<input id="af251" type="radio" name="sc251" value="fail"><label for="af251">Fail</label>
+						<input id="an251" type="radio" name="sc251" value="na"><label for="an251"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#pointer-cancellation" rel="external" aria-describedby="g25">2.5.2 Pointer Cancellation (Level&#160;A)</a></legend>
+						<input id="ap252" type="radio" name="sc252" value="pass"><label for="ap252">Pass</label>
+						<input id="af252" type="radio" name="sc252" value="fail"><label for="af252">Fail</label>
+						<input id="an252" type="radio" name="sc252" value="na"><label for="an252"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#label-in-name" rel="external" aria-describedby="g25">2.5.3 Label in Name (Level&#160;A)</a></legend>
+						<input id="ap253" type="radio" name="sc253" value="pass"><label for="ap253">Pass</label>
+						<input id="af253" type="radio" name="sc253" value="fail"><label for="af253">Fail</label>
+						<input id="an253" type="radio" name="sc253" value="na"><label for="an253"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#motion-actuation" rel="external" aria-describedby="g25">2.5.4 Motion Actuation (Level&#160;A)</a></legend>
+						<input id="ap254" type="radio" name="sc254" value="pass"><label for="ap254">Pass</label>
+						<input id="af254" type="radio" name="sc254" value="fail"><label for="af254">Fail</label>
+						<input id="an254" type="radio" name="sc254" value="na"><label for="an254"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -305,11 +398,11 @@
 	<section>
 		<h3 id="wcag3"><b>Principle:</b> Understandable</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g9"><b>Guideline 3.1 Readable:</b> Make text content readable and understandable.</h4>
+			<h4 id="g31"><b>Guideline 3.1 Readable:</b> Make text content readable and understandable.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id" rel="external" aria-describedby="g9">3.1.1 Language of Page (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id" rel="external" aria-describedby="g31">3.1.1 Language of Page (Level&#160;A)</a></legend>
 						<input id="ap311" type="radio" name="sc311" value="pass"><label for="ap311">Pass</label>
 						<input id="af311" type="radio" name="sc311" value="fail"><label for="af311">Fail</label>
 						<input id="an311" type="radio" name="sc311" value="na"><label for="an311"><abbr title="Not applicable">N/A</abbr></label>
@@ -317,7 +410,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id" rel="external" aria-describedby="g9">3.1.2 Language of Parts (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id" rel="external" aria-describedby="g31">3.1.2 Language of Parts (Level&#160;AA)</a></legend>
 						<input id="aap312" type="radio" name="sc312" value="pass"><label for="aap312">Pass</label>
 						<input id="aaf312" type="radio" name="sc312" value="fail"><label for="aaf312">Fail</label>
 						<input id="aan312" type="radio" name="sc312" value="na"><label for="aan312"><abbr title="Not applicable">N/A</abbr></label>
@@ -326,11 +419,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g10"><b>Guideline 3.2 Predictable:</b> Make Web pages appear and operate in predictable ways.</h4>
+			<h4 id="g32"><b>Guideline 3.2 Predictable:</b> Make Web pages appear and operate in predictable ways.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus" rel="external" aria-describedby="g10">3.2.1 On Focus (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus" rel="external" aria-describedby="g32">3.2.1 On Focus (Level&#160;A)</a></legend>
 						<input id="ap321" type="radio" name="sc321" value="pass"><label for="ap321">Pass</label>
 						<input id="af321" type="radio" name="sc321" value="fail"><label for="af321">Fail</label>
 						<input id="an321" type="radio" name="sc321" value="na"><label for="an321"><abbr title="Not applicable">N/A</abbr></label>
@@ -338,7 +431,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change" rel="external" aria-describedby="g10">3.2.2 On Input (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change" rel="external" aria-describedby="g32">3.2.2 On Input (Level&#160;A)</a></legend>
 						<input id="ap322" type="radio" name="sc322" value="pass"><label for="ap322">Pass</label>
 						<input id="af322" type="radio" name="sc322" value="fail"><label for="af322">Fail</label>
 						<input id="an322" type="radio" name="sc322" value="na"><label for="an322"><abbr title="Not applicable">N/A</abbr></label>
@@ -346,7 +439,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations" rel="external" aria-describedby="g10">3.2.3 Consistent Navigation (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations" rel="external" aria-describedby="g32">3.2.3 Consistent Navigation (Level&#160;AA)</a></legend>
 						<input id="aap323" type="radio" name="sc323" value="pass"><label for="aap323">Pass</label>
 						<input id="aaf323" type="radio" name="sc323" value="fail"><label for="aaf323">Fail</label>
 						<input id="aan323" type="radio" name="sc323" value="na"><label for="aan323"><abbr title="Not applicable">N/A</abbr></label>
@@ -354,7 +447,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality" rel="external" aria-describedby="g10">3.2.4 Consistent Identification (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality" rel="external" aria-describedby="g32">3.2.4 Consistent Identification (Level&#160;AA)</a></legend>
 						<input id="aap324" type="radio" name="sc324" value="pass"><label for="aap324">Pass</label>
 						<input id="aaf324" type="radio" name="sc324" value="fail"><label for="aaf324">Fail</label>
 						<input id="aan324" type="radio" name="sc324" value="na"><label for="aan324"><abbr title="Not applicable">N/A</abbr></label>
@@ -363,11 +456,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g11"><b>Guideline 3.3 Input Assistance:</b> Help users avoid and correct mistakes.</h4>
+			<h4 id="g33"><b>Guideline 3.3 Input Assistance:</b> Help users avoid and correct mistakes.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-identified" rel="external" aria-describedby="g11">3.3.1 Error Identification (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-identified" rel="external" aria-describedby="g33">3.3.1 Error Identification (Level&#160;A)</a></legend>
 						<input id="ap331" type="radio" name="sc331" value="pass"><label for="ap331">Pass</label>
 						<input id="af331" type="radio" name="sc331" value="fail"><label for="af331">Fail</label>
 						<input id="an331" type="radio" name="sc331" value="na"><label for="an331"><abbr title="Not applicable">N/A</abbr></label>
@@ -375,7 +468,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-cues" rel="external" aria-describedby="g11">3.3.2 Labels or Instructions (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-cues" rel="external" aria-describedby="g33">3.3.2 Labels or Instructions (Level&#160;A)</a></legend>
 						<input id="ap332" type="radio" name="sc332" value="pass"><label for="ap332">Pass</label>
 						<input id="af332" type="radio" name="sc332" value="fail"><label for="af332">Fail</label>
 						<input id="an332" type="radio" name="sc332" value="na"><label for="an332"><abbr title="Not applicable">N/A</abbr></label>
@@ -383,7 +476,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions" rel="external" aria-describedby="g11">3.3.3 Error Suggestion (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions" rel="external" aria-describedby="g33">3.3.3 Error Suggestion (Level&#160;AA)</a></legend>
 						<input id="aap333" type="radio" name="sc333" value="pass"><label for="aap333">Pass</label>
 						<input id="aaf333" type="radio" name="sc333" value="fail"><label for="aaf333">Fail</label>
 						<input id="aan333" type="radio" name="sc333" value="na"><label for="aan333"><abbr title="Not applicable">N/A</abbr></label>
@@ -391,7 +484,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible" rel="external" aria-describedby="g11">3.3.4 Error Prevention (Legal, Financial, Data) (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible" rel="external" aria-describedby="g33">3.3.4 Error Prevention (Legal, Financial, Data) (Level&#160;AA)</a></legend>
 						<input id="aap334" type="radio" name="sc334" value="pass"><label for="aap334">Pass</label>
 						<input id="aaf334" type="radio" name="sc334" value="fail"><label for="aaf334">Fail</label>
 						<input id="aan334" type="radio" name="sc334" value="na"><label for="aan334"><abbr title="Not applicable">N/A</abbr></label>
@@ -404,11 +497,11 @@
 	<section>
 		<h3 id="wcag4"><b>Principle:</b> Robust</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g12"><b>Guideline 4.1 Compatible:</b> Maximize compatibility with current and future user agents, including assistive technologies.</h4>
+			<h4 id="g41"><b>Guideline 4.1 Compatible:</b> Maximize compatibility with current and future user agents, including assistive technologies.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses" rel="external" aria-describedby="g12">4.1.1 Parsing (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses" rel="external" aria-describedby="g41">4.1.1 Parsing (Level&#160;A)</a></legend>
 						<input id="ap411" type="radio" name="sc411" value="pass"><label for="ap411">Pass</label>
 						<input id="af411" type="radio" name="sc411" value="fail"><label for="af411">Fail</label>
 						<input id="an411" type="radio" name="sc411" value="na"><label for="an411"><abbr title="Not applicable">N/A</abbr></label>
@@ -416,10 +509,18 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv" rel="external" aria-describedby="g12">4.1.2 Name, Role, Value (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv" rel="external" aria-describedby="g41">4.1.2 Name, Role, Value (Level&#160;A)</a></legend>
 						<input id="ap412" type="radio" name="sc412" value="pass"><label for="ap412">Pass</label>
 						<input id="af412" type="radio" name="sc412" value="fail"><label for="af412">Fail</label>
 						<input id="an412" type="radio" name="sc412" value="na"><label for="an412"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#status-messages" rel="external" aria-describedby="g41">4.1.3 Status Messages (Level&#160;AA)</a></legend>
+						<input id="aap413" type="radio" name="sc413" value="pass"><label for="aap413">Pass</label>
+						<input id="aaf413" type="radio" name="sc413" value="fail"><label for="aaf413">Fail</label>
+						<input id="aan413" type="radio" name="sc413" value="na"><label for="aan413"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -432,23 +533,23 @@
 			<tbody>
 				<tr>
 					<th scope="row">Level&#160;A Success Criteria passed</th>
-					<td class="text-right"><span id="rsltA"></span>/25 (<span id="percA"></span>%)</td>
+					<td class="text-right"><span id="rsltA"></span>/30 (<span id="percA"></span>%)</td>
 				</tr>
 				<tr>
 					<th scope="row">Level&#160;AA Success Criteria passed</th>
-					<td class="text-right"><span id="rsltAA"></span>/13 (<span id="percAA"></span>%)</td>
+					<td class="text-right"><span id="rsltAA"></span>/20 (<span id="percAA"></span>%)</td>
 				</tr>
 				<tr class="success">
 					<th scope="row">Total Success Criteria passed</th>
-					<td class="text-right"><span id="rsltTotal"></span>/38 (<span id="percTotal"></span>%)</td>
+					<td class="text-right"><span id="rsltTotal"></span>/50 (<span id="percTotal"></span>%)</td>
 				</tr>
 				<tr class="active">
 					<th scope="row">Success Criteria evaluated</th>
-					<td class="text-right"><span id="evalTotal"></span>/38 (<span id="percEvalTotal"></span>%)</td>
+					<td class="text-right"><span id="evalTotal"></span>/50 (<span id="percEvalTotal"></span>%)</td>
 				</tr>
 				<tr class="active">
 					<th scope="row">Success Criteria <abbr title="Not applicable">N/A</abbr></th>
-					<td class="text-right"><span id="naTotal"></span>/38 (<span id="percNATotal"></span>%)</td>
+					<td class="text-right"><span id="naTotal"></span>/50 (<span id="percNATotal"></span>%)</td>
 				</tr>
 			</tbody>
 		</table>

--- a/src/other/wamethod/wamethod-AA-fr.hbs
+++ b/src/other/wamethod/wamethod-AA-fr.hbs
@@ -3,24 +3,24 @@
 	"title": "Méthodologie d’évaluation sur l’accessibilité des sites Web (niveau AA)",
 	"language": "fr",
 	"category": "Autre",
-	"description": "Offre une méthodologie d’évaluation qui permet de mesurer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.0 pour les critères de succès de niveau A et AA.",
+	"description": "Offre une méthodologie d’évaluation qui permet de mesurer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.1 pour les critères de succès de niveau A et AA.",
 	"tag": "wamethod",
 	"parentdir": "wamethod",
 	"altLangPrefix": "wamethod-AA",
 	"css": ["demo/wamethod"],
 	"js": ["demo/wamethod"],
-	"dateModified": "2014-04-07"
+	"dateModified": "2019-08-05"
 }
 ---
 <section>
 	<h2>But</h2>
-	<p>Aider à mesurer les <a href="#success">critères de succès</a> de niveau A et AA des <a href="https://www.w3.org/Translations/WCAG20-fr/" rel="external">Règles&#160;pour&#160;l’accessibilité des contenus Web (WCAG)&#160;2.0</a>.</p>
+	<p>Aider à mesurer les <a href="#success">critères de succès</a> de niveau A et AA des <a href="https://www.w3.org/TR/WCAG21/" rel="external">Règles&#160;pour&#160;l’accessibilité des contenus Web (WCAG)&#160;2.1 (anglais seulement)</a>.</p>
 </section>
 
 <section>
 	<h2>Table des matières</h2>
 	<ul>
-		<li><a href="#wcag">Liste de vérification des critères de succès des <abbr title="Règles pour l’accessibilité des contenus Web">WCAG</abbr>&#160;2.0</a>
+		<li><a href="#wcag">Liste de vérification des critères de succès des <abbr title="Règles pour l’accessibilité des contenus Web">WCAG</abbr>&#160;2.1</a>
 			<ul>
 				<li><a href="#wcag1">Principe&#160;: Perceptible</a></li>
 				<li><a href="#wcag2">Principe&#160;: Utilisable</a></li>
@@ -33,9 +33,9 @@
 	</ul>
 </section>
 
-<p>Les suivantes sont requises pour qu’une <a href="#webpagedef">page Web</a> réponde à un critère de succès des <abbr title="Règles pour l’accessibilité des contenus Web">WCAG</abbr>&#160;2.0&#160;:</p>
+<p>Les suivantes sont requises pour qu’une <a href="#webpagedef">page Web</a> réponde à un critère de succès des <abbr title="Règles pour l’accessibilité des contenus Web">WCAG</abbr>&#160;2.1&#160;:</p>
 <ol>
-	<li>La page Web évite avec succès chaque <a href="https://www.w3.org/TR/WCAG20-TECHS/failures.html" rel="external">échec fréquent (anglais seulement)</a> pour le critère&#160;de&#160;succès.</li>
+	<li>La page Web évite avec succès chaque <a href="https://www.w3.org/WAI/WCAG21/Techniques/#failures" rel="external">échec fréquent (anglais seulement)</a> pour le critère&#160;de&#160;succès.</li>
 	<li>La page Web exécute avec succès des <a href="#sufftech">techniques suffisantes</a> ou des combinaisons de techniques suffisantes pour le critère de succès qui sont&#160;:
 		<ol>
 			<li>propres à chaque situation applicable;</li>
@@ -45,15 +45,15 @@
 </ol>
 
 <section class="wb-wamethod">
-	<h2 id="wcag">Liste de vérification des critères de succès des WCAG&#160;2.0 (12&#160;règles, 38&#160;critères de succès)</h2>
+	<h2 id="wcag">Liste de vérification des critères de succès des WCAG&#160;2.1 (13&#160;règles, 50&#160;critères de succès)</h2>
 	<section>
 		<h3 id="wcag1"><b>Principe&#160;:</b> Perceptible</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g1"><b>Règle 1.1 Les équivalents textuels&#160;:</b> Proposer des équivalents textuels à tout contenu non textuel qui pourra alors être modifié en d'autres formes selon les besoins de l'utilisateur&#160;: grands caractères, braille, synthèse vocale, symboles ou langage simplifié.</h4>
+			<h4 id="g11"><b>Règle 1.1 Les équivalents textuels&#160;:</b> Proposer des équivalents textuels à tout contenu non textuel qui pourra alors être modifié en d'autres formes selon les besoins de l'utilisateur&#160;: grands caractères, braille, synthèse vocale, symboles ou langage simplifié.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#text-equiv-all" rel="external" aria-describedby="g1">1.1.1 Contenu non textuel (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#text-equiv-all" rel="external" aria-describedby="g11">1.1.1 Contenu non textuel (Niveau&#160;A)</a></legend>
 						<input id="ap111" type="radio" name="sc111" value="pass"><label for="ap111">Réussi</label>
 						<input id="af111" type="radio" name="sc111" value="fail"><label for="af111">Échouée</label>
 						<input id="an111" type="radio" name="sc111" value="na"><label for="an111"><abbr title="Sans objet">S/O</abbr></label>
@@ -62,11 +62,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g2"><b>Règle 1.2 Média temporel&#160;:</b> Proposer des versions de remplacement aux médias temporels.</h4>
+			<h4 id="g12"><b>Règle 1.2 Média temporel&#160;:</b> Proposer des versions de remplacement aux médias temporels.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-av-only-alt" rel="external" aria-describedby="g2">1.2.1 Contenu seulement audio ou vidéo (pré-enregistré) (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-av-only-alt" rel="external" aria-describedby="g12">1.2.1 Contenu seulement audio ou vidéo (pré-enregistré) (Niveau&#160;A)</a></legend>
 						<input id="ap121" type="radio" name="sc121" value="pass"><label for="ap121">Réussi</label>
 						<input id="af121" type="radio" name="sc121" value="fail"><label for="af121">Échouée</label>
 						<input id="an121" type="radio" name="sc121" value="na"><label for="an121"><abbr title="Sans objet">S/O</abbr></label>
@@ -74,7 +74,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-captions" rel="external" aria-describedby="g2">1.2.2 Sous-titres (pré-enregistrés) (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-captions" rel="external" aria-describedby="g12">1.2.2 Sous-titres (pré-enregistrés) (Niveau&#160;A)</a></legend>
 						<input id="ap122" type="radio" name="sc122" value="pass"><label for="ap122">Réussi</label>
 						<input id="af122" type="radio" name="sc122" value="fail"><label for="af122">Échouée</label>
 						<input id="an122" type="radio" name="sc122" value="na"><label for="an122"><abbr title="Sans objet">S/O</abbr></label>
@@ -82,7 +82,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-audio-desc" rel="external" aria-describedby="g2">1.2.3 Audio-description ou version de remplacement pour un média temporel (pré-enregistré) (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-audio-desc" rel="external" aria-describedby="g12">1.2.3 Audio-description ou version de remplacement pour un média temporel (pré-enregistré) (Niveau&#160;A)</a></legend>
 						<input id="ap123" type="radio" name="sc123" value="pass"><label for="ap123">Réussi</label>
 						<input id="af123" type="radio" name="sc123" value="fail"><label for="af123">Échouée</label>
 						<input id="an123" type="radio" name="sc123" value="na"><label for="an123"><abbr title="Sans objet">S/O</abbr></label>
@@ -90,7 +90,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-real-time-captions" rel="external" aria-describedby="g2">1.2.4 Sous-titres (en direct) (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-real-time-captions" rel="external" aria-describedby="g12">1.2.4 Sous-titres (en direct) (Niveau&#160;AA)</a></legend>
 						<input id="aap124" type="radio" name="sc124" value="pass"><label for="aap124">Réussi</label>
 						<input id="aaf124" type="radio" name="sc124" value="fail"><label for="aaf124">Échouée</label>
 						<input id="aan124" type="radio" name="sc124" value="na"><label for="aan124"><abbr title="Sans objet">S/O</abbr></label>
@@ -98,7 +98,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-audio-desc-only" rel="external" aria-describedby="g2">1.2.5 Audio-description (pré-enregistrée) (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-audio-desc-only" rel="external" aria-describedby="g12">1.2.5 Audio-description (pré-enregistrée) (Niveau&#160;AA)</a></legend>
 						<input id="aap125" type="radio" name="sc125" value="pass"><label for="aap125">Réussi</label>
 						<input id="aaf125" type="radio" name="sc125" value="fail"><label for="aaf125">Échouée</label>
 						<input id="aan125" type="radio" name="sc125" value="na"><label for="aan125"><abbr title="Sans objet">S/O</abbr></label>
@@ -107,11 +107,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g3"><b>Règle 1.3 Adaptable&#160;:</b> Créer un contenu qui puisse être présenté de différentes manières sans perte d'information ni de structure (par exemple avec une mise en page simplifiée).</h4>
+			<h4 id="g13"><b>Règle 1.3 Adaptable&#160;:</b> Créer un contenu qui puisse être présenté de différentes manières sans perte d'information ni de structure (par exemple avec une mise en page simplifiée).</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-programmatic" rel="external" aria-describedby="g3">1.3.1 Information et relations (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-programmatic" rel="external" aria-describedby="g13">1.3.1 Information et relations (Niveau&#160;A)</a></legend>
 						<input id="ap131" type="radio" name="sc131" value="pass"><label for="ap131">Réussi</label>
 						<input id="af131" type="radio" name="sc131" value="fail"><label for="af131">Échouée</label>
 						<input id="an131" type="radio" name="sc131" value="na"><label for="an131"><abbr title="Sans objet">S/O</abbr></label>
@@ -119,7 +119,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-sequence" rel="external" aria-describedby="g3">1.3.2 Ordre séquentiel logique (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-sequence" rel="external" aria-describedby="g13">1.3.2 Ordre séquentiel logique (Niveau&#160;A)</a></legend>
 						<input id="ap132" type="radio" name="sc132" value="pass"><label for="ap132">Réussi</label>
 						<input id="af132" type="radio" name="sc132" value="fail"><label for="af132">Échouée</label>
 						<input id="an132" type="radio" name="sc132" value="na"><label for="an132"><abbr title="Sans objet">S/O</abbr></label>
@@ -127,20 +127,36 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-understanding" rel="external" aria-describedby="g3">1.3.3 Caractéristiques sensorielles (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-understanding" rel="external" aria-describedby="g13">1.3.3 Caractéristiques sensorielles (Niveau&#160;A)</a></legend>
 						<input id="ap133" type="radio" name="sc133" value="pass"><label for="ap133">Réussi</label>
 						<input id="af133" type="radio" name="sc133" value="fail"><label for="af133">Échouée</label>
 						<input id="an133" type="radio" name="sc133" value="na"><label for="an133"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#orientation" rel="external" aria-describedby="g13"><span lang="en">1.3.4 Orientation (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap134" type="radio" name="sc134" value="pass"><label for="aap134">Réussi</label>
+						<input id="aaf134" type="radio" name="sc134" value="fail"><label for="aaf134">Échouée</label>
+						<input id="aan134" type="radio" name="sc134" value="na"><label for="aan134"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#identify-input-purpose" rel="external" aria-describedby="g13"><span lang="en">1.3.5 Identify Input Purpose (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap135" type="radio" name="sc135" value="pass"><label for="aap135">Réussi</label>
+						<input id="aaf135" type="radio" name="sc135" value="fail"><label for="aaf135">Échouée</label>
+						<input id="aan135" type="radio" name="sc135" value="na"><label for="aan135"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g4"><b>Règle 1.4 Distinguable&#160;:</b> Faciliter la perception visuelle et auditive du contenu par l'utilisateur, notamment en séparant le premier plan de l'arrière-plan.</h4>
+			<h4 id="g14"><b>Règle 1.4 Distinguable&#160;:</b> Faciliter la perception visuelle et auditive du contenu par l'utilisateur, notamment en séparant le premier plan de l'arrière-plan.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-without-color" rel="external" aria-describedby="g4">1.4.1 Utilisation de la couleur (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-without-color" rel="external" aria-describedby="g14">1.4.1 Utilisation de la couleur (Niveau&#160;A)</a></legend>
 						<input id="ap141" type="radio" name="sc141" value="pass"><label for="ap141">Réussi</label>
 						<input id="af141" type="radio" name="sc141" value="fail"><label for="af141">Échouée</label>
 						<input id="an141" type="radio" name="sc141" value="na"><label for="an141"><abbr title="Sans objet">S/O</abbr></label>
@@ -148,7 +164,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-dis-audio" rel="external" aria-describedby="g4">1.4.2 Contrôle du son (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-dis-audio" rel="external" aria-describedby="g14">1.4.2 Contrôle du son (Niveau&#160;A)</a></legend>
 						<input id="ap142" type="radio" name="sc142" value="pass"><label for="ap142">Réussi</label>
 						<input id="af142" type="radio" name="sc142" value="fail"><label for="af142">Échouée</label>
 						<input id="an142" type="radio" name="sc142" value="na"><label for="an142"><abbr title="Sans objet">S/O</abbr></label>
@@ -156,7 +172,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-contrast" rel="external" aria-describedby="g4">1.4.3 Contraste (minimum) (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-contrast" rel="external" aria-describedby="g14">1.4.3 Contraste (minimum) (Niveau&#160;AA)</a></legend>
 						<input id="aap143" type="radio" name="sc143" value="pass"><label for="aap143">Réussi</label>
 						<input id="aaf143" type="radio" name="sc143" value="fail"><label for="aaf143">Échouée</label>
 						<input id="aan143" type="radio" name="sc143" value="na"><label for="aan143"><abbr title="Sans objet">S/O</abbr></label>
@@ -164,7 +180,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-scale" rel="external" aria-describedby="g4">1.4.4 Redimensionnement du texte (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-scale" rel="external" aria-describedby="g14">1.4.4 Redimensionnement du texte (Niveau&#160;AA)</a></legend>
 						<input id="aap144" type="radio" name="sc144" value="pass"><label for="aap144">Réussi</label>
 						<input id="aaf144" type="radio" name="sc144" value="fail"><label for="aaf144">Échouée</label>
 						<input id="aan144" type="radio" name="sc144" value="na"><label for="aan144"><abbr title="Sans objet">S/O</abbr></label>
@@ -172,10 +188,42 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-text-presentation" rel="external" aria-describedby="g4">1.4.5 Texte sous forme d'image (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-text-presentation" rel="external" aria-describedby="g14">1.4.5 Texte sous forme d'image (Niveau&#160;AA)</a></legend>
 						<input id="aap145" type="radio" name="sc145" value="pass"><label for="aap145">Réussi</label>
 						<input id="aaf145" type="radio" name="sc145" value="fail"><label for="aaf145">Échouée</label>
 						<input id="aan145" type="radio" name="sc145" value="na"><label for="aan145"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#reflow" rel="external" aria-describedby="g14"><span lang="en">1.4.10 Reflow (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap1410" type="radio" name="sc1410" value="pass"><label for="aap1410">Réussi</label>
+						<input id="aaf1410" type="radio" name="sc1410" value="fail"><label for="aaf1410">Échouée</label>
+						<input id="aan1410" type="radio" name="sc1410" value="na"><label for="aan1410"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#non-text-contrast" rel="external" aria-describedby="g14"><span lang="en">1.4.11 Non-Text Contrast (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap1411" type="radio" name="sc1411" value="pass"><label for="aap1411">Réussi</label>
+						<input id="aaf1411" type="radio" name="sc1411" value="fail"><label for="aaf1411">Échouée</label>
+						<input id="aan1411" type="radio" name="sc1411" value="na"><label for="aan1411"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#text-spacing" rel="external" aria-describedby="g14"><span lang="en">1.4.12 Text Spacing (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap1412" type="radio" name="sc1412" value="pass"><label for="aap1412">Réussi</label>
+						<input id="aaf1412" type="radio" name="sc1412" value="fail"><label for="aaf1412">Échouée</label>
+						<input id="aan1412" type="radio" name="sc1412" value="na"><label for="aan1412"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus" rel="external" aria-describedby="g14"><span lang="en">1.4.13 Content on Hover or Focus (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap1413" type="radio" name="sc1413" value="pass"><label for="aap1413">Réussi</label>
+						<input id="aaf1413" type="radio" name="sc1413" value="fail"><label for="aaf1413">Échouée</label>
+						<input id="aan1413" type="radio" name="sc1413" value="na"><label for="aan1413"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -185,11 +233,11 @@
 	<section>
 		<h3 id="wcag2"><b>Principe&#160;:</b> Utilisable</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g5"><b>Règle 2.1 Accessibilité au clavier&#160;:</b> Rendre toutes les fonctionnalités accessibles au clavier.</h4>
+			<h4 id="g21"><b>Règle 2.1 Accessibilité au clavier&#160;:</b> Rendre toutes les fonctionnalités accessibles au clavier.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#keyboard-operation-keyboard-operable" rel="external" aria-describedby="g5">2.1.1 Clavier (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#keyboard-operation-keyboard-operable" rel="external" aria-describedby="g21">2.1.1 Clavier (Niveau&#160;A)</a></legend>
 						<input id="ap211" type="radio" name="sc211" value="pass"><label for="ap211">Réussi</label>
 						<input id="af211" type="radio" name="sc211" value="fail"><label for="af211">Échouée</label>
 						<input id="an211" type="radio" name="sc211" value="na"><label for="an211"><abbr title="Sans objet">S/O</abbr></label>
@@ -197,20 +245,28 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#keyboard-operation-trapping" rel="external" aria-describedby="g5">2.1.2 Pas de piège au clavier (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#keyboard-operation-trapping" rel="external" aria-describedby="g21">2.1.2 Pas de piège au clavier (Niveau&#160;A)</a></legend>
 						<input id="ap212" type="radio" name="sc212" value="pass"><label for="ap212">Réussi</label>
 						<input id="af212" type="radio" name="sc212" value="fail"><label for="af212">Échouée</label>
 						<input id="an212" type="radio" name="sc212" value="na"><label for="an212"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#character-key-shortcuts" rel="external" aria-describedby="g21"><span lang="en">2.1.4 Character Key Shortcuts (Niveau&#160;A)</span> (anglais seulement)</a></legend>
+						<input id="ap214" type="radio" name="sc214" value="pass"><label for="ap214">Réussi</label>
+						<input id="af214" type="radio" name="sc214" value="fail"><label for="af214">Échouée</label>
+						<input id="an214" type="radio" name="sc214" value="na"><label for="an214"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g6"><b>Règle 2.2 Délai suffisant&#160;:</b> Laisser à l'utilisateur suffisamment de temps pour lire et utiliser le contenu.</h4>
+			<h4 id="g22"><b>Règle 2.2 Délai suffisant&#160;:</b> Laisser à l'utilisateur suffisamment de temps pour lire et utiliser le contenu.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-required-behaviors" rel="external" aria-describedby="g6">2.2.1 Réglage du délai (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-required-behaviors" rel="external" aria-describedby="g22">2.2.1 Réglage du délai (Niveau&#160;A)</a></legend>
 						<input id="ap221" type="radio" name="sc221" value="pass"><label for="ap221">Réussi</label>
 						<input id="af221" type="radio" name="sc221" value="fail"><label for="af221">Échouée</label>
 						<input id="an221" type="radio" name="sc221" value="na"><label for="an221"><abbr title="Sans objet">S/O</abbr></label>
@@ -218,7 +274,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-pause" rel="external" aria-describedby="g6">2.2.2 Mettre en pause, arrêter, masquer (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-pause" rel="external" aria-describedby="g22">2.2.2 Mettre en pause, arrêter, masquer (Niveau&#160;A)</a></legend>
 						<input id="ap222" type="radio" name="sc222" value="pass"><label for="ap222">Réussi</label>
 						<input id="af222" type="radio" name="sc222" value="fail"><label for="af222">Échouée</label>
 						<input id="an222" type="radio" name="sc222" value="na"><label for="an222"><abbr title="Sans objet">S/O</abbr></label>
@@ -227,11 +283,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g7"><b>Règle 2.3 Crises&#160;:</b> Ne pas concevoir de contenu susceptible de provoquer des crises.</h4>
+			<h4 id="g23"><b>Règle 2.3 Crises&#160;:</b> Ne pas concevoir de contenu susceptible de provoquer des crises.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#seizure-does-not-violate" rel="external" aria-describedby="g7">2.3.1 Pas plus de trois flashs ou sous le seuil critique (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#seizure-does-not-violate" rel="external" aria-describedby="g23">2.3.1 Pas plus de trois flashs ou sous le seuil critique (Niveau&#160;A)</a></legend>
 						<input id="ap231" type="radio" name="sc231" value="pass"><label for="ap231">Réussi</label>
 						<input id="af231" type="radio" name="sc231" value="fail"><label for="af231">Échouée</label>
 						<input id="an231" type="radio" name="sc231" value="na"><label for="an231"><abbr title="Sans objet">S/O</abbr></label>
@@ -240,11 +296,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g8"><b>Règle 2.4 Navigable&#160;:</b> Fournir à l'utilisateur des éléments d'orientation pour naviguer, trouver le contenu et se situer dans le site.</h4>
+			<h4 id="g24"><b>Règle 2.4 Navigable&#160;:</b> Fournir à l'utilisateur des éléments d'orientation pour naviguer, trouver le contenu et se situer dans le site.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-skip" rel="external" aria-describedby="g8">2.4.1 Contourner des blocs (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-skip" rel="external" aria-describedby="g24">2.4.1 Contourner des blocs (Niveau&#160;A)</a></legend>
 						<input id="ap241" type="radio" name="sc241" value="pass"><label for="ap241">Réussi</label>
 						<input id="af241" type="radio" name="sc241" value="fail"><label for="af241">Échouée</label>
 						<input id="an241" type="radio" name="sc241" value="na"><label for="an241"><abbr title="Sans objet">S/O</abbr></label>
@@ -252,7 +308,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-title" rel="external" aria-describedby="g8">2.4.2 Titre de page (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-title" rel="external" aria-describedby="g24">2.4.2 Titre de page (Niveau&#160;A)</a></legend>
 						<input id="ap242" type="radio" name="sc242" value="pass"><label for="ap242">Réussi</label>
 						<input id="af242" type="radio" name="sc242" value="fail"><label for="af242">Échouée</label>
 						<input id="an242" type="radio" name="sc242" value="na"><label for="an242"><abbr title="Sans objet">S/O</abbr></label>
@@ -260,7 +316,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-focus-order" rel="external" aria-describedby="g8">2.4.3 Parcours du focus (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-focus-order" rel="external" aria-describedby="g24">2.4.3 Parcours du focus (Niveau&#160;A)</a></legend>
 						<input id="ap243" type="radio" name="sc243" value="pass"><label for="ap243">Réussi</label>
 						<input id="af243" type="radio" name="sc243" value="fail"><label for="af243">Échouée</label>
 						<input id="an243" type="radio" name="sc243" value="na"><label for="an243"><abbr title="Sans objet">S/O</abbr></label>
@@ -268,7 +324,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-refs" rel="external" aria-describedby="g8">2.4.4 Fonction du lien (selon le contexte) (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-refs" rel="external" aria-describedby="g24">2.4.4 Fonction du lien (selon le contexte) (Niveau&#160;A)</a></legend>
 						<input id="ap244" type="radio" name="sc244" value="pass"><label for="ap244">Réussi</label>
 						<input id="af244" type="radio" name="sc244" value="fail"><label for="af244">Échouée</label>
 						<input id="an244" type="radio" name="sc244" value="na"><label for="an244"><abbr title="Sans objet">S/O</abbr></label>
@@ -276,7 +332,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-mult-loc" rel="external" aria-describedby="g8">2.4.5 Accès multiples (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-mult-loc" rel="external" aria-describedby="g24">2.4.5 Accès multiples (Niveau&#160;AA)</a></legend>
 						<input id="aap245" type="radio" name="sc245" value="pass"><label for="aap245">Réussi</label>
 						<input id="aaf245" type="radio" name="sc245" value="fail"><label for="aaf245">Échouée</label>
 						<input id="aan245" type="radio" name="sc245" value="na"><label for="aan245"><abbr title="Sans objet">S/O</abbr></label>
@@ -284,7 +340,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-descriptive" rel="external" aria-describedby="g8">2.4.6 En-têtes et étiquettes (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-descriptive" rel="external" aria-describedby="g24">2.4.6 En-têtes et étiquettes (Niveau&#160;AA)</a></legend>
 						<input id="aap246" type="radio" name="sc246" value="pass"><label for="aap246">Réussi</label>
 						<input id="aaf246" type="radio" name="sc246" value="fail"><label for="aaf246">Échouée</label>
 						<input id="aan246" type="radio" name="sc246" value="na"><label for="aan246"><abbr title="Sans objet">S/O</abbr></label>
@@ -292,10 +348,50 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-focus-visible" rel="external" aria-describedby="g8">2.4.7 Visibilité du focus (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-focus-visible" rel="external" aria-describedby="g24">2.4.7 Visibilité du focus (Niveau&#160;AA)</a></legend>
 						<input id="aap247" type="radio" name="sc247" value="pass"><label for="aap247">Réussi</label>
 						<input id="aaf247" type="radio" name="sc247" value="fail"><label for="aaf247">Échouée</label>
 						<input id="aan247" type="radio" name="sc247" value="na"><label for="aan247"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+			</ol>
+		</section>
+		<section class="mrgn-tp-lg">
+			<div lang="en">
+			<h4 id="g25"><b>Guideline 2.5 Input Modalities:</b> Make it easier for users to operate functionality through various inputs beyond keyboard.</h4>
+			<p><strong>Needs translation</strong></p>
+			</div>
+			<ol>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#pointer-gestures" rel="external" aria-describedby="g25"><span lang="en">2.5.1 Pointer Gestures (Niveau&#160;A)</span> (anglais seulement)</a></legend>
+						<input id="ap251" type="radio" name="sc251" value="pass"><label for="ap251">Réussi</label>
+						<input id="af251" type="radio" name="sc251" value="fail"><label for="af251">Échouée</label>
+						<input id="an251" type="radio" name="sc251" value="na"><label for="an251"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#pointer-cancellation" rel="external" aria-describedby="g25"><span lang="en">2.5.2 Pointer Cancellation (Niveau&#160;A)</span> (anglais seulement)</a></legend>
+						<input id="ap252" type="radio" name="sc252" value="pass"><label for="ap252">Réussi</label>
+						<input id="af252" type="radio" name="sc252" value="fail"><label for="af252">Échouée</label>
+						<input id="an252" type="radio" name="sc252" value="na"><label for="an252"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#label-in-name" rel="external" aria-describedby="g25"><span lang="en">2.5.3 Label in Name (Niveau&#160;A)</span> (anglais seulement)</a></legend>
+						<input id="ap253" type="radio" name="sc253" value="pass"><label for="ap253">Réussi</label>
+						<input id="af253" type="radio" name="sc253" value="fail"><label for="af253">Échouée</label>
+						<input id="an253" type="radio" name="sc253" value="na"><label for="an253"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#motion-actuation" rel="external" aria-describedby="g25"><span lang="en">2.5.4 Motion Actuation (Niveau&#160;A)</span> (anglais seulement)</a></legend>
+						<input id="ap254" type="radio" name="sc254" value="pass"><label for="ap254">Réussi</label>
+						<input id="af254" type="radio" name="sc254" value="fail"><label for="af254">Échouée</label>
+						<input id="an254" type="radio" name="sc254" value="na"><label for="an254"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -305,11 +401,11 @@
 	<section>
 		<h3 id="wcag3"><b>Principe&#160;:</b> Compréhensible</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g9"><b>Règle 3.1 Lisible&#160;:</b> Rendre le contenu textuel lisible et compréhensible.</h4>
+			<h4 id="g31"><b>Règle 3.1 Lisible&#160;:</b> Rendre le contenu textuel lisible et compréhensible.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-doc-lang-id" rel="external" aria-describedby="g9">3.1.1 Langue de la page (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-doc-lang-id" rel="external" aria-describedby="g31">3.1.1 Langue de la page (Niveau&#160;A)</a></legend>
 						<input id="ap311" type="radio" name="sc311" value="pass"><label for="ap311">Réussi</label>
 						<input id="af311" type="radio" name="sc311" value="fail"><label for="af311">Échouée</label>
 						<input id="an311" type="radio" name="sc311" value="na"><label for="an311"><abbr title="Sans objet">S/O</abbr></label>
@@ -317,7 +413,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-other-lang-id" rel="external" aria-describedby="g9">3.1.2 Langue d'un passage (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-other-lang-id" rel="external" aria-describedby="g31">3.1.2 Langue d'un passage (Niveau&#160;AA)</a></legend>
 						<input id="aap312" type="radio" name="sc312" value="pass"><label for="aap312">Réussi</label>
 						<input id="aaf312" type="radio" name="sc312" value="fail"><label for="aaf312">Échouée</label>
 						<input id="aan312" type="radio" name="sc312" value="na"><label for="aan312"><abbr title="Sans objet">S/O</abbr></label>
@@ -326,11 +422,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g10"><b>Règle 3.2 Prévisible&#160;:</b> Faire en sorte que les pages apparaissent et fonctionnent de manière prévisible.</h4>
+			<h4 id="g32"><b>Règle 3.2 Prévisible&#160;:</b> Faire en sorte que les pages apparaissent et fonctionnent de manière prévisible.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-receive-focus" rel="external" aria-describedby="g10">3.2.1 Au focus (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-receive-focus" rel="external" aria-describedby="g32">3.2.1 Au focus (Niveau&#160;A)</a></legend>
 						<input id="ap321" type="radio" name="sc321" value="pass"><label for="ap321">Réussi</label>
 						<input id="af321" type="radio" name="sc321" value="fail"><label for="af321">Échouée</label>
 						<input id="an321" type="radio" name="sc321" value="na"><label for="an321"><abbr title="Sans objet">S/O</abbr></label>
@@ -338,7 +434,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-unpredictable-change" rel="external" aria-describedby="g10">3.2.2 À la saisie (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-unpredictable-change" rel="external" aria-describedby="g32">3.2.2 À la saisie (Niveau&#160;A)</a></legend>
 						<input id="ap322" type="radio" name="sc322" value="pass"><label for="ap322">Réussi</label>
 						<input id="af322" type="radio" name="sc322" value="fail"><label for="af322">Échouée</label>
 						<input id="an322" type="radio" name="sc322" value="na"><label for="an322"><abbr title="Sans objet">S/O</abbr></label>
@@ -346,7 +442,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-consistent-locations" rel="external" aria-describedby="g10">3.2.3 Navigation cohérente (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-consistent-locations" rel="external" aria-describedby="g32">3.2.3 Navigation cohérente (Niveau&#160;AA)</a></legend>
 						<input id="aap323" type="radio" name="sc323" value="pass"><label for="aap323">Réussi</label>
 						<input id="aaf323" type="radio" name="sc323" value="fail"><label for="aaf323">Échouée</label>
 						<input id="aan323" type="radio" name="sc323" value="na"><label for="aan323"><abbr title="Sans objet">S/O</abbr></label>
@@ -354,7 +450,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-consistent-functionality" rel="external" aria-describedby="g10">3.2.4 Identification cohérente (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-consistent-functionality" rel="external" aria-describedby="g32">3.2.4 Identification cohérente (Niveau&#160;AA)</a></legend>
 						<input id="aap324" type="radio" name="sc324" value="pass"><label for="aap324">Réussi</label>
 						<input id="aaf324" type="radio" name="sc324" value="fail"><label for="aaf324">Échouée</label>
 						<input id="aan324" type="radio" name="sc324" value="na"><label for="aan324"><abbr title="Sans objet">S/O</abbr></label>
@@ -363,11 +459,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g11"><b>Règle 3.3 Assistance à la saisie&#160;:</b> Aider l'utilisateur à éviter et à corriger les erreurs de saisie.</h4>
+			<h4 id="g33"><b>Règle 3.3 Assistance à la saisie&#160;:</b> Aider l'utilisateur à éviter et à corriger les erreurs de saisie.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-identified" rel="external" aria-describedby="g11">3.3.1 Identification des erreurs (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-identified" rel="external" aria-describedby="g33">3.3.1 Identification des erreurs (Niveau&#160;A)</a></legend>
 						<input id="ap331" type="radio" name="sc331" value="pass"><label for="ap331">Réussi</label>
 						<input id="af331" type="radio" name="sc331" value="fail"><label for="af331">Échouée</label>
 						<input id="an331" type="radio" name="sc331" value="na"><label for="an331"><abbr title="Sans objet">S/O</abbr></label>
@@ -375,7 +471,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-cues" rel="external" aria-describedby="g11">3.3.2 Étiquettes ou instructions (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-cues" rel="external" aria-describedby="g33">3.3.2 Étiquettes ou instructions (Niveau&#160;A)</a></legend>
 						<input id="ap332" type="radio" name="sc332" value="pass"><label for="ap332">Réussi</label>
 						<input id="af332" type="radio" name="sc332" value="fail"><label for="af332">Échouée</label>
 						<input id="an332" type="radio" name="sc332" value="na"><label for="an332"><abbr title="Sans objet">S/O</abbr></label>
@@ -383,7 +479,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-suggestions" rel="external" aria-describedby="g11">3.3.3 Suggestion après une erreur (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-suggestions" rel="external" aria-describedby="g33">3.3.3 Suggestion après une erreur (Niveau&#160;AA)</a></legend>
 						<input id="aap333" type="radio" name="sc333" value="pass"><label for="aap333">Réussi</label>
 						<input id="aaf333" type="radio" name="sc333" value="fail"><label for="aaf333">Échouée</label>
 						<input id="aan333" type="radio" name="sc333" value="na"><label for="aan333"><abbr title="Sans objet">S/O</abbr></label>
@@ -391,7 +487,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-reversible" rel="external" aria-describedby="g11">3.3.4 Prévention des erreurs (juridiques, financières, de données) (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-reversible" rel="external" aria-describedby="g33">3.3.4 Prévention des erreurs (juridiques, financières, de données) (Niveau&#160;AA)</a></legend>
 						<input id="aap334" type="radio" name="sc334" value="pass"><label for="aap334">Réussi</label>
 						<input id="aaf334" type="radio" name="sc334" value="fail"><label for="aaf334">Échouée</label>
 						<input id="aan334" type="radio" name="sc334" value="na"><label for="aan334"><abbr title="Sans objet">S/O</abbr></label>
@@ -404,11 +500,11 @@
 	<section>
 		<h3 id="wcag4"><b>Principe&#160;:</b> Robuste</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g12"><b>Règle 4.1 Compatible&#160;:</b> Optimiser la compatibilité avec les agents utilisateurs actuels et futurs, y compris les technologies d'assistance.</h4>
+			<h4 id="g41"><b>Règle 4.1 Compatible&#160;:</b> Optimiser la compatibilité avec les agents utilisateurs actuels et futurs, y compris les technologies d'assistance.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#ensure-compat-parses" rel="external" aria-describedby="g12">4.1.1 Analyse syntaxique (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#ensure-compat-parses" rel="external" aria-describedby="g41">4.1.1 Analyse syntaxique (Niveau&#160;A)</a></legend>
 						<input id="ap411" type="radio" name="sc411" value="pass"><label for="ap411">Réussi</label>
 						<input id="af411" type="radio" name="sc411" value="fail"><label for="af411">Échouée</label>
 						<input id="an411" type="radio" name="sc411" value="na"><label for="an411"><abbr title="Sans objet">S/O</abbr></label>
@@ -416,10 +512,18 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#ensure-compat-rsv" rel="external" aria-describedby="g12">4.1.2 Nom, rôle et valeur (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#ensure-compat-rsv" rel="external" aria-describedby="g41">4.1.2 Nom, rôle et valeur (Niveau&#160;A)</a></legend>
 						<input id="ap412" type="radio" name="sc412" value="pass"><label for="ap412">Réussi</label>
 						<input id="af412" type="radio" name="sc412" value="fail"><label for="af412">Échouée</label>
 						<input id="an412" type="radio" name="sc412" value="na"><label for="an412"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#status-messages" rel="external" aria-describedby="g41"><span lang="en">4.1.3 Status Messages (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap413" type="radio" name="sc413" value="pass"><label for="aap413">Réussi</label>
+						<input id="aaf413" type="radio" name="sc413" value="fail"><label for="aaf413">Échouée</label>
+						<input id="aan413" type="radio" name="sc413" value="na"><label for="aan413"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -432,23 +536,23 @@
 			<tbody>
 				<tr>
 					<th scope="row">Critères de succès de niveau&#160;A réussis</th>
-					<td class="text-right"><span id="rsltA"></span>/25 (<span id="percA"></span>%)</td>
+					<td class="text-right"><span id="rsltA"></span>/30 (<span id="percA"></span>%)</td>
 				</tr>
 				<tr>
 					<th scope="row">Critères de succès de niveau&#160;AA réussis</th>
-					<td class="text-right"><span id="rsltAA"></span>/13 (<span id="percAA"></span>%)</td>
+					<td class="text-right"><span id="rsltAA"></span>/20 (<span id="percAA"></span>%)</td>
 				</tr>
 				<tr class="success">
 					<th scope="row">Critères de succès totaux réussis</th>
-					<td class="text-right"><span id="rsltTotal"></span>/38 (<span id="percTotal"></span>%)</td>
+					<td class="text-right"><span id="rsltTotal"></span>/50 (<span id="percTotal"></span>%)</td>
 				</tr>
 				<tr class="active">
 					<th scope="row">Critéres de succès évalués</th>
-					<td class="text-right"><span id="evalTotal"></span>/38 (<span id="percEvalTotal"></span>%)</td>
+					<td class="text-right"><span id="evalTotal"></span>/50 (<span id="percEvalTotal"></span>%)</td>
 				</tr>
 				<tr class="active">
 					<th scope="row">Critéres de succès <abbr title="Sans objet">S/O</abbr></th>
-					<td class="text-right"><span id="naTotal"></span>/38 (<span id="percNATotal"></span>%)</td>
+					<td class="text-right"><span id="naTotal"></span>/50 (<span id="percNATotal"></span>%)</td>
 				</tr>
 			</tbody>
 		</table>

--- a/src/other/wamethod/wamethod-AAA-en.hbs
+++ b/src/other/wamethod/wamethod-AAA-en.hbs
@@ -3,25 +3,24 @@
 	"title": "Web Accessibility Assessment Methodology (Level AAA)",
 	"language": "en",
 	"category": "Other",
-	"description": "Provides an assessment methodology that assists with measuring conformance to the Web Content Accessibility Guidelines (WCAG) 2.0 Level A, AA, and AAA Success Criteria.",
+	"description": "Provides an assessment methodology that assists with measuring conformance to the Web Content Accessibility Guidelines (WCAG) 2.1 Level A, AA, and AAA Success Criteria.",
 	"tag": "wamethod",
 	"parentdir": "wamethod",
 	"altLangPrefix": "wamethod-AAA",
 	"css": ["demo/wamethod"],
 	"js": ["demo/wamethod"],
-	"dateModified": "2014-02-19"
+	"dateModified": "2019-08-05"
 }
 ---
-
 <section>
 	<h2>Purpose</h2>
-	<p>Assist with measuring conformance to the <a href="https://www.w3.org/TR/WCAG20/" rel="external">Web Content Accessibility Guidelines (WCAG)&#160;2.0</a> Level&#160;A, Level&#160;AA and Level&#160;AAA <a href="#success">Success Criteria</a>.</p>
+	<p>Assist with measuring conformance to the <a href="https://www.w3.org/TR/WCAG21/" rel="external">Web Content Accessibility Guidelines (WCAG)&#160;2.1</a> Level&#160;A, Level&#160;AA and Level&#160;AAA <a href="#success">Success Criteria</a>.</p>
 </section>
 
 <nav role="navigation">
 	<h2>Table of Contents</h2>
 	<ul>
-		<li><a href="#wcag"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.0 Success Criteria Checklist</a>
+		<li><a href="#wcag"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.1 Success Criteria Checklist</a>
 			<ul>
 				<li><a href="#wcag1">Principle: Perceivable</a></li>
 				<li><a href="#wcag2">Principle: Operable</a></li>
@@ -34,9 +33,9 @@
 	</ul>
 </nav>
 
-<p>The following are required for a <a href="#webpagedef">Web page</a> to satisfy a <abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.0 Success Criterion:</p>
+<p>The following are required for a <a href="#webpagedef">Web page</a> to satisfy a <abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.1 Success Criterion:</p>
 <ol>
-	<li>Web page successfully avoids each <a href="https://www.w3.org/TR/WCAG20-TECHS/failures.html" rel="external">common failure</a> of the Success Criterion.</li>
+	<li>Web page successfully avoids each <a href="https://www.w3.org/WAI/WCAG21/Techniques/#failures" rel="external">common failure</a> of the Success Criterion.</li>
 	<li>Web page successfully implements <a href="#sufftech">sufficient techniques</a> or combinations of sufficient techniques for the Success Criterion that are:
 		<ol>
 			<li>Specific to each applicable situation; and</li>
@@ -46,15 +45,15 @@
 </ol>
 
 <section class="wb-wamethod">
-	<h2 id="wcag"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.0 Success Criteria Checklist (12&#160;Guidelines, 61&#160;Success Criteria)</h2>
+	<h2 id="wcag"><abbr title="Web Content Accessibility Guidelines">WCAG</abbr>&#160;2.1 Success Criteria Checklist (13&#160;Guidelines, 78&#160;Success Criteria)</h2>
 	<section>
 		<h3 id="wcag1"><b>Principle:</b> Perceivable</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g1"><b>Guideline 1.1 Text Alternatives:</b> Provide text alternatives for any non-text content so that it can be changed into other forms people need, such as large print, braille, speech, symbols or simpler language.</h4>
+			<h4 id="g11"><b>Guideline 1.1 Text Alternatives:</b> Provide text alternatives for any non-text content so that it can be changed into other forms people need, such as large print, braille, speech, symbols or simpler language.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#text-equiv-all" rel="external" aria-describedby="g1">1.1.1 Non-text content (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#text-equiv-all" rel="external" aria-describedby="g11">1.1.1 Non-text content (Level&#160;A)</a></legend>
 						<input id="ap111" type="radio" name="sc111" value="pass"><label for="ap111">Pass</label>
 						<input id="af111" type="radio" name="sc111" value="fail"><label for="af111">Fail</label>
 						<input id="an111" type="radio" name="sc111" value="na"><label for="an111"><abbr title="Not applicable">N/A</abbr></label>
@@ -63,11 +62,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g2"><b>Guideline 1.2 Time-based Media:</b> Provide alternatives for time-based media.</h4>
+			<h4 id="g12"><b>Guideline 1.2 Time-based Media:</b> Provide alternatives for time-based media.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt" rel="external" aria-describedby="g2">1.2.1 Audio-only and Video-only (Prerecorded) (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt" rel="external" aria-describedby="g12">1.2.1 Audio-only and Video-only (Prerecorded) (Level&#160;A)</a></legend>
 						<input id="ap121" type="radio" name="sc121" value="pass"><label for="ap121">Pass</label>
 						<input id="af121" type="radio" name="sc121" value="fail"><label for="af121">Fail</label>
 						<input id="an121" type="radio" name="sc121" value="na"><label for="an121"><abbr title="Not applicable">N/A</abbr></label>
@@ -75,7 +74,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions" rel="external" aria-describedby="g2">1.2.2 Captions (Prerecorded) (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions" rel="external" aria-describedby="g12">1.2.2 Captions (Prerecorded) (Level&#160;A)</a></legend>
 						<input id="ap122" type="radio" name="sc122" value="pass"><label for="ap122">Pass</label>
 						<input id="af122" type="radio" name="sc122" value="fail"><label for="af122">Fail</label>
 						<input id="an122" type="radio" name="sc122" value="na"><label for="an122"><abbr title="Not applicable">N/A</abbr></label>
@@ -83,7 +82,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc" rel="external" aria-describedby="g2">1.2.3 Audio Description or Media Alternative (Prerecorded) (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc" rel="external" aria-describedby="g12">1.2.3 Audio Description or Media Alternative (Prerecorded) (Level&#160;A)</a></legend>
 						<input id="ap123" type="radio" name="sc123" value="pass"><label for="ap123">Pass</label>
 						<input id="af123" type="radio" name="sc123" value="fail"><label for="af123">Fail</label>
 						<input id="an123" type="radio" name="sc123" value="na"><label for="an123"><abbr title="Not applicable">N/A</abbr></label>
@@ -91,7 +90,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions" rel="external" aria-describedby="g2">1.2.4 Captions (Live) (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions" rel="external" aria-describedby="g12">1.2.4 Captions (Live) (Level&#160;AA)</a></legend>
 						<input id="aap124" type="radio" name="sc124" value="pass"><label for="aap124">Pass</label>
 						<input id="aaf124" type="radio" name="sc124" value="fail"><label for="aaf124">Fail</label>
 						<input id="aan124" type="radio" name="sc124" value="na"><label for="aan124"><abbr title="Not applicable">N/A</abbr></label>
@@ -99,7 +98,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only" rel="external" aria-describedby="g2">1.2.5 Audio Description (Prerecorded) (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only" rel="external" aria-describedby="g12">1.2.5 Audio Description (Prerecorded) (Level&#160;AA)</a></legend>
 						<input id="aap125" type="radio" name="sc125" value="pass"><label for="aap125">Pass</label>
 						<input id="aaf125" type="radio" name="sc125" value="fail"><label for="aaf125">Fail</label>
 						<input id="aan125" type="radio" name="sc125" value="na"><label for="aan125"><abbr title="Not applicable">N/A</abbr></label>
@@ -107,7 +106,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-sign" rel="external" aria-describedby="g2">1.2.6 Sign Language (Prerecorded) (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-sign" rel="external" aria-describedby="g12">1.2.6 Sign Language (Prerecorded) (Level&#160;AAA)</a></legend>
 						<input id="aaap126" type="radio" name="sc126" value="pass"><label for="aaap126">Pass</label>
 						<input id="aaaf126" type="radio" name="sc126" value="fail"><label for="aaaf126">Fail</label>
 						<input id="aaan126" type="radio" name="sc126" value="na"><label for="aaan126"><abbr title="Not applicable">N/A</abbr></label>
@@ -115,7 +114,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad" rel="external" aria-describedby="g2">1.2.7 Extended Audio Description (Prerecorded) (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad" rel="external" aria-describedby="g12">1.2.7 Extended Audio Description (Prerecorded) (Level&#160;AAA)</a></legend>
 						<input id="aaap127" type="radio" name="sc127" value="pass"><label for="aaap127">Pass</label>
 						<input id="aaaf127" type="radio" name="sc127" value="fail"><label for="aaaf127">Fail</label>
 						<input id="aaan127" type="radio" name="sc127" value="na"><label for="aaan127"><abbr title="Not applicable">N/A</abbr></label>
@@ -123,7 +122,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-text-doc" rel="external" aria-describedby="g2">1.2.8 Media Alternative (Prerecorded) (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-text-doc" rel="external" aria-describedby="g12">1.2.8 Media Alternative (Prerecorded) (Level&#160;AAA)</a></legend>
 						<input id="aaap128" type="radio" name="sc128" value="pass"><label for="aaap128">Pass</label>
 						<input id="aaaf128" type="radio" name="sc128" value="fail"><label for="aaaf128">Fail</label>
 						<input id="aaan128" type="radio" name="sc128" value="na"><label for="aaan128"><abbr title="Not applicable">N/A</abbr></label>
@@ -131,7 +130,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only" rel="external" aria-describedby="g2">1.2.9 Audio-only (Live) (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only" rel="external" aria-describedby="g12">1.2.9 Audio-only (Live) (Level&#160;AAA)</a></legend>
 						<input id="aaap129" type="radio" name="sc129" value="pass"><label for="aaap129">Pass</label>
 						<input id="aaaf129" type="radio" name="sc129" value="fail"><label for="aaaf129">Fail</label>
 						<input id="aaan129" type="radio" name="sc129" value="na"><label for="aaan129"><abbr title="Not applicable">N/A</abbr></label>
@@ -140,11 +139,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g3"><b>Guideline 1.3 Adaptable:</b> Create content that can be presented in different ways (for example simpler layout) without losing information or structure.</h4>
+			<h4 id="g13"><b>Guideline 1.3 Adaptable:</b> Create content that can be presented in different ways (for example simpler layout) without losing information or structure.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic" rel="external" aria-describedby="g3">1.3.1 Info and Relationships (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic" rel="external" aria-describedby="g13">1.3.1 Info and Relationships (Level&#160;A)</a></legend>
 						<input id="ap131" type="radio" name="sc131" value="pass"><label for="ap131">Pass</label>
 						<input id="af131" type="radio" name="sc131" value="fail"><label for="af131">Fail</label>
 						<input id="an131" type="radio" name="sc131" value="na"><label for="an131"><abbr title="Not applicable">N/A</abbr></label>
@@ -152,7 +151,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence" rel="external" aria-describedby="g3">1.3.2 Meaningful Sequence (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence" rel="external" aria-describedby="g13">1.3.2 Meaningful Sequence (Level&#160;A)</a></legend>
 						<input id="ap132" type="radio" name="sc132" value="pass"><label for="ap132">Pass</label>
 						<input id="af132" type="radio" name="sc132" value="fail"><label for="af132">Fail</label>
 						<input id="an132" type="radio" name="sc132" value="na"><label for="an132"><abbr title="Not applicable">N/A</abbr></label>
@@ -160,20 +159,44 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding" rel="external" aria-describedby="g3">1.3.3 Sensory Characteristics (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding" rel="external" aria-describedby="g13">1.3.3 Sensory Characteristics (Level&#160;A)</a></legend>
 						<input id="ap133" type="radio" name="sc133" value="pass"><label for="ap133">Pass</label>
 						<input id="af133" type="radio" name="sc133" value="fail"><label for="af133">Fail</label>
 						<input id="an133" type="radio" name="sc133" value="na"><label for="an133"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#orientation" rel="external" aria-describedby="g13">1.3.4 Orientation (Level&#160;AA)</a></legend>
+						<input id="aap134" type="radio" name="sc134" value="pass"><label for="aap134">Pass</label>
+						<input id="aaf134" type="radio" name="sc134" value="fail"><label for="aaf134">Fail</label>
+						<input id="aan134" type="radio" name="sc134" value="na"><label for="aan134"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#identify-input-purpose" rel="external" aria-describedby="g13">1.3.5 Identify Input Purpose (Level&#160;AA)</a></legend>
+						<input id="aap135" type="radio" name="sc135" value="pass"><label for="aap135">Pass</label>
+						<input id="aaf135" type="radio" name="sc135" value="fail"><label for="aaf135">Fail</label>
+						<input id="aan135" type="radio" name="sc135" value="na"><label for="aan135"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#identify-purpose" rel="external" aria-describedby="g13">1.3.6 Identify Purpose (Level&#160;AAA)</a></legend>
+						<input id="aaap136" type="radio" name="sc136" value="pass"><label for="aaap136">Pass</label>
+						<input id="aaaf136" type="radio" name="sc136" value="fail"><label for="aaaf136">Fail</label>
+						<input id="aaan136" type="radio" name="sc136" value="na"><label for="aaan136"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g4"><b>Guideline 1.4 Distinguishable:</b> Make it easier for users to see and hear content including separating foreground from background.</h4>
+			<h4 id="g14"><b>Guideline 1.4 Distinguishable:</b> Make it easier for users to see and hear content including separating foreground from background.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color" rel="external" aria-describedby="g4">1.4.1 Use of Color (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color" rel="external" aria-describedby="g14">1.4.1 Use of Color (Level&#160;A)</a></legend>
 						<input id="ap141" type="radio" name="sc141" value="pass"><label for="ap141">Pass</label>
 						<input id="af141" type="radio" name="sc141" value="fail"><label for="af141">Fail</label>
 						<input id="an141" type="radio" name="sc141" value="na"><label for="an141"><abbr title="Not applicable">N/A</abbr></label>
@@ -181,7 +204,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio" rel="external" aria-describedby="g4">1.4.2 Audio Control (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio" rel="external" aria-describedby="g14">1.4.2 Audio Control (Level&#160;A)</a></legend>
 						<input id="ap142" type="radio" name="sc142" value="pass"><label for="ap142">Pass</label>
 						<input id="af142" type="radio" name="sc142" value="fail"><label for="af142">Fail</label>
 						<input id="an142" type="radio" name="sc142" value="na"><label for="an142"><abbr title="Not applicable">N/A</abbr></label>
@@ -189,7 +212,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast" rel="external" aria-describedby="g4">1.4.3 Contrast (Minimum) (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast" rel="external" aria-describedby="g14">1.4.3 Contrast (Minimum) (Level&#160;AA)</a></legend>
 						<input id="aap143" type="radio" name="sc143" value="pass"><label for="aap143">Pass</label>
 						<input id="aaf143" type="radio" name="sc143" value="fail"><label for="aaf143">Fail</label>
 						<input id="aan143" type="radio" name="sc143" value="na"><label for="aan143"><abbr title="Not applicable">N/A</abbr></label>
@@ -197,7 +220,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale" rel="external" aria-describedby="g4">1.4.4 Resize text (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale" rel="external" aria-describedby="g14">1.4.4 Resize text (Level&#160;AA)</a></legend>
 						<input id="aap144" type="radio" name="sc144" value="pass"><label for="aap144">Pass</label>
 						<input id="aaf144" type="radio" name="sc144" value="fail"><label for="aaf144">Fail</label>
 						<input id="aan144" type="radio" name="sc144" value="na"><label for="aan144"><abbr title="Not applicable">N/A</abbr></label>
@@ -205,7 +228,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation" rel="external" aria-describedby="g4">1.4.5 Images of Text (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation" rel="external" aria-describedby="g14">1.4.5 Images of Text (Level&#160;AA)</a></legend>
 						<input id="aap145" type="radio" name="sc145" value="pass"><label for="aap145">Pass</label>
 						<input id="aaf145" type="radio" name="sc145" value="fail"><label for="aaf145">Fail</label>
 						<input id="aan145" type="radio" name="sc145" value="na"><label for="aan145"><abbr title="Not applicable">N/A</abbr></label>
@@ -213,7 +236,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7" rel="external" aria-describedby="g4">1.4.6 Contrast (Enhanced) (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7" rel="external" aria-describedby="g14">1.4.6 Contrast (Enhanced) (Level&#160;AAA)</a></legend>
 						<input id="aaap146" type="radio" name="sc146" value="pass"><label for="aaap146">Pass</label>
 						<input id="aaaf146" type="radio" name="sc146" value="fail"><label for="aaaf146">Fail</label>
 						<input id="aaan146" type="radio" name="sc146" value="na"><label for="aaan146"><abbr title="Not applicable">N/A</abbr></label>
@@ -221,7 +244,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio" rel="external" aria-describedby="g4">1.4.7 Low or No Background Audio (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio" rel="external" aria-describedby="g14">1.4.7 Low or No Background Audio (Level&#160;AAA)</a></legend>
 						<input id="aaap147" type="radio" name="sc147" value="pass"><label for="aaap147">Pass</label>
 						<input id="aaaf147" type="radio" name="sc147" value="fail"><label for="aaaf147">Fail</label>
 						<input id="aaan147" type="radio" name="sc147" value="na"><label for="aaan147"><abbr title="Not applicable">N/A</abbr></label>
@@ -229,7 +252,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation" rel="external" aria-describedby="g4">1.4.8 Visual Presentation (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation" rel="external" aria-describedby="g14">1.4.8 Visual Presentation (Level&#160;AAA)</a></legend>
 						<input id="aaap148" type="radio" name="sc148" value="pass"><label for="aaap148">Pass</label>
 						<input id="aaaf148" type="radio" name="sc148" value="fail"><label for="aaaf148">Fail</label>
 						<input id="aaan148" type="radio" name="sc148" value="na"><label for="aaan148"><abbr title="Not applicable">N/A</abbr></label>
@@ -237,10 +260,42 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images" rel="external" aria-describedby="g4">1.4.9 Images of Text (No Exception) (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images" rel="external" aria-describedby="g14">1.4.9 Images of Text (No Exception) (Level&#160;AAA)</a></legend>
 						<input id="aaap149" type="radio" name="sc149" value="pass"><label for="aaap149">Pass</label>
 						<input id="aaaf149" type="radio" name="sc149" value="fail"><label for="aaaf149">Fail</label>
 						<input id="aaan149" type="radio" name="sc149" value="na"><label for="aaan149"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#reflow" rel="external" aria-describedby="g14">1.4.10 Reflow (Level&#160;AA)</a></legend>
+						<input id="aap1410" type="radio" name="sc1410" value="pass"><label for="aap1410">Pass</label>
+						<input id="aaf1410" type="radio" name="sc1410" value="fail"><label for="aaf1410">Fail</label>
+						<input id="aan1410" type="radio" name="sc1410" value="na"><label for="aan1410"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#non-text-contrast" rel="external" aria-describedby="g14">1.4.11 Non-Text Contrast (Level&#160;AA)</a></legend>
+						<input id="aap1411" type="radio" name="sc1411" value="pass"><label for="aap1411">Pass</label>
+						<input id="aaf1411" type="radio" name="sc1411" value="fail"><label for="aaf1411">Fail</label>
+						<input id="aan1411" type="radio" name="sc1411" value="na"><label for="aan1411"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#text-spacing" rel="external" aria-describedby="g14">1.4.12 Text Spacing (Level&#160;AA)</a></legend>
+						<input id="aap1412" type="radio" name="sc1412" value="pass"><label for="aap1412">Pass</label>
+						<input id="aaf1412" type="radio" name="sc1412" value="fail"><label for="aaf1412">Fail</label>
+						<input id="aan1412" type="radio" name="sc1412" value="na"><label for="aan1412"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus" rel="external" aria-describedby="g14">1.4.13 Content on Hover or Focus (Level&#160;AA)</a></legend>
+						<input id="aap1413" type="radio" name="sc1413" value="pass"><label for="aap1413">Pass</label>
+						<input id="aaf1413" type="radio" name="sc1413" value="fail"><label for="aaf1413">Fail</label>
+						<input id="aan1413" type="radio" name="sc1413" value="na"><label for="aan1413"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -250,11 +305,11 @@
 	<section>
 		<h3 id="wcag2"><b>Principle:</b> Operable</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g5"><b>Guideline 2.1 Keyboard Accessible:</b> Make all functionality available from a keyboard.</h4>
+			<h4 id="g21"><b>Guideline 2.1 Keyboard Accessible:</b> Make all functionality available from a keyboard.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable" rel="external" aria-describedby="g5">2.1.1 Keyboard (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable" rel="external" aria-describedby="g21">2.1.1 Keyboard (Level&#160;A)</a></legend>
 						<input id="ap211" type="radio" name="sc211" value="pass"><label for="ap211">Pass</label>
 						<input id="af211" type="radio" name="sc211" value="fail"><label for="af211">Fail</label>
 						<input id="an211" type="radio" name="sc211" value="na"><label for="an211"><abbr title="Not applicable">N/A</abbr></label>
@@ -262,7 +317,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping" rel="external" aria-describedby="g5">2.1.2 No Keyboard Trap (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping" rel="external" aria-describedby="g21">2.1.2 No Keyboard Trap (Level&#160;A)</a></legend>
 						<input id="ap212" type="radio" name="sc212" value="pass"><label for="ap212">Pass</label>
 						<input id="af212" type="radio" name="sc212" value="fail"><label for="af212">Fail</label>
 						<input id="an212" type="radio" name="sc212" value="na"><label for="an212"><abbr title="Not applicable">N/A</abbr></label>
@@ -270,20 +325,28 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs" rel="external" aria-describedby="g5">2.1.3 Keyboard (No Exception) (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs" rel="external" aria-describedby="g21">2.1.3 Keyboard (No Exception) (Level&#160;AAA)</a></legend>
 						<input id="aaap213" type="radio" name="sc213" value="pass"><label for="aaap213">Pass</label>
 						<input id="aaaf213" type="radio" name="sc213" value="fail"><label for="aaaf213">Fail</label>
 						<input id="aaan213" type="radio" name="sc213" value="na"><label for="aaan213"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#character-key-shortcuts" rel="external" aria-describedby="g21">2.1.4 Character Key Shortcuts (Level&#160;A)</a></legend>
+						<input id="ap214" type="radio" name="sc214" value="pass"><label for="ap214">Pass</label>
+						<input id="af214" type="radio" name="sc214" value="fail"><label for="af214">Fail</label>
+						<input id="an214" type="radio" name="sc214" value="na"><label for="an214"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g6"><b>Guideline 2.2 Enough Time:</b> Provide users enough time to read and use content.</h4>
+			<h4 id="g22"><b>Guideline 2.2 Enough Time:</b> Provide users enough time to read and use content.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors" rel="external" aria-describedby="g6">2.2.1 Timing Adjustable (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors" rel="external" aria-describedby="g22">2.2.1 Timing Adjustable (Level&#160;A)</a></legend>
 						<input id="ap221" type="radio" name="sc221" value="pass"><label for="ap221">Pass</label>
 						<input id="af221" type="radio" name="sc221" value="fail"><label for="af221">Fail</label>
 						<input id="an221" type="radio" name="sc221" value="na"><label for="an221"><abbr title="Not applicable">N/A</abbr></label>
@@ -291,7 +354,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-pause" rel="external" aria-describedby="g6">2.2.2 Pause, Stop, Hide (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-pause" rel="external" aria-describedby="g22">2.2.2 Pause, Stop, Hide (Level&#160;A)</a></legend>
 						<input id="ap222" type="radio" name="sc222" value="pass"><label for="ap222">Pass</label>
 						<input id="af222" type="radio" name="sc222" value="fail"><label for="af222">Fail</label>
 						<input id="an222" type="radio" name="sc222" value="na"><label for="an222"><abbr title="Not applicable">N/A</abbr></label>
@@ -299,7 +362,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions" rel="external" aria-describedby="g6">2.2.3 No Timing (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions" rel="external" aria-describedby="g22">2.2.3 No Timing (Level&#160;AAA)</a></legend>
 						<input id="aaap223" type="radio" name="sc223" value="pass"><label for="aaap223">Pass</label>
 						<input id="aaaf223" type="radio" name="sc223" value="fail"><label for="aaaf223">Fail</label>
 						<input id="aaan223" type="radio" name="sc223" value="na"><label for="aaan223"><abbr title="Not applicable">N/A</abbr></label>
@@ -307,7 +370,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-postponed" rel="external" aria-describedby="g6">2.2.4 Interruptions (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-postponed" rel="external" aria-describedby="g22">2.2.4 Interruptions (Level&#160;AAA)</a></legend>
 						<input id="aaap224" type="radio" name="sc224" value="pass"><label for="aaap224">Pass</label>
 						<input id="aaaf224" type="radio" name="sc224" value="fail"><label for="aaaf224">Fail</label>
 						<input id="aaan224" type="radio" name="sc224" value="na"><label for="aaan224"><abbr title="Not applicable">N/A</abbr></label>
@@ -315,20 +378,28 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-server-timeout" rel="external" aria-describedby="g6">2.2.5 Re-authenticating (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#time-limits-server-timeout" rel="external" aria-describedby="g22">2.2.5 Re-authenticating (Level&#160;AAA)</a></legend>
 						<input id="aaap225" type="radio" name="sc225" value="pass"><label for="aaap225">Pass</label>
 						<input id="aaaf225" type="radio" name="sc225" value="fail"><label for="aaaf225">Fail</label>
 						<input id="aaan225" type="radio" name="sc225" value="na"><label for="aaan225"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#timeouts" rel="external" aria-describedby="g22">2.2.6 Timeouts (Level&#160;AAA)</a></legend>
+						<input id="aaap226" type="radio" name="sc226" value="pass"><label for="aaap226">Pass</label>
+						<input id="aaaf226" type="radio" name="sc226" value="fail"><label for="aaaf226">Fail</label>
+						<input id="aaan226" type="radio" name="sc226" value="na"><label for="aaan226"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g7"><b>Guideline 2.3 Seizures:</b> Do not design content in a way that is known to cause seizures.</h4>
+			<h4 id="g23"><b>Guideline 2.3 Seizures:</b> Do not design content in a way that is known to cause seizures.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate" rel="external" aria-describedby="g7">2.3.1 Three Flashes or Below Threshold (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate" rel="external" aria-describedby="g23">2.3.1 Three Flashes or Below Threshold (Level&#160;A)</a></legend>
 						<input id="ap231" type="radio" name="sc231" value="pass"><label for="ap231">Pass</label>
 						<input id="af231" type="radio" name="sc231" value="fail"><label for="af231">Fail</label>
 						<input id="an231" type="radio" name="sc231" value="na"><label for="an231"><abbr title="Not applicable">N/A</abbr></label>
@@ -336,20 +407,28 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#seizure-three-times" rel="external" aria-describedby="g7">2.3.2 Three Flashes (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#seizure-three-times" rel="external" aria-describedby="g23">2.3.2 Three Flashes (Level&#160;AAA)</a></legend>
 						<input id="aaap232" type="radio" name="sc232" value="pass"><label for="aaap232">Pass</label>
 						<input id="aaaf232" type="radio" name="sc232" value="fail"><label for="aaaf232">Fail</label>
 						<input id="aaan232" type="radio" name="sc232" value="na"><label for="aaan232"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#animation-from-interactions" rel="external" aria-describedby="g23">2.3.3 Animation from Interactions (Level&#160;AAA)</a></legend>
+						<input id="aaap233" type="radio" name="sc233" value="pass"><label for="aaap233">Pass</label>
+						<input id="aaaf233" type="radio" name="sc233" value="fail"><label for="aaaf233">Fail</label>
+						<input id="aaan233" type="radio" name="sc233" value="na"><label for="aaan233"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g8"><b>Guideline 2.4 Navigable:</b> Provide ways to help users navigate, find content, and determine where they are.</h4>
+			<h4 id="g24"><b>Guideline 2.4 Navigable:</b> Provide ways to help users navigate, find content, and determine where they are.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip" rel="external" aria-describedby="g8">2.4.1 Bypass Blocks (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip" rel="external" aria-describedby="g24">2.4.1 Bypass Blocks (Level&#160;A)</a></legend>
 						<input id="ap241" type="radio" name="sc241" value="pass"><label for="ap241">Pass</label>
 						<input id="af241" type="radio" name="sc241" value="fail"><label for="af241">Fail</label>
 						<input id="an241" type="radio" name="sc241" value="na"><label for="an241"><abbr title="Not applicable">N/A</abbr></label>
@@ -357,7 +436,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title" rel="external" aria-describedby="g8">2.4.2 Page Titled (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title" rel="external" aria-describedby="g24">2.4.2 Page Titled (Level&#160;A)</a></legend>
 						<input id="ap242" type="radio" name="sc242" value="pass"><label for="ap242">Pass</label>
 						<input id="af242" type="radio" name="sc242" value="fail"><label for="af242">Fail</label>
 						<input id="an242" type="radio" name="sc242" value="na"><label for="an242"><abbr title="Not applicable">N/A</abbr></label>
@@ -365,7 +444,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order" rel="external" aria-describedby="g8">2.4.3 Focus Order (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order" rel="external" aria-describedby="g24">2.4.3 Focus Order (Level&#160;A)</a></legend>
 						<input id="ap243" type="radio" name="sc243" value="pass"><label for="ap243">Pass</label>
 						<input id="af243" type="radio" name="sc243" value="fail"><label for="af243">Fail</label>
 						<input id="an243" type="radio" name="sc243" value="na"><label for="an243"><abbr title="Not applicable">N/A</abbr></label>
@@ -373,7 +452,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs" rel="external" aria-describedby="g8">2.4.4 Link Purpose (In Context) (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs" rel="external" aria-describedby="g24">2.4.4 Link Purpose (In Context) (Level&#160;A)</a></legend>
 						<input id="ap244" type="radio" name="sc244" value="pass"><label for="ap244">Pass</label>
 						<input id="af244" type="radio" name="sc244" value="fail"><label for="af244">Fail</label>
 						<input id="an244" type="radio" name="sc244" value="na"><label for="an244"><abbr title="Not applicable">N/A</abbr></label>
@@ -381,7 +460,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc" rel="external" aria-describedby="g8">2.4.5 Multiple ways (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc" rel="external" aria-describedby="g24">2.4.5 Multiple ways (Level&#160;AA)</a></legend>
 						<input id="aap245" type="radio" name="sc245" value="pass"><label for="aap245">Pass</label>
 						<input id="aaf245" type="radio" name="sc245" value="fail"><label for="aaf245">Fail</label>
 						<input id="aan245" type="radio" name="sc245" value="na"><label for="aan245"><abbr title="Not applicable">N/A</abbr></label>
@@ -389,7 +468,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive" rel="external" aria-describedby="g8">2.4.6 Headings and Labels (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive" rel="external" aria-describedby="g24">2.4.6 Headings and Labels (Level&#160;AA)</a></legend>
 						<input id="aap246" type="radio" name="sc246" value="pass"><label for="aap246">Pass</label>
 						<input id="aaf246" type="radio" name="sc246" value="fail"><label for="aaf246">Fail</label>
 						<input id="aan246" type="radio" name="sc246" value="na"><label for="aan246"><abbr title="Not applicable">N/A</abbr></label>
@@ -397,7 +476,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible" rel="external" aria-describedby="g8">2.4.7 Focus Visible (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible" rel="external" aria-describedby="g24">2.4.7 Focus Visible (Level&#160;AA)</a></legend>
 						<input id="aap247" type="radio" name="sc247" value="pass"><label for="aap247">Pass</label>
 						<input id="aaf247" type="radio" name="sc247" value="fail"><label for="aaf247">Fail</label>
 						<input id="aan247" type="radio" name="sc247" value="na"><label for="aan247"><abbr title="Not applicable">N/A</abbr></label>
@@ -405,7 +484,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location" rel="external" aria-describedby="g8">2.4.8 Location (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location" rel="external" aria-describedby="g24">2.4.8 Location (Level&#160;AAA)</a></legend>
 						<input id="aaap248" type="radio" name="sc248" value="pass"><label for="aaap248">Pass</label>
 						<input id="aaaf248" type="radio" name="sc248" value="fail"><label for="aaaf248">Fail</label>
 						<input id="aaan248" type="radio" name="sc248" value="na"><label for="aaan248"><abbr title="Not applicable">N/A</abbr></label>
@@ -413,7 +492,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link" rel="external" aria-describedby="g8">2.4.9 Link Purpose (Link Only) (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link" rel="external" aria-describedby="g24">2.4.9 Link Purpose (Link Only) (Level&#160;AAA)</a></legend>
 						<input id="aaap249" type="radio" name="sc249" value="pass"><label for="aaap249">Pass</label>
 						<input id="aaaf249" type="radio" name="sc249" value="fail"><label for="aaaf249">Fail</label>
 						<input id="aaan249" type="radio" name="sc249" value="na"><label for="aaan249"><abbr title="Not applicable">N/A</abbr></label>
@@ -421,10 +500,63 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings" rel="external" aria-describedby="g8">2.4.10 Section Headings (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings" rel="external" aria-describedby="g24">2.4.10 Section Headings (Level&#160;AAA)</a></legend>
 						<input id="aaap2410" type="radio" name="sc2410" value="pass"><label for="aaap2410">Pass</label>
 						<input id="aaaf2410" type="radio" name="sc2410" value="fail"><label for="aaaf2410">Fail</label>
 						<input id="aaan2410" type="radio" name="sc2410" value="na"><label for="aaan2410"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+			</ol>
+		</section>
+		<section class="mrgn-tp-lg">
+			<h4 id="g25"><b>Guideline 2.5 Input Modalities:</b> Make it easier for users to operate functionality through various inputs beyond keyboard.</h4>
+			<ol>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#pointer-gestures" rel="external" aria-describedby="g25">2.5.1 Pointer Gestures (Level&#160;A)</a></legend>
+						<input id="ap251" type="radio" name="sc251" value="pass"><label for="ap251">Pass</label>
+						<input id="af251" type="radio" name="sc251" value="fail"><label for="af251">Fail</label>
+						<input id="an251" type="radio" name="sc251" value="na"><label for="an251"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#pointer-cancellation" rel="external" aria-describedby="g25">2.5.2 Pointer Cancellation (Level&#160;A)</a></legend>
+						<input id="ap252" type="radio" name="sc252" value="pass"><label for="ap252">Pass</label>
+						<input id="af252" type="radio" name="sc252" value="fail"><label for="af252">Fail</label>
+						<input id="an252" type="radio" name="sc252" value="na"><label for="an252"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#label-in-name" rel="external" aria-describedby="g25">2.5.3 Label in Name (Level&#160;A)</a></legend>
+						<input id="ap253" type="radio" name="sc253" value="pass"><label for="ap253">Pass</label>
+						<input id="af253" type="radio" name="sc253" value="fail"><label for="af253">Fail</label>
+						<input id="an253" type="radio" name="sc253" value="na"><label for="an253"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#motion-actuation" rel="external" aria-describedby="g25">2.5.4 Motion Actuation (Level&#160;A)</a></legend>
+						<input id="ap254" type="radio" name="sc254" value="pass"><label for="ap254">Pass</label>
+						<input id="af254" type="radio" name="sc254" value="fail"><label for="af254">Fail</label>
+						<input id="an254" type="radio" name="sc254" value="na"><label for="an254"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#target-size" rel="external" aria-describedby="g25">2.5.5 Target Size (Level&#160;AAA)</a></legend>
+						<input id="aaap255" type="radio" name="sc255" value="pass"><label for="aaap255">Pass</label>
+						<input id="aaaf255" type="radio" name="sc255" value="fail"><label for="aaaf255">Fail</label>
+						<input id="aaan255" type="radio" name="sc255" value="na"><label for="aaan255"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#concurrent-input-mechanisms" rel="external" aria-describedby="g25">2.5.6 Concurrent Input Mechanisms (Level&#160;AAA)</a></legend>
+						<input id="aaap256" type="radio" name="sc256" value="pass"><label for="aaap256">Pass</label>
+						<input id="aaaf256" type="radio" name="sc256" value="fail"><label for="aaaf256">Fail</label>
+						<input id="aaan256" type="radio" name="sc256" value="na"><label for="aaan256"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -434,11 +566,11 @@
 	<section>
 		<h3 id="wcag3"><b>Principle:</b> Understandable</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g9"><b>Guideline 3.1 Readable:</b> Make text content readable and understandable.</h4>
+			<h4 id="g31"><b>Guideline 3.1 Readable:</b> Make text content readable and understandable.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id" rel="external" aria-describedby="g9">3.1.1 Language of Page (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id" rel="external" aria-describedby="g31">3.1.1 Language of Page (Level&#160;A)</a></legend>
 						<input id="ap311" type="radio" name="sc311" value="pass"><label for="ap311">Pass</label>
 						<input id="af311" type="radio" name="sc311" value="fail"><label for="af311">Fail</label>
 						<input id="an311" type="radio" name="sc311" value="na"><label for="an311"><abbr title="Not applicable">N/A</abbr></label>
@@ -446,7 +578,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id" rel="external" aria-describedby="g9">3.1.2 Language of Parts (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id" rel="external" aria-describedby="g31">3.1.2 Language of Parts (Level&#160;AA)</a></legend>
 						<input id="aap312" type="radio" name="sc312" value="pass"><label for="aap312">Pass</label>
 						<input id="aaf312" type="radio" name="sc312" value="fail"><label for="aaf312">Fail</label>
 						<input id="aan312" type="radio" name="sc312" value="na"><label for="aan312"><abbr title="Not applicable">N/A</abbr></label>
@@ -454,7 +586,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-idioms" rel="external" aria-describedby="g9">3.1.3 Unusual Words (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-idioms" rel="external" aria-describedby="g31">3.1.3 Unusual Words (Level&#160;AAA)</a></legend>
 						<input id="aaap313" type="radio" name="sc313" value="pass"><label for="aaap313">Pass</label>
 						<input id="aaaf313" type="radio" name="sc313" value="fail"><label for="aaaf313">Fail</label>
 						<input id="aaan313" type="radio" name="sc313" value="na"><label for="aaan313"><abbr title="Not applicable">N/A</abbr></label>
@@ -462,7 +594,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-located" rel="external" aria-describedby="g9">3.1.4 Abbreviations (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-located" rel="external" aria-describedby="g31">3.1.4 Abbreviations (Level&#160;AAA)</a></legend>
 						<input id="aaap314" type="radio" name="sc314" value="pass"><label for="aaap314">Pass</label>
 						<input id="aaaf314" type="radio" name="sc314" value="fail"><label for="aaaf314">Fail</label>
 						<input id="aaan314" type="radio" name="sc314" value="na"><label for="aaan314"><abbr title="Not applicable">N/A</abbr></label>
@@ -470,7 +602,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-supplements" rel="external" aria-describedby="g9">3.1.5 Reading Level (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-supplements" rel="external" aria-describedby="g31">3.1.5 Reading Level (Level&#160;AAA)</a></legend>
 						<input id="aaap315" type="radio" name="sc315" value="pass"><label for="aaap315">Pass</label>
 						<input id="aaaf315" type="radio" name="sc315" value="fail"><label for="aaaf315">Fail</label>
 						<input id="aaan315" type="radio" name="sc315" value="na"><label for="aaan315"><abbr title="Not applicable">N/A</abbr></label>
@@ -478,7 +610,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-pronunciation" rel="external" aria-describedby="g9">3.1.6 Pronunciation (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#meaning-pronunciation" rel="external" aria-describedby="g31">3.1.6 Pronunciation (Level&#160;AAA)</a></legend>
 						<input id="aaap316" type="radio" name="sc316" value="pass"><label for="aaap316">Pass</label>
 						<input id="aaaf316" type="radio" name="sc316" value="fail"><label for="aaaf316">Fail</label>
 						<input id="aaan316" type="radio" name="sc316" value="na"><label for="aaan316"><abbr title="Not applicable">N/A</abbr></label>
@@ -487,11 +619,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g10"><b>Guideline 3.2 Predictable:</b> Make Web pages appear and operate in predictable ways.</h4>
+			<h4 id="g32"><b>Guideline 3.2 Predictable:</b> Make Web pages appear and operate in predictable ways.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus" rel="external" aria-describedby="g10">3.2.1 On Focus (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus" rel="external" aria-describedby="g32">3.2.1 On Focus (Level&#160;A)</a></legend>
 						<input id="ap321" type="radio" name="sc321" value="pass"><label for="ap321">Pass</label>
 						<input id="af321" type="radio" name="sc321" value="fail"><label for="af321">Fail</label>
 						<input id="an321" type="radio" name="sc321" value="na"><label for="an321"><abbr title="Not applicable">N/A</abbr></label>
@@ -499,7 +631,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change" rel="external" aria-describedby="g10">3.2.2 On Input (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change" rel="external" aria-describedby="g32">3.2.2 On Input (Level&#160;A)</a></legend>
 						<input id="ap322" type="radio" name="sc322" value="pass"><label for="ap322">Pass</label>
 						<input id="af322" type="radio" name="sc322" value="fail"><label for="af322">Fail</label>
 						<input id="an322" type="radio" name="sc322" value="na"><label for="an322"><abbr title="Not applicable">N/A</abbr></label>
@@ -507,7 +639,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations" rel="external" aria-describedby="g10">3.2.3 Consistent Navigation (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations" rel="external" aria-describedby="g32">3.2.3 Consistent Navigation (Level&#160;AA)</a></legend>
 						<input id="aap323" type="radio" name="sc323" value="pass"><label for="aap323">Pass</label>
 						<input id="aaf323" type="radio" name="sc323" value="fail"><label for="aaf323">Fail</label>
 						<input id="aan323" type="radio" name="sc323" value="na"><label for="aan323"><abbr title="Not applicable">N/A</abbr></label>
@@ -515,7 +647,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality" rel="external" aria-describedby="g10">3.2.4 Consistent Identification (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality" rel="external" aria-describedby="g32">3.2.4 Consistent Identification (Level&#160;AA)</a></legend>
 						<input id="aap324" type="radio" name="sc324" value="pass"><label for="aap324">Pass</label>
 						<input id="aaf324" type="radio" name="sc324" value="fail"><label for="aaf324">Fail</label>
 						<input id="aan324" type="radio" name="sc324" value="na"><label for="aan324"><abbr title="Not applicable">N/A</abbr></label>
@@ -523,7 +655,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context" rel="external" aria-describedby="g10">3.2.5 Change on Request (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context" rel="external" aria-describedby="g32">3.2.5 Change on Request (Level&#160;AAA)</a></legend>
 						<input id="aaap325" type="radio" name="sc325" value="pass"><label for="aaap325">Pass</label>
 						<input id="aaaf325" type="radio" name="sc325" value="fail"><label for="aaaf325">Fail</label>
 						<input id="aaan325" type="radio" name="sc325" value="na"><label for="aaan325"><abbr title="Not applicable">N/A</abbr></label>
@@ -532,11 +664,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g11"><b>Guideline 3.3 Input Assistance:</b> Help users avoid and correct mistakes.</h4>
+			<h4 id="g33"><b>Guideline 3.3 Input Assistance:</b> Help users avoid and correct mistakes.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-identified" rel="external" aria-describedby="g11">3.3.1 Error Identification (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-identified" rel="external" aria-describedby="g33">3.3.1 Error Identification (Level&#160;A)</a></legend>
 						<input id="ap331" type="radio" name="sc331" value="pass"><label for="ap331">Pass</label>
 						<input id="af331" type="radio" name="sc331" value="fail"><label for="af331">Fail</label>
 						<input id="an331" type="radio" name="sc331" value="na"><label for="an331"><abbr title="Not applicable">N/A</abbr></label>
@@ -544,7 +676,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-cues" rel="external" aria-describedby="g11">3.3.2 Labels or Instructions (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-cues" rel="external" aria-describedby="g33">3.3.2 Labels or Instructions (Level&#160;A)</a></legend>
 						<input id="ap332" type="radio" name="sc332" value="pass"><label for="ap332">Pass</label>
 						<input id="af332" type="radio" name="sc332" value="fail"><label for="af332">Fail</label>
 						<input id="an332" type="radio" name="sc332" value="na"><label for="an332"><abbr title="Not applicable">N/A</abbr></label>
@@ -552,7 +684,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions" rel="external" aria-describedby="g11">3.3.3 Error Suggestion (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions" rel="external" aria-describedby="g33">3.3.3 Error Suggestion (Level&#160;AA)</a></legend>
 						<input id="aap333" type="radio" name="sc333" value="pass"><label for="aap333">Pass</label>
 						<input id="aaf333" type="radio" name="sc333" value="fail"><label for="aaf333">Fail</label>
 						<input id="aan333" type="radio" name="sc333" value="na"><label for="aan333"><abbr title="Not applicable">N/A</abbr></label>
@@ -560,7 +692,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible" rel="external" aria-describedby="g11">3.3.4 Error Prevention (Legal, Financial, Data) (Level&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible" rel="external" aria-describedby="g33">3.3.4 Error Prevention (Legal, Financial, Data) (Level&#160;AA)</a></legend>
 						<input id="aap334" type="radio" name="sc334" value="pass"><label for="aap334">Pass</label>
 						<input id="aaf334" type="radio" name="sc334" value="fail"><label for="aaf334">Fail</label>
 						<input id="aan334" type="radio" name="sc334" value="na"><label for="aan334"><abbr title="Not applicable">N/A</abbr></label>
@@ -568,7 +700,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-context-help" rel="external" aria-describedby="g11">3.3.5 Help (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-context-help" rel="external" aria-describedby="g33">3.3.5 Help (Level&#160;AAA)</a></legend>
 						<input id="aaap335" type="radio" name="sc335" value="pass"><label for="aaap335">Pass</label>
 						<input id="aaaf335" type="radio" name="sc335" value="fail"><label for="aaaf335">Fail</label>
 						<input id="aaan335" type="radio" name="sc335" value="na"><label for="aaan335"><abbr title="Not applicable">N/A</abbr></label>
@@ -576,7 +708,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all" rel="external" aria-describedby="g11">3.3.6 Error Prevention (All) (Level&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all" rel="external" aria-describedby="g33">3.3.6 Error Prevention (All) (Level&#160;AAA)</a></legend>
 						<input id="aaap336" type="radio" name="sc336" value="pass"><label for="aaap336">Pass</label>
 						<input id="aaaf336" type="radio" name="sc336" value="fail"><label for="aaaf336">Fail</label>
 						<input id="aaan336" type="radio" name="sc336" value="na"><label for="aaan336"><abbr title="Not applicable">N/A</abbr></label>
@@ -589,11 +721,11 @@
 	<section>
 		<h3 id="wcag4"><b>Principle:</b> Robust</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g12"><b>Guideline 4.1 Compatible:</b> Maximize compatibility with current and future user agents, including assistive technologies.</h4>
+			<h4 id="g41"><b>Guideline 4.1 Compatible:</b> Maximize compatibility with current and future user agents, including assistive technologies.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses" rel="external" aria-describedby="g12">4.1.1 Parsing (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses" rel="external" aria-describedby="g41">4.1.1 Parsing (Level&#160;A)</a></legend>
 						<input id="ap411" type="radio" name="sc411" value="pass"><label for="ap411">Pass</label>
 						<input id="af411" type="radio" name="sc411" value="fail"><label for="af411">Fail</label>
 						<input id="an411" type="radio" name="sc411" value="na"><label for="an411"><abbr title="Not applicable">N/A</abbr></label>
@@ -601,10 +733,18 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv" rel="external" aria-describedby="g12">4.1.2 Name, Role, Value (Level&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv" rel="external" aria-describedby="g41">4.1.2 Name, Role, Value (Level&#160;A)</a></legend>
 						<input id="ap412" type="radio" name="sc412" value="pass"><label for="ap412">Pass</label>
 						<input id="af412" type="radio" name="sc412" value="fail"><label for="af412">Fail</label>
 						<input id="an412" type="radio" name="sc412" value="na"><label for="an412"><abbr title="Not applicable">N/A</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#status-messages" rel="external" aria-describedby="g41">4.1.3 Status Messages (Level&#160;AA)</a></legend>
+						<input id="aap413" type="radio" name="sc413" value="pass"><label for="aap413">Pass</label>
+						<input id="aaf413" type="radio" name="sc413" value="fail"><label for="aaf413">Fail</label>
+						<input id="aan413" type="radio" name="sc413" value="na"><label for="aan413"><abbr title="Not applicable">N/A</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -617,27 +757,27 @@
 			<tbody>
 				<tr>
 					<th scope="row">Level&#160;A Success Criteria passed</th>
-					<td class="text-right"><span id="rsltA"></span>/25 (<span id="percA"></span>%)</td>
+					<td class="text-right"><span id="rsltA"></span>/30 (<span id="percA"></span>%)</td>
 				</tr>
 				<tr>
 					<th scope="row">Level&#160;AA Success Criteria passed</th>
-					<td class="text-right"><span id="rsltAA"></span>/13 (<span id="percAA"></span>%)</td>
+					<td class="text-right"><span id="rsltAA"></span>/20 (<span id="percAA"></span>%)</td>
 				</tr>
 				<tr>
 					<th scope="row">Level&#160;AAA Success Criteria passed</th>
-					<td class="text-right"><span id="rsltAAA"></span>/23 (<span id="percAAA"></span>%)</td>
+					<td class="text-right"><span id="rsltAAA"></span>/28 (<span id="percAAA"></span>%)</td>
 				</tr>
 				<tr class="success">
 					<th scope="row">Total Success Criteria passed</th>
-					<td class="text-right"><span id="rsltTotal"></span>/61 (<span id="percTotal"></span>%)</td>
+					<td class="text-right"><span id="rsltTotal"></span>/78 (<span id="percTotal"></span>%)</td>
 				</tr>
 				<tr class="active">
 					<th scope="row">Success Criteria evaluated</th>
-					<td class="text-right"><span id="evalTotal"></span>/61 (<span id="percEvalTotal"></span>%)</td>
+					<td class="text-right"><span id="evalTotal"></span>/78 (<span id="percEvalTotal"></span>%)</td>
 				</tr>
 				<tr class="active">
 					<th scope="row">Success Criteria <abbr title="Not applicable">N/A</abbr></th>
-					<td class="text-right"><span id="naTotal"></span>/61 (<span id="percNATotal"></span>%)</td>
+					<td class="text-right"><span id="naTotal"></span>/78 (<span id="percNATotal"></span>%)</td>
 				</tr>
 			</tbody>
 		</table>

--- a/src/other/wamethod/wamethod-AAA-fr.hbs
+++ b/src/other/wamethod/wamethod-AAA-fr.hbs
@@ -3,24 +3,24 @@
 	"title": "Méthodologie d’évaluation sur l’accessibilité des sites Web (niveau AAA)",
 	"language": "fr",
 	"category": "Autre",
-	"description": "Offre une méthodologie d’évaluation qui permet de mesurer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.0 pour les critères de succès de niveau A, AA et AAA.",
+	"description": "Offre une méthodologie d’évaluation qui permet de mesurer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.1 pour les critères de succès de niveau A, AA et AAA.",
 	"tag": "wamethod",
 	"parentdir": "wamethod",
 	"altLangPrefix": "wamethod-AAA",
 	"css": ["demo/wamethod"],
 	"js": ["demo/wamethod"],
-	"dateModified": "2014-02-19"
+	"dateModified": "2019-08-05"
 }
 ---
 <section>
 	<h2>But</h2>
-	<p>Aider à mesurer les <a href="#success">critères de succès</a> de niveau A, AA et AA des <a href="https://www.w3.org/Translations/WCAG20-fr/" rel="external">Règles&#160;pour&#160;l’accessibilité des contenus Web (WCAG)&#160;2.0</a>.</p>
+	<p>Aider à mesurer les <a href="#success">critères de succès</a> de niveau A, AA et AA des <a href="https://www.w3.org/TR/WCAG21/" rel="external">Règles&#160;pour&#160;l’accessibilité des contenus Web (WCAG)&#160;2.1 (anglais seulement)</a>.</p>
 </section>
 
 <section>
 	<h2>Table des matières</h2>
 	<ul>
-		<li><a href="#wcag">Liste de vérification des critères de succès des <abbr title="Règles pour l’accessibilité des contenus Web">WCAG</abbr>&#160;2.0</a>
+		<li><a href="#wcag">Liste de vérification des critères de succès des <abbr title="Règles pour l’accessibilité des contenus Web">WCAG</abbr>&#160;2.1</a>
 			<ul>
 				<li><a href="#wcag1">Principe&#160;: Perceptible</a></li>
 				<li><a href="#wcag2">Principe&#160;: Utilisable</a></li>
@@ -33,9 +33,9 @@
 	</ul>
 </section>
 
-<p>Les suivantes sont requises pour qu’une <a href="#webpagedef">page Web</a> réponde à un critère de succès des <abbr title="Règles pour l’accessibilité des contenus Web">WCAG</abbr>&#160;2.0&#160;:</p>
+<p>Les suivantes sont requises pour qu’une <a href="#webpagedef">page Web</a> réponde à un critère de succès des <abbr title="Règles pour l’accessibilité des contenus Web">WCAG</abbr>&#160;2.1&#160;:</p>
 <ol>
-	<li>La page Web évite avec succès chaque <a href="https://www.w3.org/TR/WCAG20-TECHS/failures.html" rel="external">échec fréquent (anglais seulement)</a> pour le critère&#160;de&#160;succès.</li>
+	<li>La page Web évite avec succès chaque <a href="https://www.w3.org/WAI/WCAG21/Techniques/#failures" rel="external">échec fréquent (anglais seulement)</a> pour le critère&#160;de&#160;succès.</li>
 	<li>La page Web exécute avec succès des <a href="#sufftech">techniques suffisantes</a> ou des combinaisons de techniques suffisantes pour le critère de succès qui sont&#160;:
 		<ol>
 			<li>propres à chaque situation applicable;</li>
@@ -45,15 +45,15 @@
 </ol>
 
 <section class="wb-wamethod">
-	<h2 id="wcag">Liste de vérification des critères de succès des WCAG&#160;2.0 (12&#160;règles, 61&#160;critères de succès)</h2>
+	<h2 id="wcag">Liste de vérification des critères de succès des WCAG&#160;2.1 (13&#160;règles, 78&#160;critères de succès)</h2>
 	<section>
 		<h3 id="wcag1"><b>Principe&#160;:</b> Perceptible</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g1"><b>Règle 1.1 Les équivalents textuels&#160;:</b> Proposer des équivalents textuels à tout contenu non textuel qui pourra alors être modifié en d'autres formes selon les besoins de l'utilisateur&#160;: grands caractères, braille, synthèse vocale, symboles ou langage simplifié.</h4>
+			<h4 id="g11"><b>Règle 1.1 Les équivalents textuels&#160;:</b> Proposer des équivalents textuels à tout contenu non textuel qui pourra alors être modifié en d'autres formes selon les besoins de l'utilisateur&#160;: grands caractères, braille, synthèse vocale, symboles ou langage simplifié.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#text-equiv-all" rel="external" aria-describedby="g1">1.1.1 Contenu non textuel (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#text-equiv-all" rel="external" aria-describedby="g11">1.1.1 Contenu non textuel (Niveau&#160;A)</a></legend>
 						<input id="ap111" type="radio" name="sc111" value="pass"><label for="ap111">Réussi</label>
 						<input id="af111" type="radio" name="sc111" value="fail"><label for="af111">Échouée</label>
 						<input id="an111" type="radio" name="sc111" value="na"><label for="an111"><abbr title="Sans objet">S/O</abbr></label>
@@ -62,11 +62,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g2"><b>Règle 1.2 Média temporel&#160;:</b> Proposer des versions de remplacement aux médias temporels.</h4>
+			<h4 id="g12"><b>Règle 1.2 Média temporel&#160;:</b> Proposer des versions de remplacement aux médias temporels.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-av-only-alt" rel="external" aria-describedby="g2">1.2.1 Contenu seulement audio ou vidéo (pré-enregistré) (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-av-only-alt" rel="external" aria-describedby="g12">1.2.1 Contenu seulement audio ou vidéo (pré-enregistré) (Niveau&#160;A)</a></legend>
 						<input id="ap121" type="radio" name="sc121" value="pass"><label for="ap121">Réussi</label>
 						<input id="af121" type="radio" name="sc121" value="fail"><label for="af121">Échouée</label>
 						<input id="an121" type="radio" name="sc121" value="na"><label for="an121"><abbr title="Sans objet">S/O</abbr></label>
@@ -74,7 +74,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-captions" rel="external" aria-describedby="g2">1.2.2 Sous-titres (pré-enregistrés) (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-captions" rel="external" aria-describedby="g12">1.2.2 Sous-titres (pré-enregistrés) (Niveau&#160;A)</a></legend>
 						<input id="ap122" type="radio" name="sc122" value="pass"><label for="ap122">Réussi</label>
 						<input id="af122" type="radio" name="sc122" value="fail"><label for="af122">Échouée</label>
 						<input id="an122" type="radio" name="sc122" value="na"><label for="an122"><abbr title="Sans objet">S/O</abbr></label>
@@ -82,7 +82,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-audio-desc" rel="external" aria-describedby="g2">1.2.3 Audio-description ou version de remplacement pour un média temporel (pré-enregistré) (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-audio-desc" rel="external" aria-describedby="g12">1.2.3 Audio-description ou version de remplacement pour un média temporel (pré-enregistré) (Niveau&#160;A)</a></legend>
 						<input id="ap123" type="radio" name="sc123" value="pass"><label for="ap123">Réussi</label>
 						<input id="af123" type="radio" name="sc123" value="fail"><label for="af123">Échouée</label>
 						<input id="an123" type="radio" name="sc123" value="na"><label for="an123"><abbr title="Sans objet">S/O</abbr></label>
@@ -90,7 +90,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-real-time-captions" rel="external" aria-describedby="g2">1.2.4 Sous-titres (en direct) (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-real-time-captions" rel="external" aria-describedby="g12">1.2.4 Sous-titres (en direct) (Niveau&#160;AA)</a></legend>
 						<input id="aap124" type="radio" name="sc124" value="pass"><label for="aap124">Réussi</label>
 						<input id="aaf124" type="radio" name="sc124" value="fail"><label for="aaf124">Échouée</label>
 						<input id="aan124" type="radio" name="sc124" value="na"><label for="aan124"><abbr title="Sans objet">S/O</abbr></label>
@@ -98,7 +98,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-audio-desc-only" rel="external" aria-describedby="g2">1.2.5 Audio-description (pré-enregistrée) (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-audio-desc-only" rel="external" aria-describedby="g12">1.2.5 Audio-description (pré-enregistrée) (Niveau&#160;AA)</a></legend>
 						<input id="aap125" type="radio" name="sc125" value="pass"><label for="aap125">Réussi</label>
 						<input id="aaf125" type="radio" name="sc125" value="fail"><label for="aaf125">Échouée</label>
 						<input id="aan125" type="radio" name="sc125" value="na"><label for="aan125"><abbr title="Sans objet">S/O</abbr></label>
@@ -106,7 +106,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-sign" rel="external" aria-describedby="g2">1.2.6 Langue des signes (pré-enregistrée) (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-sign" rel="external" aria-describedby="g12">1.2.6 Langue des signes (pré-enregistrée) (Niveau&#160;AAA)</a></legend>
 						<input id="aaap126" type="radio" name="sc126" value="pass"><label for="aaap126">Réussi</label>
 						<input id="aaaf126" type="radio" name="sc126" value="fail"><label for="aaaf126">Échouée</label>
 						<input id="aaan126" type="radio" name="sc126" value="na"><label for="aaan126"><abbr title="Sans objet">S/O</abbr></label>
@@ -114,7 +114,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-extended-ad" rel="external" aria-describedby="g2">1.2.7 Audio-description étendue (pré-enregistrée) (Prerecorded) (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-extended-ad" rel="external" aria-describedby="g12">1.2.7 Audio-description étendue (pré-enregistrée) (Prerecorded) (Niveau&#160;AAA)</a></legend>
 						<input id="aaap127" type="radio" name="sc127" value="pass"><label for="aaap127">Réussi</label>
 						<input id="aaaf127" type="radio" name="sc127" value="fail"><label for="aaaf127">Échouée</label>
 						<input id="aaan127" type="radio" name="sc127" value="na"><label for="aaan127"><abbr title="Sans objet">S/O</abbr></label>
@@ -122,7 +122,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-text-doc" rel="external" aria-describedby="g2">1.2.8 Version de remplacement pour un média temporel (pré-enregistrée) (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-text-doc" rel="external" aria-describedby="g12">1.2.8 Version de remplacement pour un média temporel (pré-enregistrée) (Niveau&#160;AAA)</a></legend>
 						<input id="aaap128" type="radio" name="sc128" value="pass"><label for="aaap128">Réussi</label>
 						<input id="aaaf128" type="radio" name="sc128" value="fail"><label for="aaaf128">Échouée</label>
 						<input id="aaan128" type="radio" name="sc128" value="na"><label for="aaan128"><abbr title="Sans objet">S/O</abbr></label>
@@ -130,7 +130,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-live-audio-only" rel="external" aria-describedby="g2">1.2.9 Seulement audio (en direct) (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#media-equiv-live-audio-only" rel="external" aria-describedby="g12">1.2.9 Seulement audio (en direct) (Niveau&#160;AAA)</a></legend>
 						<input id="aaap129" type="radio" name="sc129" value="pass"><label for="aaap129">Réussi</label>
 						<input id="aaaf129" type="radio" name="sc129" value="fail"><label for="aaaf129">Échouée</label>
 						<input id="aaan129" type="radio" name="sc129" value="na"><label for="aaan129"><abbr title="Sans objet">S/O</abbr></label>
@@ -139,11 +139,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g3"><b>Règle 1.3 Adaptable&#160;:</b> Créer un contenu qui puisse être présenté de différentes manières sans perte d'information ni de structure (par exemple avec une mise en page simplifiée).</h4>
+			<h4 id="g13"><b>Règle 1.3 Adaptable&#160;:</b> Créer un contenu qui puisse être présenté de différentes manières sans perte d'information ni de structure (par exemple avec une mise en page simplifiée).</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-programmatic" rel="external" aria-describedby="g3">1.3.1 Information et relations (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-programmatic" rel="external" aria-describedby="g13">1.3.1 Information et relations (Niveau&#160;A)</a></legend>
 						<input id="ap131" type="radio" name="sc131" value="pass"><label for="ap131">Réussi</label>
 						<input id="af131" type="radio" name="sc131" value="fail"><label for="af131">Échouée</label>
 						<input id="an131" type="radio" name="sc131" value="na"><label for="an131"><abbr title="Sans objet">S/O</abbr></label>
@@ -151,7 +151,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-sequence" rel="external" aria-describedby="g3">1.3.2 Ordre séquentiel logique (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-sequence" rel="external" aria-describedby="g13">1.3.2 Ordre séquentiel logique (Niveau&#160;A)</a></legend>
 						<input id="ap132" type="radio" name="sc132" value="pass"><label for="ap132">Réussi</label>
 						<input id="af132" type="radio" name="sc132" value="fail"><label for="af132">Échouée</label>
 						<input id="an132" type="radio" name="sc132" value="na"><label for="an132"><abbr title="Sans objet">S/O</abbr></label>
@@ -159,20 +159,44 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-understanding" rel="external" aria-describedby="g3">1.3.3 Caractéristiques sensorielles (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#content-structure-separation-understanding" rel="external" aria-describedby="g13">1.3.3 Caractéristiques sensorielles (Niveau&#160;A)</a></legend>
 						<input id="ap133" type="radio" name="sc133" value="pass"><label for="ap133">Réussi</label>
 						<input id="af133" type="radio" name="sc133" value="fail"><label for="af133">Échouée</label>
 						<input id="an133" type="radio" name="sc133" value="na"><label for="an133"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#orientation" rel="external" aria-describedby="g13"><span lang="en">1.3.4 Orientation (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap134" type="radio" name="sc134" value="pass"><label for="aap134">Réussi</label>
+						<input id="aaf134" type="radio" name="sc134" value="fail"><label for="aaf134">Échouée</label>
+						<input id="aan134" type="radio" name="sc134" value="na"><label for="aan134"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#identify-input-purpose" rel="external" aria-describedby="g13"><span lang="en">1.3.5 Identify Input Purpose (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap135" type="radio" name="sc135" value="pass"><label for="aap135">Réussi</label>
+						<input id="aaf135" type="radio" name="sc135" value="fail"><label for="aaf135">Échouée</label>
+						<input id="aan135" type="radio" name="sc135" value="na"><label for="aan135"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#identify-purpose" rel="external" aria-describedby="g13"><span lang="en">1.3.6 Identify Purpose (Niveau&#160;AAA)</span> (anglais seulement)</a></legend>
+						<input id="aaap136" type="radio" name="sc136" value="pass"><label for="aaap136">Réussi</label>
+						<input id="aaaf136" type="radio" name="sc136" value="fail"><label for="aaaf136">Échouée</label>
+						<input id="aaan136" type="radio" name="sc136" value="na"><label for="aaan136"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g4"><b>Règle 1.4 Distinguable&#160;:</b> Faciliter la perception visuelle et auditive du contenu par l'utilisateur, notamment en séparant le premier plan de l'arrière-plan.</h4>
+			<h4 id="g14"><b>Règle 1.4 Distinguable&#160;:</b> Faciliter la perception visuelle et auditive du contenu par l'utilisateur, notamment en séparant le premier plan de l'arrière-plan.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-without-color" rel="external" aria-describedby="g4">1.4.1 Utilisation de la couleur (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-without-color" rel="external" aria-describedby="g14">1.4.1 Utilisation de la couleur (Niveau&#160;A)</a></legend>
 						<input id="ap141" type="radio" name="sc141" value="pass"><label for="ap141">Réussi</label>
 						<input id="af141" type="radio" name="sc141" value="fail"><label for="af141">Échouée</label>
 						<input id="an141" type="radio" name="sc141" value="na"><label for="an141"><abbr title="Sans objet">S/O</abbr></label>
@@ -180,7 +204,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-dis-audio" rel="external" aria-describedby="g4">1.4.2 Contrôle du son (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-dis-audio" rel="external" aria-describedby="g14">1.4.2 Contrôle du son (Niveau&#160;A)</a></legend>
 						<input id="ap142" type="radio" name="sc142" value="pass"><label for="ap142">Réussi</label>
 						<input id="af142" type="radio" name="sc142" value="fail"><label for="af142">Échouée</label>
 						<input id="an142" type="radio" name="sc142" value="na"><label for="an142"><abbr title="Sans objet">S/O</abbr></label>
@@ -188,7 +212,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-contrast" rel="external" aria-describedby="g4">1.4.3 Contraste (minimum) (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-contrast" rel="external" aria-describedby="g14">1.4.3 Contraste (minimum) (Niveau&#160;AA)</a></legend>
 						<input id="aap143" type="radio" name="sc143" value="pass"><label for="aap143">Réussi</label>
 						<input id="aaf143" type="radio" name="sc143" value="fail"><label for="aaf143">Échouée</label>
 						<input id="aan143" type="radio" name="sc143" value="na"><label for="aan143"><abbr title="Sans objet">S/O</abbr></label>
@@ -196,7 +220,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-scale" rel="external" aria-describedby="g4">1.4.4 Redimensionnement du texte (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-scale" rel="external" aria-describedby="g14">1.4.4 Redimensionnement du texte (Niveau&#160;AA)</a></legend>
 						<input id="aap144" type="radio" name="sc144" value="pass"><label for="aap144">Réussi</label>
 						<input id="aaf144" type="radio" name="sc144" value="fail"><label for="aaf144">Échouée</label>
 						<input id="aan144" type="radio" name="sc144" value="na"><label for="aan144"><abbr title="Sans objet">S/O</abbr></label>
@@ -204,7 +228,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-text-presentation" rel="external" aria-describedby="g4">1.4.5 Texte sous forme d'image (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-text-presentation" rel="external" aria-describedby="g14">1.4.5 Texte sous forme d'image (Niveau&#160;AA)</a></legend>
 						<input id="aap145" type="radio" name="sc145" value="pass"><label for="aap145">Réussi</label>
 						<input id="aaf145" type="radio" name="sc145" value="fail"><label for="aaf145">Échouée</label>
 						<input id="aan145" type="radio" name="sc145" value="na"><label for="aan145"><abbr title="Sans objet">S/O</abbr></label>
@@ -212,7 +236,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast7" rel="external" aria-describedby="g4">1.4.6 Contraste (amélioré) (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast7" rel="external" aria-describedby="g14">1.4.6 Contraste (amélioré) (Niveau&#160;AAA)</a></legend>
 						<input id="aaap146" type="radio" name="sc146" value="pass"><label for="aaap146">Réussi</label>
 						<input id="aaaf146" type="radio" name="sc146" value="fail"><label for="aaaf146">Échouée</label>
 						<input id="aaan146" type="radio" name="sc146" value="na"><label for="aaan146"><abbr title="Sans objet">S/O</abbr></label>
@@ -220,7 +244,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-noaudio" rel="external" aria-describedby="g4">1.4.7 Arrière-plan sonore de faible volume ou absent (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-noaudio" rel="external" aria-describedby="g14">1.4.7 Arrière-plan sonore de faible volume ou absent (Niveau&#160;AAA)</a></legend>
 						<input id="aaap147" type="radio" name="sc147" value="pass"><label for="aaap147">Réussi</label>
 						<input id="aaaf147" type="radio" name="sc147" value="fail"><label for="aaaf147">Échouée</label>
 						<input id="aaan147" type="radio" name="sc147" value="na"><label for="aaan147"><abbr title="Sans objet">S/O</abbr></label>
@@ -228,7 +252,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-visual-presentation" rel="external" aria-describedby="g4">1.4.8 Présentation visuelle (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-visual-presentation" rel="external" aria-describedby="g14">1.4.8 Présentation visuelle (Niveau&#160;AAA)</a></legend>
 						<input id="aaap148" type="radio" name="sc148" value="pass"><label for="aaap148">Réussi</label>
 						<input id="aaaf148" type="radio" name="sc148" value="fail"><label for="aaaf148">Échouée</label>
 						<input id="aaan148" type="radio" name="sc148" value="na"><label for="aaan148"><abbr title="Sans objet">S/O</abbr></label>
@@ -236,10 +260,42 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-text-images" rel="external" aria-describedby="g4">1.4.9 Texte sous forme d'image (sans exception) (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#visual-audio-contrast-text-images" rel="external" aria-describedby="g14">1.4.9 Texte sous forme d'image (sans exception) (Niveau&#160;AAA)</a></legend>
 						<input id="aaap149" type="radio" name="sc149" value="pass"><label for="aaap149">Réussi</label>
 						<input id="aaaf149" type="radio" name="sc149" value="fail"><label for="aaaf149">Échouée</label>
 						<input id="aaan149" type="radio" name="sc149" value="na"><label for="aaan149"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#reflow" rel="external" aria-describedby="g14"><span lang="en">1.4.10 Reflow (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap1410" type="radio" name="sc1410" value="pass"><label for="aap1410">Réussi</label>
+						<input id="aaf1410" type="radio" name="sc1410" value="fail"><label for="aaf1410">Échouée</label>
+						<input id="aan1410" type="radio" name="sc1410" value="na"><label for="aan1410"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#non-text-contrast" rel="external" aria-describedby="g14"><span lang="en">1.4.11 Non-Text Contrast (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap1411" type="radio" name="sc1411" value="pass"><label for="aap1411">Réussi</label>
+						<input id="aaf1411" type="radio" name="sc1411" value="fail"><label for="aaf1411">Échouée</label>
+						<input id="aan1411" type="radio" name="sc1411" value="na"><label for="aan1411"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#text-spacing" rel="external" aria-describedby="g14"><span lang="en">1.4.12 Text Spacing (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap1412" type="radio" name="sc1412" value="pass"><label for="aap1412">Réussi</label>
+						<input id="aaf1412" type="radio" name="sc1412" value="fail"><label for="aaf1412">Échouée</label>
+						<input id="aan1412" type="radio" name="sc1412" value="na"><label for="aan1412"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus" rel="external" aria-describedby="g14"><span lang="en">1.4.13 Content on Hover or Focus (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap1413" type="radio" name="sc1413" value="pass"><label for="aap1413">Réussi</label>
+						<input id="aaf1413" type="radio" name="sc1413" value="fail"><label for="aaf1413">Échouée</label>
+						<input id="aan1413" type="radio" name="sc1413" value="na"><label for="aan1413"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -249,11 +305,11 @@
 	<section>
 		<h3 id="wcag2"><b>Principe&#160;:</b> Utilisable</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g5"><b>Règle 2.1 Accessibilité au clavier&#160;:</b> Rendre toutes les fonctionnalités accessibles au clavier.</h4>
+			<h4 id="g21"><b>Règle 2.1 Accessibilité au clavier&#160;:</b> Rendre toutes les fonctionnalités accessibles au clavier.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#keyboard-operation-keyboard-operable" rel="external" aria-describedby="g5">2.1.1 Clavier (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#keyboard-operation-keyboard-operable" rel="external" aria-describedby="g21">2.1.1 Clavier (Niveau&#160;A)</a></legend>
 						<input id="ap211" type="radio" name="sc211" value="pass"><label for="ap211">Réussi</label>
 						<input id="af211" type="radio" name="sc211" value="fail"><label for="af211">Échouée</label>
 						<input id="an211" type="radio" name="sc211" value="na"><label for="an211"><abbr title="Sans objet">S/O</abbr></label>
@@ -261,7 +317,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#keyboard-operation-trapping" rel="external" aria-describedby="g5">2.1.2 Pas de piège au clavier (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#keyboard-operation-trapping" rel="external" aria-describedby="g21">2.1.2 Pas de piège au clavier (Niveau&#160;A)</a></legend>
 						<input id="ap212" type="radio" name="sc212" value="pass"><label for="ap212">Réussi</label>
 						<input id="af212" type="radio" name="sc212" value="fail"><label for="af212">Échouée</label>
 						<input id="an212" type="radio" name="sc212" value="na"><label for="an212"><abbr title="Sans objet">S/O</abbr></label>
@@ -269,20 +325,28 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#keyboard-operation-all-funcs" rel="external" aria-describedby="g5">2.1.3 Clavier (pas d'exception) (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#keyboard-operation-all-funcs" rel="external" aria-describedby="g21">2.1.3 Clavier (pas d'exception) (Niveau&#160;AAA)</a></legend>
 						<input id="aaap213" type="radio" name="sc213" value="pass"><label for="aaap213">Réussi</label>
 						<input id="aaaf213" type="radio" name="sc213" value="fail"><label for="aaaf213">Échouée</label>
 						<input id="aaan213" type="radio" name="sc213" value="na"><label for="aaan213"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#character-key-shortcuts" rel="external" aria-describedby="g21"><span lang="en">2.1.4 Character Key Shortcuts (Niveau&#160;A)</span> (anglais seulement)</a></legend>
+						<input id="ap214" type="radio" name="sc214" value="pass"><label for="ap214">Réussi</label>
+						<input id="af214" type="radio" name="sc214" value="fail"><label for="af214">Échouée</label>
+						<input id="an214" type="radio" name="sc214" value="na"><label for="an214"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g6"><b>Règle 2.2 Délai suffisant&#160;:</b> Laisser à l'utilisateur suffisamment de temps pour lire et utiliser le contenu.</h4>
+			<h4 id="g22"><b>Règle 2.2 Délai suffisant&#160;:</b> Laisser à l'utilisateur suffisamment de temps pour lire et utiliser le contenu.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-required-behaviors" rel="external" aria-describedby="g6">2.2.1 Réglage du délai (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-required-behaviors" rel="external" aria-describedby="g22">2.2.1 Réglage du délai (Niveau&#160;A)</a></legend>
 						<input id="ap221" type="radio" name="sc221" value="pass"><label for="ap221">Réussi</label>
 						<input id="af221" type="radio" name="sc221" value="fail"><label for="af221">Échouée</label>
 						<input id="an221" type="radio" name="sc221" value="na"><label for="an221"><abbr title="Sans objet">S/O</abbr></label>
@@ -290,7 +354,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-pause" rel="external" aria-describedby="g6">2.2.2 Mettre en pause, arrêter, masquer (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-pause" rel="external" aria-describedby="g22">2.2.2 Mettre en pause, arrêter, masquer (Niveau&#160;A)</a></legend>
 						<input id="ap222" type="radio" name="sc222" value="pass"><label for="ap222">Réussi</label>
 						<input id="af222" type="radio" name="sc222" value="fail"><label for="af222">Échouée</label>
 						<input id="an222" type="radio" name="sc222" value="na"><label for="an222"><abbr title="Sans objet">S/O</abbr></label>
@@ -298,7 +362,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-no-exceptions" rel="external" aria-describedby="g6">2.2.3 Pas de délai d'exécution (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-no-exceptions" rel="external" aria-describedby="g22">2.2.3 Pas de délai d'exécution (Niveau&#160;AAA)</a></legend>
 						<input id="aaap223" type="radio" name="sc223" value="pass"><label for="aaap223">Réussi</label>
 						<input id="aaaf223" type="radio" name="sc223" value="fail"><label for="aaaf223">Échouée</label>
 						<input id="aaan223" type="radio" name="sc223" value="na"><label for="aaan223"><abbr title="Sans objet">S/O</abbr></label>
@@ -306,7 +370,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-postponed" rel="external" aria-describedby="g6">2.2.4 Interruptions (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-postponed" rel="external" aria-describedby="g22">2.2.4 Interruptions (Niveau&#160;AAA)</a></legend>
 						<input id="aaap224" type="radio" name="sc224" value="pass"><label for="aaap224">Réussi</label>
 						<input id="aaaf224" type="radio" name="sc224" value="fail"><label for="aaaf224">Échouée</label>
 						<input id="aaan224" type="radio" name="sc224" value="na"><label for="aaan224"><abbr title="Sans objet">S/O</abbr></label>
@@ -314,20 +378,28 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-server-timeout" rel="external" aria-describedby="g6">2.2.5 Nouvelle authentification (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#time-limits-server-timeout" rel="external" aria-describedby="g22">2.2.5 Nouvelle authentification (Niveau&#160;AAA)</a></legend>
 						<input id="aaap225" type="radio" name="sc225" value="pass"><label for="aaap225">Réussi</label>
 						<input id="aaaf225" type="radio" name="sc225" value="fail"><label for="aaaf225">Échouée</label>
 						<input id="aaan225" type="radio" name="sc225" value="na"><label for="aaan225"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#timeouts" rel="external" aria-describedby="g22"><span lang="en">2.2.6 Timeouts (Niveau&#160;AAA)</span> (anglais seulement)</a></legend>
+						<input id="aaap226" type="radio" name="sc226" value="pass"><label for="aaap226">Réussi</label>
+						<input id="aaaf226" type="radio" name="sc226" value="fail"><label for="aaaf226">Échouée</label>
+						<input id="aaan226" type="radio" name="sc226" value="na"><label for="aaan226"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g7"><b>Règle 2.3 Crises&#160;:</b> Ne pas concevoir de contenu susceptible de provoquer des crises.</h4>
+			<h4 id="g23"><b>Règle 2.3 Crises&#160;:</b> Ne pas concevoir de contenu susceptible de provoquer des crises.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#seizure-does-not-violate" rel="external" aria-describedby="g7">2.3.1 Pas plus de trois flashs ou sous le seuil critique (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#seizure-does-not-violate" rel="external" aria-describedby="g23">2.3.1 Pas plus de trois flashs ou sous le seuil critique (Niveau&#160;A)</a></legend>
 						<input id="ap231" type="radio" name="sc231" value="pass"><label for="ap231">Réussi</label>
 						<input id="af231" type="radio" name="sc231" value="fail"><label for="af231">Échouée</label>
 						<input id="an231" type="radio" name="sc231" value="na"><label for="an231"><abbr title="Sans objet">S/O</abbr></label>
@@ -335,20 +407,28 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#seizure-three-times" rel="external" aria-describedby="g7">2.3.2 Trois flashs (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#seizure-three-times" rel="external" aria-describedby="g23">2.3.2 Trois flashs (Niveau&#160;AAA)</a></legend>
 						<input id="aaap232" type="radio" name="sc232" value="pass"><label for="aaap232">Réussi</label>
 						<input id="aaaf232" type="radio" name="sc232" value="fail"><label for="aaaf232">Échouée</label>
 						<input id="aaan232" type="radio" name="sc232" value="na"><label for="aaan232"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#animation-from-interactions" rel="external" aria-describedby="g23"><span lang="en">2.3.3 Animation from Interactions (Niveau&#160;AAA)</span> (anglais seulement)</a></legend>
+						<input id="aaap233" type="radio" name="sc233" value="pass"><label for="aaap233">Réussi</label>
+						<input id="aaaf233" type="radio" name="sc233" value="fail"><label for="aaaf233">Échouée</label>
+						<input id="aaan233" type="radio" name="sc233" value="na"><label for="aaan233"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g8"><b>Règle 2.4 Navigable&#160;:</b> Fournir à l'utilisateur des éléments d'orientation pour naviguer, trouver le contenu et se situer dans le site.</h4>
+			<h4 id="g24"><b>Règle 2.4 Navigable&#160;:</b> Fournir à l'utilisateur des éléments d'orientation pour naviguer, trouver le contenu et se situer dans le site.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-skip" rel="external" aria-describedby="g8">2.4.1 Contourner des blocs (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-skip" rel="external" aria-describedby="g24">2.4.1 Contourner des blocs (Niveau&#160;A)</a></legend>
 						<input id="ap241" type="radio" name="sc241" value="pass"><label for="ap241">Réussi</label>
 						<input id="af241" type="radio" name="sc241" value="fail"><label for="af241">Échouée</label>
 						<input id="an241" type="radio" name="sc241" value="na"><label for="an241"><abbr title="Sans objet">S/O</abbr></label>
@@ -356,7 +436,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-title" rel="external" aria-describedby="g8">2.4.2 Titre de page (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-title" rel="external" aria-describedby="g24">2.4.2 Titre de page (Niveau&#160;A)</a></legend>
 						<input id="ap242" type="radio" name="sc242" value="pass"><label for="ap242">Réussi</label>
 						<input id="af242" type="radio" name="sc242" value="fail"><label for="af242">Échouée</label>
 						<input id="an242" type="radio" name="sc242" value="na"><label for="an242"><abbr title="Sans objet">S/O</abbr></label>
@@ -364,7 +444,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-focus-order" rel="external" aria-describedby="g8">2.4.3 Parcours du focus (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-focus-order" rel="external" aria-describedby="g24">2.4.3 Parcours du focus (Niveau&#160;A)</a></legend>
 						<input id="ap243" type="radio" name="sc243" value="pass"><label for="ap243">Réussi</label>
 						<input id="af243" type="radio" name="sc243" value="fail"><label for="af243">Échouée</label>
 						<input id="an243" type="radio" name="sc243" value="na"><label for="an243"><abbr title="Sans objet">S/O</abbr></label>
@@ -372,7 +452,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-refs" rel="external" aria-describedby="g8">2.4.4 Fonction du lien (selon le contexte) (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-refs" rel="external" aria-describedby="g24">2.4.4 Fonction du lien (selon le contexte) (Niveau&#160;A)</a></legend>
 						<input id="ap244" type="radio" name="sc244" value="pass"><label for="ap244">Réussi</label>
 						<input id="af244" type="radio" name="sc244" value="fail"><label for="af244">Échouée</label>
 						<input id="an244" type="radio" name="sc244" value="na"><label for="an244"><abbr title="Sans objet">S/O</abbr></label>
@@ -380,7 +460,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-mult-loc" rel="external" aria-describedby="g8">2.4.5 Accès multiples (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-mult-loc" rel="external" aria-describedby="g24">2.4.5 Accès multiples (Niveau&#160;AA)</a></legend>
 						<input id="aap245" type="radio" name="sc245" value="pass"><label for="aap245">Réussi</label>
 						<input id="aaf245" type="radio" name="sc245" value="fail"><label for="aaf245">Échouée</label>
 						<input id="aan245" type="radio" name="sc245" value="na"><label for="aan245"><abbr title="Sans objet">S/O</abbr></label>
@@ -388,7 +468,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-descriptive" rel="external" aria-describedby="g8">2.4.6 En-têtes et étiquettes (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-descriptive" rel="external" aria-describedby="g24">2.4.6 En-têtes et étiquettes (Niveau&#160;AA)</a></legend>
 						<input id="aap246" type="radio" name="sc246" value="pass"><label for="aap246">Réussi</label>
 						<input id="aaf246" type="radio" name="sc246" value="fail"><label for="aaf246">Échouée</label>
 						<input id="aan246" type="radio" name="sc246" value="na"><label for="aan246"><abbr title="Sans objet">S/O</abbr></label>
@@ -396,7 +476,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-focus-visible" rel="external" aria-describedby="g8">2.4.7 Visibilité du focus (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-focus-visible" rel="external" aria-describedby="g24">2.4.7 Visibilité du focus (Niveau&#160;AA)</a></legend>
 						<input id="aap247" type="radio" name="sc247" value="pass"><label for="aap247">Réussi</label>
 						<input id="aaf247" type="radio" name="sc247" value="fail"><label for="aaf247">Échouée</label>
 						<input id="aan247" type="radio" name="sc247" value="na"><label for="aan247"><abbr title="Sans objet">S/O</abbr></label>
@@ -404,7 +484,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-location" rel="external" aria-describedby="g8">2.4.8 Localisation (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-location" rel="external" aria-describedby="g24">2.4.8 Localisation (Niveau&#160;AAA)</a></legend>
 						<input id="aaap248" type="radio" name="sc248" value="pass"><label for="aaap248">Réussi</label>
 						<input id="aaaf248" type="radio" name="sc248" value="fail"><label for="aaaf248">Échouée</label>
 						<input id="aaan248" type="radio" name="sc248" value="na"><label for="aaan248"><abbr title="Sans objet">S/O</abbr></label>
@@ -412,7 +492,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-link" rel="external" aria-describedby="g8">2.4.9 Fonction du lien (lien uniquement) (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-link" rel="external" aria-describedby="g24">2.4.9 Fonction du lien (lien uniquement) (Niveau&#160;AAA)</a></legend>
 						<input id="aaap249" type="radio" name="sc249" value="pass"><label for="aaap249">Réussi</label>
 						<input id="aaaf249" type="radio" name="sc249" value="fail"><label for="aaaf249">Échouée</label>
 						<input id="aaan249" type="radio" name="sc249" value="na"><label for="aaan249"><abbr title="Sans objet">S/O</abbr></label>
@@ -420,10 +500,66 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-headings" rel="external" aria-describedby="g8">2.4.10 En-têtes de section (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#navigation-mechanisms-headings" rel="external" aria-describedby="g24">2.4.10 En-têtes de section (Niveau&#160;AAA)</a></legend>
 						<input id="aaap2410" type="radio" name="sc2410" value="pass"><label for="aaap2410">Réussi</label>
 						<input id="aaaf2410" type="radio" name="sc2410" value="fail"><label for="aaaf2410">Échouée</label>
 						<input id="aaan2410" type="radio" name="sc2410" value="na"><label for="aaan2410"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+			</ol>
+		</section>
+		<section class="mrgn-tp-lg">
+			<div lang="en">
+			<h4 id="g25"><b>Guideline 2.5 Input Modalities:</b> Make it easier for users to operate functionality through various inputs beyond keyboard.</h4>
+			<p><strong>Needs translation</strong></p>
+			</div>
+			<ol>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#pointer-gestures" rel="external" aria-describedby="g25"><span lang="en">2.5.1 Pointer Gestures (Niveau&#160;A)</span> (anglais seulement)</a></legend>
+						<input id="ap251" type="radio" name="sc251" value="pass"><label for="ap251">Réussi</label>
+						<input id="af251" type="radio" name="sc251" value="fail"><label for="af251">Échouée</label>
+						<input id="an251" type="radio" name="sc251" value="na"><label for="an251"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#pointer-cancellation" rel="external" aria-describedby="g25"><span lang="en">2.5.2 Pointer Cancellation (Niveau&#160;A)</span> (anglais seulement)</a></legend>
+						<input id="ap252" type="radio" name="sc252" value="pass"><label for="ap252">Réussi</label>
+						<input id="af252" type="radio" name="sc252" value="fail"><label for="af252">Échouée</label>
+						<input id="an252" type="radio" name="sc252" value="na"><label for="an252"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#label-in-name" rel="external" aria-describedby="g25"><span lang="en">2.5.3 Label in Name (Niveau&#160;A)</span> (anglais seulement)</a></legend>
+						<input id="ap253" type="radio" name="sc253" value="pass"><label for="ap253">Réussi</label>
+						<input id="af253" type="radio" name="sc253" value="fail"><label for="af253">Échouée</label>
+						<input id="an253" type="radio" name="sc253" value="na"><label for="an253"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#motion-actuation" rel="external" aria-describedby="g25"><span lang="en">2.5.4 Motion Actuation (Niveau&#160;A)</span> (anglais seulement)</a></legend>
+						<input id="ap254" type="radio" name="sc254" value="pass"><label for="ap254">Réussi</label>
+						<input id="af254" type="radio" name="sc254" value="fail"><label for="af254">Échouée</label>
+						<input id="an254" type="radio" name="sc254" value="na"><label for="an254"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#target-size" rel="external" aria-describedby="g25"><span lang="en">2.5.5 Target Size (Niveau&#160;AAA)</span> (anglais seulement)</a></legend>
+						<input id="aaap255" type="radio" name="sc255" value="pass"><label for="aaap255">Réussi</label>
+						<input id="aaaf255" type="radio" name="sc255" value="fail"><label for="aaaf255">Échouée</label>
+						<input id="aaan255" type="radio" name="sc255" value="na"><label for="aaan255"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#concurrent-input-mechanisms" rel="external" aria-describedby="g25"><span lang="en">2.5.6 Concurrent Input Mechanisms (Niveau&#160;AAA)</span> (anglais seulement)</a></legend>
+						<input id="aaap256" type="radio" name="sc256" value="pass"><label for="aaap256">Réussi</label>
+						<input id="aaaf256" type="radio" name="sc256" value="fail"><label for="aaaf256">Échouée</label>
+						<input id="aaan256" type="radio" name="sc256" value="na"><label for="aaan256"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -433,11 +569,11 @@
 	<section>
 		<h3 id="wcag3"><b>Principe&#160;:</b> Compréhensible</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g9"><b>Règle 3.1 Lisible&#160;:</b> Rendre le contenu textuel lisible et compréhensible.</h4>
+			<h4 id="g31"><b>Règle 3.1 Lisible&#160;:</b> Rendre le contenu textuel lisible et compréhensible.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-doc-lang-id" rel="external" aria-describedby="g9">3.1.1 Langue de la page (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-doc-lang-id" rel="external" aria-describedby="g31">3.1.1 Langue de la page (Niveau&#160;A)</a></legend>
 						<input id="ap311" type="radio" name="sc311" value="pass"><label for="ap311">Réussi</label>
 						<input id="af311" type="radio" name="sc311" value="fail"><label for="af311">Échouée</label>
 						<input id="an311" type="radio" name="sc311" value="na"><label for="an311"><abbr title="Sans objet">S/O</abbr></label>
@@ -445,7 +581,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-other-lang-id" rel="external" aria-describedby="g9">3.1.2 Langue d'un passage (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-other-lang-id" rel="external" aria-describedby="g31">3.1.2 Langue d'un passage (Niveau&#160;AA)</a></legend>
 						<input id="aap312" type="radio" name="sc312" value="pass"><label for="aap312">Réussi</label>
 						<input id="aaf312" type="radio" name="sc312" value="fail"><label for="aaf312">Échouée</label>
 						<input id="aan312" type="radio" name="sc312" value="na"><label for="aan312"><abbr title="Sans objet">S/O</abbr></label>
@@ -453,7 +589,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-idioms" rel="external" aria-describedby="g9">3.1.3 Mots rares (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-idioms" rel="external" aria-describedby="g31">3.1.3 Mots rares (Niveau&#160;AAA)</a></legend>
 						<input id="aaap313" type="radio" name="sc313" value="pass"><label for="aaap313">Réussi</label>
 						<input id="aaaf313" type="radio" name="sc313" value="fail"><label for="aaaf313">Échouée</label>
 						<input id="aaan313" type="radio" name="sc313" value="na"><label for="aaan313"><abbr title="Sans objet">S/O</abbr></label>
@@ -461,7 +597,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-located" rel="external" aria-describedby="g9">3.1.4 Abréviations (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-located" rel="external" aria-describedby="g31">3.1.4 Abréviations (Niveau&#160;AAA)</a></legend>
 						<input id="aaap314" type="radio" name="sc314" value="pass"><label for="aaap314">Réussi</label>
 						<input id="aaaf314" type="radio" name="sc314" value="fail"><label for="aaaf314">Échouée</label>
 						<input id="aaan314" type="radio" name="sc314" value="na"><label for="aaan314"><abbr title="Sans objet">S/O</abbr></label>
@@ -469,7 +605,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-supplements" rel="external" aria-describedby="g9">3.1.5 Niveau de lecture (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-supplements" rel="external" aria-describedby="g31">3.1.5 Niveau de lecture (Niveau&#160;AAA)</a></legend>
 						<input id="aaap315" type="radio" name="sc315" value="pass"><label for="aaap315">Réussi</label>
 						<input id="aaaf315" type="radio" name="sc315" value="fail"><label for="aaaf315">Échouée</label>
 						<input id="aaan315" type="radio" name="sc315" value="na"><label for="aaan315"><abbr title="Sans objet">S/O</abbr></label>
@@ -477,7 +613,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-pronunciation" rel="external" aria-describedby="g9">3.1.6 Prononciation (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#meaning-pronunciation" rel="external" aria-describedby="g31">3.1.6 Prononciation (Niveau&#160;AAA)</a></legend>
 						<input id="aaap316" type="radio" name="sc316" value="pass"><label for="aaap316">Réussi</label>
 						<input id="aaaf316" type="radio" name="sc316" value="fail"><label for="aaaf316">Échouée</label>
 						<input id="aaan316" type="radio" name="sc316" value="na"><label for="aaan316"><abbr title="Sans objet">S/O</abbr></label>
@@ -486,11 +622,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g10"><b>Règle 3.2 Prévisible&#160;:</b> Faire en sorte que les pages apparaissent et fonctionnent de manière prévisible.</h4>
+			<h4 id="g32"><b>Règle 3.2 Prévisible&#160;:</b> Faire en sorte que les pages apparaissent et fonctionnent de manière prévisible.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-receive-focus" rel="external" aria-describedby="g10">3.2.1 Au focus (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-receive-focus" rel="external" aria-describedby="g32">3.2.1 Au focus (Niveau&#160;A)</a></legend>
 						<input id="ap321" type="radio" name="sc321" value="pass"><label for="ap321">Réussi</label>
 						<input id="af321" type="radio" name="sc321" value="fail"><label for="af321">Échouée</label>
 						<input id="an321" type="radio" name="sc321" value="na"><label for="an321"><abbr title="Sans objet">S/O</abbr></label>
@@ -498,7 +634,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-unpredictable-change" rel="external" aria-describedby="g10">3.2.2 À la saisie (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-unpredictable-change" rel="external" aria-describedby="g32">3.2.2 À la saisie (Niveau&#160;A)</a></legend>
 						<input id="ap322" type="radio" name="sc322" value="pass"><label for="ap322">Réussi</label>
 						<input id="af322" type="radio" name="sc322" value="fail"><label for="af322">Échouée</label>
 						<input id="an322" type="radio" name="sc322" value="na"><label for="an322"><abbr title="Sans objet">S/O</abbr></label>
@@ -506,7 +642,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-consistent-locations" rel="external" aria-describedby="g10">3.2.3 Navigation cohérente (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-consistent-locations" rel="external" aria-describedby="g32">3.2.3 Navigation cohérente (Niveau&#160;AA)</a></legend>
 						<input id="aap323" type="radio" name="sc323" value="pass"><label for="aap323">Réussi</label>
 						<input id="aaf323" type="radio" name="sc323" value="fail"><label for="aaf323">Échouée</label>
 						<input id="aan323" type="radio" name="sc323" value="na"><label for="aan323"><abbr title="Sans objet">S/O</abbr></label>
@@ -514,7 +650,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-consistent-functionality" rel="external" aria-describedby="g10">3.2.4 Identification cohérente (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-consistent-functionality" rel="external" aria-describedby="g32">3.2.4 Identification cohérente (Niveau&#160;AA)</a></legend>
 						<input id="aap324" type="radio" name="sc324" value="pass"><label for="aap324">Réussi</label>
 						<input id="aaf324" type="radio" name="sc324" value="fail"><label for="aaf324">Échouée</label>
 						<input id="aan324" type="radio" name="sc324" value="na"><label for="aan324"><abbr title="Sans objet">S/O</abbr></label>
@@ -522,7 +658,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-no-extreme-changes-context" rel="external" aria-describedby="g10">3.2.5 Changement à la demande (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#consistent-behavior-no-extreme-changes-context" rel="external" aria-describedby="g32">3.2.5 Changement à la demande (Niveau&#160;AAA)</a></legend>
 						<input id="aaap325" type="radio" name="sc325" value="pass"><label for="aaap325">Réussi</label>
 						<input id="aaaf325" type="radio" name="sc325" value="fail"><label for="aaaf325">Échouée</label>
 						<input id="aaan325" type="radio" name="sc325" value="na"><label for="aaan325"><abbr title="Sans objet">S/O</abbr></label>
@@ -531,11 +667,11 @@
 			</ol>
 		</section>
 		<section class="mrgn-tp-lg">
-			<h4 id="g11"><b>Règle 3.3 Assistance à la saisie&#160;:</b> Aider l'utilisateur à éviter et à corriger les erreurs de saisie.</h4>
+			<h4 id="g33"><b>Règle 3.3 Assistance à la saisie&#160;:</b> Aider l'utilisateur à éviter et à corriger les erreurs de saisie.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-identified" rel="external" aria-describedby="g11">3.3.1 Identification des erreurs (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-identified" rel="external" aria-describedby="g33">3.3.1 Identification des erreurs (Niveau&#160;A)</a></legend>
 						<input id="ap331" type="radio" name="sc331" value="pass"><label for="ap331">Réussi</label>
 						<input id="af331" type="radio" name="sc331" value="fail"><label for="af331">Échouée</label>
 						<input id="an331" type="radio" name="sc331" value="na"><label for="an331"><abbr title="Sans objet">S/O</abbr></label>
@@ -543,7 +679,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-cues" rel="external" aria-describedby="g11">3.3.2 Étiquettes ou instructions (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-cues" rel="external" aria-describedby="g33">3.3.2 Étiquettes ou instructions (Niveau&#160;A)</a></legend>
 						<input id="ap332" type="radio" name="sc332" value="pass"><label for="ap332">Réussi</label>
 						<input id="af332" type="radio" name="sc332" value="fail"><label for="af332">Échouée</label>
 						<input id="an332" type="radio" name="sc332" value="na"><label for="an332"><abbr title="Sans objet">S/O</abbr></label>
@@ -551,7 +687,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-suggestions" rel="external" aria-describedby="g11">3.3.3 Suggestion après une erreur (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-suggestions" rel="external" aria-describedby="g33">3.3.3 Suggestion après une erreur (Niveau&#160;AA)</a></legend>
 						<input id="aap333" type="radio" name="sc333" value="pass"><label for="aap333">Réussi</label>
 						<input id="aaf333" type="radio" name="sc333" value="fail"><label for="aaf333">Échouée</label>
 						<input id="aan333" type="radio" name="sc333" value="na"><label for="aan333"><abbr title="Sans objet">S/O</abbr></label>
@@ -559,7 +695,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-reversible" rel="external" aria-describedby="g11">3.3.4 Prévention des erreurs (juridiques, financières, de données) (Niveau&#160;AA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-reversible" rel="external" aria-describedby="g33">3.3.4 Prévention des erreurs (juridiques, financières, de données) (Niveau&#160;AA)</a></legend>
 						<input id="aap334" type="radio" name="sc334" value="pass"><label for="aap334">Réussi</label>
 						<input id="aaf334" type="radio" name="sc334" value="fail"><label for="aaf334">Échouée</label>
 						<input id="aan334" type="radio" name="sc334" value="na"><label for="aan334"><abbr title="Sans objet">S/O</abbr></label>
@@ -567,7 +703,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-context-help" rel="external" aria-describedby="g11">3.3.5 Aide (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-context-help" rel="external" aria-describedby="g33">3.3.5 Aide (Niveau&#160;AAA)</a></legend>
 						<input id="aaap335" type="radio" name="sc335" value="pass"><label for="aaap335">Réussi</label>
 						<input id="aaaf335" type="radio" name="sc335" value="fail"><label for="aaaf335">Échouée</label>
 						<input id="aaan335" type="radio" name="sc335" value="na"><label for="aaan335"><abbr title="Sans objet">S/O</abbr></label>
@@ -575,7 +711,7 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-reversible-all" rel="external" aria-describedby="g11">3.3.6 Prévention des erreurs (toutes) (Niveau&#160;AAA)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#minimize-error-reversible-all" rel="external" aria-describedby="g33">3.3.6 Prévention des erreurs (toutes) (Niveau&#160;AAA)</a></legend>
 						<input id="aaap336" type="radio" name="sc336" value="pass"><label for="aaap336">Réussi</label>
 						<input id="aaaf336" type="radio" name="sc336" value="fail"><label for="aaaf336">Échouée</label>
 						<input id="aaan336" type="radio" name="sc336" value="na"><label for="aaan336"><abbr title="Sans objet">S/O</abbr></label>
@@ -588,11 +724,11 @@
 	<section>
 		<h3 id="wcag4"><b>Principe&#160;:</b> Robuste</h3>
 		<section class="mrgn-tp-lg">
-			<h4 id="g12"><b>Règle 4.1 Compatible&#160;:</b> Optimiser la compatibilité avec les agents utilisateurs actuels et futurs, y compris les technologies d'assistance.</h4>
+			<h4 id="g41"><b>Règle 4.1 Compatible&#160;:</b> Optimiser la compatibilité avec les agents utilisateurs actuels et futurs, y compris les technologies d'assistance.</h4>
 			<ol>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#ensure-compat-parses" rel="external" aria-describedby="g12">4.1.1 Analyse syntaxique (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#ensure-compat-parses" rel="external" aria-describedby="g41">4.1.1 Analyse syntaxique (Niveau&#160;A)</a></legend>
 						<input id="ap411" type="radio" name="sc411" value="pass"><label for="ap411">Réussi</label>
 						<input id="af411" type="radio" name="sc411" value="fail"><label for="af411">Échouée</label>
 						<input id="an411" type="radio" name="sc411" value="na"><label for="an411"><abbr title="Sans objet">S/O</abbr></label>
@@ -600,10 +736,18 @@
 				</li>
 				<li>
 					<fieldset>
-						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#ensure-compat-rsv" rel="external" aria-describedby="g12">4.1.2 Nom, rôle et valeur (Niveau&#160;A)</a></legend>
+						<legend><a href="https://www.w3.org/Translations/WCAG20-fr/#ensure-compat-rsv" rel="external" aria-describedby="g41">4.1.2 Nom, rôle et valeur (Niveau&#160;A)</a></legend>
 						<input id="ap412" type="radio" name="sc412" value="pass"><label for="ap412">Réussi</label>
 						<input id="af412" type="radio" name="sc412" value="fail"><label for="af412">Échouée</label>
 						<input id="an412" type="radio" name="sc412" value="na"><label for="an412"><abbr title="Sans objet">S/O</abbr></label>
+					</fieldset>
+				</li>
+				<li>
+					<fieldset>
+						<legend><a href="https://www.w3.org/TR/WCAG21/#status-messages" rel="external" aria-describedby="g41"><span lang="en">4.1.3 Status Messages (Niveau&#160;AA)</span> (anglais seulement)</a></legend>
+						<input id="aap413" type="radio" name="sc413" value="pass"><label for="aap413">Réussi</label>
+						<input id="aaf413" type="radio" name="sc413" value="fail"><label for="aaf413">Échouée</label>
+						<input id="aan413" type="radio" name="sc413" value="na"><label for="aan413"><abbr title="Sans objet">S/O</abbr></label>
 					</fieldset>
 				</li>
 			</ol>
@@ -616,27 +760,27 @@
 			<tbody>
 				<tr>
 					<th scope="row">Critères de succès de niveau&#160;A réussis</th>
-					<td class="text-right"><span id="rsltA"></span>/25 (<span id="percA"></span>%)</td>
+					<td class="text-right"><span id="rsltA"></span>/30 (<span id="percA"></span>%)</td>
 				</tr>
 				<tr>
 					<th scope="row">Critères de succès de niveau&#160;AA réussis</th>
-					<td class="text-right"><span id="rsltAA"></span>/13 (<span id="percAA"></span>%)</td>
+					<td class="text-right"><span id="rsltAA"></span>/20 (<span id="percAA"></span>%)</td>
 				</tr>
 				<tr>
 					<th scope="row">Critères de succès de niveau&#160;AAA réussis</th>
-					<td class="text-right"><span id="rsltAAA"></span>/23 (<span id="percAAA"></span>%)</td>
+					<td class="text-right"><span id="rsltAAA"></span>/28 (<span id="percAAA"></span>%)</td>
 				</tr>
 				<tr class="success">
 					<th scope="row">Critères de succès totaux réussis</th>
-					<td class="text-right"><span id="rsltTotal"></span>/61 (<span id="percTotal"></span>%)</td>
+					<td class="text-right"><span id="rsltTotal"></span>/78 (<span id="percTotal"></span>%)</td>
 				</tr>
 				<tr class="active">
 					<th scope="row">Critéres de succès évalués</th>
-					<td class="text-right"><span id="evalTotal"></span>/61 (<span id="percEvalTotal"></span>%)</td>
+					<td class="text-right"><span id="evalTotal"></span>/78 (<span id="percEvalTotal"></span>%)</td>
 				</tr>
 				<tr class="active">
 					<th scope="row">Critéres de succès <abbr title="Sans objet">S/O</abbr></th>
-					<td class="text-right"><span id="naTotal"></span>/61 (<span id="percNATotal"></span>%)</td>
+					<td class="text-right"><span id="naTotal"></span>/78 (<span id="percNATotal"></span>%)</td>
 				</tr>
 			</tbody>
 		</table>


### PR DESCRIPTION
* Updated original content
* Added WCAG 2.1's extra success criteria to the tool
* Changed naming scheme of guideline IDs/aria-describedby attributes due to guideline 2.5's introduction and to be easier to maintain
* Changed total numbers of success criteria in the tool
* Kept links to WCAG 2.0 success criteria and glossary section as-is...
  * No authorized French translation of WCAG 2.1 currently exists
  * WCAG 2.0's success criteria is unchanged in 2.1
  * Glossary content sourced from WCAG 2.0 is virtually identical in 2.1 (only differences are note/example heading naming schemes, coloured boxes, coding markup and term link destinations)