### PR TITLE
Multimedia player: Disable top border radii on details/summary

### DIFF
--- a/src/plugins/multimedia/_base.scss
+++ b/src/plugins/multimedia/_base.scss
@@ -182,6 +182,11 @@
 		text-align: right;
 	}
 
+	summary,
+	details[open] {
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+	}
 }
 
 .wb-mm-cc {


### PR DESCRIPTION
When WET's media player uses an embedded transcript via expandable/collapsible content, it's intended to be situated directly below the media player's controls.

Previously, the expandable/collapsible content looked slightly-disconnected from the player due to its rounded top border. This change addresses it by disabling the top border radii.

**Screenshots...**

**Before:**
![multimedia-transcript-border-before](https://user-images.githubusercontent.com/1907279/109570482-159b4300-7ab8-11eb-9e82-d36add34abed.png)

**After:**
![multimedia-transcript-border-after](https://user-images.githubusercontent.com/1907279/109570486-16cc7000-7ab8-11eb-9237-8cc2ae9f8b0e.png)