### PR TITLE
Postback form action fix

### DIFF
--- a/src/plugins/wb-postback/wb-postback.js
+++ b/src/plugins/wb-postback/wb-postback.js
@@ -61,7 +61,7 @@ var $document = wb.doc,
 
 				$.ajax( {
 					type: this.method,
-					url: this.attr,
+					url: this.action,
 					data: $.param( data )
 				} )
 				.done( function() {


### PR DESCRIPTION
AJAX call was using an unexisting attr attribute as the url, so I switched it to what it is supposed to be, which is action.