### PR TITLE
Multimedia player: Add hidden volume slider label

### DIFF
--- a/src/plugins/multimedia/assets/mediacontrols.html
+++ b/src/plugins/multimedia/assets/mediacontrols.html
@@ -9,7 +9,8 @@ wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licenc
 		<div class="btn-group">
 			<button type="button" class="btn btn-default playpause" aria-controls="{{mId}}"  aria-labelledby="{{mId}}" title="{{play}}" data-state-on="{{play}}" data-state-off="{{pause}}"><span class="glyphicon glyphicon-play"><span class="wb-inv">{{play}}</span></span></button>
 			<button type="button" class="btn btn-default mute" aria-controls="{{mId}}" aria-labelledby="{{mId}}" title="{{mute_on}}" data-state-on="{{mute_on}}" data-state-off="{{mute_off}}" aria-pressed="false"><span class="glyphicon glyphicon-volume-up"><span class="wb-inv">{{mute_on}}</span></span></button>
-			<input type="range" class="volume" aria-controls="{{mId}}" aria-labelledby="{{mId}}" title="{{volume}}" min="0" max="100" value="100" step="5" />
+			<p id="{{mId}}-vlm-lbl" hidden>{{volume}}</p>
+			<input type="range" class="volume" aria-controls="{{mId}}" aria-labelledby="{{mId}}" aria-describedby="{{mId}}-vlm-lbl" title="{{volume}}" min="0" max="100" value="100" step="5" />
 		</div>
 	</div>
 	<div class="tline">


### PR DESCRIPTION
Doesn't function like a typical label... aria-describedby is being used to programmatically-associate it to the volume slider.

The volume slider was already using an aria-labelledby attribute to programmatically-associate it to the video's title - just like all the other controls. That causes the video's title to function as every control's label. So for each control, screen readers announce the video's title as a prefix, then the control's attributes, then the control's name (i.e. "Play", "Mute", etc...).

It would've been possible to add the label's ID at the end of the volume slider's aria-labelledby attribute, but that caused "Volume" to be announced before the slider control's attributes in NVDA + Firefox/Chrome. So it produced "Looking for a Job Volume slider 100" instead of "Looking for a Job slider 100 Volume". Not ideal.

By comparison, aria-describedby gets announced after the volume slider's attributes and supersedes the title attribute. That relegates the label to secondary information, but is better overall since it's consistent with how all the other controls are announced.

Fixes #8939.