### PR TITLE
Release v4.0.36

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-boew",
-  "version": "4.0.35",
+  "version": "4.0.36",
   "homepage": "https://wet-boew.github.io",
   "authors": [
     "WET-BOEW Team"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-boew",
-  "version": "4.0.35",
+  "version": "4.0.36",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-boew",
-  "version": "4.0.35",
+  "version": "4.0.36",
   "description": "Web Experience Toolkit (WET): Open source code library for building innovative websites that are accessible, usable, interoperable, mobile-friendly and multilingual. This collaborative open source project is led by the Government of Canada. / Boîte à outils de l’expérience Web (BOEW) : Une bibliothèque de code primée pour construire des sites Web innovants qui sont accessibles, faciles d'emploi, interopérables, optimisés pour les appareils mobiles et multilingues. Ceci est un projet à source ouverte collaboratif dirigé par le Gouvernement du Canada.",
   "main": "index.html",
   "engines": {

--- a/site/pages/docs/versions/dwnld-en.hbs
+++ b/site/pages/docs/versions/dwnld-en.hbs
@@ -4,7 +4,7 @@
 	"language": "en",
 	"description": "Downloads - Version history - Web Experience Toolkit (WET)",
 	"altLangPrefix": "dwnld",
-	"dateModified": "2020-04-29"
+	"dateModified": "2020-06-15"
 }
 ---
 <p>WET-BOEW and GCWeb are at least quarterly released.</p>
@@ -41,13 +41,13 @@
 		<tbody>
 			<tr>
 				<td>Web Experience Toolkit (WET)</td>
-				<td>v4.0.35</td>
-				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/wet-boew/releases/latest">Download<span class="wb-inv"> - v4.0.35 - Web Experience Toolkit (WET) theme</span></a></td>
+				<td>v4.0.36</td>
+				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/wet-boew/releases/latest">Download<span class="wb-inv"> - v4.0.36 - Web Experience Toolkit (WET) theme</span></a></td>
 			</tr>
 			<tr>
 				<td>Canada.ca (GCWeb)</td>
-				<td>v7.0.1</td>
-				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Download<span class="wb-inv"> - v7.0.1 - Canada.ca theme</span></a></td>
+				<td>v8.0</td>
+				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Download<span class="wb-inv"> - v8.0 - Canada.ca theme</span></a></td>
 			</tr>
 		</tbody>
 	</table>
@@ -63,6 +63,29 @@
 <section>
 	<h2>Canada.ca theme (GCWeb) (Release)</h2>
 
+	<h3>Version 8.x</h3>
+	<section>
+		<h4 id="gcweb-v8.0">v8.0</h4>
+		<p><a href="https://github.com/wet-boew/GCWeb/releases/tag/v8.0">Release notes<span class="wb-inv"> - v8.0</span></a> (Subresource integrity hash included)</p>
+		<table class="table table-bordered">
+			<thead>
+				<tr>
+					<th>Theme</th>
+					<th>Based on WET-BOEW</th>
+					<th>Source code</th>
+					<th>Production files</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Canada.ca theme (GCWeb)</td>
+					<td>v4.0.36</td>
+					<td><a href="https://github.com/wet-boew/GCWeb/archive/v8.0.zip">Download<span class="wb-inv"> - v8.0 source code - Canada.ca theme</span> (theme only)</a></td>
+					<td><a href="https://github.com/wet-boew/GCWeb/releases/download/v8.0/themes-dist-8.0-gcweb.zip">Download<span class="wb-inv"> - v8.0 production files - Canada.ca theme</span></a></td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
 	<h3>Version 7.x</h3>
 	<section>
 		<h4 id="gcweb-v7.0.1">v7.0.1 (STR)</h4>
@@ -246,6 +269,29 @@
 	<h2>WET-BOEW (Release)</h2>
 
 	<h3 id="v40">Version 4.0 (<span id="v40stable">Stable release</span>)</h3>
+
+	<section>
+		<h4 id="v4036">v4.0.36</h4>
+		<p><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.36">Release notes</a> (Subresource integrity hash included)</p>
+		<table class="table table-bordered">
+			<thead>
+				<tr>
+					<th>Theme</th>
+					<th>Source code</th>
+					<th>Production files</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Web Experience Toolkit (WET)</td>
+					<td><a href="https://github.com/wet-boew/wet-boew/archive/v4.0.36.zip">Download<span class="wb-inv"> - v4.0.36 source code - Web Experience Toolkit (WET) theme</span></a></td>
+					<td><a href="https://github.com/wet-boew/wet-boew/releases/download/v4.0.31/wet-boew-dist-4.0.36.zip">Download<span class="wb-inv"> - v4.0.36 production files - Web Experience Toolkit (WET) theme</span></a></td>
+				</tr>
+			</tbody>
+		</table>
+		<h5>Browser supported:</h5>
+		<p class="mrgn-bttm-xl">See release notes.</p>
+	</section>
 
 	<section>
 		<h4 id="v4035">v4.0.35 (STR)</h4>

--- a/site/pages/docs/versions/dwnld-fr.hbs
+++ b/site/pages/docs/versions/dwnld-fr.hbs
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"description": "Téléchargements - Historique des versions - Boîte à outils de l'expérience Web (BOEW)",
 	"altLangPrefix": "dwnld",
-	"dateModified": "2020-04-29"
+	"dateModified": "2020-06-15"
 }
 ---
 <p>La BOEW et GCWeb sont publié au minimum selon cycle trimestrielle.<p>
