### PR TITLE
Table validator: Fix bootlint errors

### DIFF
--- a/src/other/tablevalidator/tablevalidator-en.hbs
+++ b/src/other/tablevalidator/tablevalidator-en.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "tablevalidator",
 	"altLangPrefix": "tablevalidator",
 	"js": ["demo/tablevalidator"],
-	"dateModified": "2014-04-28"
+	"dateModified": "2019-10-18"
 }
 ---
 <div class="wb-prettify"></div>
@@ -26,35 +26,25 @@
 <form id="formtablevalidator" class="col-xs-12">
 	<fieldset>
 		<legend>Options</legend>
-		<div class="checkbox-inline">
-			<label for="chkHassum">
-				<input type="checkbox" value="chkHassum" id="chkHassum" /> Has a summary group
-			</label>
-		</div>
-		<div class="checkbox-inline">
-			<label for="chkCleanMarkup">
-				<input type="checkbox" value="chkCleanMarkup" id="chkCleanMarkup" /> Do not clean up the HTML
-			</label>
-		</div>
+		<label class="checkbox-inline" for="chkHassum">
+			<input type="checkbox" value="chkHassum" id="chkHassum" /> Has a summary group
+		</label>
+		<label class="checkbox-inline" for="chkCleanMarkup">
+			<input type="checkbox" value="chkCleanMarkup" id="chkCleanMarkup" /> Do not clean up the HTML
+		</label>
 	</fieldset>
 
 	<fieldset>
 		<legend>Accessibility</legend>
-		<div class="radio-inline">
-			<label for="access-1">
-				<input type="radio" name="access" checked="checked" id="access-1" /> Auto detect <em>(default)</em>
-			</label>
-		</div>
-		<div class="radio-inline">
-			<label for="access-2">
-				<input type="radio" name="access" id="access-2" /> Scope
-			</label>
-		</div>
-		<div class="radio-inline">
-			<label for="access-3">
-				<input type="radio" name="access" id="access-3" /> Ids/headers
-			</label>
-		</div>
+		<label class="radio-inline" for="access-1">
+			<input type="radio" name="access" checked="checked" id="access-1" /> Auto detect <em>(default)</em>
+		</label>
+		<label class="radio-inline" for="access-2">
+			<input type="radio" name="access" id="access-2" /> Scope
+		</label>
+		<label class="radio-inline" for="access-3">
+			<input type="radio" name="access" id="access-3" /> Ids/headers
+		</label>
 	</fieldset>
 
 	<fieldset>

--- a/src/other/tablevalidator/tablevalidator-fr.hbs
+++ b/src/other/tablevalidator/tablevalidator-fr.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "tablevalidator",
 	"altLangPrefix": "tablevalidator",
 	"js": ["demo/tablevalidator"],
-	"dateModified": "2014-04-23"
+	"dateModified": "2019-10-18"
 }
 ---
 <div class="wb-prettify"></div>
@@ -28,35 +28,25 @@
 <form id="formtablevalidator" class="col-xs-12">
 	<fieldset>
 		<legend>Options</legend>
-		<div class="checkbox-inline">
-			<label for="chkHassum">
-				<input type="checkbox" value="chkHassum" id="chkHassum" /> Contient des groupes sommaire
-			</label>
-		</div>
-		<div class="checkbox-inline">
-			<label for="chkCleanMarkup">
-				<input type="checkbox" value="chkCleanMarkup" id="chkCleanMarkup" /> Ne pas nettoyer l'HTML
-			</label>
-		</div>
+		<label class="checkbox-inline" for="chkHassum">
+			<input type="checkbox" value="chkHassum" id="chkHassum" /> Contient des groupes sommaire
+		</label>
+		<label class="checkbox-inline" for="chkCleanMarkup">
+			<input type="checkbox" value="chkCleanMarkup" id="chkCleanMarkup" /> Ne pas nettoyer l'HTML
+		</label>
 	</fieldset>
 
 	<fieldset>
 		<legend>Accessibilité</legend>
-		<div class="radio-inline">
-			<label for="access-1">
-				<input type="radio" name="access" checked="checked" id="access-1" /> Automatique <em>(par défaut)</em>
-			</label>
-		</div>
-		<div class="radio-inline">
-			<label for="access-2">
-				<input type="radio" name="access" id="access-2" /> Scope
-			</label>
-		</div>
-		<div class="radio-inline">
-			<label for="access-3">
-				<input type="radio" name="access" id="access-3" /> Ids/headers
-			</label>
-		</div>
+		<label class="radio-inline" for="access-1">
+			<input type="radio" name="access" checked="checked" id="access-1" /> Automatique <em>(par défaut)</em>
+		</label>
+		<label class="radio-inline" for="access-2">
+			<input type="radio" name="access" id="access-2" /> Scope
+		</label>
+		<label class="radio-inline" for="access-3">
+			<input type="radio" name="access" id="access-3" /> Ids/headers
+		</label>
 	</fieldset>
 
 	<fieldset>


### PR DESCRIPTION
This commit fixes a few bootlint errors that were introduced in #8699.

The purpose of the change in #8699 that caused the bootlint errors seemed to be to visually-bold certain checkbox and radio button labels. This commit reverts that change, which consequently removes the bolding.

@thekodester @duboisp @GormFrank FYI