### PR TITLE
Build: Fail on bootlint errors/warnings

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -997,6 +997,9 @@ module.exports = (grunt) ->
 		bootlint:
 			all:
 				options:
+					stoponerror: true
+					stoponwarning: true
+					showallerrors: true
 					relaxerror: [
 						# We recommend handling this through the server headers so it never appears in the markup
 						"W002" # `<head>` is missing X-UA-Compatible `<meta>` tag that disables old IE compatibility modes


### PR DESCRIPTION
This aborts the build if the bootlint task runs into any errors or warnings (in line with how the other linters work). It'll show all issues it found before failing.

Should make it much more obvious if any future changes introduce bootlint issues.