### PR TITLE
Toggle: Fix prettify issues in demo pages

### DIFF
--- a/src/plugins/toggle/toggle-en.hbs
+++ b/src/plugins/toggle/toggle-en.hbs
@@ -8,9 +8,11 @@
 	"parentdir": "toggle",
 	"altLangPrefix": "toggle",
 	"css": ["demo/toggle"],
-	"dateModified": "2015-04-22"
+	"dateModified": "2020-03-10"
 }
 ---
+<span class="wb-prettify all-pre linenums"></span>
+
 <section>
 	<h2>Purpose</h2>
 	<p>Create an element that toggles elements between on and off states.</p>
@@ -108,10 +110,10 @@
 
 			<p>For example, the following element will always toggle on elements with the <code>.foo</code> CSS class that are contained in a parent with the <code>.bar</code> CSS class. In addition, the elements it controls will be toggled on when the page is printed.</p>
 
-			<pre class="lang-css"><code>&lt;button type="button" class="wb-toggle" data-toggle='{"type": "on", "selector": ".foo", "parent": ".bar", "print": "on"}'&gt;Turn on&lt;/button&gt;</code></pre>
+			<pre><code>&lt;button type="button" class="wb-toggle" data-toggle='{"type": "on", "selector": ".foo", "parent": ".bar", "print": "on"}'&gt;Turn on&lt;/button&gt;</code></pre>
 		</section>
 
-		<section class="wb-prettify all-pre linenums">
+		<section>
 			<h2 id="simple">Simple Example</h2>
 			<p>This simple example shows:</p>
 			<ul>
@@ -464,7 +466,7 @@
 
 			<p>If you're using details elements for the accordion sections, the HTML should look like the following once you're finished:</p>
 
-<pre class="lang-html"><code>&lt;div class="accordion"&gt;
+<pre><code>&lt;div class="accordion"&gt;
 
 	&lt;!-- Accordion section 1 --&gt;
 	&lt;details class="acc-group"&gt;

--- a/src/plugins/toggle/toggle-fr.hbs
+++ b/src/plugins/toggle/toggle-fr.hbs
@@ -8,9 +8,11 @@
 	"parentdir": "toggle",
 	"altLangPrefix": "toggle",
 	"css": ["demo/toggle"],
-	"dateModified": "2015-04-22"
+	"dateModified": "2020-03-10"
 }
 ---
+<span class="wb-prettify all-pre linenums"></span>
+
 <section>
 	<h2>Intention</h2>
 	<p>Plugiciel qui permet un lien à basculer des éléments entre les états activé et désactivé.</p>
@@ -109,7 +111,7 @@
 
 			<p>For example, the following element will always toggle on elements with the <code>.foo</code> CSS class that are contained in a parent with the <code>.bar</code> CSS class. In addition, the elements it controls will be toggled on when the page is printed.</p>
 
-			<pre class="lang-css"><code>&lt;button type="button" class="wb-toggle" data-toggle='{"type": "on", "selector": ".foo", "parent": ".bar", "print": "on"}'&gt;Turn on&lt;/button&gt;</code></pre>
+			<pre><code>&lt;button type="button" class="wb-toggle" data-toggle='{"type": "on", "selector": ".foo", "parent": ".bar", "print": "on"}'&gt;Turn on&lt;/button&gt;</code></pre>
 		</section>
 
 		<section>


### PR DESCRIPTION
**English:**
* Move prettify's all-pre declaration to an empty span element at the start of the content area
  * Makes this prettify implementation more consistent with other plugin demo pages
* Remove "lang-html" class from the accordion code sample
  * This was the only instance of that class within the entire repo

**French:**
* Add prettify (it was previously missing)

**Both languages:**
* Remove misused "lang-css" classes