### PR TITLE
Breadcrumb: fix issues related to new version of Chrome - focus outline

### DIFF
--- a/src/base/breadcrumb/_base.scss
+++ b/src/base/breadcrumb/_base.scss
@@ -10,11 +10,13 @@
 		ol {
 			border-radius: 0;
 			margin-bottom: 0;
+			padding: 3px 13px;
 		}
 
 		li {
 			max-width: 100%;
 			overflow: hidden;
+			padding: 5px 2px;
 			text-overflow: ellipsis;
 			white-space: nowrap;
 


### PR DESCRIPTION
As described in #8875

Give a little bit more breathing space for the breadcrumb elements to show the outline that was hidden because of the overflow hidden. Adjusted the spacing around the breadcrumb to keep the same outside spacing as before. However, this adds a bit more space horizontally on the breadcrumb items without causing any layout issue (from what I tested).