### PR TITLE
Multimedia player: Calculate CC container's height

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -219,6 +219,8 @@ $mm-progress-bg-color: #fff !default;
 
 $mm-cc-fg-color: #fff !default;
 $mm-cc-bg-color: #000 !default;
+$mm-cc-lines: 2 !default;
+$mm-cc-padding: .5em !default;
 
 $mm-ctrl-fg-color: #fff !default;
 $mm-ctrl-bg-color: #3e3e3e !default;

--- a/src/plugins/multimedia/_base.scss
+++ b/src/plugins/multimedia/_base.scss
@@ -70,7 +70,7 @@
 
 %captions_text_box {
 	display: table-cell;
-	height: 3em;
+	height: #{$line-height-base * $mm-cc-lines}em;
 	vertical-align: middle;
 }
 
@@ -116,8 +116,8 @@
 	&.cc_on {
 		.wb-mm-cc {
 			display: table;
-			height: 4em;
-			padding: .5em;
+			height: calc(#{$line-height-base * $mm-cc-lines}em + #{$mm-cc-padding * 2});
+			padding: $mm-cc-padding;
 		}
 
 		&:not(.errmsg) {


### PR DESCRIPTION
Replaces the closed captions container's hardcoded heights with calculations that leverage some new SASS variables.

This way of doing things is more meaningful than hardcoding heights that make assumptions about line height, number of lines and the container's amount of padding.

Btw in practice this will produce marginally smaller container heights than before (3em is now reduced to 2.875em since that's the real height of 2 lines of closed captions). But the difference is virtually imperceptible.

Related to wet-boew/GCWeb#1802.

**Screenshots...**

**Before** (CC container height: hardcoded 3em + 1em for padding):
![multimedia-cc-container-before](https://user-images.githubusercontent.com/1907279/114905232-b9318000-9de6-11eb-985a-eb525e2441c7.png)

**After** (CC container height: calculated 2.875em + 1em for padding):
![multimedia-cc-container-after](https://user-images.githubusercontent.com/1907279/114905240-bafb4380-9de6-11eb-9d6c-def37206fb84.png)