### PR TITLE
Build: Update grunt-html to ^11.1.1 and remove outdated htmllint ignore rules

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -980,9 +980,6 @@ module.exports = (grunt) ->
 			all:
 				options:
 					ignore: [
-						"The “date” input type is not supported in all browsers. Please be sure to test, and consider using a polyfill."
-						"The “time” input type is not supported in all browsers. Please be sure to test, and consider using a polyfill."
-						"The “longdesc” attribute on the “img” element is obsolete. Use a regular “a” element to link to the description."
 						# TODO: Should be removed and fixed now that HTML5 specs updated
 						"The “main” role is unnecessary for element “main”."
 						"The “contentinfo” role is unnecessary for element “footer”."

--- a/package-lock.json
+++ b/package-lock.json
@@ -4896,14 +4896,14 @@
       }
     },
     "grunt-html": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-9.2.0.tgz",
-      "integrity": "sha512-JTRLWLC3TvTF5JSwgOwi8p+T2we28taPdAk555mUg2rPwViXSBfUcKeaSzVw0jNq3ntlNaULjqUAU5qQWzsYVw==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-11.1.1.tgz",
+      "integrity": "sha512-YAurPMB/GUsy8UZdNYZ38pTTGYKoXuTxi6CkIYtxSRfxKEJCCK0JSDJn5UbAvA0MK86CMhOsMeO+4qcu9KnPHw==",
       "dev": true,
       "requires": {
-        "async": "2.6.1",
-        "chalk": "2.4.1",
-        "vnu-jar": "18.7.23"
+        "async": "^3.1.0",
+        "chalk": "^2.4.2",
+        "vnu-jar": "19.9.4"
       },
       "dependencies": {
         "ansi-styles": {
@@ -4916,18 +4916,15 @@
           }
         },
         "async": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-          "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.10"
-          }
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+          "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ==",
+          "dev": true
         },
         "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
@@ -4935,26 +4932,14 @@
             "supports-color": "^5.3.0"
           }
         },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
           }
-        },
-        "vnu-jar": {
-          "version": "18.7.23",
-          "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-18.7.23.tgz",
-          "integrity": "sha512-40X+8KQ/dTkbOswDG64G7CKzxSlwv1b45dCBc9VAXd+aAdxUu0sN6sHkol/GkO85phj5CoYT8zCrN0aJvmhOug==",
-          "dev": true
         }
       }
     },
@@ -13880,6 +13865,12 @@
       "requires": {
         "indexof": "0.0.1"
       }
+    },
+    "vnu-jar": {
+      "version": "19.9.4",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-19.9.4.tgz",
+      "integrity": "sha512-x91WyaNr1oPJaYZkbyMElRyV60BUaxPuhm3zXXjlFOpW3E2KavPWlyohX0LTf6gX7/tujIMgLE5UGc0jn7o4XQ==",
+      "dev": true
     },
     "void-elements": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "grunt-cssmin-ie8-clean": "0.0.1",
     "grunt-eslint": "^19.0.0",
     "grunt-gh-pages": "~2.0.0",
-    "grunt-html": "^9.2.0",
+    "grunt-html": "^11.1.1",
     "grunt-i18n-csv": "^0.1.0",
     "grunt-lintspaces": "^0.8.3",
     "grunt-markdownlint": "^1.1.3",


### PR DESCRIPTION
Updates grunt-html to ^11.1.1 and removes outdated ignore rules from its associated task (htmllint).