### PR TITLE
Form validation: Hide "required" label text from screen readers

### DIFF
--- a/site/includes/alertariahidden.hbs
+++ b/site/includes/alertariahidden.hbs
@@ -1,0 +1,8 @@
+{{! Page content include}}
+{{#contains this.alert "false"}}{{else}}<div class="alert alert-info">{{/contains}}
+{{#contains language "en"}}
+	<p>Consider adding an <code>aria-hidden="true"</code> attribute to <code>&lt;strong class="required"&gt;</code> (i.e. <code>&lt;strong class="required" aria-hidden="true"&gt;</code>) in required field labels. Hardcoding it will prevent screen readers from announcing "required" twice in the noscript and basic HTML versions of the page. The form validation plugin automatically adds the attribute to the JavaScript version. Don't use the attribute in required <code>&lt;legend&gt;</code> elements.</p>
+{{else}}
+	<p>Considérez ajouter un attribut <code lang="en">aria-hidden="true"</code> à <code lang="en">&lt;strong class="required"&gt;</code> (c.-à-d. <code lang="en">&lt;strong class="required" aria-hidden="true"&gt;</code>) dans les libellés des champs obligatoires. Le code ajouté de façon statique préviendra les lecteurs d’écran d’annoncer «&#160;obligatoire&#160;» deux fois dans les versions sans script et HTML simplifiée de la page. Le plugiciel de validation de formulaires ajoute l’attribut automatiquement à la version JavaScript. N’utilisez pas l’attribut dans les éléments <code lang="en">&lt;legend&gt;</code> obligatoires.</p>
+{{/contains}}
+{{#contains this.alert "false"}}{{else}}</div>{{/contains}}

--- a/site/pages/docs/ref/formvalid/formvalid-en.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-en.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Provides generic validation and error message handling for Web forms.",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2022-01-25"
+	"dateModified": "2022-04-13"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -278,6 +278,10 @@
 		<dd>Overwrites the default generic message that comes with the use of the pattern attribute by the one given through this attribute.</dd>
 	</dl>
 	<p>See <a href="https://html.spec.whatwg.org/#the-pattern-attribute" rel="external">WHATWG HTML Living Standards</a> for more details about the pattern attribute.</p>
+</section>
+<section>
+	<h3 id="required">Prevent screen readers from announcing "required" twice</h3>
+	{{>alertariahidden alert="false"}}
 </section>
 <section>
 	<h3 id="MergeSCE">Merge Server-Client errors functionality</h3>

--- a/site/pages/docs/ref/formvalid/formvalid-fr.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-fr.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Effectue la validation de formulaires Web selon un ensemble de règles de base avant qu'ils soient soumis.",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2022-01-25"
+	"dateModified": "2022-04-13"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -281,6 +281,10 @@
 		<dd>Overwrites the default generic message that comes with the use of the pattern attribute by the one given through this attribute.</dd>
 	</dl>
 	<p>See <a href="https://html.spec.whatwg.org/#the-pattern-attribute" rel="external">WHATWG HTML Living Standards</a> for more details about the pattern attribute.</p>
+</section>
+<section lang="fr">
+	<h3 id="required">Préviens les lecteurs d’écran d’annoncer «&#160;obligatoire&#160;» deux fois</h3>
+	{{>alertariahidden alert="false"}}
 </section>
 <section>
 	<h3 id="MergeSCE">Merge Server-Client errors functionality</h3>

--- a/src/other/feedback/feedback-en.hbs
+++ b/src/other/feedback/feedback-en.hbs
@@ -9,9 +9,10 @@
 	"altLangPrefix": "feedback",
 	"css": ["demo/feedback"],
 	"js": ["demo/feedback"],
-	"dateModified": "2015-03-06"
+	"dateModified": "2022-04-13"
 }
 ---
+{{>alertariahidden}}
 <div class="wb-frmvld wb-fdbck nojs-hide">
 	<p>If you have difficulty with the following form, you can use any of our <a href="#osc-avs">other service channels</a> to contact us.</p>
 	<form action="#" method="get" id="fdbck-frm">

--- a/src/other/feedback/feedback-fr.hbs
+++ b/src/other/feedback/feedback-fr.hbs
@@ -9,9 +9,10 @@
 	"altLangPrefix": "feedback",
 	"css": ["demo/feedback"],
 	"js": ["demo/feedback"],
-	"dateModified": "2014-02-28"
+	"dateModified": "2022-04-13"
 }
 ---
+{{>alertariahidden}}
 <div class="wb-frmvld wb-fdbck nojs-hide">
 	<p>Si vous avez des problèmes avec le formulaire suivant, vous pouvez utiliser une des <a href="#osc-avs">autres voies de service</a> pour communiquer avec nous.</p>
 	<form action="#" method="get" id="fdbck-frm">

--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2022-01-25"
+	"dateModified": "2022-04-13"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -43,6 +43,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -64,6 +65,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -79,6 +81,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -94,6 +97,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -109,6 +113,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -154,6 +159,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>View code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -358,6 +364,7 @@
 			</div>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
+				{{>alertariahidden}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -460,6 +467,7 @@
 			</div>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
+				{{>alertariahidden}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 				&lt;form action="#" method="get" id="validation-example"&gt;
 					...

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2022-01-25"
+	"dateModified": "2022-04-13"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -43,6 +43,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -64,6 +65,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -79,6 +81,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -94,6 +97,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -109,6 +113,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -154,6 +159,7 @@
 				</div>
 				<details class="mrgn-bttm-md">
 					<summary>Voir le code</summary>
+					{{>alertariahidden}}
 					<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -358,6 +364,7 @@
 			</div>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
+				{{>alertariahidden}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -460,6 +467,7 @@
 			</div>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
+				{{>alertariahidden}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 				&lt;form action="#" method="get" id="validation-example"&gt;
 					...

--- a/src/plugins/formvalid/formvalid-server-en.hbs
+++ b/src/plugins/formvalid/formvalid-server-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid-server",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid-server",
-	"dateModified": "2021-11-03"
+	"dateModified": "2022-04-13"
 }
 ---
 
@@ -25,6 +25,8 @@
 
 <section>
 	<h2>Example</h2>
+
+	{{>alertariahidden}}
 
 	<p>After submitting your page, the server returned 4 server errors. Now if you try to resubmit your form with some
 		client errors, the component will add these errors to the existing server errors.</p>

--- a/src/plugins/formvalid/formvalid-server-fr.hbs
+++ b/src/plugins/formvalid/formvalid-server-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid-server",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid-server",
-	"dateModified": "2021-08-11"
+	"dateModified": "2022-04-13"
 }
 ---
 
@@ -25,6 +25,8 @@
 
 <section>
 	<h2>Exemple</h2>
+
+	{{>alertariahidden}}
 
 	<p>Après avoir soumis votre page, le serveur retoune 4 erreurs serveur. Maintenant si vous essayez de resoumettre
 		votre formulaire avec des erreurs clients, ce composant ajoutera ces erreurs aux erreurs serveur déjà existantes.</p>

--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -102,6 +102,26 @@ var componentName = "wb-frmvld",
 						labels[ i ].innerHTML += " ";
 					}
 
+					// Hide "required" label text in older forms from screen readers
+					// Prevents redundant "required" announcements on semantically-required fields whose labels mention they're required
+					$form.find( "strong.required:not([aria-hidden='true'])" ).each( function() {
+						const $requiredText = $( this ),
+							$label = $requiredText.closest( "label" ),
+							fieldId = $label.attr( "for" );
+						let $field = fieldId ? $( "#" + fieldId ) : $label.find( ":input" ).first();
+
+						// If the label's field has yet to be found, look for fields that refer to the label via aria-labelledby
+						if ( !$field.length ) {
+							const labelId = $label.attr( "id" ) || $requiredText.closest( "id" );
+							$field = $form.find( "[aria-labelledby~='" + labelId + "']:input" ).first();
+						}
+
+						// Hide the "required" text if its field is semantically-required
+						if ( $field.is( "[required], [aria-required='true']" ) ) {
+							$requiredText.attr( "aria-hidden", "true" );
+						}
+					} );
+
 					// The jQuery validation plug-in in action
 					validator = $form.validate( {
 						meta: "validate",

--- a/src/plugins/wb-postback/wb-postback-en.hbs
+++ b/src/plugins/wb-postback/wb-postback-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "wb-postback",
 	"parentdir": "wb-postback",
 	"altLangPrefix": "wb-postback",
-	"dateModified": "2020-12-09"
+	"dateModified": "2022-03-13"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -97,6 +97,7 @@
 </div>
 <details class="mrgn-tp-md mrgn-bttm-md">
 	<summary>View code</summary>
+	{{>alertariahidden}}
 	<pre><code>
 		&lt;div class="wb-frmvld"&gt;
 		&lt;form action="wb-postback-en.html" class="wb-postback" data-wb-postback="{&amp;quot;success&amp;quot;:&amp;quot;success-message-2&amp;quot;,&amp;quot;failure&amp;quot;:&amp;quot;failure-message-2&amp;quot;}"&gt;

--- a/src/plugins/wb-postback/wb-postback-fr.hbs
+++ b/src/plugins/wb-postback/wb-postback-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "wb-postback",
 	"parentdir": "wb-postback",
 	"altLangPrefix": "wb-postback",
-	"dateModified": "2020-04-16"
+	"dateModified": "2022-04-13"
 }
 ---
 
@@ -95,6 +95,7 @@
 <p class="failure-message-2 hide">Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.</p>
 </div>
 <details class="mrgn-tp-md mrgn-bttm-md">
+	{{>alertariahidden}}
 	<summary>View code</summary>
 	<pre><code>
 		&lt;div class="wb-frmvld"&gt;


### PR DESCRIPTION
* Makes the plugin automatically add ``aria-hidden="true"`` to required indicators in the labels of semantically-required fields (i.e. any fields that use ``required`` or ``aria-required="true"`` attributes)
  * Useful for older/pre-existing forms that might not otherwise benefit from this change
* Adds info alerts to recommend hardcoding aria-hidden="true" near required field labels in demo pages
* Adds a new section to the plugin's documentation that re-uses the include's content
* Fixes #6966
* Fixes #7002
* Fixes #8091
* Fixes #9132
* Depends on #9166

CC @StacyBleeks @shawnthompson