### PR TITLE
MathML polyfill: Add "table-responsive" div to demos

### DIFF
--- a/src/polyfills/mathml/mathml-en.hbs
+++ b/src/polyfills/mathml/mathml-en.hbs
@@ -80,6 +80,7 @@ Given the quadratic equation
 </section>
 
 <section><h2>Examples of complex formulas</h2>
+<div class="table-responsive">
 <table class="table">
 <thead>
 <tr>
@@ -1332,4 +1333,5 @@ Given the quadratic equation
 </tr>
 </tbody>
 </table>
+</div>
 </section>

--- a/src/polyfills/mathml/mathml-fr.hbs
+++ b/src/polyfills/mathml/mathml-fr.hbs
@@ -82,7 +82,8 @@ Compte tenu de l'équation quadratique
 </section>
 
 <section><h2>Exemples de formules complexes</h2>
-<table class="table width-30">
+<div class="table-responsive">
+<table class="table">
 <thead>
 <tr>
 <th scope="col" style="width: 30%">Formule</th>
@@ -1334,4 +1335,5 @@ Compte tenu de l'équation quadratique
 </tr>
 </tbody>
 </table>
+</div>
 </section>


### PR DESCRIPTION
Prevents the demo page's very wide table from causing the entire page to scroll horizontally in smaller viewports.

Only the table itself will scroll horizontally as a result of this change.