### PR TITLE
Form SCSS: Remove invalid selector and associated scss-lint rule

### DIFF
--- a/src/base/forms/_base.scss
+++ b/src/base/forms/_base.scss
@@ -10,11 +10,9 @@ $asterisk-width: .665em;
 	font-weight: 700;
 }
 
-// scss-lint:disable QualifyingElement
 label,
 legend,
-.checkbox,
-input[type="checkbox"] {
+.checkbox {
 	&.required {
 		&:before {
 			@extend %forms-color-red-bold;
@@ -29,7 +27,6 @@ input[type="checkbox"] {
 		}
 	}
 }
-// scss-lint:enable QualifyingElement
 
 [dir=rtl] {
 	label,


### PR DESCRIPTION
That selector's sub-selectors are designed to place a red wildcard in a ``::before`` pseudo-element and red text in a inner ``strong`` element on required fields. Which makes sense on labels, legends, etc... but not on void ``input`` elements.

This also removes an inline scss-lint rule whose only purpose was to prevent the checkbox input's selector from causing a linting error. WET replaced scss-lint with sass-lint long ago.