### PR TITLE
A11y name landmarks

### DIFF
--- a/site/includes/breadcrumbs.hbs
+++ b/site/includes/breadcrumbs.hbs
@@ -1,5 +1,5 @@
-<nav role="navigation" id="wb-bc" property="breadcrumb">
-	<h2>{{{i18n "you-are-here"}}}</h2>
+<nav role="navigation" id="wb-bc" property="breadcrumb" aria-labelledby="wb-bc-nm">
+	<h2 id="wb-bc-nm">{{{i18n "you-are-here"}}}</h2>
 	<div class="container">
 		<div class="row">
 			<ol class="breadcrumb">

--- a/site/includes/footer.hbs
+++ b/site/includes/footer.hbs
@@ -1,7 +1,7 @@
 <footer role="contentinfo" id="wb-info" {{>footerreplace}} class="visible-sm visible-md visible-lg wb-navcurr">
 	<div class="container">
-		<nav role="navigation" class="row">
-			<h2>{{{i18n "tmpl-about-site"}}}</h2>
+		<nav role="navigation" class="row" aria-labelledby="wb-info-a11y-nm">
+			<h2 id="wb-info-a11y-nm">{{{i18n "tmpl-about-site"}}}</h2>
 			{{>footercontent}}
 		</nav>
 	</div>


### PR DESCRIPTION

This relates the accessible names to both the breadcrumbs and footer sections of the template. This is needed when you have more than one of the same landmark elements. Hidden heading aren't enough read by users who navigate by landmarks. 


Related #9072

