### PR TITLE
Bootstrap overrides: Make [hidden] !important

### DIFF
--- a/src/base/bootstrap-overrides/_base.scss
+++ b/src/base/bootstrap-overrides/_base.scss
@@ -918,3 +918,7 @@ mark {
 	color: $txthl-color;
 	font-weight: $txthl-font-weight;
 }
+
+[hidden] {
+	display: none !important;
+}


### PR DESCRIPTION
Bootstrap 3.4.1's ``hidden`` attribute selector sets it to ``display: none;``... But that isn't powerful-enough for its purpose. Unrelated selectors can inadvertently unveil it. For example, placing an element with a ``hidden`` attribute at the beginning of a ``summary`` doesn't hide anything. Why? Because another more specific selector sets the summary's first child to ``display: inline;``.

Btw the ``"hide"`` and ``"hidden"`` classes are already set to ``display: none !important``. Latter versions of Bootstrap also updated the ``hidden`` attribute's selector to use ``!important``.