### PR TITLE
Create issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-en.md
+++ b/.github/ISSUE_TEMPLATE/bug-en.md
@@ -1,0 +1,43 @@
+---
+name: Bug
+about: Create a bug report to help us improve
+title: "[BUG] Feature name - Short description of the bug"
+labels: ''
+assignees: ''
+
+---
+
+## Required information
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+If you found another bug report related to this issue on GitHub, please mention its number e.g. #7890
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Who shall do the work?**
+[I will do it, I want to contribute] or [I am asking for Principal publisher to please do the work]
+
+## Additional information (optional)
+
+**Version of WET-BOEW/GCWeb you are using**
+e.g. v4.0.36
+
+**Desktop/Smartphone (please complete the following information)**
+ - OS or Device: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Screenshots**
+If applicable, add screenshots to help explain the bug.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-fr.md
+++ b/.github/ISSUE_TEMPLATE/bug-fr.md
@@ -1,0 +1,43 @@
+---
+name: Bogue
+about: Générer un rapport de bogue pour nous aider à nous améliorer
+title: "[BOGUE] Nom de la fonctionnalité - Courte description du bogue"
+labels: ''
+assignees: ''
+
+---
+
+## Information nécessaire
+
+**Description du bogue**
+Une description claire et concise du bogue.
+Si vous avez trouvé un autre rapport de bogue relié à ceci sur GitHub, veuillez mentionner son numéro ex. : #7890
+
+**Pour le reproduire**
+Étapes pour reproduire le problème :
+1. Allez à "..."
+2. Cliquer sur "...."
+3. Défiler jusqu'à "...."
+4. Voir erreur
+
+**Scénario attendu**
+Une description claire et concise de ce qui devrait se passer en tant normal.
+
+**Qui devrait travailler à corriger ce problem?**
+[Je vais le faire, je veux contribuer] ou [Je demande à l'Éditeur principal de faire le travail svp]
+
+## Information additionnelle (optionel)
+
+**Version de WET-BOEW/GCWeb que vous utilisez**
+e.g. v4.0.36
+
+**Ordinateur/Téléphone intelligent (svp complétez l'information suivante)**
+ - OS or Device: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Captures d'écrans**
+Si applicable, ajoutez des captures d'écran pour aider à démontrer le bogue.
+
+**Contexte additionnel**
+Ajouter du contexte en rapport avec le problème ici.

--- a/.github/ISSUE_TEMPLATE/feature-request-en.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-en.md
@@ -1,0 +1,34 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE] Short description of the feature"
+labels: ''
+assignees: ''
+
+---
+
+## Required information
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is e.g. I'm always frustrated when [...]
+If you found another feature request or bug report related to this issue on GitHub, please mention its number e.g. #7890
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Who shall do the work?**
+[I am seeking guidance because I want to contribute] or [I am asking for Principal publisher to please do the work]
+
+## Additional information (optional)
+
+**Timeline**
+Is there a deadline attached to this request? If so, please briefly describe why and provide a date (YYYY-MM-DD)
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/.github/ISSUE_TEMPLATE/feature-request-fr.md
+++ b/.github/ISSUE_TEMPLATE/feature-request-fr.md
@@ -1,0 +1,34 @@
+---
+name: Demande de fonctionnalité
+about: Suggérer une idée pour le projet
+title: "[FONCTION] Courte description de la fonctionnalité"
+labels: ''
+assignees: ''
+
+---
+
+## Information nécessaire
+
+**Est-ce que votre demande de fonctionnalité est reliée à un problème ? Veuillez élaborer.**
+Description courte et concise du problème ex. : Je suis toujours frustré(e) par [...]
+Si vous avez trouvé une autre demande de fonctionnalité ou rapport de bogue relié à ceci sur GitHub, veuillez mentionner le numéro ex. : #7890
+
+**Décrivez la solution que vous aimeriez voir**
+Description claire et concise de ce que vous voudriez avoir comme fonctionnalité.
+
+**Décrivez des alternatives que vous avez considérées**
+Description claire et concise des solutions alternatives ou autres fonctionnalités que vous avez considérées.
+
+**Qui devrait travailler à développer cette fonctionnalité?**
+[Je vais le faire, je veux contribuer] ou [Je demande à l'Éditeur principal de faire le travail svp]
+
+## Information additionnelle (optionel)
+
+**Échéance**
+Y-a-t'il une échéance relié à cette requête? Si oui, veuillez brièvement expliquer pourquoi et fournissez une date (YYYY-MM-DD)
+
+**Captures d'écrans**
+Si applicable, ajoutez des captures d'écran pour aider à démontrer le bogue.
+
+**Contexte additionnel**
+Ajoutez du contexte en rapport avec la fonctionnalité ici.

--- a/.github/ISSUE_TEMPLATE/other-en.md
+++ b/.github/ISSUE_TEMPLATE/other-en.md
@@ -1,0 +1,11 @@
+---
+name: Other
+about: Ask a question, leave a comment, seek guidance
+title: "[OTHER] Summary of the purpose"
+labels: ''
+assignees: ''
+
+---
+
+## Describe the purpose of this issue
+Ask your question, leave your comment or seek guidance here.

--- a/.github/ISSUE_TEMPLATE/other-fr.md
+++ b/.github/ISSUE_TEMPLATE/other-fr.md
@@ -1,0 +1,11 @@
+---
+name: Autre
+about: Poser une question, laisser un commentaire, demander de l'aide
+title: "[AUTRE] Résumé de la requête"
+labels: ''
+assignees: ''
+
+---
+
+## Objectif de cette requête
+Posez vos questions, laissez vos commentaires ou demandez de l'aide ici.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+_(Pick the language of your choice to fill out the following information. / Choisissez la langue de votre choix pour remplir l'information ci-dessous.)_
+
+## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
+A clear and concise description of what the code of this PR accomplishes. /// Une description claire et concise de ce que le code de cette PR accompli.
+
+## Additional information (optional) / Information additionnelle (optionel)
+
+**General checklist / Liste de contrôle générale**
+Make your own list for the purpose of your Pull request. /// Faites votre propre liste en fonction des besoins de votre demande « pull ».
+
+- [ ] Create/update documentation /// Créer/mettre à jour la documentation
+- [ ] Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
+- [ ] Validate changes against WCAG for accessibility /// Valider les changements avec WCAG pour l'accessibilité
+- [ ] Ensure documentation is bilingual /// S'assurer que la documentation soit bilingue
+
+**Related issues / Requêtes associées**
+List issues that are being closed or worked on with this pull request i.e. Closes #8941 /// Listez les autres requêtes (« issues » ou PR) qui sont fermées ou traitées avec cette demande de retrait ex. : Closes #8941
+
+**Screenshots / Captures d'écrans**
+If applicable, add screenshots to help demonstrate what this PR does. /// Si applicable, ajoutez des captures d'écran pour aider à démontrer ce que cette PR fait.


### PR DESCRIPTION
Created issue templates for:

- Bug requests;
- Feature requests;
- Other (questions/comments).

See those templates in action here: https://github.com/GormFrank/wet-boew/issues

... and created a default bilingual PR template.

- [x] Look into having two PR templates, one in EN and one in FR