### PR TITLE
Fix example of "Datalist (auto complete) - Dynamic" polyfill

### DIFF
--- a/src/polyfills/datalist/datalist-dynamic-en.hbs
+++ b/src/polyfills/datalist/datalist-dynamic-en.hbs
@@ -82,7 +82,7 @@ $document.on( &quot;change&quot;, pluginSelector, function( event ) {
 	$( this ).trigger({
 		type: &quot;ajax-fetch.wb&quot;,
 		fetch: {
-			url: encodeURI( &quot;https://api.github.com/repos/wet-boew/wet-boew/issues?labels=Plugin: &quot; + pluginName ),
+			url: encodeURI( &quot;https://api.github.com/repos/wet-boew/wet-boew/issues?labels=Feature: &quot; + pluginName ),
 			dataType: wb.ielt10 ? &quot;jsonp&quot; : &quot;json&quot;,
 			jsonp: wb.ielt10 ? &quot;callback&quot; : null
 		}

--- a/src/polyfills/datalist/datalist-dynamic-fr.hbs
+++ b/src/polyfills/datalist/datalist-dynamic-fr.hbs
@@ -83,7 +83,7 @@ $document.on( &quot;change&quot;, pluginSelector, function( event ) {
 		type: &quot;ajax-fetch.wb&quot;,
 		element: this,
 		fetch: {
-			url: encodeURI( &quot;https://api.github.com/repos/wet-boew/wet-boew/issues?labels=Plugin: &quot; + pluginName ),
+			url: encodeURI( &quot;https://api.github.com/repos/wet-boew/wet-boew/issues?labels=Feature: &quot; + pluginName ),
 			dataType: wb.ielt10 ? &quot;jsonp&quot; : &quot;json&quot;,
 			jsonp: wb.ielt10 ? &quot;callback&quot; : null
 		}

--- a/src/polyfills/datalist/demo/datalist_dynamic.js
+++ b/src/polyfills/datalist/demo/datalist_dynamic.js
@@ -15,7 +15,7 @@ $document.on( "change", pluginSelector, function( event ) {
 	$( this ).trigger( {
 		type: "ajax-fetch.wb",
 		fetch: {
-			url: encodeURI( "https://api.github.com/repos/wet-boew/wet-boew/issues?labels=Plugin: " + componentName ),
+			url: encodeURI( "https://api.github.com/repos/wet-boew/wet-boew/issues?labels=Feature: " + componentName ),
 			dataType: wb.ielt10 ? "jsonp" : "json",
 			jsonp: wb.ielt10 ? "callback" : null
 		}


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Corrects documentation examples of [Datalist (auto complete) - Dynamic](https://wet-boew.github.io/v4.0-ci/demos/datalist/datalist-dynamic-en.html) with correct prefixes that actually return issues. The example code is AJAXing in GitHub issues, filtering against "Plugin: Multimedia player" and "Plugin: Lightbox", but it appears as though the labels today are "Feature: Multimedia player" and "Feature: Lightbox".

I realize this is a minor detail in the grand scheme of things, but as a public servant in what I assume is a common situation of trying to apply a ~~unstoppable~~ small force to an immovable object (i.e. the adoption of modern digital standards in my corner of the public service), these documentation pages actually end up being very useful, authoritative examples.

## Additional information (optional) / Information additionnelle (optionel)

**General checklist / Liste de contrôle générale**
I don't actually have a true development environment setup for this kind of work and as such can't actually build the code -- but the scope of code changes is so small, this should hopefully be OK. I'm at least not so crazy to propose these changes without any supporting facts, I have included screenshots below of the JSON returned before & after the URL adjustment.

- [ ] **_N/A_** Create/update documentation /// Créer/mettre à jour la documentation
- [ ] **_See above_** Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
- [ ] **_N/A_** Validate changes against WCAG for accessibility /// Valider les changements avec WCAG pour l'accessibilité
- [ ] **_N/A_** Ensure documentation is bilingual /// S'assurer que la documentation soit bilingue

**Related issues / Requêtes associées**
I didn't open one separately -- hopefully this is ok.

**Screenshots / Captures d'écrans**
URLs as used in example today (showing raw to explicitly show empty JSON response):

[Before](https://api.github.com/repos/wet-boew/wet-boew/issues?labels=Plugin:%20Multimedia%20player):
![Incorrect URL](https://user-images.githubusercontent.com/68672040/111671663-8dbf7380-87ef-11eb-8811-77865f4b107d.PNG)
[After](https://api.github.com/repos/wet-boew/wet-boew/issues?labels=Feature:%20Multimedia%20player):
![Corrected URL](https://user-images.githubusercontent.com/68672040/111671709-96b04500-87ef-11eb-8791-1610cc44f892.PNG)