### PR TITLE
Fix clicking on child elements of anchor

### DIFF
--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -319,7 +319,7 @@ $document.on( "timerpoke.wb " + initEvent, selector, init );
 // Handler for clicking on a same page link within the overlay to outside the overlay
 $document.on( "click vclick", ".mfp-wrap a[href^='#']", function( event ) {
 	var which = event.which,
-		eventTarget = event.target,
+		eventTarget = event.currentTarget,
 		$lightbox, linkTarget;
 
 	// Ignore middle/right mouse buttons


### PR DESCRIPTION
If tabs are used in a modal window and the tab summary element has child elements (span, abbr, etc...) then clicks to the tab anchor (which is generated) throw an error on line 328. The error is thrown because the event assumes that event.target is an anchor. Since it is not (it is the child element, inside the anchor), it has no href attribute and the code fails. By changing to event.currentTarget, it ensures that the eventTarget element is the anchor from the event filter.