### PR TITLE
Form validation: Use normal spaces for radio/checkbox examples

### DIFF
--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2020-12-23"
+	"dateModified": "2021-08-11"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -354,16 +354,16 @@
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Favourite pets</span> <strong class="required">(required)</strong></legend>
 				<div class="checkbox">
-					<label for="animal1"><input type="checkbox" name="animal" value="1" id="animal1" data-rule-required="true" />&#160;&#160;Dog</label>
+					<label for="animal1"><input type="checkbox" name="animal" value="1" id="animal1" data-rule-required="true" /> Dog</label>
 				</div>
 				<div class="checkbox">
-					<label for="animal2"><input type="checkbox" name="animal" value="2" id="animal2" />&#160;&#160;Cat</label>
+					<label for="animal2"><input type="checkbox" name="animal" value="2" id="animal2" /> Cat</label>
 				</div>
 				<div class="checkbox">
-					<label for="animal3"><input type="checkbox" name="animal" value="3" id="animal3" />&#160;&#160;Fish</label>
+					<label for="animal3"><input type="checkbox" name="animal" value="3" id="animal3" /> Fish</label>
 				</div>
 				<div class="checkbox">
-					<label for="animal4"><input type="checkbox" name="animal" value="4" id="animal4" />&#160;&#160;Other</label>
+					<label for="animal4"><input type="checkbox" name="animal" value="4" id="animal4" /> Other</label>
 				</div>
 			</fieldset>
 			<details class="mrgn-bttm-md">
@@ -375,16 +375,16 @@
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Favourite pets&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="animal1"&gt;&lt;input type="checkbox" name="animal" value="1" id="animal1" data-rule-required="true" /&gt;&amp;#160;&amp;#160;Dog&lt;/label&gt;
+				&lt;label for="animal1"&gt;&lt;input type="checkbox" name="animal" value="1" id="animal1" data-rule-required="true" /&gt; Dog&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="animal2"&gt;&lt;input type="checkbox" name="animal" value="2" id="animal2" /&gt;&amp;#160;&amp;#160;Cat&lt;/label&gt;
+				&lt;label for="animal2"&gt;&lt;input type="checkbox" name="animal" value="2" id="animal2" /&gt; Cat&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="animal3"&gt;&lt;input type="checkbox" name="animal" value="3" id="animal3" /&gt;&amp;#160;&amp;#160;Fish&lt;/label&gt;
+				&lt;label for="animal3"&gt;&lt;input type="checkbox" name="animal" value="3" id="animal3" /&gt; Fish&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="animal4"&gt;&lt;input type="checkbox" name="animal" value="4" id="animal4" /&gt;&amp;#160;&amp;#160;Other&lt;/label&gt;
+				&lt;label for="animal4"&gt;&lt;input type="checkbox" name="animal" value="4" id="animal4" /&gt; Other&lt;/label&gt;
 			&lt;/div&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>
@@ -392,16 +392,16 @@
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Citizenship status</span> <strong class="required">(required)</strong></legend>
 				<div class="radio">
-					<label for="status1"><input type="radio" name="status" value="1" id="status1" data-rule-required="true" />&#160;&#160;Canadian citizen</label>
+					<label for="status1"><input type="radio" name="status" value="1" id="status1" data-rule-required="true" /> Canadian citizen</label>
 				</div>
 				<div class="radio">
-					<label for="status2"><input type="radio" name="status" value="2" id="status2" />&#160;&#160;Permanent resident</label>
+					<label for="status2"><input type="radio" name="status" value="2" id="status2" /> Permanent resident</label>
 				</div>
 				<div class="radio">
-					<label for="status3"><input type="radio" name="status" value="3" id="status3" />&#160;&#160;Work permit</label>
+					<label for="status3"><input type="radio" name="status" value="3" id="status3" /> Work permit</label>
 				</div>
 				<div class="radio">
-					<label for="status4"><input type="radio" name="status" value="4" id="status4" />&#160;&#160;Other</label>
+					<label for="status4"><input type="radio" name="status" value="4" id="status4" /> Other</label>
 				</div>
 			</fieldset>
 			<details class="mrgn-bttm-md">
