### PR TITLE
Overlay: Add bottom-right popup pattern

### DIFF
--- a/src/plugins/overlay/_base.scss
+++ b/src/plugins/overlay/_base.scss
@@ -67,6 +67,29 @@
 	bottom: 0;
 }
 
+.wb-popup-br {
+	border-radius: 6px;
+	bottom: 20px;
+	max-height: 500px;
+	min-height: 200px;
+	right: 20px;
+	width: 35%;
+}
+
+.wb-popup-flex {
+	flex-direction: column;
+	flex-wrap: nowrap;
+
+	.modal-body {
+		overflow: auto;
+	}
+
+	&.open {
+		display: inline-flex;
+		position: fixed;
+	}
+}
+
 .wb-popup-mid {
 	@extend %overlay-popup;
 	border-radius: 6px;
@@ -128,6 +151,7 @@
 
 .hidden-hd {
 	.modal-body {
+		overflow: auto;
 		padding-top: 50px;
 	}
 

--- a/src/plugins/overlay/_screen-md-min-to-screen-md-max.scss
+++ b/src/plugins/overlay/_screen-md-min-to-screen-md-max.scss
@@ -1,0 +1,8 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+
+.wb-popup-br {
+	width: 35%;
+}

--- a/src/plugins/overlay/_screen-sm-min-to-screen-sm-max.scss
+++ b/src/plugins/overlay/_screen-sm-min-to-screen-sm-max.scss
@@ -1,0 +1,8 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+
+.wb-popup-br {
+	width: 45%;
+}

--- a/src/plugins/overlay/_screen-xs-max.scss
+++ b/src/plugins/overlay/_screen-xs-max.scss
@@ -1,0 +1,14 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+
+.wb-popup-br {
+	border-radius: 0;
+	height: 100%;
+	left: 0;
+	max-height: none;
+	max-width: none;
+	top: 0;
+	width: 100%;
+}

--- a/src/plugins/overlay/overlay-en.hbs
+++ b/src/plugins/overlay/overlay-en.hbs
@@ -9,7 +9,7 @@
 	"altLangPrefix": "overlay",
 	"js": ["demo/overlay"],
 	"css": ["demo/overlay"],
-	"dateModified": "2014-07-22"
+	"dateModified": "2021-09-24"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -27,15 +27,14 @@
 			<details class="mrgn-bttm-lg">
 				<summary>View code</summary>
 				<pre><code>&lt;p&gt;&lt;a href=&quot;#left-panel&quot; aria-controls=&quot;left-panel&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Left-panel&lt;/a&gt;&lt;/p&gt;
-
-&lt;section id=&quot;left-panel&quot; class=&quot;wb-overlay modal-content overlay-def wb-panel-l&quot;&gt;
-	&lt;header class=&quot;modal-header&quot;&gt;
-		&lt;h2 class=&quot;modal-title&quot;&gt;Left panel&lt;/h2&gt;
-	&lt;/header&gt;
-	&lt;div class=&quot;modal-body&quot;&gt;
-		...
-	&lt;/div&gt;
-&lt;/section&gt;</code></pre>
+				&lt;section id=&quot;left-panel&quot; class=&quot;wb-overlay modal-content overlay-def wb-panel-l&quot;&gt;
+					&lt;header class=&quot;modal-header&quot;&gt;
+						&lt;h2 class=&quot;modal-title&quot;&gt;Left panel&lt;/h2&gt;
+					&lt;/header&gt;
+					&lt;div class=&quot;modal-body&quot;&gt;
+						...
+					&lt;/div&gt;
+				&lt;/section&gt;</code></pre>
 			</details>
 		</li>
 		<li>
@@ -43,15 +42,14 @@
 			<details class="mrgn-bttm-lg">
 				<summary>View code</summary>
 				<pre><code>&lt;p&gt;&lt;a href=&quot;#right-panel&quot; aria-controls=&quot;right-panel&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Right-panel&lt;/a&gt;&lt;/p&gt;
-
-&lt;section id=&quot;right-panel&quot; class=&quot;wb-overlay modal-content overlay-def wb-panel-r&quot;&gt;
-	&lt;header class=&quot;modal-header&quot;&gt;
-		&lt;h2 class=&quot;modal-title&quot;&gt;Right panel&lt;/h2&gt;
-	&lt;/header&gt;
-	&lt;div class=&quot;modal-body&quot;&gt;
-		...
-	&lt;/div&gt;
-&lt;/section&gt;</code></pre>
+				&lt;section id=&quot;right-panel&quot; class=&quot;wb-overlay modal-content overlay-def wb-panel-r&quot;&gt;
+					&lt;header class=&quot;modal-header&quot;&gt;
+						&lt;h2 class=&quot;modal-title&quot;&gt;Right panel&lt;/h2&gt;
+					&lt;/header&gt;
+					&lt;div class=&quot;modal-body&quot;&gt;
+						...
+					&lt;/div&gt;
+				&lt;/section&gt;</code></pre>
 			</details>
 		</li>
 		<li>
@@ -59,13 +57,12 @@
 			<details class="mrgn-bttm-lg">
 				<summary>View code</summary><p><a href="#top-bar" aria-controls="top-bar" class="overlay-lnk" role="button">Top bar</a></p>
 				<pre><code>&lt;a href=&quot;#top-bar&quot; aria-controls=&quot;top-bar&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Top bar&lt;/a&gt;&lt;/p&gt;
-
-&lt;section id=&quot;top-bar&quot; class=&quot;wb-overlay modal-content overlay-def wb-bar-t&quot;&gt;
-	&lt;header&gt;
-		&lt;h2 class=&quot;modal-title&quot;&gt;Top bar&lt;/h2&gt;
-	&lt;/header&gt;
-	...
-&lt;/section&gt;</code></pre>
+				&lt;section id=&quot;top-bar&quot; class=&quot;wb-overlay modal-content overlay-def wb-bar-t&quot;&gt;
+					&lt;header&gt;
+						&lt;h2 class=&quot;modal-title&quot;&gt;Top bar&lt;/h2&gt;
+					&lt;/header&gt;
+						...
+				&lt;/section&gt;</code></pre>
 			</details>
 		</li>
 		<li>
@@ -73,13 +70,12 @@
 			<details class="mrgn-bttm-lg">
 				<summary>View code</summary>
 				<pre><code>&lt;p&gt;&lt;a href=&quot;#bottom-bar&quot; aria-controls=&quot;bottom-bar&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Bottom bar&lt;/a&gt;&lt;/p&gt;
-
-&lt;section id=&quot;bottom-bar&quot; class=&quot;wb-overlay modal-content overlay-def wb-bar-b&quot;&gt;
-	&lt;header&gt;
-		&lt;h2 class=&quot;modal-title&quot;&gt;Bottom bar&lt;/h2&gt;
-	&lt;/header&gt;
-	...
-&lt;/section&gt;</code></pre>
+				&lt;section id=&quot;bottom-bar&quot; class=&quot;wb-overlay modal-content overlay-def wb-bar-b&quot;&gt;
+					&lt;header&gt;
+						&lt;h2 class=&quot;modal-title&quot;&gt;Bottom bar&lt;/h2&gt;
+					&lt;/header&gt;
+						...
+				&lt;/section&gt;</code></pre>
 			</details>
 		</li>
 		<li>
@@ -87,15 +83,14 @@
 			<details class="mrgn-bttm-lg">
 				<summary>View code</summary>
 				<pre><code>&lt;p&gt;&lt;a href=&quot;#centred-popup&quot; aria-controls=&quot;centred-popup&quot; class=&quot;wb-lbx&quot; role=&quot;button&quot;&gt;Centred popup (Lightbox)&lt;/a&gt;&lt;/p&gt;
-
-&lt;section id=&quot;centred-popup&quot; class=&quot;mfp-hide modal-dialog modal-content overlay-def&quot;&gt;
-	&lt;header class=&quot;modal-header&quot;&gt;
-		&lt;h2 class=&quot;modal-title&quot;&gt;Centred popup (Lightbox)&lt;/h2&gt;
-	&lt;/header&gt;
-	&lt;div class=&quot;modal-body&quot;&gt;
-		...
-	&lt;/div&gt;
-&lt;/section&gt;</code></pre>
+				&lt;section id=&quot;centred-popup&quot; class=&quot;mfp-hide modal-dialog modal-content overlay-def&quot;&gt;
+					&lt;header class=&quot;modal-header&quot;&gt;
+						&lt;h2 class=&quot;modal-title&quot;&gt;Centred popup (Lightbox)&lt;/h2&gt;
+					&lt;/header&gt;
+					&lt;div class=&quot;modal-body&quot;&gt;
+						...
+					&lt;/div&gt;
+				&lt;/section&gt;</code></pre>
 			</details>
 		</li>
 		<li>
@@ -123,6 +118,22 @@
 &lt;section id=&quot;mid-screen&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-mid&quot;&gt;
 	&lt;header class=&quot;modal-header&quot;&gt;
 		&lt;h2 class=&quot;modal-title&quot;&gt;Middle screen overlay&lt;/h2&gt;
+	&lt;/header&gt;
+	&lt;div class=&quot;modal-body&quot;&gt;
+		...
+	&lt;/div&gt;
+&lt;/section&gt;</code></pre>
+			</details>
+		</li>
+		<li>
+			<p><a href="#br-screen" aria-controls="br-screen" class="overlay-lnk" role="button">Bottom-right overlay</a></p>
+			<details class="mrgn-bttm-lg">
+				<summary>View code</summary>
+				<pre><code>&lt;p&gt;&lt;a href=&quot;#br-screen&quot; aria-controls=&quot;br-screen&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Bottom-right overlay&lt;/a&gt;&lt;/p&gt;
+
+&lt;section id=&quot;br-screen&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-br&quot;&gt;
+	&lt;header class=&quot;modal-header&quot;&gt;
+		&lt;h2 class=&quot;modal-title&quot;&gt;Bottom-right overlay&lt;/h2&gt;
 	&lt;/header&gt;
 	&lt;div class=&quot;modal-body&quot;&gt;
 		...
@@ -248,6 +259,63 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 	...
 &lt;/div&gt;
 &lt;/section&gt;</code></pre>
+		</details>
+	</section>
+
+	<section>
+		<h3>Bottom-right overlay with fix header and footer</h3>
+		<p>Add the CSS <code>wb-popup-flex</code> to the overlay dialog to enable the fix header and footer so only the body section will scroll up and down.</p>
+		<p><a href="#br-screen-flex" aria-controls="br-screen-flex" class="overlay-lnk" role="button">Bottom-right overlay with fix header and footer</a></p>
+		<details class="mrgn-bttm-lg">
+			<summary>View code</summary>
+			<pre><code>&lt;p&gt;&lt;a href=&quot;#br-screen-flex&quot; aria-controls=&quot;br-screen-flex&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Bottom-right overlay with fix header and footer&lt;/a&gt;&lt;/p&gt;
+			&lt;section id=&quot;br-screen-flex&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-br wb-popup-flex&quot;&gt;
+			&lt;header class=&quot;modal-header&quot;&gt;
+			&lt;h2 class=&quot;modal-title&quot;&gt;Bottom-right overlay with fix header and footer&lt;/h2&gt;
+			&lt;/header&gt;
+			&lt;div class=&quot;modal-body&quot;&gt;
+			...
+			&lt;/div&gt;
+		&lt;/section&gt;</code></pre>
+		</details>
+	</section>
+
+	<section>
+		<h3>Remove default footer and or make overlay persistent</h3>
+		<p>Add <code>data-wb-overlay</code> to customize footer and or disable the close event.</p>
+		<ul>
+			<li><code>{ &quot;noFooter&quot;: true }</code> this will remove the default footer from the overlay dialogue so a customized footer can be added.</li>
+			<li><code>{ &quot;noClose&quot;: true }</code> this will prevent the overlay dialogue to close when pressing the escape key or when clicking outside the overlay.</li>
+		</ul>
+
+		<p><a href="#br-screen-nf" aria-controls="br-screen" class="overlay-lnk" role="button">Bottom-right overlay without default footer</a></p>
+		<details class="mrgn-bttm-lg">
+			<summary>View code</summary>
+			<pre><code>&lt;p&gt;&lt;a href=&quot;#br-screen-nf&quot; aria-controls=&quot;br-screen-flex&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Bottom-right overlay without default footer&lt;/a&gt;&lt;/p&gt;
+			&lt;section id=&quot;br-screen-nf&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-br wb-popup-flex&quot; data-wb-overlay=&apos;{ &quot;noFooter&quot;: true }&apos;&gt;
+			&lt;header class=&quot;modal-header&quot;&gt;
+			&lt;h2 class=&quot;modal-title&quot;&gt;Bottom-right overlay without footer&lt;/h2&gt;
+			&lt;/header&gt;
+			&lt;div class=&quot;modal-body&quot;&gt;
+			...
+			&lt;/div&gt;
+		&lt;/section&gt;</code></pre>
+		</details>
+	</section>
+
+	<section>
+		<p><a href="#mid-screen-persistent" aria-controls="mid-screen" class="overlay-lnk" role="button">Persistent middle screen overlay preventing the close event</a>.</p>
+		<details class="mrgn-bttm-lg">
+			<summary>View code</summary>
+			<pre><code>&lt;p&gt;&lt;a href=&quot;#mid-screen-persistent&quot; aria-controls=&quot;mid-screen&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Persistent middle screen overlay preventing the close event&lt;/a&gt;&lt;/p&gt;
+			&lt;section id=&quot;mid-screen-persistent&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-mid&quot; data-wb-overlay=&apos;{&quot;persistent&quot;: true}&apos;&gt;
+			&lt;header class=&quot;modal-header&quot;&gt;
+			&lt;h2 class=&quot;modal-title&quot;&gt;Persistent middle screen overlay&lt;/h2&gt;
+			&lt;/header&gt;
+			&lt;div class=&quot;modal-body&quot;&gt;
+			...
+			&lt;/div&gt;
+		&lt;/section&gt;</code></pre>
 		</details>
 	</section>
 </section>
@@ -431,6 +499,28 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 	</div>
 </section>
 
+<section id="br-screen" class="wb-overlay modal-content overlay-def wb-popup-br wb-popup-flex">
+	<header class="modal-header">
+		<h2 class="modal-title">Bottom-right overlay</h2>
+	</header>
+	<div class="modal-body">
+		<ol>
+			<li>ordered list (<code>ol</code>) first level default appearance</li>
+			<li>ordered list (<code>ol</code>) first level default appearance
+				<ol>
+					<li>ordered list (<code>ol</code>) second level default appearance</li>
+					<li>ordered list (<code>ol</code>) second level default appearance
+						<ol>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+	</div>
+</section>
+
 <section id="full-screen" class="wb-overlay modal-content overlay-def wb-popup-full">
 	<header class="modal-header">
 		<h2 class="modal-title">Full-screen overlay</h2>
@@ -456,6 +546,86 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 <section id="hidden-header" class="wb-overlay modal-content wb-popup-full hidden-hd">
 	<header>
 		<h2 class="wb-inv">Full-screen overlay - Hidden header</h2>
+	</header>
+	<div class="modal-body">
+		<ol>
+			<li>ordered list (<code>ol</code>) first level default appearance</li>
+			<li>ordered list (<code>ol</code>) first level default appearance
+				<ol>
+					<li>ordered list (<code>ol</code>) second level default appearance</li>
+					<li>ordered list (<code>ol</code>) second level default appearance
+						<ol>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+	</div>
+</section>
+
+<section id="br-screen-flex" class="wb-overlay modal-content overlay-def wb-popup-br wb-popup-flex">
+	<header class="modal-header">
+		<h2 class="modal-title">Bottom-right overlay with fix header and footer</h2>
+	</header>
+	<div class="modal-body">
+		<ol>
+			<li>ordered list (<code>ol</code>) first level default appearance</li>
+			<li>ordered list (<code>ol</code>) first level default appearance
+				<ol>
+					<li>ordered list (<code>ol</code>) second level default appearance</li>
+					<li>ordered list (<code>ol</code>) second level default appearance
+						<ol>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+		<ol>
+			<li>ordered list (<code>ol</code>) first level default appearance</li>
+			<li>ordered list (<code>ol</code>) first level default appearance
+				<ol>
+					<li>ordered list (<code>ol</code>) second level default appearance</li>
+					<li>ordered list (<code>ol</code>) second level default appearance
+						<ol>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+	</div>
+</section>
+
+<section id="br-screen-nf" class="wb-overlay modal-content overlay-def wb-popup-br wb-popup" data-wb-overlay='{ "noFooter": true }'>
+	<header class="modal-header">
+		<h2 class="modal-title">Bottom-right overlay without default footer</h2>
+	</header>
+	<div class="modal-body">
+		<ol>
+			<li>ordered list (<code>ol</code>) first level default appearance</li>
+			<li>ordered list (<code>ol</code>) first level default appearance
+				<ol>
+					<li>ordered list (<code>ol</code>) second level default appearance</li>
+					<li>ordered list (<code>ol</code>) second level default appearance
+						<ol>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+	</div>
+</section>
+
+<section id="mid-screen-persistent" class="wb-overlay modal-content overlay-def wb-popup-mid" data-wb-overlay='{ "persistent": true }'>
+	<header class="modal-header">
+		<h2 class="modal-title">Persistent middle screen overlay</h2>
 	</header>
 	<div class="modal-body">
 		<ol>

--- a/src/plugins/overlay/overlay-en.hbs
+++ b/src/plugins/overlay/overlay-en.hbs
@@ -9,7 +9,7 @@
 	"altLangPrefix": "overlay",
 	"js": ["demo/overlay"],
 	"css": ["demo/overlay"],
-	"dateModified": "2021-09-24"
+	"dateModified": "2021-09-29"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -238,7 +238,7 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 		<p>Overlays/Modals through JavaScript are automatically updated with a close overlay/modal button. This button can be changed with the following code:</p>
 		<pre><code>&lt;div class=&quot;modal-footer&quot;&gt;
 ...
-&lt;button class=&quot;btn btn-primary popup-modal-dismiss&quot; type=&quot;button&quot;&gt;Close overlay/modal&lt;/button&gt;
+&lt;button class=&quot;btn btn-primary overlay-close&quot; type=&quot;button&quot;&gt;Close overlay/modal&lt;/button&gt;
 &lt;/div&gt;</code></pre>
 		<p><strong>Side Note:</strong> Close buttons must be inside the modal footer (a div with the class <code>modal-footer</code>).</p>
 	</section>
@@ -281,26 +281,11 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 	</section>
 
 	<section>
-		<h3>Remove default footer and or make overlay persistent</h3>
-		<p>Add <code>data-wb-overlay</code> to customize footer and or disable the close event.</p>
+		<h3>Persistent overlay</h3>
+		<p>Add <code>data-wb-overlay</code> to disable the close event in order to make overlay persistent.</p>
 		<ul>
-			<li><code>{ &quot;noFooter&quot;: true }</code> this will remove the default footer from the overlay dialogue so a customized footer can be added.</li>
-			<li><code>{ &quot;noClose&quot;: true }</code> this will prevent the overlay dialogue to close when pressing the escape key or when clicking outside the overlay.</li>
+			<li><code>{ &quot;noClose&quot;: true }</code> this will prevent the overlay dialogue to close when pressing the escape key or when clicking outside the overlay window.</li>
 		</ul>
-
-		<p><a href="#br-screen-nf" aria-controls="br-screen" class="overlay-lnk" role="button">Bottom-right overlay without default footer</a></p>
-		<details class="mrgn-bttm-lg">
-			<summary>View code</summary>
-			<pre><code>&lt;p&gt;&lt;a href=&quot;#br-screen-nf&quot; aria-controls=&quot;br-screen-flex&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Bottom-right overlay without default footer&lt;/a&gt;&lt;/p&gt;
-			&lt;section id=&quot;br-screen-nf&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-br wb-popup-flex&quot; data-wb-overlay=&apos;{ &quot;noFooter&quot;: true }&apos;&gt;
-			&lt;header class=&quot;modal-header&quot;&gt;
-			&lt;h2 class=&quot;modal-title&quot;&gt;Bottom-right overlay without footer&lt;/h2&gt;
-			&lt;/header&gt;
-			&lt;div class=&quot;modal-body&quot;&gt;
-			...
-			&lt;/div&gt;
-		&lt;/section&gt;</code></pre>
-		</details>
 	</section>
 
 	<section>
@@ -584,28 +569,6 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 				</ol>
 			</li>
 		</ol>
-		<ol>
-			<li>ordered list (<code>ol</code>) first level default appearance</li>
-			<li>ordered list (<code>ol</code>) first level default appearance
-				<ol>
-					<li>ordered list (<code>ol</code>) second level default appearance</li>
-					<li>ordered list (<code>ol</code>) second level default appearance
-						<ol>
-							<li>ordered list (<code>ol</code>) third level default appearance</li>
-							<li>ordered list (<code>ol</code>) third level default appearance</li>
-						</ol>
-					</li>
-				</ol>
-			</li>
-		</ol>
-	</div>
-</section>
-
-<section id="br-screen-nf" class="wb-overlay modal-content overlay-def wb-popup-br wb-popup" data-wb-overlay='{ "noFooter": true }'>
-	<header class="modal-header">
-		<h2 class="modal-title">Bottom-right overlay without default footer</h2>
-	</header>
-	<div class="modal-body">
 		<ol>
 			<li>ordered list (<code>ol</code>) first level default appearance</li>
 			<li>ordered list (<code>ol</code>) first level default appearance

--- a/src/plugins/overlay/overlay-fr.hbs
+++ b/src/plugins/overlay/overlay-fr.hbs
@@ -9,7 +9,7 @@
 	"altLangPrefix": "overlay",
 	"js": ["demo/overlay"],
 	"css": ["demo/overlay"],
-	"dateModified": "2021-09-24"
+	"dateModified": "2021-09-29"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -245,7 +245,7 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 		<p>Overlays/Modals through JavaScript are automatically updated with a close overlay/modal button. This button can be changed with the following code:</p>
 		<pre><code>&lt;div class=&quot;modal-footer&quot;&gt;
 ...
-&lt;button class=&quot;btn btn-primary popup-modal-dismiss&quot; type=&quot;button&quot;&gt;Close overlay/modal&lt;/button&gt;
+&lt;button class=&quot;btn btn-primary overlay-close&quot; type=&quot;button&quot;&gt;Close overlay/modal&lt;/button&gt;
 &lt;/div&gt;</code></pre>
 		<p><strong>Side Note:</strong> Close buttons must be inside the modal footer (a div with the class <code>modal-footer</code>).</p>
 	</section>
@@ -290,26 +290,11 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 </section>
 
 	<section>
-		<h3>Désactiver le pied de page par défaut et ou rendre le contenu superposé persistent.</h3>
-		<p>Ajouter <code>data-wb-overlay</code> afin de personaliser le pied de page et ou désactiver l'événement de fermeture.</p>
+		<h3>Rendre le contenu superposé persistent.</h3>
+		<p>Ajouter <code>data-wb-overlay</code> afin de désactiver l'événement de fermeture et ainsi rendre la fenêtre du contenu superposé persistante.</p>
 		<ul>
-			<li><code>{ &quot;noFooter&quot;: true }</code> cela désactivera le pied de page par défaut du contenu superposé afin qu'un pied de page personnalisé puisse être ajouté. </li>
 			<li><code>{ &quot;noClose&quot;: true }</code> cela empêchera le contenu superposé de se fermer lorsque vous appuyez sur la touche d'échappement ou lorsque vous cliquez en dehors de la fenêtre de superposition. </li>
 		</ul>
-
-		<p><a href="#cs-coin-inferieur-droit-sp" aria-controls="br-screen" class="overlay-lnk" role="button">Contenu superposé coin inférieur droit sans pied de page.</a></p>
-		<details class="mrgn-bttm-lg">
-			<summary>Visualiser le code</summary>
-			<pre><code>&lt;p&gt;&lt;a href=&quot;#cs-coin-inferieur-droit-sp&quot; aria-controls=&quot;br-screen&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Contenu superposé coin inférieur droit sans pied de page.&lt;/a&gt;&lt;/p&gt;
-			&lt;section id=&quot;br-screen-nf&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-br wb-popup-flex&quot; data-wb-overlay=&apos;{ &quot;noFooter&quot;: true }&apos;&gt;
-			&lt;header class=&quot;modal-header&quot;&gt;
-			&lt;h2 class=&quot;modal-title&quot;&gt;Contenu superposé coin inférieur droit sans pied de page.&lt;/h2&gt;
-			&lt;/header&gt;
-			&lt;div class=&quot;modal-body&quot;&gt;
-			...
-			&lt;/div&gt;
-		&lt;/section&gt;</code></pre>
-		</details>
 	</section>
 
 	<section>
@@ -612,28 +597,6 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 				</ol>
 			</li>
 		</ol>
-		<ol>
-			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
-			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
-				<ol>
-					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
-					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
-						<ol>
-							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
-							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
-						</ol>
-					</li>
-				</ol>
-			</li>
-		</ol>
-	</div>
-</section>
-
-<section id="cs-coin-inferieur-droit-sp" class="wb-overlay modal-content overlay-def wb-popup-br wb-popup" data-wb-overlay='{ "noFooter": true }'>
-	<header class="modal-header">
-		<h2 class="modal-title">Contenu superposé coin inférieur droit sans pied de page</h2>
-	</header>
-	<div class="modal-body">
 		<ol>
 			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
 			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut

--- a/src/plugins/overlay/overlay-fr.hbs
+++ b/src/plugins/overlay/overlay-fr.hbs
@@ -9,7 +9,7 @@
 	"altLangPrefix": "overlay",
 	"js": ["demo/overlay"],
 	"css": ["demo/overlay"],
-	"dateModified": "2014-07-22"
+	"dateModified": "2021-09-24"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -123,6 +123,22 @@
 &lt;section id=&quot;cs-mi-ecran&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-mid&quot;&gt;
 	&lt;header class=&quot;modal-header&quot;&gt;
 		&lt;h2 class=&quot;modal-title&quot;&gt;Contenu superposé mi-écran&lt;/h2&gt;
+	&lt;/header&gt;
+	&lt;div class=&quot;modal-body&quot;&gt;
+		...
+	&lt;/div&gt;
+&lt;/section&gt;</code></pre>
+			</details>
+		</li>
+		<li>
+			<p><a href="#cs-coin-inferieur-droit" aria-controls="cs-coin-inferieur-droit" class="overlay-lnk" role="button">Contenu superposé coin inférieur droit</a></p>
+			<details class="mrgn-bttm-lg">
+				<summary>View code</summary>
+				<pre><code>&lt;p&gt;&lt;a href=&quot;#cs-coin-inferieur-droit&quot; aria-controls=&quot;cs-coin-inferieur-droit&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Contenu superposé coin inferieur droit&lt;/a&gt;&lt;/p&gt;
+
+&lt;section id=&quot;cs-coin-inferieur-droit&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-br&quot;&gt;
+	&lt;header class=&quot;modal-header&quot;&gt;
+		&lt;h2 class=&quot;modal-title&quot;&gt;Contenu superposé coin inferieur droit&lt;/h2&gt;
 	&lt;/header&gt;
 	&lt;div class=&quot;modal-body&quot;&gt;
 		...
@@ -251,6 +267,64 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 	...
 &lt;/div&gt;
 &lt;/section&gt;</code></pre>
+		</details>
+	</section>
+
+	<section>
+		<h3>Contenu superposé coin inférieur droit avec un en-tête et pied de page fixes.</h3>
+		<p>Ajouter la classe CSS <code>wb-popup-flex</code> à la fenêtre superposé afin que l'en-tête et le pied de page deviennent fixes et que seulement le contenu puisse défiler de haut en bas.</p>
+		<p><a href="#cs-coin-inferieur-droit-flex" aria-controls="cs-coin-inferieur-droit-flex" class="overlay-lnk" role="button">Contenu superposé coin inférieur droit avec un en-tête et pied de page fixes.</a></p>
+		<details class="mrgn-bttm-lg">
+			<summary>Visualiser le code</summary>
+			<pre><code>&lt;p&gt;&lt;a href=&quot;#cs-coin-inferieur-droit-flex&quot; aria-controls=&quot;cs-coin-inferieur-droit-flex&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Contenu superposé coin inférieur droit avec un en-tête et pied de page fixes.&lt;/a&gt;&lt;/p&gt;
+			&lt;section id=&quot;cs-coin-inferieur-droit-flex&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-br wb-popup-flex&quot;&gt;
+			&lt;header class=&quot;modal-header&quot;&gt;
+			&lt;h2 class=&quot;modal-title&quot;&gt;Contenu superposé coin inférieur droit avec un en-tête et pied de page fixes.&lt;/h2&gt;
+			&lt;/header&gt;
+			&lt;div class=&quot;modal-body&quot;&gt;
+				...
+			&lt;/div&gt;
+		&lt;/section&gt;</code></pre>
+		</details>
+	</section>
+</section>
+
+	<section>
+		<h3>Désactiver le pied de page par défaut et ou rendre le contenu superposé persistent.</h3>
+		<p>Ajouter <code>data-wb-overlay</code> afin de personaliser le pied de page et ou désactiver l'événement de fermeture.</p>
+		<ul>
+			<li><code>{ &quot;noFooter&quot;: true }</code> cela désactivera le pied de page par défaut du contenu superposé afin qu'un pied de page personnalisé puisse être ajouté. </li>
+			<li><code>{ &quot;noClose&quot;: true }</code> cela empêchera le contenu superposé de se fermer lorsque vous appuyez sur la touche d'échappement ou lorsque vous cliquez en dehors de la fenêtre de superposition. </li>
+		</ul>
+
+		<p><a href="#cs-coin-inferieur-droit-sp" aria-controls="br-screen" class="overlay-lnk" role="button">Contenu superposé coin inférieur droit sans pied de page.</a></p>
+		<details class="mrgn-bttm-lg">
+			<summary>Visualiser le code</summary>
+			<pre><code>&lt;p&gt;&lt;a href=&quot;#cs-coin-inferieur-droit-sp&quot; aria-controls=&quot;br-screen&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Contenu superposé coin inférieur droit sans pied de page.&lt;/a&gt;&lt;/p&gt;
+			&lt;section id=&quot;br-screen-nf&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-br wb-popup-flex&quot; data-wb-overlay=&apos;{ &quot;noFooter&quot;: true }&apos;&gt;
+			&lt;header class=&quot;modal-header&quot;&gt;
+			&lt;h2 class=&quot;modal-title&quot;&gt;Contenu superposé coin inférieur droit sans pied de page.&lt;/h2&gt;
+			&lt;/header&gt;
+			&lt;div class=&quot;modal-body&quot;&gt;
+			...
+			&lt;/div&gt;
+		&lt;/section&gt;</code></pre>
+		</details>
+	</section>
+
+	<section>
+		<p><a href="#cs-mi-ecran-persistent" aria-controls="mid-screen" class="overlay-lnk" role="button">Contenu superposé mi-écran persistent prévenant la fermeture</a>.</p>
+		<details class="mrgn-bttm-lg">
+			<summary>Visualiser le code</summary>
+			<pre><code>&lt;p&gt;&lt;a href=&quot;#cs-mi-ecran-persistent&quot; aria-controls=&quot;mid-screen&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Contenu superposé mi-écran persistent prévenant l'événement de fermeture&lt;/a&gt;&lt;/p&gt;
+			&lt;section id=&quot;cs-mi-ecran-persistent&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-mid&quot; data-wb-overlay=&apos;{&quot;persistent&quot;: true}&apos;&gt;
+			&lt;header class=&quot;modal-header&quot;&gt;
+			&lt;h2 class=&quot;modal-title&quot;&gt;Contenu superposé mi-écran persistent&lt;/h2&gt;
+			&lt;/header&gt;
+			&lt;div class=&quot;modal-body&quot;&gt;
+			...
+			&lt;/div&gt;
+		&lt;/section&gt;</code></pre>
 		</details>
 	</section>
 </section>
@@ -437,6 +511,28 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 	</div>
 </section>
 
+<section id="cs-coin-inferieur-droit" class="wb-overlay modal-content overlay-def wb-popup-br">
+	<header class="modal-header">
+		<h2 class="modal-title">Contenu superposé coin inferieur droit</h2>
+	</header>
+	<div class="modal-body">
+		<ol>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
+				<ol>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
+						<ol>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+	</div>
+</section>
+
 <section id="cs-plein-ecran" class="wb-overlay modal-content overlay-def wb-popup-full">
 	<header class="modal-header">
 		<h2 class="modal-title">Contenu superposé plein écran</h2>
@@ -480,5 +576,99 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 			</li>
 		</ol>
 		<p><a href="#">Lien - apparence par défaut</a></p>
+	</div>
+</section>
+
+<section id="cs-coin-inferieur-droit-flex" class="wb-overlay modal-content overlay-def wb-popup-br wb-popup-flex">
+	<header class="modal-header">
+		<h2 class="modal-title">Contenu superposé coin inférieur droit avec un entête et pied de page fixe</h2>
+	</header>
+	<div class="modal-body">
+		<ol>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
+				<ol>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
+						<ol>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+		<ol>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
+				<ol>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
+						<ol>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+		<ol>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
+				<ol>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
+						<ol>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+	</div>
+</section>
+
+<section id="cs-coin-inferieur-droit-sp" class="wb-overlay modal-content overlay-def wb-popup-br wb-popup" data-wb-overlay='{ "noFooter": true }'>
+	<header class="modal-header">
+		<h2 class="modal-title">Contenu superposé coin inférieur droit sans pied de page</h2>
+	</header>
+	<div class="modal-body">
+		<ol>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
+				<ol>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
+						<ol>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+	</div>
+</section>
+
+<section id="cs-mi-ecran-persistent" class="wb-overlay modal-content overlay-def wb-popup-mid" data-wb-overlay='{ "persistent": true }'>
+	<header class="modal-header">
+		<h2 class="modal-title">Contenu superposé mi-écran persistant</h2>
+	</header>
+	<div class="modal-body">
+		<ol>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
+				<ol>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
+						<ol>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
 	</div>
 </section>

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -24,7 +24,6 @@ var componentName = "wb-overlay",
 	sourceLinks = {},
 	settings,
 	defaults = {
-		noFooter: false,
 		persistent: false
 	},
 	setFocusEvent = "setfocus.wb",
@@ -79,7 +78,7 @@ var componentName = "wb-overlay",
 			if ( isPanel || isPopup ) {
 				footer = $elm.find( ".modal-footer" )[ 0 ];
 				var hasFooter = ( footer && footer.length !== 0 ) ? true : false,
-					hasButton = hasFooter && $( footer ).find( closeClass ).length !== 0,
+					hasButton = $( footer ).find( "button" ).hasClass( closeClass ),
 					closeClassFtr = ( $elm.hasClass( "wb-panel-l" ) ? "pull-right " : "pull-left " )  + closeClass,
 					closeTextFtr = i18nText.close,
 					spanTextFtr = i18nText.closeOverlay,

--- a/theme/theme.scss
+++ b/theme/theme.scss
@@ -36,6 +36,7 @@
 /* Extra-small view and under */
 @media screen and (max-width: $screen-xs-max) {
 	@import "views/screen-xs-max";
+	@import "../src/plugins/overlay/screen-xs-max";
 }
 
 /* Small view and under */
@@ -91,11 +92,13 @@
 @media screen and (min-width: $screen-sm-min) and (max-width: $screen-sm-max) {
 	@import "views/screen-sm-min-to-screen-sm-max";
 	@import "search/screen-sm-min-to-screen-sm-max";
+	@import "../src/plugins/overlay/screen-sm-min-to-screen-sm-max";
 }
 
 /* Medium view */
 @media screen and (min-width: $screen-md-min) and (max-width: $screen-md-max) {
 	@import "views/screen-md-min-to-screen-md-max";
+	@import "../src/plugins/overlay/screen-md-min-to-screen-md-max";
 }
 
 /* Large view */


### PR DESCRIPTION
## What does this pull request (PR) do?
Creation of a new bottom-right popup pattern to the existing overlay WET component.

This Pull request is adding four things basically:
- An overlay that displays at the bottom right or the screen (and fullscreen when on mobile)… mostly for a chat interface.
- A config that allows to remove the close button in the footer whil keeping the “X” button obviously.
- A config that prevents the overlay from closing when clicking outside of its window.
- A class that keeps the header and footer of the overlay fixed so that only its body can scroll.

A second commit has been created to fix the bug with adding custom close buttons to overlays/modals functionality where the close function was generating an error in the console and the default close button was still appearing along with the custom button.

## Additional information (optional)
This will support the common GC chat experience: wet-136
