### PR TITLE
Form validation: Improve demo pages

### DIFF
--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -7,9 +7,10 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2020-02-04"
+	"dateModified": "2020-07-15"
 }
 ---
+<span class="wb-prettify all-pre hide"></span>
 
 <ul>
 	<li><a href="formvalid-en.html">Form Validation</a></li>
@@ -23,7 +24,7 @@
 	<p>Provides generic validation and error message handling for Web forms.</p>
 </section>
 
-<section class="wb-prettify all-pre">
+<section>
 	<h2>Examples</h2>
 
 	<div class="wb-frmvld">
@@ -42,8 +43,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -64,8 +64,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -80,8 +79,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -96,12 +94,11 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
-			&lt;label for="tel1" class="required"&gt;&lt;span class="field-name"&gt;Telephone number&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
+			&lt;label for="tel1" class="required"&gt;&lt;span class="field-name"&gt;Telephone number (including area code)&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
 			&lt;input class="form-control" id="tel1" name="tel1" type="tel" autocomplete="tel" required="required" data-rule-phoneUS="true" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
@@ -112,8 +109,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -128,8 +124,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -144,8 +139,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -160,8 +154,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -179,8 +172,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -195,8 +187,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -211,8 +202,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 	...
 	&lt;div class="form-group"&gt;
@@ -227,8 +217,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -243,8 +232,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -259,8 +247,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -275,8 +262,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -291,8 +277,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -307,8 +292,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -323,8 +307,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -339,8 +322,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -357,8 +339,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -387,8 +368,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
-				<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
@@ -425,8 +405,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
-				<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
@@ -451,7 +430,7 @@
 	</div>
 </section>
 <hr>
-<section class="wb-prettify all-pre">
+<section>
 <!-- checkbox in list item -->
 	<h2>Examples of stacked and horizontal forms using list items as container</h2>
 	<div class="wb-frmvld">
@@ -477,39 +456,27 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked checkboxes in a &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits1a"&gt;
-						&lt;input type="checkbox" name="example1" value="1" id="fruits1a" required="required" /&gt;Apple
-					&lt;/label&gt;
+					&lt;label for="fruits1a"&gt;&lt;input type="checkbox" name="example1" value="1" id="fruits1a" required="required" /&gt;Apple&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits2a"&gt;
-						&lt;input type="checkbox" name="example1" value="2" id="fruits2a" /&gt;Orange
-					&lt;/label&gt;
+					&lt;label for="fruits2a"&gt;&lt;input type="checkbox" name="example1" value="2" id="fruits2a" /&gt;Orange&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits3a"&gt;
-						&lt;input type="checkbox" name="example1" value="3" id="fruits3a" /&gt;Kiwi
-					&lt;/label&gt;
+					&lt;label for="fruits3a"&gt;&lt;input type="checkbox" name="example1" value="3" id="fruits3a" /&gt;Kiwi&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits4a"&gt;
-						&lt;input type="checkbox" name="example1" value="4" id="fruits4a" /&gt;Other
-					&lt;/label&gt;
+					&lt;label for="fruits4a"&gt;&lt;input type="checkbox" name="example1" value="4" id="fruits4a" /&gt;Other&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
-				<div class="well well-sm"><b>Note:</b> The <code>for</code> attribute in the labels is optional for this pattern</div>
+		&lt;/fieldset&gt;</code></pre>
+				<div class="well well-sm"><strong>Note:</strong> The <code>for</code> attribute in the labels is optional for this pattern</div>
 			</details>
 
 <!-- radio in a list with implicit labels -->