@@ -413,16 +413,16 @@
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Citizenship status&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="status1"&gt;&lt;input type="radio" name="status" value="1" id="status1" data-rule-required="true" /&gt;&amp;#160;&amp;#160;Canadian citizen&lt;/label&gt;
+				&lt;label for="status1"&gt;&lt;input type="radio" name="status" value="1" id="status1" data-rule-required="true" /&gt; Canadian citizen&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="status2"&gt;&lt;input type="radio" name="status" value="2" id="status2" /&gt;&amp;#160;&amp;#160;Permanent resident&lt;/label&gt;
+				&lt;label for="status2"&gt;&lt;input type="radio" name="status" value="2" id="status2" /&gt; Permanent resident&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="status3"&gt;&lt;input type="radio" name="status" value="3" id="status3" /&gt;&amp;#160;&amp;#160;Work permit&lt;/label&gt;
+				&lt;label for="status3"&gt;&lt;input type="radio" name="status" value="3" id="status3" /&gt; Work permit&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="status4"&gt;&lt;input type="radio" name="status" value="4" id="status4" /&gt;&amp;#160;&amp;#160;Other&lt;/label&gt;
+				&lt;label for="status4"&gt;&lt;input type="radio" name="status" value="4" id="status4" /&gt; Other&lt;/label&gt;
 			&lt;/div&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2020-12-23"
+	"dateModified": "2021-08-11"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -354,16 +354,16 @@
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Animaux favoris</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="checkbox">
-					<label for="animal1"><input type="checkbox" name="animal" value="1" id="animal1" data-rule-required="true" />&#160;&#160;Chien</label>
+					<label for="animal1"><input type="checkbox" name="animal" value="1" id="animal1" data-rule-required="true" /> Chien</label>
 				</div>
 				<div class="checkbox">
-					<label for="animal2"><input type="checkbox" name="animal" value="2" id="animal2" />&#160;&#160;Chat</label>
+					<label for="animal2"><input type="checkbox" name="animal" value="2" id="animal2" /> Chat</label>
 				</div>
 				<div class="checkbox">
-					<label for="animal3"><input type="checkbox" name="animal" value="3" id="animal3" />&#160;&#160;Poisson</label>
+					<label for="animal3"><input type="checkbox" name="animal" value="3" id="animal3" /> Poisson</label>
 				</div>
 				<div class="checkbox">
-					<label for="animal4"><input type="checkbox" name="animal" value="4" id="animal4" />&#160;&#160;Autre</label>
+					<label for="animal4"><input type="checkbox" name="animal" value="4" id="animal4" /> Autre</label>
 				</div>
 			</fieldset>
 			<details class="mrgn-bttm-md">
@@ -375,16 +375,16 @@
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Animaux favoris&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="animal1"&gt;&lt;input type="checkbox" name="animal" value="1" id="animal1" data-rule-required="true" /&gt;&amp;#160;&amp;#160;Chien&lt;/label&gt;
+				&lt;label for="animal1"&gt;&lt;input type="checkbox" name="animal" value="1" id="animal1" data-rule-required="true" /&gt; Chien&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="animal2"&gt;&lt;input type="checkbox" name="animal" value="2" id="animal2" /&gt;&amp;#160;&amp;#160;Chat&lt;/label&gt;
+				&lt;label for="animal2"&gt;&lt;input type="checkbox" name="animal" value="2" id="animal2" /&gt; Chat&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="animal3"&gt;&lt;input type="checkbox" name="animal" value="3" id="animal3" /&gt;&amp;#160;&amp;#160;Poisson&lt;/label&gt;
+				&lt;label for="animal3"&gt;&lt;input type="checkbox" name="animal" value="3" id="animal3" /&gt; Poisson&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="animal4"&gt;&lt;input type="checkbox" name="animal" value="4" id="animal4" /&gt;&amp;#160;&amp;#160;Autre&lt;/label&gt;
+				&lt;label for="animal4"&gt;&lt;input type="checkbox" name="animal" value="4" id="animal4" /&gt; Autre&lt;/label&gt;
 			&lt;/div&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>
@@ -392,16 +392,16 @@
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Statut de citoyen</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="radio">
-					<label for="status1"><input type="radio" name="status" value="1" id="status1" data-rule-required="true" />&#160;&#160;Citoyen canadien</label>
+					<label for="status1"><input type="radio" name="status" value="1" id="status1" data-rule-required="true" /> Citoyen canadien</label>
 				</div>
 				<div class="radio">
-					<label for="status2"><input type="radio" name="status" value="2" id="status2" />&#160;&#160;Résident permanent</label>
+					<label for="status2"><input type="radio" name="status" value="2" id="status2" /> Résident permanent</label>
 				</div>
 				<div class="radio">
-					<label for="status3"><input type="radio" name="status" value="3" id="status3" />&#160;&#160;Permis de travail</label>
+					<label for="status3"><input type="radio" name="status" value="3" id="status3" /> Permis de travail</label>
 				</div>
 				<div class="radio">
