### PR TITLE
Bootstrap overrides: Darken panel borders

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -29,6 +29,13 @@ $brand-info: #4d4d4d !default;
 $brand-warning: #f2d40d !default;
 $brand-danger: #bc3331 !default;
 
+$panel-inner-border: #8e8e8e !default;
+$panel-default-border: $panel-inner-border !default;
+$panel-success-border: #629339 !default;
+$panel-info-border: #2392A9 !default;
+$panel-warning-border: #BA8312 !default;
+$panel-danger-border: #C16171 !default;
+
 // WET Custom
 $clrWhite: #fff !default;
 $clrLight: #eee !default;


### PR DESCRIPTION
This increases the contrast between panel headings and borders to >= 3:1. The resulting effect looks very stark.

The upside of this change is that it makes the shapes of panels more perceptible to users with poor vision. It may also benefit WCAG 2.1 success criterion 1.4.11 (Non-text Contrast) - especially when panels are used with stretched links.