### PR TITLE
Web Accessibility Assessment Methodology: Remove "needs translation" notice from docs

### DIFF
--- a/site/pages/docs/ref/wamethod/wamethod-fr.hbs
+++ b/site/pages/docs/ref/wamethod/wamethod-fr.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "other",
 	"description": "Offre une méthodologie d’évaluation qui permet de mesurer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.0 pour les critères de succès de niveau A, AA et AAA.",
 	"altLangPrefix": "wamethod",
-	"dateModified": "2014-08-15"
+	"dateModified": "2019-08-05"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -16,8 +16,6 @@
 	<p>Offre une méthodologie d’évaluation qui permet de mesurer le degré de conformité aux Règles pour l’accessibilité des contenus Web (WCAG) 2.0 pour les critères de succès de niveau A, AA et AAA.</p>
 </section>
 
-<div lang="en">
-<p><strong>Needs translation</strong></p>
 <section>
 	<h2>Utiliser afin</h2>
 	<ul>
@@ -47,4 +45,3 @@
 	<h2>Code source</h2>
 	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/other/wamethod">Code source pour la méthodologie d’évaluation de l’accessibilité du web sur GitHub</a></p>
 </section>
-</div>


### PR DESCRIPTION
All of the French documentation page's content is written in French. Therefore, the notice was irrelevant. Its container's lang="en" attribute was also causing some French content to be falsely represented as English.