### PR TITLE
Loading icon not cleared after seek event in Edge

### DIFF
--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -36,6 +36,7 @@ var componentName = "wb-mltmd",
 		"timeupdate",
 		"waiting",
 		"canplay",
+		"seeked",
 		"progress",
 		captionsLoadedEvent,
 		captionsLoadFailedEvent,
@@ -1018,6 +1019,7 @@ $document.on( multimediaEvents, selector, function( event, simulated ) {
 		break;
 
 	case "canplay":
+	case "seeked":
 		this.loading = clearTimeout( this.loading );
 		$this.removeClass( "waiting" );
 		break;


### PR DESCRIPTION
In Edge (tested in v16 and v17), if you start playing a video and then seek, the playing event is not re-fired after seeked event, so the waiting/loading state is never cleared from the player. By listening to the seeked event and treating it the same as canplay, it clears the waiting/loading state so the loading icon is removed and doesn't obstruct the player as the video continues to play.