### PR TITLE
Details/Summary: Improve support for heading classes

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -178,7 +178,7 @@ $pager-border-radius: 4px !default;
 //== Expand/collapse (Details/summary)
 //
 //##
-$details-identation: 1.1em !default;
+$details-indentation: 15px !default;
 
 
 //

--- a/src/base/details/_base.scss
+++ b/src/base/details/_base.scss
@@ -26,13 +26,22 @@ summary {
 }
 
 details {
-	padding-left: $details-identation;
-	padding-right: $details-identation;
+	padding-left: $details-indentation;
+	padding-right: $details-indentation;
 
 	> {
 		summary {
-			margin-left: -$details-identation;
-			margin-right: -$details-identation;
+			margin-left: -$details-indentation;
+			margin-right: -$details-indentation;
+
+			&.h2,
+			&.h3,
+			&.h4,
+			&.h5,
+			&.h6 {
+				margin-bottom: 0;
+				margin-top: 0;
+			}
 		}
 	}
 

--- a/src/base/details/_base.scss
+++ b/src/base/details/_base.scss
@@ -33,15 +33,6 @@ details {
 		summary {
 			margin-left: -$details-indentation;
 			margin-right: -$details-indentation;
-
-			&.h2,
-			&.h3,
-			&.h4,
-			&.h5,
-			&.h6 {
-				margin-bottom: 0;
-				margin-top: 0;
-			}
 		}
 	}
 

--- a/src/base/details/_ie8.scss
+++ b/src/base/details/_ie8.scss
@@ -4,11 +4,11 @@
  */
 .lt-ie9 {
 	details {
-		padding-left: $details-identation;
+		padding-left: $details-indentation;
 
 		> {
 			summary {
-				margin-left: -$details-identation;
+				margin-left: -$details-indentation;
 			}
 		}
 	}
@@ -16,12 +16,12 @@
 	[dir=rtl] {
 		details {
 			padding-left: 0;
-			padding-right: $details-identation;
+			padding-right: $details-indentation;
 
 			> {
 				summary {
 					margin-left: 0 !important;
-					margin-right: -$details-identation;
+					margin-right: -$details-indentation;
 				}
 			}
 		}

--- a/src/plugins/collapsible-alerts/base.scss
+++ b/src/plugins/collapsible-alerts/base.scss
@@ -22,9 +22,25 @@ details {
 			margin-right: 15px;
 			padding-left: 5px;
 
+			&.h2,
+			&.h3,
+			&.h4,
+			&.h5,
+			&.h6 {
+				color: $headings-color;
+			}
+
 			&:focus,
 			&:hover {
 				text-decoration: none;
+
+				&.h2,
+				&.h3,
+				&.h4,
+				&.h5,
+				&.h6 {
+					color: $link-hover-color;
+				}
 
 				h2,
 				h3,

--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -19,10 +19,27 @@ summary {
 	}
 }
 
+%summary-goodies {
+	color: $link-color;
+	text-decoration: inherit;
+}
+
+%summary-heading-goodies {
+	margin-bottom: 0;
+	margin-top: 0;
+}
+
+/*
+TODOS:
+-Give the placeholder selectors better names
+-Are any of the extends below unnecessary? Not sure if I might be overdoing it and duplicating stuff at lower levels than what's actually needed
+*/
+
 details {
 	margin-bottom: .25em;
 
 	summary {
+		@extend %summary-goodies;
 		border: 1px solid #ddd;
 		border-radius: 4px;
 		padding: 5px 15px;
@@ -33,7 +50,22 @@ details {
 		&.h4,
 		&.h5,
 		&.h6 {
-			color: $link-color;
+			@extend %summary-goodies;
+			@extend %summary-heading-goodies;
+		}
+
+		&.summary-title {
+			@extend %summary-goodies;
+			@extend h3;
+			@extend %summary-heading-goodies;
+
+			h2,
+			h4,
+			h5,
+			h6 {
+				@extend h3;
+				@extend %summary-goodies;
+			}
 		}
 
 		&:focus,

--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -25,13 +25,21 @@ details {
 	summary {
 		border: 1px solid #ddd;
 		border-radius: 4px;
-		color: #295376;
 		padding: 5px 15px;
+
+		&,
+		&.h2,
+		&.h3,
+		&.h4,
+		&.h5,
+		&.h6 {
+			color: $link-color;
+		}
 
 		&:focus,
 		&:hover {
 			background-color: transparent;
-			color: #0535d2;
+			color: $link-hover-color;
 			text-decoration: underline;
 		}
 

--- a/src/polyfills/details/details-en.hbs
+++ b/src/polyfills/details/details-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "details",
 	"parentdir": "details",
 	"altLangPrefix": "details",
-	"dateModified": "2021-02-25"
+	"dateModified": "2021-04-25"
 }
 ---
 <p>The HTML5 <code>details</code> and <code>summary</code> elements are used to provide expandable/collapsible content. This component adds support for these elements in browsers that do not already have native support.</p>
@@ -80,7 +80,7 @@
 		</li>
 		<li>
 			<details>
-				<summary class="h3"><h3>Example 3</h3></summary>
+				<summary>Example 3</summary>
 				<p>Example content that provides more details.</p>
 				<table class="table">
 					<caption>Cups of coffee consumed by each delegate</caption>
@@ -126,13 +126,81 @@
 			...
 		&lt;/details&gt;
 	&lt;/li&gt;
-	&lt;li&gt;
-		&lt;details open="open"&gt;
-			&lt;summary class="h3"&gt;&lt;h3&gt;Example 3&lt;/h3&gt;&lt;/summary&gt;
-			...
-		&lt;/details&gt;
-	&lt;/li&gt;
 	...
 &lt;/ul&gt;</code></pre>
 	</section>
+
+	<h3>Summaries with headings</h3>
+	<ul class="list-unstyled">
+		<li>
+			<details>
+				<summary class="h2"><h2>Heading 2 (<code>h2</code>)</h2></summary>
+				<p>...</p>
+			</details>
+		</li>
+		<li>
+			<details>
+				<summary class="h3"><h3>Heading 3 (<code>h3</code>)</h3></summary>
+				<p>...</p>
+			</details>
+		</li>
+		<li>
+			<details>
+				<summary class="h4"><h4>Heading 4 (<code>h4</code>)</h4></summary>
+				<p>...</p>
+			</details>
+		</li>
+		<li>
+			<details>
+				<summary class="h5"><h5>Heading 5 (<code>h5</code>)</h5></summary>
+				<p>...</p>
+			</details>
+		</li>
+		<li>
+			<details>
+				<summary class="h6"><h6>Heading 6 (<code>h6</code>)</h6></summary>
+				<p>...</p>
+			</details>
+		</li>
+	</ul>
+
+	<h3>Summaries with <code>summary-title</code> class</h3>
+	<ul class="list-unstyled">
+		<li>
+			<details>
+				<summary class="summary-title"><h2>Heading 2 (<code>h2</code>)</h2></summary>
+				<p>...</p>
+			</details>
+		</li>
+		<li>
+			<details>
+				<summary class="summary-title"><h3>Heading 3 (<code>h3</code>)</h3></summary>
+				<p>...</p>
+			</details>
+		</li>
+		<li>
+			<details>
+				<summary class="summary-title"><h4>Heading 4 (<code>h4</code>)</h4></summary>
+				<p>...</p>
+			</details>
+		</li>
+		<li>
+			<details>
+				<summary class="summary-title"><h4>Heading 4 (<code>h4</code>)</h4></summary>
+				<p>...</p>
+			</details>
+		</li>
+		<li>
+			<details>
+				<summary class="summary-title"><h5>Heading 5 (<code>h5</code>)</h5></summary>
+				<p>...</p>
+			</details>
+		</li>
+		<li>
+			<details>
+				<summary class="summary-title"><h6>Heading 6 (<code>h6</code>)</h6></summary>
+				<p>...</p>
+			</details>
+		</li>
+	</ul>
 </section>

--- a/src/polyfills/details/details-en.hbs
+++ b/src/polyfills/details/details-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "details",
 	"parentdir": "details",
 	"altLangPrefix": "details",
-	"dateModified": "2014-07-21"
+	"dateModified": "2021-02-25"
 }
 ---
 <p>The HTML5 <code>details</code> and <code>summary</code> elements are used to provide expandable/collapsible content. This component adds support for these elements in browsers that do not already have native support.</p>
@@ -80,7 +80,7 @@
 		</li>
 		<li>
 			<details>
-				<summary>Example 3</summary>
+				<summary class="h3"><h3>Example 3</h3></summary>
 				<p>Example content that provides more details.</p>
 				<table class="table">
 					<caption>Cups of coffee consumed by each delegate</caption>
@@ -123,6 +123,12 @@
 	&lt;li&gt;
 		&lt;details open="open"&gt;
 			&lt;summary&gt;Example 2&lt;/summary&gt;
+			...
+		&lt;/details&gt;
+	&lt;/li&gt;
+	&lt;li&gt;
+		&lt;details open="open"&gt;
+			&lt;summary class="h3"&gt;&lt;h3&gt;Example 3&lt;/h3&gt;&lt;/summary&gt;
 			...
 		&lt;/details&gt;
 	&lt;/li&gt;

--- a/src/polyfills/details/details-fr.hbs
+++ b/src/polyfills/details/details-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "details",
 	"parentdir": "details",
 	"altLangPrefix": "details",
-	"dateModified": "2014-07-21"
+	"dateModified": "2021-02-25"
 }
 ---
 <p>Les éléments HTML5 «&#160;<code lang="en">details</code>&#160;» et «&#160;<code lang="en">summary</code>&#160;» sont utilisés pour fournir le contenu en arborescence affichable/masquable. Ce composant ajoute le soutien pour ces éléments dans les navigateurs qui n'ont pas déjà la prise en charge native.</p>
@@ -80,7 +80,7 @@
 		</li>
 		<li>
 			<details>
-				<summary>Exemple 3</summary>
+				<summary class="h3"><h3>Exemple 3</h3></summary>
 				<p>Le contenu d'exemple qui fournit plus de détails.</p>
 				<table class="table">
 					<caption>Tasses de café bues par chaque député</caption>
@@ -123,6 +123,12 @@
 	&lt;li&gt;
 		&lt;details open="open"&gt;
 			&lt;summary&gt;Exemple 2&lt;/summary&gt;
+		&lt;/details&gt;
+	&lt;/li&gt;
+	&lt;li&gt;
+		&lt;details open="open"&gt;
+			&lt;summary class="h3"&gt;&lt;h3&gt;Exemple 3&lt;/h3&gt;&lt;/summary&gt;
+			...
 		&lt;/details&gt;
 	&lt;/li&gt;
 	...

--- a/src/polyfills/details/details-fr.hbs
+++ b/src/polyfills/details/details-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "details",
 	"parentdir": "details",
 	"altLangPrefix": "details",
-	"dateModified": "2021-02-25"
+	"dateModified": "2021-05-25"
 }
 ---
 <p>Les éléments HTML5 «&#160;<code lang="en">details</code>&#160;» et «&#160;<code lang="en">summary</code>&#160;» sont utilisés pour fournir le contenu en arborescence affichable/masquable. Ce composant ajoute le soutien pour ces éléments dans les navigateurs qui n'ont pas déjà la prise en charge native.</p>
@@ -80,7 +80,7 @@
 		</li>
 		<li>
 			<details>
-				<summary class="h3"><h3>Exemple 3</h3></summary>
+				<summary>Exemple 3</summary>
 				<p>Le contenu d'exemple qui fournit plus de détails.</p>
 				<table class="table">
 					<caption>Tasses de café bues par chaque député</caption>
@@ -123,12 +123,6 @@
 	&lt;li&gt;
 		&lt;details open="open"&gt;
 			&lt;summary&gt;Exemple 2&lt;/summary&gt;
-		&lt;/details&gt;
-	&lt;/li&gt;
-	&lt;li&gt;
-		&lt;details open="open"&gt;
-			&lt;summary class="h3"&gt;&lt;h3&gt;Exemple 3&lt;/h3&gt;&lt;/summary&gt;
-			...
 		&lt;/details&gt;
 	&lt;/li&gt;
 	...


### PR DESCRIPTION
Fixes layout issues when using heading classes (e.g. "``h2``", etc...) on ``summary`` elements - which is needed to make disclosure widgets match the font size of child headings.

Specific changes:
* Use pixels for left/right margins (based on Bootstrap's grid gutter width... wasn't able to use ``$grid-gutter-width`` directly)
* Remove top/bottom margins on summaries that use heading classes (isn't needed for real heading elements)
* Rename the ``$details-identation`` variable to ``$details-indentation`` (typo fix)
* Use the default link colour on summaries that are styled as headings (except for collapsible alerts)
* Use the ``$link-color`` and ``$link-hover-color`` variables for summaries instead of duplicating their HEX values
* Update the third example in the details/summary polyfill's demo page to demonstrate a summary styled as a heading