### PR TITLE
Header element: Fix CSS for Geomap panel to show X button

### DIFF
--- a/src/plugins/geomap/_base.scss
+++ b/src/plugins/geomap/_base.scss
@@ -555,19 +555,13 @@ ol-geolocate button {
 	background-color: rgba(255,255,255,1);
 	height: auto;
 	margin: 10px;
-	padding: 0;
-	right: 0;
-	top: 0;
-	width: auto
-}
-
-.geomap-help-dialog {
-	background-color: rgba(255,255,255,1);
-	height: auto;
-	margin: 10px;
 	right: 0;
 	top: 0;
 	width: auto;
+
+	header {
+		position: static;
+	}
 
 	a.btn {
 		color: #333;


### PR DESCRIPTION
Fix #8880 

Set a positon static on the header element inside the panel, to take precedence on GCWeb's bold position relative on header elements, and therefore show the X button in the top right corner of the Help box.

Does not affect WET-BOEW per say, but it is preferable to do the change from here anyway instead of creating a new file in the GCWeb package just for a one-liner style overwrite, especially since it isn't negative for WET-BOEW and could prevent future problems. However, it is mostly to fix a problem on GCWeb.

... also removed some clear duplication of styles.