### PR TITLE
Forms: Fix YYYY-MM-DD/AAAA-MM-JJ date format labels

### DIFF
--- a/site/pages/docs/ref/datepicker/datepicker-fr.hbs
+++ b/site/pages/docs/ref/datepicker/datepicker-fr.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "polyfills",
 	"description": "Émule l’élément <input type=\"date\"> pour les navigateurs qui ne le supportent pas. Cela génère dynamiquement une interface de calendrier pour sélectionner une date dans un formulaire.",
 	"altLangPrefix": "datepicker",
-	"dateModified": "2014-08-06"
+	"dateModified": "2020-09-15"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -81,7 +81,7 @@
 			<tr>
 				<td>Date max</td>
 				<td>La date la plus éloignée que peut sélectionner l’utilisateur.</td>
-				<td>Ajouter l'attribut « max » avec une date en format <abbr title="Four digits year, dash, two digits month, dash, two digits day">YYYY-MM-DD</abbr> pour indiquer la date la plus éloignée que peut sélectionner l'utilisateur.</td>
+				<td>Ajouter l'attribut « max » avec une date en format <abbr title="Les quatres chiffres de l'année, tiret, les deux chiffres du mois, tiret, les deux chiffres du jour">AAAA-MM-JJ</abbr> pour indiquer la date la plus éloignée que peut sélectionner l'utilisateur.</td>
 				<td>
 					<pre><code>&lt;input type="date" id="startdate" name="startdate" max="2013-05-07" /&gt;</code></pre>
 				</td>

--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2020-07-15"
+	"dateModified": "2020-09-15"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -167,7 +167,7 @@
 			<fieldset>
 				<legend>Other examples</legend>
 				<div class="form-group">
-					<label for="date1"><span class="field-name">Date</span><span class="datepicker-format"> (YYYY-MM-DD)</span></label>
+					<label for="date1"><span class="field-name">Date</span><span class="datepicker-format"> (<abbr title="Four digits year, dash, two digits month, dash, two digits day">YYYY-MM-DD</abbr>)</span></label>
 					<input class="form-control" id="date1" name="date1" type="date" data-rule-dateISO="true" />
 				</div>
 				<details class="mrgn-bttm-md">
@@ -176,7 +176,7 @@
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
-			&lt;label for="date1"&gt;&lt;span class="field-name"&gt;Date&lt;/span&gt;&lt;span class="datepicker-format"&gt; (YYYY-MM-DD)&lt;/span&gt;&lt;/label&gt;
+			&lt;label for="date1"&gt;&lt;span class="field-name"&gt;Date&lt;/span&gt;&lt;span class="datepicker-format"&gt; (&lt;abbr title="Four digits year, dash, two digits month, dash, two digits day"&gt;YYYY-MM-DD&lt;/abbr&gt;)&lt;/span&gt;&lt;/label&gt;
 			&lt;input class="form-control" id="date1" name="date1" type="date" data-rule-dateISO="true" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2020-07-15"
+	"dateModified": "2020-09-15"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -167,7 +167,7 @@
 			<fieldset>
 				<legend>Autres exemples</legend>
 				<div class="form-group">
-					<label for="date1"><span class="field-name">Date</span><span class="datepicker-format"> (AAAA-MM-JJ)</span></label>
+					<label for="date1"><span class="field-name">Date</span><span class="datepicker-format"> (<abbr title="Les quatres chiffres de l'année, tiret, les deux chiffres du mois, tiret, les deux chiffres du jour">AAAA-MM-JJ</abbr>)</span></label>
 					<input class="form-control" id="date1" name="date1" type="date" data-rule-dateISO="true" />
 				</div>
 				<details class="mrgn-bttm-md">
