### PR TITLE
Lightbox: example for Full width inline content

### DIFF
--- a/site/pages/docs/ref/lightbox/lightbox-en.hbs
+++ b/site/pages/docs/ref/lightbox/lightbox-en.hbs
@@ -59,6 +59,18 @@
 		</thead>
 		<tbody>
 			<tr>
+				<td><code>mfp-hide</code></td>
+				<td>Hides inline popup content.</td>
+				<td>Add <code>mfp-hide</code> to the <code>class</code> attribute of the popup's <code>section</code> element.</td>
+				<td>n/a</td>
+			</tr>
+			<tr>
+				<td><code>modal-dialog</code></td>
+				<td>Restrict width of the popup.</td>
+				<td>Add <code>modal-dialog</code> to the <code>class</code> attribute of the popup's <code>section</code> element.</td>
+				<td>n/a</td>
+			</tr>
+			<tr>
 				<td><code>lbx-hide-gal</code></td>
 				<td>Hides all but the first item in the gallery.</td>
 				<td>Add <code>lbx-hide-gal</code> to the <code>class</code> attribute of the <code>section</code> or other element of the gallery.</td>

--- a/site/pages/docs/ref/lightbox/lightbox-fr.hbs
+++ b/site/pages/docs/ref/lightbox/lightbox-fr.hbs
@@ -60,6 +60,18 @@
 		</thead>
 		<tbody>
 			<tr>
+				<td><code>mfp-hide</code></td>
+				<td>Cache le contenu incorporé du popup.</td>
+				<td>Ajoutez <code>mfp-hide</code> à l'attribut <code>class</code> de l'élément <code>section</code> du popup.</td>
+				<td>n/a</td>
+			</tr>
+			<tr>
+				<td><code>modal-dialog</code></td>
+				<td>Restreindre la largeur du popup.</td>
+				<td>Ajoutez <code>modal-dialog</code> à l'attribut <code>class</code> de l'élément <code>section</code> du popup.</td>
+				<td>n/a</td>
+			</tr>
+			<tr>
 				<td><code>lbx-hide-gal</code></td>
 				<td>Cache tous les éléments d'une galerie sauf le premier.</td>
 				<td>Ajouter <code>lbx-hide-gal</code> à l'attribut <code>class</code> de la <code>section</code> ou de l'autre élément de la galerie.</td>

--- a/src/plugins/lightbox/lightbox-en.hbs
+++ b/src/plugins/lightbox/lightbox-en.hbs
@@ -86,6 +86,25 @@
 					</section>
 				</li>
 				<li>
+					<a class="wb-lbx" title="Example of full width inline content" href="#inline_content_full_width">Full width inline content</a>
+
+					<section id="inline_content_full_width" class="mfp-hide modal-content overlay-def">
+						<header class="modal-header">
+							<h2 class="modal-title">Title</h2>
+						</header>
+						<div class="modal-body">
+							<ol class="colcount-sm-2 colcount-lg-3">
+								<li>ordered list (<code>ol</code>) first level default appearance</li>
+								<li>ordered list (<code>ol</code>) first level default appearance</li>
+								<li>ordered list (<code>ol</code>) first level default appearance</li>
+								<li>ordered list (<code>ol</code>) first level default appearance</li>
+								<li>ordered list (<code>ol</code>) first level default appearance</li>
+								<li>ordered list (<code>ol</code>) first level default appearance</li>
+							</ol>
+						</div>
+					</section>
+				</li>
+				<li>
 					<a class="wb-lbx lbx-modal" title="Example of a modal popup" href="#inline_content_modal">Modal popup</a>
 
 					<section id="inline_content_modal" class="mfp-hide modal-dialog modal-content overlay-def">
@@ -132,8 +151,23 @@
 		&lt;a class="wb-lbx" title="AJAX - Example 1 of AJAX content" href="ajax/ajax-en.html"&gt;AJAX - Example 1&lt;/a&gt;
 	&lt;/li&gt;
 	&lt;li&gt;
+		AJAX - override default behaviour of image link with lbx-ajax&lt;br /&gt;
+		&lt;a class="wb-lbx lbx-ajax" title="AJAX - Example 1 of AJAX content" href="ajax/ajax1-en.html"&gt;&lt;img src="demo/1_s.jpg" alt="Image 1" /&gt;&lt;/a&gt;
+	&lt;/li&gt;
+	&lt;li&gt;
 		&lt;a class="wb-lbx" title="Example of inline content" href="#inline_content"&gt;Inline content&lt;/a&gt;
 		&lt;section id="inline_content" class="mfp-hide modal-dialog modal-content overlay-def"&gt;
