### PR TITLE
Removed the Accordion "summary" role="tab" to improve accessibility

### DIFF
--- a/src/plugins/toggle/test.js
+++ b/src/plugins/toggle/test.js
@@ -114,10 +114,6 @@ describe( "Toggle test suite", function() {
 				data = $( this ).data( "toggle" );
 				$parent = $( data.parent );
 				expect( $parent.attr( "role" ) ).to.equal( "tablist" );
-
-				$parent.find( ".tgl-tab" ).each( function() {
-					expect( this.getAttribute( "role" ) ).to.equal( "tab" );
-				} );
 				$parent.find( ".tgl-panel" ).each( function() {
 					expect( this.getAttribute( "role" ) ).to.equal( "tabpanel" );
 				} );

--- a/src/plugins/toggle/test.js
+++ b/src/plugins/toggle/test.js
@@ -114,6 +114,9 @@ describe( "Toggle test suite", function() {
 				data = $( this ).data( "toggle" );
 				$parent = $( data.parent );
 				expect( $parent.attr( "role" ) ).to.equal( "tablist" );
+				$parent.find( "div.tgl-tab" ).each( function() {
+					expect( this.getAttribute( "role" ) ).to.equal( "tab" );
+				} );
 				$parent.find( ".tgl-panel" ).each( function() {
 					expect( this.getAttribute( "role" ) ).to.equal( "tabpanel" );
 				} );
@@ -357,16 +360,16 @@ describe( "Toggle test suite", function() {
 	 * Accordion
 	 */
 	describe( "Accordion", function() {
-		var $accordion, $details, $panels, $tabs,
+		var $accordion, $details, $panels, $tabs, $wrapper,
 			testAccordionClosed = function( idx ) {
 				expect( $details.eq( idx ).hasClass( "on" ) ).to.equal( false );
-				expect( $tabs.eq( idx ).attr( "aria-selected" ) ).to.equal( "false" );
+				expect( $wrapper.eq( idx ).attr( "aria-selected" ) ).to.equal( "false" );
 				expect( $panels.eq( idx ).attr( "aria-expanded" ) ).to.equal( "false" );
 				expect( $panels.eq( idx ).attr( "aria-hidden" ) ).to.equal( "true" );
 			},
 			testAccordionOpen = function( idx ) {
 				expect( $details.eq( idx ).hasClass( "on" ) ).to.equal( true );
-				expect( $tabs.eq( idx ).attr( "aria-selected" ) ).to.equal( "true" );
+				expect( $wrapper.eq( idx ).attr( "aria-selected" ) ).to.equal( "true" );
 				expect( $panels.eq( idx ).attr( "aria-expanded" ) ).to.equal( "true" );
 				expect( $panels.eq( idx ).attr( "aria-hidden" ) ).to.equal( "false" );
 			};
@@ -384,10 +387,12 @@ describe( "Toggle test suite", function() {
 				"</div>" )
 				.appendTo( $body );
 
-			$details = $accordion.find( "details" );
-			$panels = $accordion.find( ".tgl-panel" );
 			$tabs = $accordion.find( ".tgl-tab" )
 				.trigger( "wb-init.wb-toggle" );
+			$details = $accordion.find( "details" );
+			$panels = $accordion.find( ".tgl-panel" );
+			$wrapper = $accordion.find( "div.tgl-tab" );
+
 
 			if ( !Modernizr.details ) {
 				$tabs.trigger( "wb-init.wb-details" );

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -79,7 +79,7 @@ var componentName = "wb-toggle",
 	 * @param {Object} data Simple key/value data object passed when the event was triggered
 	 */
 	initAria = function( link, data ) {
-		var i, len, elm, elms, parent, tabs, tab, panel, isOpen,
+		var i, len, elm, elms, parent, tabs, tab, panel, isOpen, wrapper,
 			ariaControls = "",
 			hasOpen = false;
 
@@ -118,11 +118,25 @@ var componentName = "wb-toggle",
 					if ( !tab.getAttribute( "id" ) ) {
 						tab.setAttribute( "id", wb.getId() );
 					}
-					tab.setAttribute( "aria-selected", isOpen );
-					tab.setAttribute( "tabindex", isOpen ? "0" : "-1" );
-					tab.setAttribute( "aria-posinset", i + 1 );
-					tab.setAttribute( "aria-setsize", len );
 
+					//Details and summary don't support aria roles and some aria attribute that is why they are wrapped in a div
+					if ( elm.nodeName.toLowerCase() === "details" ) {
+						wrapper = document.createElement( "div" );
+						wrapper.classList.add( "tgl-tab" );
+						wrapper.setAttribute( "role", "tab" );
+						wrapper.setAttribute( "aria-selected", isOpen );
+						wrapper.setAttribute( "tabindex", isOpen ? "0" : "-1" );
+						wrapper.setAttribute( "aria-posinset", i + 1 );
+						wrapper.setAttribute( "aria-setsize", len );
+						parent.replaceChild( wrapper, elm );
+						wrapper.appendChild( elm );
+					} else {
+						tab.setAttribute( "role", "tab" );
+						tab.setAttribute( "aria-selected", isOpen );
+						tab.setAttribute( "tabindex", isOpen ? "0" : "-1" );
+						tab.setAttribute( "aria-posinset", i + 1 );
+						tab.setAttribute( "aria-setsize", len );
+					}
 					panel.setAttribute( "role", "tabpanel" );
 					panel.setAttribute( "aria-labelledby", tab.getAttribute( "id" ) );
 					panel.setAttribute( "aria-expanded", isOpen );
@@ -313,7 +327,7 @@ var componentName = "wb-toggle",
 			if ( data.isTablist ) {
 
 				// Set the required aria attributes
-				$elms.find( selectorTab ).attr( {
+				$elms.find( selectorTab ).parents( selectorTab ).attr( {
 					"aria-selected": isOn,
 					tabindex: isOn ? "0" : "-1"
 				} );

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -118,7 +118,6 @@ var componentName = "wb-toggle",
 					if ( !tab.getAttribute( "id" ) ) {
 						tab.setAttribute( "id", wb.getId() );
 					}
-					tab.setAttribute( "role", "tab" );
 					tab.setAttribute( "aria-selected", isOpen );
 					tab.setAttribute( "tabindex", isOpen ? "0" : "-1" );
 					tab.setAttribute( "aria-posinset", i + 1 );


### PR DESCRIPTION
Removed the Accordion "summary" role="tab" to improve the accessibility, since ARIA role tab is not allowed for summary tags. Please see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/summary for more details.  Fixes #8919.