### PR TITLE
Polyfill/datepicker: Fix for clear button on date picker fields

### DIFF
--- a/src/polyfills/datepicker/datepicker.scss
+++ b/src/polyfills/datepicker/datepicker.scss
@@ -10,7 +10,7 @@
 
 .wb-date-wrap {
 	&.input-group {
-		width: 10em;
+		width: 11em;
 	}
 }
 


### PR DESCRIPTION
The clear ("x") button on input fields doesn't appear on date picker inputs because the width is not big enough at 10em's (the button is basically hidden in overflow). By setting the width to 11em, there's enough space for the "x" to appear (which now allows people to clear a date) and the field width is still small enough to fit inside a .col-md-2 as it did before.