### PR TITLE
Equal height CSS: Remove flex-grow by default (keep it an option)

### DIFF
--- a/src/plugins/eqht-css/_base.scss
+++ b/src/plugins/eqht-css/_base.scss
@@ -7,12 +7,14 @@
 	>[class*="col-"] {
 		display:flex;
 		flex-direction: column;
-		flex-grow:1;
-	}
 
-	>[class*="col-"]>section, .hght-inhrt {
-		display: flex;
-		flex: 1 1 auto;
-		flex-direction: column;
+		&>section, .hght-inhrt {
+			display: flex;
+			flex: 1 1 auto;
+			flex-direction: column;
+		}
+	}
+	&.grow>[class*="col-"] {
+		flex-grow: 1;
 	}
 }

--- a/src/plugins/eqht-css/demo/eqht-css.scss
+++ b/src/plugins/eqht-css/demo/eqht-css.scss
@@ -1,6 +1,6 @@
-#simple{
-	.wb-eqht-grd{
-		section{
+#simple, #grow {
+	.wb-eqht-grd {
+		section {
 			border: 1px solid #ddd;
 			border-radius: 4px;
 			margin-bottom: 23px;

--- a/src/plugins/eqht-css/eqht-css-en.hbs
+++ b/src/plugins/eqht-css/eqht-css-en.hbs
@@ -18,7 +18,6 @@
 
 <section id="simple">
 	<h2>Example</h2>
-	<p><strong>Note:</strong> The last row will always didive your columns proportionately in order to fill the full-width, as seen in the example below.</p>
 	<div class="row wb-eqht-grd">
 		<div class="col-sm-6 col-md-4">
 			<section>
@@ -101,6 +100,101 @@
 		<section>
 			<h4>CSS</h4>
 			<pre><code>#simple .wb-eqht-grd section {
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	margin-bottom: 15px;
+	padding: 15px;
+}
+</code></pre>
+		</section>
+	</section>
+</section>
+
+<section id="grow">
+	<h2>Grow Example</h2>
+	<p><strong>Note:</strong> The last row will always divide your columns proportionately in order to fill the full width.</p>
+	<div class="row wb-eqht-grd grow">
+		<div class="col-sm-6 col-md-4">
+			<section>
+				<h3>Short container</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+			</section>
+		</div>
+		<div class="col-sm-6 col-md-4">
+			<section>
+				<h3>Medium container</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
+			</section>
+		</div>
+		<div class="col-sm-6 col-md-4">
+			<section>
+				<h3>Long container</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
+				<p>Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text.</p>
+			</section>
+		</div>
+		<div class="col-sm-6 col-md-4">
+			<section>
+				<h3>Short container</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+			</section>
+		</div>
+		<div class="col-sm-6 col-md-4">
+			<section>
+				<h3>Medium container</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
+			</section>
+		</div>
+	</div>
+
+	<section>
+		<h3>Code</h3>
+		<section>
+			<h4>HTML</h4>
+			<pre><code>&lt;section id="grow"&gt;
+	&lt;h2&gt;Grow Example&lt;/h2&gt;
+
+	&lt;div class=&quot;row wb-eqht-grd grow&quot;&gt;
+		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
+			&lt;section&gt;
+				&lt;h3&gt;Short container&lt;/h3&gt;
+				...
+			&lt;/section&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
+			&lt;section&gt;
+				&lt;h3&gt;Medium container&lt;/h3&gt;
+				...
+			&lt;/section&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
+			&lt;section&gt;
+				&lt;h3&gt;Long container&lt;/h3&gt;
+				...
+			&lt;/section&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
+			&lt;section&gt;
+				&lt;h3&gt;Short container&lt;/h3&gt;
+				...
+			&lt;/section&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
+			&lt;section&gt;
+				&lt;h3&gt;Medium container&lt;/h3&gt;
+				...
+			&lt;/section&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/section&gt;</code></pre>
+		</section>
+
+		<section>
+			<h4>CSS</h4>
+			<pre><code>#grow .wb-eqht-grd section {
 	border: 1px solid #ddd;
 	border-radius: 4px;
 	margin-bottom: 15px;

--- a/src/plugins/eqht-css/eqht-css-fr.hbs
+++ b/src/plugins/eqht-css/eqht-css-fr.hbs
@@ -18,7 +18,6 @@
 
 <section id="simple">
 	<h2>Exemple</h2>
-	<p><strong>Note&nbsp;:</strong> La dernière rangée divisera toujours vos colonnes proportionellement afin de remplir la pleine largeur, tel que démontré dans l'exemple ci-dessous.</p>
 	<div class="row wb-eqht-grd">
 		<div class="col-sm-6 col-md-4">
 			<section>
@@ -101,6 +100,101 @@
 		<section>
 			<h4>CSS</h4>
 			<pre><code>#simple .wb-eqht-grd section {
+	border: 1px solid #ddd;
+	border-radius: 4px;
+	margin-bottom: 15px;
+	padding: 15px;
+}
+</code></pre>
+		</section>
+	</section>
+</section>
+
+<section id="grow">
+	<h2>Exemple remplissage</h2>
+	<p><strong>Note&nbsp;:</strong> La dernière rangée divisera toujours vos colonnes proportionellement afin de remplir la pleine largeur.</p>
+	<div class="row wb-eqht-grd grow">
+		<div class="col-sm-6 col-md-4">
+			<section>
+				<h3>Contenant à basse hauteur</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+			</section>
+		</div>
+		<div class="col-sm-6 col-md-4">
+			<section>
+				<h3>Contenant à hauteur moyenne</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
+			</section>
+		</div>
+		<div class="col-sm-6 col-md-4">
+			<section>
+				<h3>Contenant à grande hauteur</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
+				<p>Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte.</p>
+			</section>
+		</div>
+		<div class="col-sm-6 col-md-4">
+			<section>
+				<h3>Contenant à basse hauteur</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+			</section>
+		</div>
+		<div class="col-sm-6 col-md-4">
+			<section>
+				<h3>Contenant à hauteur moyenne</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
+			</section>
+		</div>
+	</div>
+
+	<section>
+		<h3>Code</h3>
+		<section>
+			<h4>HTML</h4>
+			<pre><code>&lt;section id="grow"&gt;
+	&lt;h2&gt;Exemple remplissage&lt;/h2&gt;
+
+	&lt;div class=&quot;row wb-eqht-grd grow&quot;&gt;
+		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
+			&lt;section&gt;
+				&lt;h3&gt;Contenant à basse hauteur&lt;/h3&gt;
+				...
+			&lt;/section&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
+			&lt;section&gt;
+				&lt;h3&gt;Contenant à hauteur moyenne&lt;/h3&gt;
+				...
+			&lt;/section&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
+			&lt;section&gt;
+				&lt;h3&gt;Contenant à grande hauteur&lt;/h3&gt;
+				...
+			&lt;/section&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
+			&lt;section&gt;
+				&lt;h3&gt;Contenant à basse hauteur&lt;/h3&gt;
+				...
+			&lt;/section&gt;
+		&lt;/div&gt;
+		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
+			&lt;section&gt;
+				&lt;h3&gt;Contenant à hauteur moyenne&lt;/h3&gt;
+				...
+			&lt;/section&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+&lt;/section&gt;</code></pre>
+		</section>
+
+		<section>
+			<h4>CSS</h4>
+			<pre><code>#grow .wb-eqht-grd section {
 	border: 1px solid #ddd;
 	border-radius: 4px;
 	margin-bottom: 15px;


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
The Equal height (Pure CSS) component in WET-BOEW will make columns the same height despite their differences in content length. However, it also stretches the elements horizontally in a grid if the number of elements is inferior to 12. For example, if you have two elements that are .col-md-4 (2 x 4 = 8), you are under the grid's width by 4 (which is 12), but the component will stretch it to 12 by splitting the two elements in 6s instead (2 x 6 = 12).

This behaviour is not to be expected by default, but should remain an option. This means that we have to remove the flex-grow: 1; rule by default and add a class called .grow which can be used jointly with .wb-eqht-grd and adds that rule back. 

Also added an example as part of the Working examples page: https://wet-boew.github.io/wet-boew/demos/eqht-css/eqht-css-en.html