@@ -532,98 +499,66 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked radio buttons in a &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits1b"&gt;
-						&lt;input type="radio" name="example2" value="1" id="fruits1b" required="required" /&gt;Apple
-					&lt;/label&gt;
+					&lt;label for="fruits1b"&gt;&lt;input type="radio" name="example2" value="1" id="fruits1b" required="required" /&gt;Apple&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits2b"&gt;
-						&lt;input type="radio" name="example2" value="2" id="fruits2b" /&gt;Orange
-					&lt;/label&gt;
+					&lt;label for="fruits2b"&gt;&lt;input type="radio" name="example2" value="2" id="fruits2b" /&gt;Orange&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits3b"&gt;
-						&lt;input type="radio" name="example2" value="3" id="fruits3b" /&gt;Kiwi
-					&lt;/label&gt;
+					&lt;label for="fruits3b"&gt;&lt;input type="radio" name="example2" value="3" id="fruits3b" /&gt;Kiwi&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits4b"&gt;
-						&lt;input type="radio" name="example2" value="4" id="fruits4b" /&gt;Other
-					&lt;/label&gt;
+					&lt;label for="fruits4b"&gt;&lt;input type="radio" name="example2" value="4" id="fruits4b" /&gt;Other&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
-				<div class="well well-sm"><b>Note:</b> The <code>for</code> attribute in the labels is optional for this pattern</div>
+		&lt;/fieldset&gt;</code></pre>
+				<div class="well well-sm"><strong>Note:</strong> The <code>for</code> attribute in the labels is optional for this pattern</div>
 			</details>
 
 <!-- checkbox in div pattern with implicit labels-->
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Stacked checkboxes in a <code>&lt;div&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
 				<div class="checkbox">
-					<label for="fruits1c">
-						<input type="checkbox" name="example3" value="1" id="fruits1c" required="required" />Apple
-					</label>
+					<label for="fruits1c"><input type="checkbox" name="example3" value="1" id="fruits1c" required="required" />Apple</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits2c">
-						<input type="checkbox" name="example3" value="2" id="fruits2c" />Orange
-					</label>
+					<label for="fruits2c"><input type="checkbox" name="example3" value="2" id="fruits2c" />Orange</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits3c">
-						<input type="checkbox" name="example3" value="3" id="fruits3c" />Kiwi
-					</label>
+					<label for="fruits3c"><input type="checkbox" name="example3" value="3" id="fruits3c" />Kiwi</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits4c">
-						<input type="checkbox" name="example3" value="4" id="fruits4c" />Other
-					</label>
+					<label for="fruits4c"><input type="checkbox" name="example3" value="4" id="fruits4c" />Other</label>
 				</div>
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked checkboxes in a &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits1c"&gt;
-					&lt;input type="checkbox" name="example3" value="1" id="fruits1c" required="required" /&gt;Apple
-				&lt;/label&gt;
+				&lt;label for="fruits1c"&gt;&lt;input type="checkbox" name="example3" value="1" id="fruits1c" required="required" /&gt;Apple&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits2c"&gt;
-					&lt;input type="checkbox" name="example3" value="2" id="fruits2c" /&gt;Orange
-				&lt;/label&gt;
+				&lt;label for="fruits2c"&gt;&lt;input type="checkbox" name="example3" value="2" id="fruits2c" /&gt;Orange&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits3c"&gt;
-					&lt;input type="checkbox" name="example3" value="3" id="fruits3c" /&gt;Kiwi
-				&lt;/label&gt;
+				&lt;label for="fruits3c"&gt;&lt;input type="checkbox" name="example3" value="3" id="fruits3c" /&gt;Kiwi&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits4c"&gt;
-					&lt;input type="checkbox" name="example3" value="4" id="fruits4c" /&gt;Other
-				&lt;/label&gt;
+				&lt;label for="fruits4c"&gt;&lt;input type="checkbox" name="example3" value="4" id="fruits4c" /&gt;Other&lt;/label&gt;
 			&lt;/div&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
-				<div class="well well-sm"><b>Note:</b> The <code>for</code> attribute in the labels is optional for this pattern</div>
+		&lt;/fieldset&gt;</code></pre>
+				<div class="well well-sm"><strong>Note:</strong> The <code>for</code> attribute in the labels is optional for this pattern</div>
 			</details>
 
 <!-- checkbox in list item with explicit labels-->
@@ -650,9 +585,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
@@ -675,9 +608,7 @@
 					&lt;label for="fruits8"&gt;Other&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
+		&lt;/fieldset&gt;</code></pre>
 			</details>
 
 <!-- Radio inline list item with implicit labels-->
