### PR TITLE
Multimedia player: Make YouTube play button background opaque

### DIFF
--- a/src/plugins/multimedia/_base.scss
+++ b/src/plugins/multimedia/_base.scss
@@ -144,6 +144,16 @@
 				@extend %multimedia-display-none;
 			}
 		}
+
+		&.video {
+			&:not(.playing):not(.waiting) {
+				.display {
+					&:before {
+						background: $mm-ctrl-bg-color;
+					}
+				}
+			}
+		}
 	}
 
 	/*


### PR DESCRIPTION
The multimedia's play button uses a translucent (70% opacity) background colour. That looks fine in normal videos.

But in YouTube videos... the translucency causes the YouTube player's play button to be visible behind the WET player's play button. It's especially noticeable when hovering over the video's viewport (which brightens YouTube's play button).

This commit resolves it by using an opaque colour for the play button's background. But only for YouTube videos. Normal videos will still continue to use translucent backgrounds.

**Screenshots...**

**Before (default):**
![multimedia-youtube-before-default](https://user-images.githubusercontent.com/1907279/95487189-fb729400-0961-11eb-8791-f6a93ebce594.png)

**Before (hover - bright YouTube play button is visible behind the WET player's play button):**
![multimedia-youtube-before-hover](https://user-images.githubusercontent.com/1907279/95487195-fd3c5780-0961-11eb-86d0-4b8bd249f52b.png)

**After:**
![multimedia-youtube-after](https://user-images.githubusercontent.com/1907279/95487197-ff061b00-0961-11eb-9dfc-375b542db215.png)
