### PR TITLE
Exit script - Fix Typos and translation in working example and documentation

### DIFF
--- a/site/pages/docs/ref/exitscript/exitscript-en.hbs
+++ b/site/pages/docs/ref/exitscript/exitscript-en.hbs
@@ -4,23 +4,22 @@
 	"language": "en",
 	"category": "Plugins",
 	"categoryfile": "plugins",
-	"description": "Redirects users to non secure sites.",
+	"description": "Redirects users to another sites.",
 	"altLangPrefix": "exitscript",
 	"dateModified": "2020-06-19"
 }
 ---
-<span class="wb-prettify all-pre hide"></span>
 
 <section>
 	<h2>Purpose</h2>
-	<p>Redirects users to non secure sites.</p>
+	<p>Redirects users to another sites.</p>
 </section>
 
 <section>
 	<h2>Working example</h2>
 	<ul>
 		<li><a href="../../../demos/exitscript/exitscript-en.html">English example</a></li>
-		<li><a href="../../../demos/exitscript/exitscript-fr.html">French example</a></li>
+		<li><a href="../../../demos/exitscript/exitscript-fr.html" hreflang="fr">French example</a></li>
 	</ul>
 </section>
 <section>

--- a/site/pages/docs/ref/exitscript/exitscript-fr.hbs
+++ b/site/pages/docs/ref/exitscript/exitscript-fr.hbs
@@ -1,25 +1,24 @@
 ---
 {
-	"title": "Exit script",
+	"title": "Sortie de navigation avisé",
 	"language": "fr",
 	"category": "Plugiciels",
 	"categoryfile": "plugins",
-	"description": "Redirects users to non secure sites.",
+	"description": "Aviser l'utilisateur d'une redirection vers un autre site.",
 	"altLangPrefix": "exitscript",
 	"dateModified": "2020-06-19"
 }
 ---
-<span class="wb-prettify all-pre hide"></span>
 
 <section>
 	<h2>But</h2>
-	<p lang="en">Redirects users to non secure sites.</p>
+	<p>Aviser l'utilisateur d'une redirection vers un autre site.</p>
 </section>
 
 <section>
 	<h2>Exemples</h2>
 	<ul>
-		<li><a href="../../../demos/exitscript/exitscript-en.html">Exemple anglais</a></li>
+		<li><a href="../../../demos/exitscript/exitscript-en.html" hreflang="en">Exemple anglais</a></li>
 		<li><a href="../../../demos/exitscript/exitscript-fr.html">Exemple français</a></li>
 	</ul>
 </section>

--- a/src/plugins/exitscript/exitscript-en.hbs
+++ b/src/plugins/exitscript/exitscript-en.hbs
@@ -1,16 +1,16 @@
 ---
 {
-	"title": "Exitsctipt",
+	"title": "Exit script",
 	"language": "en",
 	"category": "Plugins",
-	"description": "Redirects users to non secure sites.",
+	"description": "Redirects users to another sites.",
 	"tag": "exitscript",
 	"parentdir": "exitscript",
 	"altLangPrefix": "exitscript",
 	"dateModified": "2020-06-17"
 }
 ---
-<p>The script redirects users to non secure site.</p>
+<p>The script redirects users to another site.</p>
 <p>Plugin default settings:</p>
 <dl>
 <dt>"i18n": { "msgboxHeader": }: </dt>

--- a/src/plugins/exitscript/exitscript-fr.hbs
+++ b/src/plugins/exitscript/exitscript-fr.hbs
@@ -1,17 +1,17 @@
 ---
 {
-	"title": "Exitscript",
+	"title": "Sortie de navigation avisé",
 	"language": "fr",
 	"category": "Plugiciels",
-	"description": "Redirects users to non secure sites.",
+	"description": "Aviser l'utilisateur d'une redirection vers un autre site.",
 	"tag": "exitscript",
 	"parentdir": "exitscript",
 	"altLangPrefix": "exitscript",
 	"dateModified": "2020-06-17"
 }
 ---
-<p lang="en">The script redirects users to non secure site.</p>
-<p lang="en">Plugin default settings:</p>
+<p>Aviser l'utilisateur d'une redirection vers un autre site.</p>
+<p>Configuration par defaut:</p>
 <dl>
 <dt>"i18n": { "msgboxHeader": }: </dt>
 <dd>"Avertissement"</dd>

--- a/src/plugins/exitscript/exiturl-en.hbs
+++ b/src/plugins/exitscript/exiturl-en.hbs
@@ -1,9 +1,9 @@
 ---
 {
-	"title": "Exitsctipt middle page",
+	"title": "Exit script middle page",
 	"language": "en",
 	"category": "Plugins",
-	"description": "Redirects users to non secure sites.",
+	"description": "Redirects users to another sites.",
 	"tag": "exitscript",
 	"parentdir": "exitscript",
 	"altLangPrefix": "exitscript",

--- a/src/plugins/exitscript/exiturl-fr.hbs
+++ b/src/plugins/exitscript/exiturl-fr.hbs
@@ -1,9 +1,9 @@
 ---
 {
-	"title": "Exitscript middle page",
+	"title": "Page intermédiaire de sortie de navigation",
 	"language": "fr",
 	"category": "Plugiciels",
-	"description": "Redirects users to non secure sites.",
+	"description": "Page modèle afin d'aviser l'utilisateur d'une redirection vers un autre site.",
 	"tag": "exitscript",
 	"parentdir": "exitscript",
 	"altLangPrefix": "exitscript",


### PR DESCRIPTION
* Corrigé l'erreur indiqué par @StdGit - ref. https://github.com/wet-boew/wet-boew/pull/8894#issuecomment-721804915
* Traduction du titre du plugiciel en français
* Retiré la référence à un site non sécure car le plugiciel n'en fait aucune distinction.