@@ -690,28 +621,16 @@
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>View code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal radio buttons in a &lt;code&gt;&amp;lt;label&gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
-			&lt;label for="tech1" class="radio-inline"&gt;
-				&lt;input type="radio" name="example5" value="1" id="tech1" required="required" /&gt;Smartphone
-			&lt;/label&gt;
-			&lt;label for="tech2" class="radio-inline"&gt;
-				&lt;input type="radio" name="example5" value="2" id="tech2" /&gt;Laptop
-			&lt;/label&gt;
-			&lt;label for="tech3" class="radio-inline"&gt;
-				&lt;input type="radio" name="example5" value="3" id="tech3" /&gt;Voice assistant
-			&lt;/label&gt;
-			&lt;label for="tech4" class="radio-inline"&gt;
-				&lt;input type="radio" name="example5" value="4" id="tech4" /&gt;Fusion reactor
-			&lt;/label&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
+			&lt;label for="tech1" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="1" id="tech1" required="required" /&gt;Smartphone&lt;/label&gt;
+			&lt;label for="tech2" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="2" id="tech2" /&gt;Laptop&lt;/label&gt;
+			&lt;label for="tech3" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="3" id="tech3" /&gt;Voice assistant&lt;/label&gt;
+			&lt;label for="tech4" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="4" id="tech4" /&gt;Fusion reactor&lt;/label&gt;
+		&lt;/fieldset&gt;</code></pre>
 			</details>
 
 <!-- checkbox inline list item with explicit labels-->
@@ -736,9 +655,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>View code </summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
@@ -759,12 +676,10 @@
 				&lt;input type="checkbox" name="example6" value="4" id="tech8" /&gt;
 				&lt;label for="tech8"&gt;Fusion reactor&lt;/label&gt;
 			&lt;/div&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
+		&lt;/fieldset&gt;</code></pre>
 			</details>
 
-			<input type="submit" value="Submit" class="btn btn-primary" /> <input type="reset" value="Reset" class="btn btn-default" />
+			<input type="submit" value="Submit" class="btn btn-primary" /> <input type="reset" value="Reset page to defaults" class="btn btn-link btn-sm show p-0 pt-4" />
 		</form>
 	</div>
 

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -3,14 +3,14 @@
 	"title": "Validation de formulaires",
 	"language": "fr",
 	"category": "Plugiciels",
-	"description": "Effectue la validation de formulaires Web selon un ensemble de règles de base avant qu'ils soient
-	soumis.",
+	"description": "Effectue la validation de formulaires Web selon un ensemble de règles de base avant qu'ils soient soumis.",
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2020-02-04"
+	"dateModified": "2020-07-15"
 }
 ---
+<span class="wb-prettify all-pre hide"></span>
 
 <ul>
 	<li><a href="formvalid-fr.html">Validation de formulaires</a></li>
@@ -25,7 +25,7 @@
 </section>
 
 <section>
-	<h2>Exemple</h2>
+	<h2>Exemples</h2>
 
 	<div class="wb-frmvld">
 		<form action="#" method="get" id="validation-example">
@@ -43,8 +43,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -60,45 +59,42 @@
 				</details>
 
 				<div class="form-group">