-					<label for="status4"><input type="radio" name="status" value="4" id="status4" />&#160;&#160;Autre</label>
+					<label for="status4"><input type="radio" name="status" value="4" id="status4" /> Autre</label>
 				</div>
 			</fieldset>
 			<details class="mrgn-bttm-md">
@@ -413,16 +413,16 @@
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Statut de citoyen&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="status1"&gt;&lt;input type="radio" name="status" value="1" id="status1" data-rule-required="true" /&gt;&#160;&#160;Citoyen canadien&lt;/label&gt;
+				&lt;label for="status1"&gt;&lt;input type="radio" name="status" value="1" id="status1" data-rule-required="true" /&gt; Citoyen canadien&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="status2"&gt;&lt;input type="radio" name="status" value="2" id="status2" /&gt;&#160;&#160;Résident permanent&lt;/label&gt;
+				&lt;label for="status2"&gt;&lt;input type="radio" name="status" value="2" id="status2" /&gt; Résident permanent&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="status3"&gt;&lt;input type="radio" name="status" value="3" id="status3" /&gt;&#160;&#160;Permis de travail&lt;/label&gt;
+				&lt;label for="status3"&gt;&lt;input type="radio" name="status" value="3" id="status3" /&gt; Permis de travail&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="status4"&gt;&lt;input type="radio" name="status" value="4" id="status4" /&gt;&#160;&#160;Autre&lt;/label&gt;
+				&lt;label for="status4"&gt;&lt;input type="radio" name="status" value="4" id="status4" /&gt; Autre&lt;/label&gt;
 			&lt;/div&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>

--- a/src/plugins/formvalid/formvalid-server-en.hbs
+++ b/src/plugins/formvalid/formvalid-server-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid-server",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid-server",
-	"dateModified": "2018-06-28"
+	"dateModified": "2021-08-11"
 }
 ---
 
@@ -116,28 +116,28 @@
 
 					<fieldset class="legend-brdr-bttm">
 						<legend class="required"><span class="field-name">Citizen Status</span> <strong class="required">(Required field)</strong></legend>
-						<div class="radio required"><label for="MainContent_wbRadioButtonList0_radioButtonList0_0"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_0" required="required" type="radio" checked="checked" value="radioButtonList0_0v"><span>&nbsp;&nbsp;Canadian citizen</span> </label></div>
+						<div class="radio required"><label for="MainContent_wbRadioButtonList0_radioButtonList0_0"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_0" required="required" type="radio" checked="checked" value="radioButtonList0_0v"><span> Canadian citizen</span> </label></div>
 						<div class="radio">
-							<label for="MainContent_wbRadioButtonList0_radioButtonList0_1"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_1" type="radio" value="radioButtonList0_1v"><span>&nbsp;&nbsp;Permanent resident</span> </label></div>
+							<label for="MainContent_wbRadioButtonList0_radioButtonList0_1"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_1" type="radio" value="radioButtonList0_1v"><span> Permanent resident</span> </label></div>
 						<div class="radio">
-							<label for="MainContent_wbRadioButtonList0_radioButtonList0_2"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_2" type="radio" value="radioButtonList0_2v"><span>&nbsp;&nbsp;Work permit</span></label></div>
+							<label for="MainContent_wbRadioButtonList0_radioButtonList0_2"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_2" type="radio" value="radioButtonList0_2v"><span> Work permit</span></label></div>
 					</fieldset>
 
 					<fieldset class="legend-brdr-bttm">
 						<legend class="required"><span class="field-name">Contact Information</span> <strong class="required">(Required field)</strong><span class="label label-danger wb-server-error" id="MainContent_wbCheckBoxList0Cv"><strong><span class="prefix">Error&nbsp;3: </span>You can't choose more than 2 checkboxes</strong></span></legend>
 						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_0">
 								<input name="checkBoxList0" class="required_js valid" id="MainContent_wbCheckBoxList0_checkBoxList0_0" aria-invalid="false" required="required" type="checkbox" checked="checked" value="checkBoxList0_0v">
