### PR TITLE
Fix Bootstrap 4 spacing classes

### DIFF
--- a/src/base/_bootstrap-4.scss
+++ b/src/base/_bootstrap-4.scss
@@ -8,10 +8,12 @@
 	padding: 0 !important;
 }
 
-.pl-2
+.pl-2,
 .px-2 {
 	padding-left: 5px !important;
 }
+
+.pr-2,
 .px-2 {
 	padding-right: 5px !important;
 }
@@ -20,6 +22,8 @@
 .py-4 {
 	padding-top: 30px !important;
 }
+
+.pb-4,
 .py-4 {
 	padding-bottom: 30px !important;
 }


### PR DESCRIPTION
Took advantage of this to add ".pr-2" and ".pb-4" at the same time.