### PR TITLE
Add CDTS Address to WET-Boew index page

### DIFF
--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -66,7 +66,7 @@
 			<ul>
 				<li><a href="https://github.com/wet-boew/wet-boew-dotnet-controls">Web Control Library .NET</a></li>
 				<li><a href="https://github.com/wet-boew/wet-boew-drupal">Drupal WxT variant</a></li>
-				<li>CDTS - Centralized template services</li>
+				<li><a href="https://www.gcpedia.gc.ca/wiki/Centrally_Deployed_Templates_Solution_(CDTS) ">CDTS - Centralized template services</a></li>
 				<li><a href="https://github.com/orgs/wet-boew/projects/1">WCAG 2.1 Level AA review</a></li>
 			</ul>
 			<p><small>(<a href="https://wet-boew.github.io/wet-boew-documentation/projects-en.html">All projects</a>)</small></p>

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -67,7 +67,7 @@
 			<ul>
 				<li><a hreflang="en" lang="en" href="https://github.com/wet-boew/wet-boew-dotnet-controls">Web Control Library .NET</a> (en anglais)</li>
 				<li><a hreflang="en" lang="en" href="https://github.com/wet-boew/wet-boew-drupal">Drupal WxT variant</a> (en anglais)</li>
-				<li>CDTS - Service centralisé de gabarit</li>
+				<li><a hreflang="fr" lang="fr" href="https://www.gcpedia.gc.ca/wiki/Solution_de_gabarits_à_déploiement_centralisé_(SGDC)">SGDC - Service centralisé de gabarit</a></li>
 				<li><a hreflang="en" lang="en" href="https://github.com/orgs/wet-boew/projects/1">WCAG 2.1 Level AA review</a> (en anglais)</li>
 			</ul>
 			<p><small>(<a hreflang="en" lang="en" href="https://wet-boew.github.io/wet-boew-documentation/projects-en.html">All projects</a> - en anglais)</small></p>


### PR DESCRIPTION
Once Documentation is updated, We will change this link to
https://cenw-wscoe.github.io/sgdc-cdts/docs/index-en.html