### PR TITLE
Disable event: Fix ampersand in basic HTML mode's activation link

### DIFF
--- a/src/plugins/wb-disable/disable.js
+++ b/src/plugins/wb-disable/disable.js
@@ -41,7 +41,7 @@ var componentName = "wb-disable",
 			// Rebuild the query string
 			for ( param in pageUrl.params ) {
 				if ( param && Object.prototype.hasOwnProperty.call( pageUrl.params, param ) && param !== "wbdisable" ) {
-					nQuery += param + "=" + pageUrl.params[ param ] + "&#38;";
+					nQuery += param + "=" + pageUrl.params[ param ] + "&";
 				}
 			}
 


### PR DESCRIPTION
This plugin adds an ampersand before ``wbdisable=true`` if the current page's URL contains parameters.

The plugin used to build basic HTML mode's activation link using ``innerHTML``. Later on, #9036 changed it to use the ``addSkipLink`` helper method.

However, that changed how the ampersand got interpreted. It started getting double-escaped (``&amp;&#38;``).

This resolves it by changing the ampersand from a numeric entity into a normal ampersand character. It'll get transformed into ``&amp;`` upon being inserted into the page by ``addSkipLink``.

The ``addSkipLink`` method uses ``setAttribute`` (which expects plain-text values) to set the activation link's destination. Afterwards, ``appendChild`` subsequently changes the ampersand into a named entity.

Fixes #9139.

**Related reading:**
* [Stack Overflow: Does setAttribute automatically escape HTML characters?](https://stackoverflow.com/questions/50140983/does-setattribute-automatically-escape-html-characters)