### PR TITLE
Country content: Fix plugin

### DIFF
--- a/src/plugins/country-content/country-content-en.hbs
+++ b/src/plugins/country-content/country-content-en.hbs
@@ -3,11 +3,11 @@
 	"title": "Country Content",
 	"language": "en",
 	"category": "Plugins",
-	"description": "A basic AjaxLoader wrapper that inserts AJAXed-in content based on a visitor's country as determined by https://freegeoip.net",
+	"description": "A basic AjaxLoader wrapper that inserts AJAXed-in content based on a visitor's country as determined by freegeoip.app",
 	"tag": "country-content",
 	"parentdir": "country-content",
 	"altLangPrefix": "country-content",
-	"dateModified": "2014-08-07"
+	"dateModified": "2020-09-10"
 }
 ---
 <p>{{description}}</p>

--- a/src/plugins/country-content/country-content-fr.hbs
+++ b/src/plugins/country-content/country-content-fr.hbs
@@ -3,11 +3,11 @@
 	"title": "Contenu par pays",
 	"language": "fr",
 	"category": "Plugiciels",
-	"description": "Un enveloppeur de AjaxLoader qui insère de contenu télécharger via AJAX. Le contenu est basée sur l'emplacement des visiteurs comme déterminé par https://freegeoip.net",
+	"description": "Un enveloppeur de AjaxLoader qui insère de contenu télécharger via AJAX. Le contenu est basée sur l'emplacement des visiteurs comme déterminé par freegeoip.app",
 	"tag": "country-content",
 	"parentdir": "country-content",
 	"altLangPrefix": "country-content",
-	"dateModified": "2014-08-07"
+	"dateModified": "2020-09-10"
 }
 ---
 <p>{{description}}</p>

--- a/src/plugins/country-content/country-content.js
+++ b/src/plugins/country-content/country-content.js
@@ -1,6 +1,6 @@
 /**
  * @title WET-BOEW Country Content
- * @overview A basic AjaxLoader wrapper that inserts AJAXed in content based on a visitors country as resolved by https://freegeoip.net
+ * @overview A basic AjaxLoader wrapper that inserts AJAXed in content based on a visitors country as resolved by freegeoip.app
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author @nschonni
  */
@@ -65,7 +65,7 @@ var componentName = "wb-ctrycnt",
 
 			// From https://github.com/aFarkas/webshim/blob/master/src/shims/geolocation.js#L89-L127
 			$.ajax( {
-				url: "https://freegeoip.net/json/",
+				url: "https://freegeoip.app/json/",
 				dataType: "jsonp",
 				cache: true,
 				jsonp: "callback",

--- a/src/plugins/country-content/test.js
+++ b/src/plugins/country-content/test.js
@@ -59,7 +59,7 @@ describe( "Country Content test suite", function() {
 
 			for ( ; i !== len && !isLookup; i += 1 ) {
 				if ( args[ i ] instanceof Array ) {
-					isLookup = args[ i ].length && args[ i ][ 0 ].url === "https://freegeoip.net/json/";
+					isLookup = args[ i ].length && args[ i ][ 0 ].url === "https://freegeoip.app/json/";
 				}
 			}
 			expect( isLookup ).to.equal( true );


### PR DESCRIPTION
Replaces all references to freegeoip.net with freegeoip.app (free drop-in replacement that works without an API key).

Also removed "https://" from content that mentions its domain name for the sake of simplicity.

* Fixes #8365
* Fixes #8710

@freegeoipapp Thanks :)!