### PR TITLE
WET-140 Spacing Issue Fixed

### DIFF
--- a/src/base/bootstrap-overrides/_base.scss
+++ b/src/base/bootstrap-overrides/_base.scss
@@ -265,6 +265,10 @@ abbr[title] {
 			}
 		}
 
+		p {
+			margin-bottom: 11.5px;
+		}
+
 		strong,
 		em,
 		span {


### PR DESCRIPTION
* According to WET-140 Ticket, the spacing for <p> element in Alert component has margin inherited from Bootstrap. So I overrode it with a value of 11.5px which is used for our <p> elements everywhere.
* For panel component, I haven't found an example that is exhibiting the same pattern. 