### PR TITLE
Build: Remove SauceLabs leftovers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
 before_install:
   - sudo groupadd --gid 1000 dockerbuild && sudo usermod -a -G 1000 $USER && sudo chown -R :dockerbuild .
   - echo "machine github.com login $GH_TOKEN" >> ~/.netrc
-  - env -0 | while IFS='=' read -r -d '' n v; do echo "$n"="$(echo $v)";done | grep  'TRAVIS\|CI\|SAUCE\|GIT\|REPO\|BRANCH' >> script/docker/env
+  - env -0 | while IFS='=' read -r -d '' n v; do echo "$n"="$(echo $v)";done | grep  'TRAVIS\|CI\|GIT\|REPO\|BRANCH' >> script/docker/env
   - shopt -s expand_aliases
   - source script/docker/activate
   - npm --version

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -77,19 +77,6 @@ module.exports = (grunt) ->
 	)
 
 	@registerTask(
-		"saucelabs"
-		"Run tests on SauceLabs. Currently only for Travis builds"
-		->
-			# TODO: Add error message when TRAVIS_SECURE_VARS is fixed (see https://github.com/wet-boew/wet-boew/pull/6108#discussion_r18190951)
-			if process.env.SAUCE_USERNAME isnt `undefined` and process.env.SAUCE_ACCESS_KEY isnt `undefined`
-				grunt.task.run [
-					"pre-mocha"
-					(if process.env.TRAVIS is "true" then "saucelabs-mocha:travis" else "saucelabs-mocha:local")
-				]
-
-	)
-
-	@registerTask(
 		"init"
 		"Only needed when the repo is first cloned"
 		[
@@ -231,7 +218,7 @@ module.exports = (grunt) ->
 
 	@registerTask(
 		"test"
-		"INTERNAL: Runs testing tasks except for SauceLabs testing"
+		"INTERNAL: Runs testing tasks"
 		[
 			"eslint"
 			"sasslint"
@@ -1397,34 +1384,6 @@ module.exports = (grunt) ->
 				options:
 					reporter: "Spec"
 					urls: ["http://localhost:8000/dist/unmin/test/test.html?txthl=just%20some%7Ctest"]
-
-		"saucelabs-mocha":
-			options:
-				urls: "<%= mocha.all.options.urls %>"
-				throttled: 3
-				browsers: @file.readJSON "browsers.json"
-				tunnelArgs: [
-					"-D"
-					"ajax.googleapis.com"
-				]
-				sauceConfig:
-					"video-upload-on-pass": false
-					"single-window": true
-					"record-screenshots": false
-					"capture-html": true
-				maxRetries: 3
-			travis:
-				options:
-					testname: process.env.TRAVIS_COMMIT_MSG
-					build: process.env.TRAVIS_BUILD_NUMBER
-					tags: [
-						process.env.TRAVIS_JOB_ID
-						process.env.TRAVIS_BRANCH
-						process.env.TRAVIS_COMMIT
-					]
-			local:
-				options:
-					testname: "Local Test - <%= grunt.template.today('yyyy-mm-dd hh:MM') %>"
 
 		"string-replace":
 			inline:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 [![Build Status](https://secure.travis-ci.org/wet-boew/wet-boew.svg?branch=master)](https://travis-ci.org/wet-boew/wet-boew)
 [![devDependency Status](https://david-dm.org/wet-boew/wet-boew/dev-status.svg)](https://david-dm.org/wet-boew/wet-boew#info=devDependencies)
 
-[![Selenium Test Status](https://saucelabs.com/browser-matrix/wet-boew-bot.svg)](https://saucelabs.com/u/wet-boew-bot)
-
 ## What is the Web Experience Toolkit?
 
 * An [award-winning](https://wet-boew.github.io/wet-boew/docs/ref/accolades-en.html#awards) front-end framework for building websites that are [accessible](https://wet-boew.github.io/wet-boew/index-en.html#accessibility), [usable](https://wet-boew.github.io/wet-boew/index-en.html#usability), [interoperable](https://wet-boew.github.io/wet-boew/index-en.html#interoperability), [mobile friendly](https://wet-boew.github.io/wet-boew/index-en.html#mobile-friendly-responsive-design) and [multilingual](https://wet-boew.github.io/wet-boew/index-en.html#multilingual)

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,24 +123,6 @@
       "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
       "dev": true
     },
-    "agent-base": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.1.1.tgz",
-      "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
-      "dev": true,
-      "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
-          "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
-          "dev": true
-        }
-      }
-    },
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
@@ -439,12 +421,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
       "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-      "dev": true
-    },
-    "aws4": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
     },
     "babel-code-frame": {
@@ -3319,24 +3295,6 @@
         "pend": "~1.2.0"
       }
     },
-    "fg-lodash": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/fg-lodash/-/fg-lodash-0.0.2.tgz",
-      "integrity": "sha1-mINSU39CfaavIiEpu2OsyknmL6M=",
-      "dev": true,
-      "requires": {
-        "lodash": "^2.4.1",
-        "underscore.string": "~2.3.3"
-      },
-      "dependencies": {
-        "underscore.string": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
-          "integrity": "sha1-ccCL9rQosRM/N+ePo6Icgvcymw0=",
-          "dev": true
-        }
-      }
-    },
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -5248,40 +5206,6 @@
         "sass-lint": "^1.12.0"
       }
     },