-								<span>&nbsp;&nbsp;<span class="field-name">Contact me by email</span></span>
+								<span> <span class="field-name">Contact me by email</span></span>
 							</label></div>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_1"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_1" type="checkbox" checked="checked" value="checkBoxList0_1v"><span>&nbsp;&nbsp;<span class="field-name">Contact me by phone</span></span> </label></div>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_2"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_2" type="checkbox" checked="checked" value="checkBoxList0_2v"><span>&nbsp;&nbsp;<span class="field-name">Contact me by text messaging</span></span></label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_1"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_1" type="checkbox" checked="checked" value="checkBoxList0_1v"><span> <span class="field-name">Contact me by phone</span></span> </label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_2"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_2" type="checkbox" checked="checked" value="checkBoxList0_2v"><span> <span class="field-name">Contact me by text messaging</span></span></label></div>
 					</fieldset>
 
 					<fieldset class="legend-brdr-bttm">
 						<legend class="required"><span class="field-name">Signature</span> <strong class="required">(Required field)</strong></legend>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_0"><input name="checkBoxList1" class="required_js valid" id="MainContent_wbCheckBoxList1_checkBoxList1_0" required="required" type="checkbox" checked="checked" value="checkBoxList1_0v"><span>&nbsp;&nbsp;<span class="field-name">Print this page</span></span> </label></div>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_1"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_1" type="checkbox" value="checkBoxList1_1v"><span>&nbsp;&nbsp;<span class="field-name">Please send me more information</span></span> </label></div>
-						<div class="checkbox required"><label for="MainContent_wbCheckBoxList1_checkBoxList1_2"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_2" aria-invalid="false" required="required" type="checkbox" value="checkBoxList1_2v"><span>&nbsp;&nbsp;<span class="field-name">I agree with the directives</span><strong class="required"> (Required field)</strong></span><span class="label label-danger wb-server-error" id="MainContent_wbCheckBoxList1_checkBoxList1_2Cv"><strong><span class="prefix">Error&nbsp;4: </span>This field is mandatory</strong></span></label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_0"><input name="checkBoxList1" class="required_js valid" id="MainContent_wbCheckBoxList1_checkBoxList1_0" required="required" type="checkbox" checked="checked" value="checkBoxList1_0v"><span> <span class="field-name">Print this page</span></span> </label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_1"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_1" type="checkbox" value="checkBoxList1_1v"><span> <span class="field-name">Please send me more information</span></span> </label></div>
+						<div class="checkbox required"><label for="MainContent_wbCheckBoxList1_checkBoxList1_2"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_2" aria-invalid="false" required="required" type="checkbox" value="checkBoxList1_2v"><span> <span class="field-name">I agree with the directives</span><strong class="required"> (Required field)</strong></span><span class="label label-danger wb-server-error" id="MainContent_wbCheckBoxList1_checkBoxList1_2Cv"><strong><span class="prefix">Error&nbsp;4: </span>This field is mandatory</strong></span></label></div>
 					</fieldset>
 
 					<ul class="list-inline">

--- a/src/plugins/formvalid/formvalid-server-fr.hbs
+++ b/src/plugins/formvalid/formvalid-server-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid-server",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid-server",
-	"dateModified": "2018-06-28"
+	"dateModified": "2021-08-11"
 }
 ---
 
@@ -93,9 +93,9 @@
 
 					<fieldset class="legend-brdr-bttm">
 						<legend class="required"><span class="field-name">Statut de citoyen</span> <strong class="required">(Champ requis)</strong></legend>
-						<div class="radio required"><label for="MainContent_wbRadioButtonList0_radioButtonList0_0"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_0" required="required" type="radio" checked="checked" value="radioButtonList0_0v"><span>&nbsp;&nbsp;Citoyen canadien</span> </label></div>
-						<div class="radio"><label for="MainContent_wbRadioButtonList0_radioButtonList0_1"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_1" type="radio" value="radioButtonList0_1v"><span>&nbsp;&nbsp;Résident permanent</span> </label></div>
-						<div class="radio"><label for="MainContent_wbRadioButtonList0_radioButtonList0_2"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_2" type="radio" value="radioButtonList0_2v"><span>&nbsp;&nbsp;Permis de travail</span> </label></div>
+						<div class="radio required"><label for="MainContent_wbRadioButtonList0_radioButtonList0_0"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_0" required="required" type="radio" checked="checked" value="radioButtonList0_0v"><span> Citoyen canadien</span> </label></div>
+						<div class="radio"><label for="MainContent_wbRadioButtonList0_radioButtonList0_1"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_1" type="radio" value="radioButtonList0_1v"><span> Résident permanent</span> </label></div>
+						<div class="radio"><label for="MainContent_wbRadioButtonList0_radioButtonList0_2"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_2" type="radio" value="radioButtonList0_2v"><span> Permis de travail</span> </label></div>
 					</fieldset>
 
 					<fieldset class="legend-brdr-bttm">
