### PR TITLE
Stepsform Focus Order Fix

### DIFF
--- a/src/plugins/stepsform/stepsform.js
+++ b/src/plugins/stepsform/stepsform.js
@@ -204,6 +204,9 @@ var componentName = "wb-steps",
 				buttonGroup = fieldset.querySelector( "div.buttons" );
 				if ( legend ) {
 					legend.classList.add( "wb-steps-active" );
+					legend.tabIndex = 0;
+					legend.focus();
+					legend.tabIndex = -1;
 				}
 				if ( elm ) {
 					elm.classList.remove( "hidden" );


### PR DESCRIPTION
When next or prev button is clicked, the legend element will be focused.
closes #8871 