### PR TITLE
Form validation: Add "chkbxrdio-grp" class to some examples

### DIFF
--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2019-07-29"
+	"dateModified": "2020-02-04"
 }
 ---
 
@@ -370,7 +370,7 @@
 				</details>
 			</fieldset>
 
-			<fieldset>
+			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Favourite pets</span> <strong class="required">(required)</strong></legend>
 				<div class="checkbox">
 					<label for="animal1"><input type="checkbox" name="animal" value="1" id="animal1" required="required" />&#160;&#160;Dog</label>
@@ -391,7 +391,7 @@
 &lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
-		&lt;fieldset&gt;
+		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Favourite pets&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="checkbox"&gt;
 				&lt;label for="animal1"&gt;&lt;input type="checkbox" name="animal" value="1" id="animal1" required="required" /&gt;&amp;#160;&amp;#160;Dog&lt;/label&gt;
@@ -408,7 +408,7 @@
 		&lt;/fieldset&gt;</code></pre>
 			</details>
 
-			<fieldset>
+			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Citizenship status</span> <strong class="required">(required)</strong></legend>
 				<div class="radio">
 					<label for="status1"><input type="radio" name="status" value="1" id="status1" required="required" />&#160;&#160;Canadian citizen</label>
@@ -429,7 +429,7 @@
 &lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
-		&lt;fieldset&gt;
+		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Citizenship status&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="radio"&gt;
 				&lt;label for="status1"&gt;&lt;input type="radio" name="status" value="1" id="status1" required="required" /&gt;&amp;#160;&amp;#160;Canadian citizen&lt;/label&gt;

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -8,7 +8,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2019-07-29"
+	"dateModified": "2020-02-04"
 }
 ---
 
@@ -371,7 +371,7 @@
 				</details>
 			</fieldset>
 
-			<fieldset>
+			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Animaux favoris</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="checkbox">
 					<label for="animal1"><input type="checkbox" name="animal" value="1" id="animal1" required="required" />&#160;&#160;Chien</label>
@@ -391,7 +391,7 @@
 				<pre class="prettyprint prettyprinted"><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
-		&lt;fieldset&gt;
+		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Animaux favoris&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="checkbox"&gt;
 				&lt;label for="animal1"&gt;&lt;input type="checkbox" name="animal" value="1" id="animal1" required="required" /&gt;&amp;#160;&amp;#160;Chien&lt;/label&gt;
@@ -408,7 +408,7 @@
 		&lt;/fieldset&gt;</code></pre>
 			</details>
 
-			<fieldset>
+			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Statut de citoyen</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="radio">
 					<label for="status1" class="required"><input type="radio" name="status" value="1" id="status1" required="required" />&#160;&#160;Citoyen canadien</label>
@@ -428,7 +428,7 @@
 				<pre class="prettyprint prettyprinted"><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
-		&lt;fieldset&gt;
+		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Statut de citoyen&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="radio"&gt;
 				&lt;label for="status1" class="required"&gt;&lt;input type="radio" name="status" value="1" id="status1" required="required" /&gt;&#160;&#160;Citoyen canadien&lt;/label&gt;


### PR DESCRIPTION
This adds the "chkbxrdio-grp" class to the default checkbox and radio button examples ("Favourite pets" and "Citizenship status") to prevent their legends from looking like category headings. Stacked and horizontal form examples already use it.