@@ -46,13 +46,13 @@
 		<tbody>
 			<tr>
 				<td>Boîte à outils de l'expérience Web (WET-BOEW)</td>
-				<td>v4.0.35</td>
-				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/wet-boew/releases/latest">Télécharger<span class="wb-inv"> - v4.0.35 - Thème de la Boîte à outils de l'expérience Web (WET-BOEW)</span></a></td>
+				<td>v4.0.36</td>
+				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/wet-boew/releases/latest">Télécharger<span class="wb-inv"> - v4.0.36 - Thème de la Boîte à outils de l'expérience Web (WET-BOEW)</span></a></td>
 			</tr>
 			<tr>
 				<td>Canada.ca (GCWeb)</td>
-				<td>v7.0.1</td>
-				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Télécharger<span class="wb-inv"> - v7.0.1 - Thème Canada.ca</span></a></td>
+				<td>v8.0</td>
+				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Télécharger<span class="wb-inv"> - v8.0 - Thème Canada.ca</span></a></td>
 			</tr>
 		</tbody>
 	</table>
@@ -67,6 +67,29 @@
 
 <section>
 	<h2>Thème du Canada.ca (GCWeb) (Publication)</h2>
+
+	<h3>Version 8.x</h3>
+	<section>
+		<h4 id="gcweb-v8.0">v8.0 (DCT)</h4>
+		<p><a href="https://github.com/wet-boew/GCWeb/releases/tag/v8.0">Notes de version<span class="wb-inv"> - v8.0</span></a> (Condensés numérique de l'intégrité des sous-ressource inclus)</p>
+		<table class="table table-bordered">
+			<thead>
+				<tr>
+					<th>Thème</th>
+					<th>Basé sur WET-BOEW</th>
+					<th>Code source</th>
+					<th>Fichiers de production</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Canada.ca theme (GCWeb)</td>
+					<td>v4.0.36</td>
+					<td><a href="https://github.com/wet-boew/GCWeb/archive/v8.0.zip">Télécharger<span class="wb-inv"> - Code source de v8.0 - Thème Canada.ca</span> (thème seulement)</a></td>
+					<td><a href="https://github.com/wet-boew/GCWeb/releases/download/v8.0/themes-dist-8.0-gcweb.zip">Télécharger<span class="wb-inv"> - Fichiers de production de v8.0 - Thème Canada.ca</span></a></td>
+				</tr>
+			</tbody>
+		</table>
 
 	<h3>Version 7.x</h3>
 	<section>
@@ -255,7 +278,30 @@
 	<h3 id="v40">Version 4.0 (<span id="v40stable">Versions stables</span>)</h3>
 
 	<section>
-		<h4 id="v40341">v4.0.35 (DCT)</h4>
+		<h4 id="v4036">v4.0.36</h4>
+		<p><a href="https://github.com/wet-boew/wet-boew/releases/tag/v4.0.36">Notes de version</a> (Condensés numérique de l'intégrité inclus)</p>
+		<table class="table table-bordered">
+			<thead>
+				<tr>
+					<th scope="col">Thème</th>
+					<th scope="col">Code source</th>
+					<th scope="col">Fichiers de production</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>Boîte à outils de l'expérience Web (BOEW)</td>
+					<td><a href="https://github.com/wet-boew/wet-boew/archive/v4.0.36.zip">Télécharger<span class="wb-inv"> - Code source de v4.0.36 - Thème de la Boîte à outils de l'expérience Web (BOEW)</span></a></td>
+					<td><a href="https://github.com/wet-boew/wet-boew/releases/download/v4.0.35/wet-boew-dist-4.0.36.zip">Télécharger<span class="wb-inv"> - Fichiers de production de v4.0.36 - Thème de la Boîte à outils de l'expérience Web (BOEW)</span></a></td>
+				</tr>
+			</tbody>
+		</table>
+		<h5>Fureteur supporté:</h5>
+		<p class="mrgn-bttm-xl">Voir notes de versions.</p>
+	</section>
+
+	<section>
+		<h4 id="v4035">v4.0.35 (DCT)</h4>
 		<p><a href="https://wet-boew.github.io/wet-boew/docs/versions/v4.0/v4.0.35-fr.html">Notes de version</a> (<a href="v4.0/v4.0.35-fr.html#sri">Condensés numérique de l'intégrité des sous-ressource</a>)</p>
 		<table class="table table-bordered">
 			<thead>

--- a/site/pages/docs/versions/v4.0/v4.0.35-fr.hbs
+++ b/site/pages/docs/versions/v4.0/v4.0.35-fr.hbs
@@ -12,7 +12,7 @@
 	<li><strong>Date de lancement&#160;:</strong>
 		<time>2020-04-16</time>
 	</li>
-	<li><a href="../dwnld-fr.html#v40341">Téléchargements</a></li>
+	<li><a href="../dwnld-fr.html#v4035">Téléchargements</a></li>
 </ul>
 <div class="wb-prettify all-pre"></div>
 <section>


### PR DESCRIPTION
New release process, which is meant to be lighter.

Complete release notes will be in the GitHub release section.