### PR TITLE
Limited the div wrapping to only accordions elements

### DIFF
--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -120,7 +120,7 @@ var componentName = "wb-toggle",
 					}
 
 					//Details and summary don't support aria roles and some aria attribute that is why they are wrapped in a div
-					if ( elm.nodeName.toLowerCase() === "details" ) {
+					if ( elm.nodeName.toLowerCase() === "details" && elm.parentNode.className.toLowerCase() === "accordion" ) {
 						wrapper = document.createElement( "div" );
 						wrapper.classList.add( "tgl-tab" );
 						wrapper.setAttribute( "role", "tab" );

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -120,7 +120,7 @@ var componentName = "wb-toggle",
 					}
 
 					//Details and summary don't support aria roles and some aria attribute that is why they are wrapped in a div
-					if ( elm.nodeName.toLowerCase() === "details" && elm.parentNode.className.toLowerCase() === "accordion" ) {
+					if ( elm.nodeName.toLowerCase() === "details" && elm.parentNode.className.toLowerCase().indexOf( "accordion" ) > -1 ) {
 						wrapper = document.createElement( "div" );
 						wrapper.classList.add( "tgl-tab" );
 						wrapper.setAttribute( "role", "tab" );

--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -120,7 +120,7 @@ var componentName = "wb-toggle",
 					}
 
 					//Details and summary don't support aria roles and some aria attribute that is why they are wrapped in a div
-					if ( elm.nodeName.toLowerCase() === "details" && elm.parentNode.className.toLowerCase() === "accordion" ) {
+					if ( elm.nodeName.toLowerCase() === "details" && elm.parentNode.className.toLowerCase().indexOf("accordion") > -1 ) {
 						wrapper = document.createElement( "div" );
 						wrapper.classList.add( "tgl-tab" );
 						wrapper.setAttribute( "role", "tab" );


### PR DESCRIPTION
The div wrapping was causing some issues with tabs elements as indicated [here](https://github.com/wet-boew/wet-boew/issues/8982#issuecomment-731401209) and [here](https://github.com/wet-boew/wet-boew/issues/8984). Now the wrapping only happens with Accordions elements, which fixes the two issues. Fixes #8982 and Fixes #8984.