+			&lt;header class="modal-header"&gt;
+				&lt;h2 class="modal-title"&gt;Title&lt;/h2&gt;
+			&lt;/header&gt;
+			&lt;div class="modal-body"&gt;
+				...
+			&lt;/div&gt;
+		&lt;/section&gt;
+	&lt;/li&gt;
+	&lt;li&gt;
+		&lt;a class="wb-lbx" title="Example of full width inline content" href="#inline_content_full_width"&gt;Full width inline content&lt;/a&gt;
+		&lt;section id="inline_content_full_width" class="mfp-hide modal-content overlay-def"&gt;
 			&lt;header class="modal-header"&gt;
 				&lt;h2 class="modal-title"&gt;Title&lt;/h2&gt;
 			&lt;/header&gt;

--- a/src/plugins/lightbox/lightbox-fr.hbs
+++ b/src/plugins/lightbox/lightbox-fr.hbs
@@ -85,6 +85,25 @@
 					</section>
 				</li>
 				<li>
+					<a class="wb-lbx" title="Exemple de contenu incorporé plein écran" href="#inline_content_full_width">Contenu incorporé plein écran</a>
+
+					<section id="inline_content_full_width" class="mfp-hide modal-content overlay-def">
+						<header class="modal-header">
+							<h2 class="modal-title">Titre</h2>
+						</header>
+						<div class="modal-body">
+							<ol class="colcount-sm-2 colcount-lg-3">
+								<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+								<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+								<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+								<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+								<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+								<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+							</ol>
+						</div>
+					</section>
+				</li>
+				<li>
 					<a class="wb-lbx lbx-modal" title="Exemple de contenu superposé modal" href="#inline_content_modal">Contenu superposé modal</a>
 					<section id="inline_content_modal" class="mfp-hide modal-dialog modal-content overlay-def">
 						<header class="modal-header">
@@ -131,6 +150,10 @@
 		&lt;a class="wb-lbx" title="Exemple de contenu AJAX" href="ajax/ajax-en.html"&gt;Contenu AJAX&lt;/a&gt;
 	&lt;/li&gt;
 	&lt;li&gt;
+		AJAX - remplacer le comportement par defaut d'un lien sur une image avec lbx-ajax&lt;br /&gt;
+		&lt;a class="wb-lbx lbx-ajax" title="AJAX - Exemple 1 de contenu AJAX" href="ajax/ajax1-fr.html"&gt;&lt;img src="demo/1_s.jpg" alt="Image 1" /&gt;&lt;/a&gt;
+	&lt;/li&gt;
+	&lt;li&gt;
 		&lt;a class="wb-lbx" title="Exemple de contenu incorporé" href="#inline_content"&gt;Contenu incorporé&lt;/a&gt;
 
 		&lt;div id="inline_content" class="mfp-hide modal-dialog modal-content overlay-def"&gt;
@@ -143,6 +166,17 @@
 				&lt;/div&gt;
 			&lt;/section&gt;
 		&lt;/div&gt;
+	&lt;/li&gt;
+	&lt;li&gt;
+		&lt;a class="wb-lbx" title="Exemple de contenu incorporé plein écran" href="#inline_content_full_width"&gt;Contenu incorporé plein écran&lt;/a&gt;
+		&lt;section id="inline_content_full_width" class="mfp-hide modal-content overlay-def"&gt;
+			&lt;header class="modal-header"&gt;
+				&lt;h2 class="modal-title"&gt;Titre&lt;/h2&gt;
+			&lt;/header&gt;
+			&lt;div class="modal-body"&gt;
+					...
+			&lt;/div&gt;
+		&lt;/section&gt;
 	&lt;/li&gt;
 	&lt;li&gt;
 		&lt;a class="wb-lbx lbx-modal" title="Exemple de contenu superposé modal" href="#inline_content_modal"&gt;Contenu superposé modal&lt;/a&gt;


### PR DESCRIPTION
The new example is called "Full width inline content" which is placed under Examples-Single items. 

It's similar as the example of Inline content but the popup window is in full width. 