### PR TITLE
Disable event: Remove trailing ampersand when exiting basic HTML mode

### DIFF
--- a/src/plugins/wb-disable/disable.js
+++ b/src/plugins/wb-disable/disable.js
@@ -72,7 +72,7 @@ var componentName = "wb-disable",
 					}
 
 					// Remove variable from URL
-					var lc = window.location.href.replace( "wbdisable=false", "" ).replace( "?#", "#" );
+					var lc = window.location.href.replace( /&?wbdisable=false/gi, "" ).replace( "?#", "#" );
 					if ( lc.indexOf( "?" ) === ( lc.length - 1 ) ) {
 						lc = lc.replace( "?", "" );
 					}


### PR DESCRIPTION
Activating the "switch to standard version" link while in basic HTML mode previously caused a trailing ampersand to appear in the URL if the page contained multiple URL parameters.

This removes it by using a case-insensitive regex to check for an optional ampersand before "wbdisable=false".

Complements #9144.

**Example of an affected URL:**
https://wet-boew.github.io/v4.0-ci/index-en.html?param=0&wbdisable=true

**Before (upon switching to standard version):**
https://wet-boew.github.io/v4.0-ci/index-en.html?param=0&

**After (upon switching to standard version):**
https://wet-boew.github.io/v4.0-ci/index-en.html?param=0