@@ -104,16 +104,16 @@
 							<span class="label label-danger wb-server-error" id="MainContent_wbCheckBoxList0Cv"><strong><span class="prefix">Erreur&nbsp;3&nbsp;:
 									</span>Vous ne pouvez sélectionner plus de 2 cases à cocher</strong></span>
 						</legend>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_0"><input name="checkBoxList0" class="required_js valid" id="MainContent_wbCheckBoxList0_checkBoxList0_0" aria-invalid="false" required="required" type="checkbox" checked="checked" value="checkBoxList0_0v"><span>&nbsp;&nbsp;<span class="field-name">Contactez-moi par courrier électronique</span></span> </label></div>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_1"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_1" type="checkbox" checked="checked" value="checkBoxList0_1v"><span>&nbsp;&nbsp;<span class="field-name">Contactez-moi par téléphone</span></span> </label></div>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_2"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_2" type="checkbox" checked="checked" value="checkBoxList0_2v"><span>&nbsp;&nbsp;<span class="field-name">Contactez-moi par message texte</span></span> </label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_0"><input name="checkBoxList0" class="required_js valid" id="MainContent_wbCheckBoxList0_checkBoxList0_0" aria-invalid="false" required="required" type="checkbox" checked="checked" value="checkBoxList0_0v"><span> <span class="field-name">Contactez-moi par courrier électronique</span></span> </label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_1"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_1" type="checkbox" checked="checked" value="checkBoxList0_1v"><span> <span class="field-name">Contactez-moi par téléphone</span></span> </label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_2"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_2" type="checkbox" checked="checked" value="checkBoxList0_2v"><span> <span class="field-name">Contactez-moi par message texte</span></span> </label></div>
 					</fieldset>
 
 					<fieldset class="legend-brdr-bttm">
 						<legend class="required"><span class="field-name">Signature</span> <strong class="required">(Champ requis)</strong></legend>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_0"><input name="checkBoxList1" class="required_js valid" id="MainContent_wbCheckBoxList1_checkBoxList1_0" required="required" type="checkbox" checked="checked" value="checkBoxList1_0v"><span>&nbsp;&nbsp;<span class="field-name">Imprimer cette page</span></span> </label></div>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_1"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_1" type="checkbox" value="checkBoxList1_1v"><span>&nbsp;&nbsp;<span class="field-name">Veuillez m'envoyer de l'information complémentaire</span></span> </label></div>
-						<div class="checkbox required"><label for="MainContent_wbCheckBoxList1_checkBoxList1_2"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_2" aria-invalid="false" required="required" type="checkbox" value="checkBoxList1_2v"><span>&nbsp;&nbsp;<span class="field-name">Je suis en accord avec les directives</span><strong class="required"> (Champ requis)</strong></span><span class="label label-danger wb-server-error" id="MainContent_wbCheckBoxList1_checkBoxList1_2Cv"><strong><span class="prefix">Erreur&nbsp;4&nbsp;: </span>Ce champs est obligatoire</strong></span> </label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_0"><input name="checkBoxList1" class="required_js valid" id="MainContent_wbCheckBoxList1_checkBoxList1_0" required="required" type="checkbox" checked="checked" value="checkBoxList1_0v"><span> <span class="field-name">Imprimer cette page</span></span> </label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_1"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_1" type="checkbox" value="checkBoxList1_1v"><span> <span class="field-name">Veuillez m'envoyer de l'information complémentaire</span></span> </label></div>
+						<div class="checkbox required"><label for="MainContent_wbCheckBoxList1_checkBoxList1_2"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_2" aria-invalid="false" required="required" type="checkbox" value="checkBoxList1_2v"><span> <span class="field-name">Je suis en accord avec les directives</span><strong class="required"> (Champ requis)</strong></span><span class="label label-danger wb-server-error" id="MainContent_wbCheckBoxList1_checkBoxList1_2Cv"><strong><span class="prefix">Erreur&nbsp;4&nbsp;: </span>Ce champs est obligatoire</strong></span> </label></div>
 					</fieldset>
 
 					<ul class="list-inline">


### PR DESCRIPTION
Many checkbox/radio button examples were previously using two non-breaking spaces to create a large space between their inputs and labels.

That was a bad practice due to the following:
* Went against the idea of using CSS to separate content from presentation
* Caused horizontal alignment to be inconsistent in multi-line labels
* The space looked overly large

This resolves it by replacing the non-breaking spaces with single normal space characters.

CC @StdGit