### PR TITLE
Focus: Always jump to URL hashes

### DIFF
--- a/src/plugins/wb-focus/focus.js
+++ b/src/plugins/wb-focus/focus.js
@@ -10,6 +10,8 @@
 var $document = wb.doc,
 	$window = wb.win,
 	clickEvents = "click vclick",
+	hash,
+	jumpToHash = false,
 	setFocusEvent = "setfocus.wb",
 	linkSelector = "a[href]",
 	$linkTarget,
@@ -18,9 +20,10 @@ var $document = wb.doc,
 	 * @method processHash
 	 */
 	processHash = function() {
-		var hash = wb.pageUrlParts.hash;
+		hash = wb.pageUrlParts.hash;
 
 		if ( hash && ( $linkTarget = $( "#" + wb.jqEscape( hash.substring( 1 ) ) ) ).length !== 0 ) {
+			jumpToHash = true;
 			$linkTarget.trigger( setFocusEvent );
 		}
 	};
@@ -55,6 +58,13 @@ $document.on( setFocusEvent, function( event ) {
 
 		// Assigns focus to an element (delay allows for revealing of hidden content)
 		setTimeout( function() {
+
+			//Navigate to the URL hash to trigger the browser's natural link jumping behaviour
+			if ( jumpToHash ) {
+				window.location.assign( hash );
+				jumpToHash = false;
+			}
+
 			$elm.trigger( "focus" );
 
 			var $topBar = $( ".wb-bar-t[aria-hidden=false]" );


### PR DESCRIPTION
When visiting a hash link (``#id``), WET's focus plugin checks whether the destination is situated within a closed ``details`` element or tab panel. If so, the plugin automatically expands the destination's ``details`` element or tab panel. The plugin subsequently focuses onto the destination.

However, that sometimes causes inconsistent scrolling behaviour. Scrolling will work differently depending on if the link's destination is in the same page or on a separate page.

If a user visits a same-page hash link whose destination is in a closed details element/tab panel, everything works as expected. The plugin will expand the parent and the browser will jump to the destination. The destination will appear at the top of the browser viewport.

If a user visits a hash link whose destination is on a separate page, the plugin will run... but won't jump to the destination. Instead of jumping, the browser will scroll to show the destination at the bottom (Gecko/Trident) or the middle (Blink/Webkit) of the viewport. This is due to the focus plugin causing browsers to incorrectly use their natural focus scrolling behaviour in this context.

This commit corrects that behaviour by adding a flag to always navigate to hashes that are being focused on. As a result, browsers can use their natural link jumping behaviour. It also doesn't add anything to the browser's navigation history (since the hash was already in the page's URL beforehand).