-    "grunt-saucelabs": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-saucelabs/-/grunt-saucelabs-9.0.0.tgz",
-      "integrity": "sha1-1ogCWgVQHeysCp4SndTk9QpCAUo=",
-      "dev": true,
-      "requires": {
-        "colors": "~1.1.2",
-        "lodash": "~4.13.1",
-        "q": "~1.4.1",
-        "requestretry": "~1.9.0",
-        "sauce-tunnel": "~2.5.0",
-        "saucelabs": "~1.2.0"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-          "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.13.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz",
-          "integrity": "sha1-g+SxCRP0hJbU0W/sSlYK8u50S2g=",
-          "dev": true
-        },
-        "q": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-          "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
-          "dev": true
-        }
-      }
-    },
     "grunt-spritesmith": {
       "version": "6.6.3",
       "resolved": "https://registry.npmjs.org/grunt-spritesmith/-/grunt-spritesmith-6.6.3.tgz",
@@ -6443,12 +6367,6 @@
       "integrity": "sha1-JhK+Wu2PICaXN8cxHaFcnC11+7w=",
       "dev": true
     },
-    "har-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-      "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-      "dev": true
-    },
     "har-validator": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
@@ -6696,17 +6614,6 @@
       "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
       "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
       "dev": true
-    },
-    "https-proxy-agent": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
-      "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
-      "dev": true,
-      "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
-      }
     },
     "iconv-lite": {
       "version": "0.2.11",
@@ -9876,12 +9783,6 @@
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
       "dev": true
     },
-    "performance-now": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-      "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-      "dev": true
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -10631,107 +10532,6 @@
       "dev": true,
       "requires": {
         "throttleit": "^1.0.0"
-      }
-    },
-    "requestretry": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.9.1.tgz",
-      "integrity": "sha1-CioATq8hGWnEzCz+vz/p5XuSx04=",
-      "dev": true,
-      "requires": {
-        "extend": "^3.0.0",
-        "fg-lodash": "0.0.2",
-        "request": "^2.74.x",
-        "when": "~3.7.5"
-      },
-      "dependencies": {
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
-          }
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "dev": true,
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        }
       }
     },
     "require-directory": {
@@ -12076,115 +11876,6 @@
         }
       }
     },
-    "sauce-tunnel": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/sauce-tunnel/-/sauce-tunnel-2.5.0.tgz",
-      "integrity": "sha1-DuTE/5tH4BPosHLL+sSVt/7Y6Os=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.3",
-        "request": "^2.72.0",
-        "split": "^1.0.0"
-      },
-      "dependencies": {
-        "caseless": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-          "dev": true
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.5",
-            "mime-types": "^2.1.12"
-          }
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "requires": {
-            "ajv": "^4.9.1",
-            "har-schema": "^1.0.5"
-          }
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "~0.6.0",
-            "aws4": "^1.2.1",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.5",
-            "extend": "~3.0.0",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.1.1",
-            "har-validator": "~4.2.1",
-            "hawk": "~3.1.3",
-            "http-signature": "~1.1.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.7",
-            "oauth-sign": "~0.8.1",
-            "performance-now": "^0.2.0",
-            "qs": "~6.4.0",
-            "safe-buffer": "^5.0.1",
-            "stringstream": "~0.0.4",
-            "tough-cookie": "~2.3.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.0.0"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
-          "dev": true,
-          "requires": {
-            "punycode": "^1.4.1"
-          }
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.0.1"
-          }
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
-          "dev": true
-        }
-      }
-    },
-    "saucelabs": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.2.0.tgz",
-      "integrity": "sha1-XoBHazbaG0LRDzlwfprypTsD2Io=",
-      "dev": true,
-      "requires": {
-        "https-proxy-agent": "^1.0.0"
-      }
-    },
     "save-pixels": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/save-pixels/-/save-pixels-2.3.4.tgz",
@@ -12525,15 +12216,6 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
       "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
       "dev": true
-    },
-    "split": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
-      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
-      "dev": true,
-      "requires": {
-        "through": "2"
-      }
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -13904,12 +13586,6 @@
       "requires": {
         "wrap-fn": "^0.1.0"
       }
-    },
-    "when": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/when/-/when-3.7.8.tgz",
-      "integrity": "sha1-xxMLan6gRpPoQs3J56Hyqjmjn4I=",
-      "dev": true
     },
     "which": {
       "version": "1.0.9",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "grunt-postcss": "^0.9.0",
     "grunt-sass": "^3.0.2",
     "grunt-sass-lint": "^0.2.4",
-    "grunt-saucelabs": "^9.0.0",
     "grunt-spritesmith": "^6.6.3",
     "grunt-sri": "^0.2.0",
     "grunt-string-replace": "^1.3.1",


### PR DESCRIPTION
Removes the following:
* "saucelabs" and "saucelabs-mocha" grunt tasks
* Mention of SauceLabs in the "test" task's description
* SauceLabs reference from readme
* grunt-saucelabs dependency
* "SAUCE\\|" from grep command in .travis.yml

SauceLabs was disabled in #8031.