### PR TITLE
Proposing rel='noreferrer noopener' for share links

### DIFF
--- a/src/plugins/share/share.js
+++ b/src/plugins/share/share.js
@@ -205,7 +205,7 @@ var componentName = "wb-share",
 							.replace( /\{d\}/, pageDescription );
 					panel += "<li><a href='" + url + "' class='" + shareLink +
 						" " + ( siteProperties.isMailto ? "email" : key ) +
-						" btn btn-default' target='_blank'>" +
+						" btn btn-default' target='_blank' rel='noreferrer noopener'>" +
 						siteProperties.name + "</a></li>";
 				}
 


### PR DESCRIPTION
Suggestion based on "Links to cross-origin destinations are unsafe" (https://developers.google.com/web/tools/lighthouse/audits/noopener?utm_source=lighthouse&utm_medium=devtools)