### PR TITLE
Core: Fix jqEscape() regression

### DIFF
--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -172,7 +172,8 @@ wb.addSkipLink = function( text, attr, isBtn, isLast ) {
 // Escapes the characters in a string for use in a jQuery selector
 // Based on https://totaldev.com/content/escaping-characters-get-valid-jquery-id
 wb.jqEscape = function( selector ) {
-	return selector.replace( /([;&,.+*~':"\\!^/#$%@[]()=>\|])/g, "\\$1" );
+	// eslint-disable-next-line no-useless-escape
+	return selector.replace( /([;&,\.\+\*\~':"\\\!\^\/#$%@\[\]\(\)=>\|])/g, "\\$1" );
 };
 
 // RegEx used by formattedNumCompare


### PR DESCRIPTION
#8990 removed some of that helper method's backslashes, which in turn made it unable to escape certain special characters.

This resolves it by reintroducing the aforementioned backslashes. Also adds a configuration comment to prevent ESLint's ``no-useless-escape`` rule from treating them as errors.

* Fixes #9085
* Related to #9107

CC @nschonni @thekodester