-					<label for="fname" class="required"><span class="field-name">Prénom</span> <strong class="required">(obligatoire)</strong></label>
-					<input class="form-control" id="fname" name="fname" type="text" autocomplete="given-name" required="required" pattern=".{2,}" data-rule-minlength="2" />
+					<label for="fname1" class="required"><span class="field-name">Prénom</span> <strong class="required">(obligatoire)</strong></label>
+					<input class="form-control" id="fname1" name="fname1" type="text" autocomplete="given-name" required="required" pattern=".{2,}" data-rule-minlength="2" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
-			&lt;label for="fname" class="required"&gt;&lt;span class="field-name"&gt;Prénom&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="fname" name="fname" type="text" autocomplete="given-name" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
+			&lt;label for="fname1" class="required"&gt;&lt;span class="field-name"&gt;Prénom&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="fname1" name="fname1" type="text" autocomplete="given-name" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
-					<label for="lname" class="required"><span class="field-name">Nom de famille</span> <strong class="required">(obligatoire)</strong></label>
-					<input class="form-control" id="lname" name="lname" type="text" autocomplete="family-name" required="required" pattern=".{2,}" data-rule-minlength="2" />
+					<label for="lname1" class="required"><span class="field-name">Nom de famille</span> <strong class="required">(obligatoire)</strong></label>
+					<input class="form-control" id="lname1" name="lname1" type="text" autocomplete="family-name" required="required" pattern=".{2,}" data-rule-minlength="2" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
-			&lt;label for="lname" class="required"&gt;&lt;span class="field-name"&gt;Nom de famille&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="lname" name="lname" type="text" autocomplete="family-name" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
+			&lt;label for="lname1" class="required"&gt;&lt;span class="field-name"&gt;Nom de famille&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="lname1" name="lname1" type="text" autocomplete="family-name" required="required" pattern=".{2,}" data-rule-minlength="2" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
-					<label for="tel1" class="required"><span class="field-name">Numéro de téléphone</span> <strong class="required">(obligatoire)</strong></label>
+					<label for="tel1" class="required"><span class="field-name">Numéro de téléphone (avec l'indicatif régional)</span> <strong class="required">(obligatoire)</strong></label>
 					<input class="form-control" id="tel1" name="tel1" type="tel" autocomplete="tel" required="required" data-rule-phoneUS="true" />
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -113,8 +109,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -129,8 +124,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -145,8 +139,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -161,8 +154,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -180,8 +172,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -196,8 +187,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -212,14 +202,13 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
-					&lt;form action="#" method="get" id="validation-example"&gt;
-						...
-						&lt;div class="form-group"&gt;
-							&lt;label for="number1"&gt;&lt;span class="field-name"&gt;Nombre&lt;/span&gt; (entre -1 et 1, par pas de 0,1)&lt;/label&gt;
-							&lt;input class="form-control" id="number1" name="number1" type="number" min="-1" max="1" step="0.1"/&gt;
-						&lt;/div&gt;</code></pre>
+					<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+	...
+	&lt;div class="form-group"&gt;
+		&lt;label for="number1"&gt;&lt;span class="field-name"&gt;Nombre&lt;/span&gt; (entre -1 et 1, par pas de 0,1)&lt;/label&gt;
+		&lt;input class="form-control" id="number1" name="number1" type="number" min="-1" max="1" step="0.1"/&gt;
+	&lt;/div&gt;</code></pre>
 				</details>
 
 				<div class="form-group">
@@ -228,8 +217,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -244,8 +232,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -260,8 +247,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -276,8 +262,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -292,8 +277,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -308,8 +292,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -324,8 +307,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -340,8 +322,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -358,8 +339,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
-					<pre class="prettyprint prettyprinted"><code>
-&lt;div class="wb-frmvld"&gt;
+					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
@@ -388,7 +368,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
-				<pre class="prettyprint prettyprinted"><code>&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
@@ -411,7 +391,7 @@
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Statut de citoyen</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="radio">
-					<label for="status1" class="required"><input type="radio" name="status" value="1" id="status1" required="required" />&#160;&#160;Citoyen canadien</label>
+					<label for="status1"><input type="radio" name="status" value="1" id="status1" required="required" />&#160;&#160;Citoyen canadien</label>
 				</div>
 				<div class="radio">
 					<label for="status2"><input type="radio" name="status" value="2" id="status2" />&#160;&#160;Résident permanent</label>
@@ -425,13 +405,13 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
-				<pre class="prettyprint prettyprinted"><code>&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Statut de citoyen&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="status1" class="required"&gt;&lt;input type="radio" name="status" value="1" id="status1" required="required" /&gt;&#160;&#160;Citoyen canadien&lt;/label&gt;
+				&lt;label for="status1"&gt;&lt;input type="radio" name="status" value="1" id="status1" required="required" /&gt;&#160;&#160;Citoyen canadien&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="radio"&gt;
 				&lt;label for="status2"&gt;&lt;input type="radio" name="status" value="2" id="status2" /&gt;&#160;&#160;Résident permanent&lt;/label&gt;
@@ -448,6 +428,13 @@
 			<input type="submit" value="Soumettre" class="btn btn-primary" /> <input type="reset" value="Réinitialiser la page aux valeurs par défaut" class="btn btn-link btn-sm show p-0 pt-4" />
 		</form>
 	</div>
+</section>
+<hr>
+<section>
+<!-- checkbox in list item -->
+	<h2>Exemples de formulaires verticaux et horizontaux utilisant des éléments de liste comme contenants</h2>
+	<div class="wb-frmvld">
+		<form action="#" method="get" id="validation-example-2">
 
 <!-- checkbox in list item with implicit labels-->
 			<fieldset class="chkbxrdio-grp">
@@ -469,9 +456,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
@@ -490,15 +475,13 @@
 					&lt;label for="fruits4a"&gt;&lt;input type="checkbox" name="example1" value="4" id="fruits4a" /&gt;Autre&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
-				<div class="well well-sm"><b>Remarque&nbsp;:</b> L'attribut <code>for</code> dans les étiquettes est facultatif pour ce modèle</div>
+		&lt;/fieldset&gt;</code></pre>
+				<div class="well well-sm"><strong>Remarque&nbsp;:</strong> L'attribut <code>for</code> dans les étiquettes est facultatif pour ce modèle</div>
 			</details>
 
 <!-- radio in a list with implicit labels -->
 			<fieldset class="chkbxrdio-grp">
-				<legend class="required"><span class="field-name">Boutons radio empilés dans un modèle d'éléments <code>&lt;li&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
+				<legend class="required"><span class="field-name">Boutons radio verticaux dans un modèle d'éléments <code>&lt;li&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<ul class="form-group list-unstyled">
 					<li class="radio">
 						<label for="fruits1b"><input type="radio" name="example2" value="1" id="fruits1b" required="required" />Pomme</label>
@@ -516,13 +499,11 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
-			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radio empilés dans un modèle d'éléments &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radio verticaux dans un modèle d'éléments &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="radio"&gt;
 					&lt;label for="fruits1b"&gt;&lt;input type="radio" name="example2" value="1" id="fruits1b" required="required" /&gt;Pomme&lt;/label&gt;
@@ -537,69 +518,47 @@
 					&lt;label for="fruits4b"&gt;&lt;input type="radio" name="example2" value="4" id="fruits4b" /&gt;Autre&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
-				<div class="well well-sm"><b>Remarque&nbsp;:</b> L'attribut <code>for</code> dans les étiquettes est facultatif pour ce modèle</div>
+		&lt;/fieldset&gt;</code></pre>
+				<div class="well well-sm"><strong>Remarque&nbsp;:</strong> L'attribut <code>for</code> dans les étiquettes est facultatif pour ce modèle</div>
 			</details>
 
 <!-- checkbox in div pattern with implicit labels-->
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Cases à cocher empilées dans un modèle d’éléments <code>&lt;div&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="checkbox">
-					<label for="fruits1c">
-						<input type="checkbox" name="example3" value="1" id="fruits1c" required="required" />Pomme
-					</label>
+					<label for="fruits1c"><input type="checkbox" name="example3" value="1" id="fruits1c" required="required" />Pomme</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits2c">
-						<input type="checkbox" name="example3" value="2" id="fruits2c" />Orange
-					</label>
+					<label for="fruits2c"><input type="checkbox" name="example3" value="2" id="fruits2c" />Orange</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits3c">
-						<input type="checkbox" name="example3" value="3" id="fruits3c" />Kiwi
-					</label>
+					<label for="fruits3c"><input type="checkbox" name="example3" value="3" id="fruits3c" />Kiwi</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits4c">
-						<input type="checkbox" name="example3" value="4" id="fruits4c" />Autre
-					</label>
+					<label for="fruits4c"><input type="checkbox" name="example3" value="4" id="fruits4c" />Autre</label>
 				</div>
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher empilées dans un modèle d’éléments &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits1c"&gt;
-					&lt;input type="checkbox" name="example3" value="1" id="fruits1c" required="required" /&gt;Pomme
-				&lt;/label&gt;
+				&lt;label for="fruits1c"&gt;&lt;input type="checkbox" name="example3" value="1" id="fruits1c" required="required" /&gt;Pomme&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits2c"&gt;
-					&lt;input type="checkbox" name="example3" value="2" id="fruits2c" /&gt;Orange
-				&lt;/label&gt;
+				&lt;label for="fruits2c"&gt;&lt;input type="checkbox" name="example3" value="2" id="fruits2c" /&gt;Orange&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits3c"&gt;
-					&lt;input type="checkbox" name="example3" value="3" id="fruits3c" /&gt;Kiwi
-				&lt;/label&gt;
+				&lt;label for="fruits3c"&gt;&lt;input type="checkbox" name="example3" value="3" id="fruits3c" /&gt;Kiwi&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits4c"&gt;
-					&lt;input type="checkbox" name="example3" value="4" id="fruits4c" /&gt;Autre
-				&lt;/label&gt;
+				&lt;label for="fruits4c"&gt;&lt;input type="checkbox" name="example3" value="4" id="fruits4c" /&gt;Autre&lt;/label&gt;
 			&lt;/div&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
-				<div class="well well-sm"><b>Remarque&nbsp;:</b> L'attribut <code>for</code> dans les étiquettes est facultatif pour ce modèle</div>
+		&lt;/fieldset&gt;</code></pre>
+				<div class="well well-sm"><strong>Remarque&nbsp;:</strong> L'attribut <code>for</code> dans les étiquettes est facultatif pour ce modèle</div>
 			</details>
 
 <!-- checkbox in list item with explicit labels-->
@@ -626,9 +585,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
@@ -651,9 +608,7 @@
 					&lt;label for="fruits8"&gt;Autre&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
+		&lt;/fieldset&gt;</code></pre>
 			</details>
 
 <!-- Radio inline list item with implicit labels-->
@@ -666,28 +621,16 @@
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>Voir le code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radio horizontaux dans un modèle d'éléments &lt;code&gt;&amp;lt;label&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
-			&lt;label for="tech1" class="radio-inline"&gt;
-				&lt;input type="radio" name="example5" value="1" id="tech1" required="required" /&gt;Téléphone intelligent
-			&lt;/label&gt;
-			&lt;label for="tech2" class="radio-inline"&gt;
-				&lt;input type="radio" name="example5" value="2" id="tech2" /&gt;Ordinateur portatif
-			&lt;/label&gt;
-			&lt;label for="tech3" class="radio-inline"&gt;
-				&lt;input type="radio" name="example5" value="3" id="tech3" /&gt;Système d’assistance vocale
-			&lt;/label&gt;
-			&lt;label for="tech4" class="radio-inline"&gt;
-				&lt;input type="radio" name="example5" value="4" id="tech4" /&gt;Réacteur à fusion
-			&lt;/label&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
+			&lt;label for="tech1" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="1" id="tech1" required="required" /&gt;Téléphone intelligent&lt;/label&gt;
+			&lt;label for="tech2" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="2" id="tech2" /&gt;Ordinateur portatif&lt;/label&gt;
+			&lt;label for="tech3" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="3" id="tech3" /&gt;Système d’assistance vocale&lt;/label&gt;
+			&lt;label for="tech4" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="4" id="tech4" /&gt;Réacteur à fusion&lt;/label&gt;
+		&lt;/fieldset&gt;</code></pre>
 			</details>
 
 <!-- checkbox inline list item with explicit labels-->
@@ -712,9 +655,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>Voir le code</summary>
-				<pre class="prettyprint prettyprinted">
-					<code>
-&lt;div class="wb-frmvld"&gt;
+				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
@@ -735,12 +676,10 @@
 				&lt;input type="checkbox" name="example6" value="4" id="tech8" /&gt;
 				&lt;label for="tech8"&gt;Réacteur à fusion&lt;/label&gt;
 			&lt;/div&gt;
-		&lt;/fieldset&gt;
-					</code>
-				</pre>
+		&lt;/fieldset&gt;</code></pre>
 			</details>
 
-			<input type="submit" value="Soumettre" class="btn btn-primary" /> <input type="reset" value="Réinitialiser" class="btn btn-default" />
+			<input type="submit" value="Soumettre" class="btn btn-primary" /> <input type="reset" value="Réinitialiser la page aux valeurs par défaut" class="btn btn-link btn-sm show p-0 pt-4" />
 		</form>
 	</div>
 


### PR DESCRIPTION
Overview of changes...
- Both:
  - Fix prettify implementations.
  - Use strong elements (instead of b) for bolded note box text.
  - Remove problematic class="required" attributes from certain checkbox labels.
  - Make code indentation more consistent (by always placing labels with child inputs on the same line).
  - Remove empty lines from start/end of code samples.
  - Update second reset button to match the first one.
- English:
  - Add " (including area code)" to the phone number label's code sample. It was already present in the phone number's demo.
- French:
  - Place metadata description on a single line.
  - Port some English-only changes from #8744 (i.e. plural examples heading, second section and its H2 heading).
  - Rename "empilés" to "verticaux".
  - Add "1" to the end IDs/names in certain demos to make them consistent with their English counterparts.
  - Add " (avec l'indicatif régional)" to the phone number label. It was already present in the phone number's code sample.
  - Reduce indentation of number field's code sample.