### PR TITLE
Multimedia player: Fix presentation of closed captioning errors

### DIFF
--- a/src/plugins/multimedia/_base.scss
+++ b/src/plugins/multimedia/_base.scss
@@ -87,13 +87,6 @@
 			@include multimedia_overlay_play;
 		}
 
-		&.playing {
-
-			.errmsg {
-				display: none;
-			}
-		}
-
 		&.waiting {
 			@include multimedia_overlay_loading;
 		}
@@ -127,13 +120,15 @@
 			padding: .5em;
 		}
 
-		.cc {
-			&:after {
-				border-bottom: 3px solid $mm-ctrl-cc-color;
-				content: " ";
-				display: block;
-				margin-left: -2px;
-				width: 1.2em;
+		&:not(.errmsg) {
+			.cc {
+				&:after {
+					border-bottom: 3px solid $mm-ctrl-cc-color;
+					content: " ";
+					display: block;
+					margin-left: -2px;
+					width: 1.2em;
+				}
 			}
 		}
 	}
@@ -171,6 +166,14 @@
 				background: #fff;
 				border: 0;
 				color: #000;
+
+				&[disabled] {
+					&:active {
+						&:hover {
+							color: #000;
+						}
+					}
+				}
 			}
 		}
 	}
@@ -222,6 +225,18 @@
 		}
 		color: $mm-ctrl-fg-color;
 		font-size: 130%;
+
+		&[disabled] {
+			&:active {
+				&:hover {
+					color: $mm-ctrl-fg-color;
+				}
+			}
+
+			&:hover {
+				background-color: transparent;
+			}
+		}
 	}
 
 	.frstpnl {

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -805,7 +805,7 @@ $document.on( "click", selector, function( event ) {
 	// JSPerf for multiple class matching https://jsperf.com/hasclass-vs-is-stackoverflow/7
 	if ( className.match( /playpause|-play|-pause|display/ ) || $target.is( "object" ) || $target.is( "video" ) ) {
 		this.player( "getPaused" ) || this.player( "getEnded" ) ? this.player( "play" ) : this.player( "pause" );
-	} else if ( className.match( /(^|\s)cc\b|-subtitles/ )  ) {
+	} else if ( className.match( /(^|\s)cc\b|-subtitles/ ) && !$target.attr( "disabled" ) && !$target.parent().attr( "disabled" ) ) {
 		this.player( "setCaptionsVisible", !this.player( "getCaptionsVisible" ) );
 	} else if ( className.match( /\bmute\b|-volume-(up|off)/ ) ) {
 		this.player( "setMuted", !this.player( "getMuted" ) );
@@ -989,11 +989,15 @@ $document.on( multimediaEvents, selector, function( event, simulated ) {
 
 	case "ccloadfail":
 		if ( eventNamespace === componentName ) {
-			$this.find( ".wb-mm-cc" )
-				.append( "<p class='errmsg'><span>" + i18nText.cc_error + "</span></p>" )
-				.end()
-				.find( ".cc" )
-				.attr( "disabled", "" );
+			if ( !$this.hasClass( "errmsg" ) ) {
+				$this.addClass( "cc_on errmsg" )
+					.find( ".wb-mm-cc" )
+					.append( "<div>" + i18nText.cc_error + "</div>" )
+					.end()
+					.find( ".cc" )
+					.attr( "disabled", "" )
+					.removeAttr( "aria-pressed" );
+			}
 		}
 		break;
 


### PR DESCRIPTION
The media player previously had strange, buggy behaviour when failing to load closed captions. It put the CC button into a disabled state and inserted an error message into the collapsed captions panel.

But that setup had several problems:
* The captions panel isn't open by default and therefore couldn't be expanded since the CC button was disabled.
* The same error message was repeated twice in a row.
* The errors overflowed on top of content below the media player.
* The errors were almost invisible since they use a white colour.
* The errors were hidden via display: none; while the media player was playing... and unveiled when paused.
* Hovering over the disabled CC button caused its background colour to brighten and contrast poorly with the CC icon.
* Clicking the disabled CC button caused a flicker effect.
* The disabled CC button had an aria-pressed="false" attribute... which got announced by screen readers despite being irrelevant.

This commit resolves the problems as follows:
* Automatically opens the captions panel if an error occurs.
* Intentionally keeps the panel open to make the error message stand out. It can't be collapsed.
* Only shows one instance of the error.
* Doesn't hide the error during playback.
* Fixes the disabled CC button's hover/flicker issues.
* Removes the CC button's aria-pressed="false" attribute.

**Screenshots...**

**Before (dotted white pixels in the "View code" summary's top border):**
![multimedia-cc-error-before-1](https://user-images.githubusercontent.com/1907279/95358449-12987f80-0897-11eb-868f-dac500472678.png)

**Before (highlighted the white error messages):**
![multimedia-cc-error-before-2](https://user-images.githubusercontent.com/1907279/95358457-14fad980-0897-11eb-8ee1-b7e8916b66f5.png)

**After:**
![multimedia-cc-error-after](https://user-images.githubusercontent.com/1907279/95358459-16c49d00-0897-11eb-94ee-1c216281c76f.png)
