### PR TITLE
Multimedia player: Fix captions collapse bug

### DIFF
--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -805,7 +805,7 @@ $document.on( "click", selector, function( event ) {
 	// JSPerf for multiple class matching https://jsperf.com/hasclass-vs-is-stackoverflow/7
 	if ( className.match( /playpause|-play|-pause|display/ ) || $target.is( "object" ) || $target.is( "video" ) ) {
 		this.player( "getPaused" ) || this.player( "getEnded" ) ? this.player( "play" ) : this.player( "pause" );
-	} else if ( className.match( /\bcc\b|-subtitles/ )  ) {
+	} else if ( className.match( /(^|\s)cc\b|-subtitles/ )  ) {
 		this.player( "setCaptionsVisible", !this.player( "getCaptionsVisible" ) );
 	} else if ( className.match( /\bmute\b|-volume-(up|off)/ ) ) {
 		this.player( "setMuted", !this.player( "getMuted" ) );


### PR DESCRIPTION
Clicking certain areas of the captions panel was causing it to collapse.

Specifically:
* Anywhere inside the panel if no caption text is visible
* The edges of the panel (i.e. its padding)
* The ::before pseudo-element's space character

That behaviour was due to a click event that used a flawed regex to check for the CC button's "cc" class. Its looked for word boundaries around "cc"... but dashes count as boundary separators. So the captions panel's "wb-mm-cc" class was getting matched.

This fixes it by replacing the regex's first boundary with an alternation operator.

Related to #8951.

**Screenshot (clicking anywhere in the highlighted purple area used to cause the captions panel to collapse):**
![multimedia-cc-panel-highlight](https://user-images.githubusercontent.com/1907279/96041409-c7074800-0e39-11eb-82ca-d10a8bafc078.png)
