### PR TITLE
Form validation: Improve standalone checkboxes

### DIFF
--- a/site/pages/docs/ref/formvalid/formvalid-en.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-en.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Provides generic validation and error message handling for Web forms.",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2020-12-23"
+	"dateModified": "2022-01-25"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -55,9 +55,12 @@
 		<li>Add <code>required="required"</code> to each mandatory form field
 			<pre><code>&lt;input id="fname1" name="fname1" type="text" autocomplete="given-name" required="required" /&gt;</code></pre>
 		</li>
-		<li><p><strong>Optional: </strong>For input fields, add one of these <a href="#SpecializedValidation">options</a> for specialized validation, or else you can use a <a href="#pattern">custom pattern validation</a> only if your pattern is very specific and is not part of the options for specialized validation.</p></li>
-		<li><strong>Optional: </strong>For ASP validators add the following attributes to enable the <a href="#MergeSCE">Merge Server-Client errors functionality</a>
-			<p><code>Display="Dynamic" EnableClientScript="false" CssClass="label label-danger wb-server-error"</code></p>
+		<li><strong>Optional:</strong>
+			<ul class="lst-spcd">
+				<li>To make a standalone checkbox field's label look consistent with text field labels (i.e. bolded), add the <code>checkbox checkbox-standalone</code> classes to the checkbox and place it in a <code>&lt;div class="form-group"&gt;</code> element.</li>
+				<li>For input fields, add one of these <a href="#SpecializedValidation">options</a> for specialized validation, or else you can use a <a href="#pattern">custom pattern validation</a> only if your pattern is very specific and is not part of the options for specialized validation.</li>
+				<li>For ASP validators add the following attributes to enable the <a href="#MergeSCE">Merge Server-Client errors functionality</a>:<br /><code>Display="Dynamic" EnableClientScript="false" CssClass="label label-danger wb-server-error"</code></li>
+			</ul>
 		</li>
 	</ol>
 </section>

--- a/site/pages/docs/ref/formvalid/formvalid-fr.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-fr.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Effectue la validation de formulaires Web selon un ensemble de règles de base avant qu'ils soient soumis.",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2020-12-23"
+	"dateModified": "2022-01-25"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -58,9 +58,12 @@
 		<li>Add <code>required="required"</code> to each mandatory form field
 			<pre><code>&lt;input id="fname1" name="fname1" type="text" autocomplete="given-name" required="required" /&gt;</code></pre>
 		</li>
-		<li><p><strong>Optional: </strong>For input fields, add one of these <a href="#SpecializedValidation">options</a> for specialized validation, or else you can use a <a href="#pattern">custom pattern validation</a> only if your pattern is very specific and is not part of the options for specialized validation.</p></li>
-		<li><strong>Optional: </strong>For ASP validators add the following attributes to enable the <a href="#MergeSCE">Merge Server-Client errors functionality</a>
-			<p><code>Display="Dynamic" EnableClientScript="false" CssClass="label label-danger wb-server-error"</code></p>
+		<li><strong>Optional:</strong>
+			<ul class="lst-spcd">
+				<li>To make a standalone checkbox field's label look consistent with text field labels (i.e. bolded), add the <code>checkbox checkbox-standalone</code> classes to the checkbox and place it in a <code>&lt;div class="form-group"&gt;</code> element.</li>
+				<li>For input fields, add one of these <a href="#SpecializedValidation">options</a> for specialized validation, or else you can use a <a href="#pattern">custom pattern validation</a> only if your pattern is very specific and is not part of the options for specialized validation.</li>
+				<li>For ASP validators add the following attributes to enable the <a href="#MergeSCE">Merge Server-Client errors functionality</a>:<br /><code>Display="Dynamic" EnableClientScript="false" CssClass="label label-danger wb-server-error"</code></li>
+			</ul>
 		</li>
 	</ol>
 </section>

--- a/src/base/forms/_base.scss
+++ b/src/base/forms/_base.scss
@@ -3,7 +3,7 @@
   @title: Form additions to WET-BOEW
  */
 