@@ -176,7 +176,7 @@
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;div class="form-group"&gt;
-			&lt;label for="date1"&gt;&lt;span class="field-name"&gt;Date&lt;/span&gt;&lt;span class="datepicker-format"&gt; (AAAA-MM-JJ)&lt;/span&gt;&lt;/label&gt;
+			&lt;label for="date1"&gt;&lt;span class="field-name"&gt;Date&lt;/span&gt;&lt;span class="datepicker-format"&gt; (&lt;abbr title="Les quatres chiffres de l'année, tiret, les deux chiffres du mois, tiret, les deux chiffres du jour"&gt;AAAA-MM-JJ&lt;/abbr&gt;)&lt;/span&gt;&lt;/label&gt;
 			&lt;input class="form-control" id="date1" name="date1" type="date" data-rule-dateISO="true" /&gt;
 		&lt;/div&gt;</code></pre>
 				</details>

--- a/src/plugins/stepsform/stepsform-en.hbs
+++ b/src/plugins/stepsform/stepsform-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "stepsform",
 	"parentdir": "stepsform",
 	"altLangPrefix": "stepsform",
-	"dateModified": "2020-04-16"
+	"dateModified": "2020-09-15"
 }
 ---
 <div class="alert alert-warning">
@@ -39,7 +39,7 @@
 						<input class="form-control" id="lastname" name="lastname" type="text" data-rule-minlength="2" required="required" />
 					</div>
 					<div class="form-group">
-						<label for="dateOfBirth" class="required"><span class="field-name">Date of Birth</span></label>
+						<label for="dateOfBirth" class="required"><span class="field-name">Date of Birth</span><span class="datepicker-format"> (<abbr title="Four digits year, dash, two digits month, dash, two digits day">YYYY-MM-DD</abbr>)</span></label>
 						<input class="form-control" id="dateOfBirth" name="dateOfBirth" type="date" required="required" />
 					</div>
 				</div>

--- a/src/plugins/stepsform/stepsform-fr.hbs
+++ b/src/plugins/stepsform/stepsform-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "stepsform",
 	"parentdir": "stepsform",
 	"altLangPrefix": "stepsform",
-	"dateModified": "2020-04-16"
+	"dateModified": "2020-09-15"
 }
 ---
 
@@ -40,7 +40,7 @@
 						<input class="form-control" id="lastname" name="lastname" type="text" data-rule-minlength="2" required="required" />
 					</div>
 					<div class="form-group">
-						<label for="dateOfBirth" class="required"><span class="field-name">Date de naissance</span></label>
+						<label for="dateOfBirth" class="required"><span class="field-name">Date de naissance</span><span class="datepicker-format"> (<abbr title="Les quatres chiffres de l'année, tiret, les deux chiffres du mois, tiret, les deux chiffres du jour">AAAA-MM-JJ</abbr>)</span></label>
 						<input class="form-control" id="dateOfBirth" name="dateOfBirth" type="date" required="required" />
 					</div>
 				</div>

--- a/src/polyfills/datepicker/test.js
+++ b/src/polyfills/datepicker/test.js
@@ -114,7 +114,7 @@ runTest( "Input type=\"date\" polyfill (date picker)", function() {
 	describe( "with a date format and error in the label", function() {
 		var label = "<label for=\"appointment\">" +
 				"<span class=\"field-name\">Appointment Date</span>" +
-				"<span class=\"datepicker-format\">(YYYY-MM-DD)</span>" +
+	"<span class=\"datepicker-format\"> (<abbr title=\"Four digits year, dash, two digits month, dash, two digits day\">YYYY-MM-DD</abbr>)</span>" +
 				"<strong class=\"error\" id=\"appointment-error\">" +
 					"<span class=\"label label-danger\">" +
 						"<span class=\"prefix\">Error 1: </span>Please enter a valid date" +


### PR DESCRIPTION
* Change a mention of "YYYY-MM-DD" to "AAAA-MM-JJ" in the date picker polyfill's French documentation
* Add abbreviation into one of the date picker polyfill's unit tests
* Add abbreviation into the form validation demo's date field
* Add date format into the steps form demo's date of birth label
* Partially addresses #8916