### PR TITLE
4.0.39 Release

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-boew",
-  "version": "4.0.38",
+  "version": "4.0.39",
   "homepage": "https://wet-boew.github.io",
   "authors": [
     "WET-BOEW Team"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-boew",
-  "version": "4.0.38",
+  "version": "4.0.39",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-boew",
-  "version": "4.0.38",
+  "version": "4.0.39",
   "description": "Web Experience Toolkit (WET): Open source code library for building innovative websites that are accessible, usable, interoperable, mobile-friendly and multilingual. This collaborative open source project is led by the Government of Canada. / Boîte à outils de l’expérience Web (BOEW) : Une bibliothèque de code primée pour construire des sites Web innovants qui sont accessibles, faciles d'emploi, interopérables, optimisés pour les appareils mobiles et multilingues. Ceci est un projet à source ouverte collaboratif dirigé par le Gouvernement du Canada.",
   "main": "index.html",
   "engines": {

--- a/site/pages/docs/versions/dwnld-en.hbs
+++ b/site/pages/docs/versions/dwnld-en.hbs
@@ -4,7 +4,7 @@
 	"language": "en",
 	"description": "Downloads - Version history - Web Experience Toolkit (WET)",
 	"altLangPrefix": "dwnld",
-	"dateModified": "2020-09-18"
+	"dateModified": "2020-11-02"
 }
 ---
 <p>WET-BOEW and GCWeb are at least quarterly released.</p>
@@ -41,13 +41,13 @@
 		<tbody>
 			<tr>
 				<td>Web Experience Toolkit (WET)</td>
-				<td>v4.0.38 (STR)</td>
-				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/wet-boew/releases/latest">Download<span class="wb-inv"> - v4.0.38 (STR) - Web Experience Toolkit (WET) theme</span></a></td>
+				<td>v4.0.39</td>
+				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/wet-boew/releases/latest">Download<span class="wb-inv"> - v4.0.39 - Web Experience Toolkit (WET) theme</span></a></td>
 			</tr>
 			<tr>
 				<td>Canada.ca (GCWeb)</td>
-				<td>v8.0.2 (STR)</td>
-				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Download<span class="wb-inv"> - v8.0.2 (STR) - Canada.ca theme</span></a></td>
+				<td>v8.1.0</td>
+				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Download<span class="wb-inv"> - v8.1.0 - Canada.ca theme</span></a></td>
 			</tr>
 		</tbody>
 	</table>

--- a/site/pages/docs/versions/dwnld-fr.hbs
+++ b/site/pages/docs/versions/dwnld-fr.hbs
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"description": "Téléchargements - Historique des versions - Boîte à outils de l'expérience Web (BOEW)",
 	"altLangPrefix": "dwnld",
-	"dateModified": "2020-09-18"
+	"dateModified": "2020-11-02"
 }
 ---
 <p>La BOEW et GCWeb sont publié au minimum selon cycle trimestrielle.<p>
@@ -46,13 +46,13 @@
 		<tbody>
 			<tr>
 				<td>Boîte à outils de l'expérience Web (WET-BOEW)</td>
-				<td>v4.0.38 (DCT)</td>
-				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/wet-boew/releases/latest">Télécharger<span class="wb-inv"> - v4.0.38 (DCT) - Thème de la Boîte à outils de l'expérience Web (WET-BOEW)</span></a></td>
+				<td>v4.0.39</td>
+				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/wet-boew/releases/latest">Télécharger<span class="wb-inv"> - v4.0.39 - Thème de la Boîte à outils de l'expérience Web (WET-BOEW)</span></a></td>
 			</tr>
 			<tr>
 				<td>Canada.ca (GCWeb)</td>
-				<td>v8.0.2 (DCT)</td>
-				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Télécharger<span class="wb-inv"> - v8.0.2 (DCT) - Thème Canada.ca</span></a></td>
+				<td>v8.1.0</td>
+				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Télécharger<span class="wb-inv"> - v8.1.0 - Thème Canada.ca</span></a></td>
 			</tr>
 		</tbody>
 	</table>


### PR DESCRIPTION
This is a **MINOR release** (without breaking changes):

## What’s new?
The following lists all the "What's new?" items since the last regular release (non-STR), which was v4.0.36.

* **Template:**
	* Head - Remove no longer supported Internet Explorer conditionals

* **Styles and plugins:**
	* Minor - Exit script - Add plugin that can notify user they are being redirected to a non secure site.
	* Patch - Share widget - Remove Bit.ly image since it is not relevant anymore
	* Patch - Lightbox - Fix color contrast for navigation arrows
	* Patch - Multimedia player - Fixed presentation of caption errors and show when parsing fails
	* Patch - Multimedia player - Make YouTube play button background opaque
	* Patch - Multimedia player - Fix closed captions collapse bug and hide in print view
	* Patch - Lightbox - Fix clicking on child elements of summary when using tabs
	* Patch - Toggle - Removed the Accordion "summary" role="tab" to improve the accessibility
	* Patch - Bootstrap - Increases the contrast between panel headings and borders to >= 3:1
	* Bootstrap 4 - Add two new spacer classes: ".pr-2" and ".pb-4"
	* Bootstrap 4 - Fix two spacer classes: ".pl-2" and ".px-2"
	* Bootstrap 4 - Added ".position-relative" to improve stretched-link
	* Multimedia player - Clear loading icon after seek event in Edge
	* Prettify - Adjust tabbing space in code samples and make ins tag bold and no underline
	* Data tables - Fix data tables for more recents versions of jQuery
	* Country content - Fix URL to "freegeoip.app" for AJAX call
	* Form validation - Reduce aggressiveness of "onfocusout" validation
	* Lightbox - Adjust focus cycle to intentionally "trap" keyboard users in the lightbox
	* Datepicker - Fix clear button visibility on date fields (on IE 11)