-$asterisk-width: .665em;
+$asterisk-width: .67em;
 
 %forms-color-red-bold {
 	color: #d3080c;
@@ -20,6 +20,7 @@ input[type="checkbox"] {
 			@extend %forms-color-red-bold;
 			content: "* ";
 			margin-left: -$asterisk-width;
+			vertical-align: top;
 		}
 
 		strong {
@@ -30,6 +31,22 @@ input[type="checkbox"] {
 	}
 }
 // scss-lint:enable QualifyingElement
+
+.form-group {
+	&.has-error {
+		.checkbox {
+			color: $text-color;
+		}
+	}
+
+	.checkbox {
+		&.checkbox-standalone {
+			label {
+				font-weight: 700;
+			}
+		}
+	}
+}
 
 [dir=rtl] {
 	label,

--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2021-08-11"
+	"dateModified": "2022-01-25"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -350,6 +350,23 @@
 		&lt;/div&gt;</code></pre>
 				</details>
 			</fieldset>
+
+			<div class="form-group">
+				<div class="checkbox checkbox-standalone required">
+					<label for="agree1"><input id="agree1" name="agree1" type="checkbox" required> <span class="field-name">I agree</span> <strong class="required">(required)</strong></label>
+				</div>
+			</div>
+			<details class="mrgn-bttm-md">
+				<summary>View code</summary>
+				<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+		...
+			&lt;div class="form-group"&gt;
+				&lt;div class="checkbox checkbox-standalone required"&gt;
+					&lt;label for="agree1"&gt;&lt;input id="agree1" name="agree1" type="checkbox" required&gt; &lt;span class="field-name"&gt;I agree&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;</code></pre>
+			</details>
 
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Favourite pets</span> <strong class="required">(required)</strong></legend>

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2021-08-11"
+	"dateModified": "2022-01-25"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -350,6 +350,23 @@
 		&lt;/div&gt;</code></pre>
 				</details>
 			</fieldset>
+
+			<div class="form-group">
+				<div class="checkbox checkbox-standalone required">
+					<label for="agree1"><input id="agree1" name="agree1" type="checkbox" required> <span class="field-name">Je suis d’accord</span> <strong class="required">(obligatoire)</strong></label>
+				</div>
+			</div>
+			<details class="mrgn-bttm-md">
+				<summary>Voir le code</summary>
+				<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+		...
+			&lt;div class="form-group"&gt;
+				&lt;div class="checkbox checkbox-standalone required"&gt;
+					&lt;label for="agree1"&gt;&lt;input id="agree1" name="agree1" type="checkbox" required&gt; &lt;span class="field-name"&gt;Je suis d’accord&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
+				&lt;/div&gt;
+			&lt;/div&gt;</code></pre>
+			</details>
 
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Animaux favoris</span> <strong class="required">(obligatoire)</strong></legend>

--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -163,8 +163,8 @@ var componentName = "wb-frmvld",
 
 							//Std If we have a label and the input field is inside the label
 							// need to add a css-implicite-input
-							if ( $form.find( "label" ).find( "input[name='" + $element.attr( "name" ) + "']" ).length > 0 ) {
-								$error.insertBefore( $form.find( "input[name='" + $element.attr( "name" ) + "']" ) );
+							if ( $form.find( "label" ).find( ".wb-server-error + input.css-implicite-input[name='" + $element.attr( "name" ) + "']" ).length > 0 ) {
+								$error.insertBefore( $form.find( ".wb-server-error + input.css-implicite-input[name='" + $element.attr( "name" ) + "']" ) );
 								return;
 							}
 


### PR DESCRIPTION
* Add an example of a required standalone checkbox
* Move validation error messages to the end of standalone checkbox labels instead of the beginning (pre-#8397 behaviour for fields that don't use the "wb-server-error"/"css-implicite-input" classes)
* Add a "checkbox-standalone" class to allow standalone checkbox labels to match those of other kinds of standalone fields (e.g. text inputs, etc...)
* Cover the "checkbox-standalone" class in the documentation's how to implement section.
* Enhance the look of required standalone checkboxes:
  * Prevent wildcard symbols from shifting downwards if a validation error appears
  * Prevent multi-line labels from causing the checkbox/label to appear on a different line than the wildcard
  * Don't change the label to dark red if a validation error appears

CC @StdGit @delisma

**Screenshots...**

**Before #8397:**
![checkbox-required-before-pr-8397](https://user-images.githubusercontent.com/1907279/128901361-b8546a38-9701-4a72-91f6-cb4ff86d1cc2.png)

**After #8397:**
![checkbox-required-after-pr-8397](https://user-images.githubusercontent.com/1907279/128901409-6b9f71a6-9ac0-45bd-86f7-b3cfde8f8528.png)

**After this PR (without bolding):**
![checkbox-required-after-pr-9150-v2](https://user-images.githubusercontent.com/1907279/129105983-1a498c96-bd86-4a48-9d24-3bf7fc3442b4.png)

**After this PR (with bolding):**
![checkbox-required-after-pr-9150-bold-v2](https://user-images.githubusercontent.com/1907279/129105993-22c7c481-93ab-497c-b409-b813d9a741f0.png)