### PR TITLE
Disable event: Remove & if wbdisable=false is first of many params

### DIFF
--- a/src/plugins/wb-disable/disable.js
+++ b/src/plugins/wb-disable/disable.js
@@ -72,7 +72,7 @@ var componentName = "wb-disable",
 					}
 
 					// Remove variable from URL
-					var lc = window.location.href.replace( /&?wbdisable=false/gi, "" ).replace( "?#", "#" );
+					var lc = window.location.href.replace( /&?wbdisable=false/gi, "" ).replace( "?&", "?" ).replace( "?#", "#" );
 					if ( lc.indexOf( "?" ) === ( lc.length - 1 ) ) {
 						lc = lc.replace( "?", "" );
 					}


### PR DESCRIPTION
This removes a superfluous ampersand from the current page's URL if it contains multiple parameters and the first one happens to be wbdisable=false.

Supplements #9151 (which only handled ampersands preceding wbdisable=false).

**Example of an affected URL:**
https://wet-boew.github.io/v4.0-ci/index-en.html?wbdisable=false&param=0

**Before:**
https://wet-boew.github.io/v4.0-ci/index-en.html?&param=0

**After:**
https://wet-boew.github.io/v4.0-ci/index-en.html?param=0

CC @GormFrank (btw sorry... wasn't planning on a trilogy of PRs lol)