### PR TITLE
Build: Make "js" call the "string-replace" task

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -40,7 +40,6 @@ module.exports = (grunt) ->
 			"sprite"
 			"css"
 			"js"
-			"string-replace"
 		]
 	)
 
@@ -127,6 +126,7 @@ module.exports = (grunt) ->
 			"copy:js"
 			"concat:core"
 			"concat:coreIE8"
+			"string-replace"
 			"concat:pluginsIE8"
 			"concat:i18n"
 		]
@@ -1321,7 +1321,6 @@ module.exports = (grunt) ->
 				files: "<%= eslint.all.src %>"
 				tasks: [
 					"js"
-					"string-replace"
 				]
 			css:
 				files: [


### PR DESCRIPTION
WET's core JavaScript file contains a MathJax CDN URL that uses "WET_BOEW_VERSION_MATHJAX" as a stand-in for a semver version number. The build system is setup to replace it with a real version number via the "string-replace" task. But only the "build" and "watch" tasks trigger it. That works out for ``grunt``, ``grunt dist``, ``grunt watch``, etc... But not when running the "js" task on its own (i.e. ``grunt js``).

This fixes it by:
* Adding a call to "string-replace" in the "js" task right after the core JS files get built.
* Scrapping the "build"/"watch" tasks' calls to "string-replace" (they already call "js").