* **[Provisional](https://wet-boew.github.io/themes-dist/GCWeb/provisional-en.html):**
	* Background center - Position background image to the center with ".bg-center"
	* Steps form - Fix focus order to ease keyboard navigation
	* Postback - Prevent multiple submissions by double-clicking on submit

### Modified files for implementation
* wet-boew/js/wet-boew.js
* wet-boew/js/wet-boew.min.js
* theme-wet-boew/css/theme.css
* theme-wet-boew/css/theme.min.css

## Details
[List of commits](https://github.com/wet-boew/wet-boew/releases/tag/v4.0.39)

### Browsers supported (as described in [Design decision 2](https://wet-boew.github.io/wet-boew-documentation/decision/2.html))
* Chrome 85
* Chrome 84
* Firefox 80
* Firefox 79
* Firefox ESR - 68.12
* Safari 13.1.2
* Edge 85.0.564.51

## Subresource integrity ([SRI](https://www.w3.org/TR/SRI/))
wet-boew/js/wet-boew.min.js: `Coming soon...`

------------

Ceci est un **déploiement MINEUR** (sans changement non rétrocompatible) :

## Quoi de neuf?
Les items suivants liste tous les "Quoi de neuf?" depuis le dernier déploiement régulier (non-DCT) qui était v4.0.36.

* **Gabarit:**
	* En-tête - Retirer les conditionnels d'Internet Explorer qui ne sont plus supportés

* **Styles et plugiciels :**
	* Mineur - Script de sortie - Ajouter un plugiciel qui permet d'avertir l'utilisateur qu'il ou elle est redirigé(e) vers un site non-sécure
	* Correctif - Gadget de partage - Enlever l'image de Bit.ly puisque ce n'est plus pertinent
	* Correctif - Lecteur multimédia - Corriger la présentation des sous-titres codés et afficher lorsque l'analyse du fichier est un échec
	* Correctif - Lecteur multimédia - Rendre le fond d'écran du bouton YouTube plus opaque
	* Correctif - Lecteur multimédia - Corriger les sous-titres codés lorsqu'on les ferme et les cacher dans la vue d'imprimerie
	* Correctif - Lightbox - Corriger le clic sur les éléments enfants des "summary" lors de l'utilisation de tabs
	* Correctif - Basculer - Retirer le role="tab" de l'accordéon "summary" pour améliorer l'accessibilité
	* Correctif - Bootstrap - Augmenter le contraste les en-tête et les bordures de "panel" afin qu'ils soient >= 3:1
	* Bootstrap 4 - Ajouté ".position-relative" pour améliorer stretched-link
	* Bootstrap 4 - Ajouter deux nouvelles classes d'espacement : ".pr-2" et ".pb-4"
	* Bootstrap 4 - Réparer deux classes d'espacement : ".pl-2" et ".px-2"
	* Lecteur multimédia - Retirer l'icône de chargement après un événément de recherche dans Edge
	* Prettify - Ajuster l'espace de tabulation dans les exemples de code et rendre les ins en gras et sans soulignement
	* Data tables - Corrigé les data tables pour des versions plus récentes de jQuery
	* Country content - Corrigé l'URL de "freegeoip.app" pour l'appel AJAX
	* Form validation - Réduire l'agressivité de la validation "onfocusout"
	* Lightbox - Ajuster le cycle de focus pour "piéger" intentionnellement les utilisateurs avec clavier dans le lightbox
	* Sélecteur de date - Corriger la visibilité du bouton effacer sur les champs de date (sur IE 11)

* **[Provisoire](https://wet-boew.github.io/themes-dist/GCWeb/provisional-fr.html) :**
	* Fond d'écran centré - Positionner l'image de fond d'écran au centre avec ".bg-center"
	* Postback - Prévenir les multiples soumissions en double-cliquant sur le bouton soumettre
	* Formulaire à étapes - Ordre de focus pour faciliter la navigation par clavier

### Fichiers modifiés pour implémentation
* wet-boew/js/wet-boew.js
* wet-boew/js/wet-boew.min.js
* theme-wet-boew/css/theme.css
* theme-wet-boew/css/theme.min.css

## Détails
[Liste des contributions](https://github.com/wet-boew/wet-boew/releases/tag/v4.0.39)

### Fureteurs supportés (Tel que défini par la [Décision de conception 2](https://wet-boew.github.io/wet-boew-documentation/decision/2.html))
* Chrome 85
* Chrome 84
* Firefox 80
* Firefox 79
* Firefox ESR - 68.12
* Safari 13.1.2
* Edge 85.0.564.51

## Intégrité des sous-ressource ([SRI](https://www.w3.org/TR/SRI/))
wet-boew/js/wet-boew.min.js: `À venir...`