### PR TITLE
Postback: Remove undefined URL parameter

### DIFF
--- a/src/plugins/wb-postback/wb-postback.js
+++ b/src/plugins/wb-postback/wb-postback.js
@@ -44,11 +44,11 @@ var $document = wb.doc,
 
 				if ( !$( this ).attr( attrEngaged ) ) {
 					var data = $elm.serializeArray(),
-						$btn = $( "[type=submit][" + attrEngaged + "]", $elm ),
+						$btn = $( "[type=submit][name][" + attrEngaged + "]", $elm ),
 						$selectorSuccess = $( selectorSuccess ),
 						$selectorFailure = $( selectorFailure );
 
-					if ( $btn ) {
+					if ( $btn.length ) {
 						data.push( { name: $btn.attr( "name" ), value: $btn.val() } );
 					}
 					$( this ).attr( attrEngaged, true );


### PR DESCRIPTION
This fixes a bug in how the postback plugin deals with submit buttons that contain name/value attributes.

Previously, submitting a postback form would cause the plugin to create a jQuery object for its submit button. An if condition would subsequently check whether the button's jQuery object exists and add its name/value to an array of URL parameters.

That had two flaws:
* It assumed the button always has a name (it doesn't)
* The button's jQuery object always exists (even if its selector doesn't match anything)

The end result was that the postback plugin's AJAX requests would always contain an empty undefined parameter unless the form contained a submit button with a name attribute.

This fixes it by:
* Adjusting the button's jQuery selector to check for a name attribute
* Making the if condition check the length of the button's jQuery object (to ensure it actually exists)

CC @GormFrank