### PR TITLE
ESLint: Allow IE11-friendly ES6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,16 @@
 {
+  "plugins": [
+    "es5",
+    "ie11"
+  ],
   "extends": [
     "eslint:recommended",
-    "jquery"
+    "jquery",
+    "plugin:es5/no-es2015"
   ],
   "env": {
     "browser": true,
+    "es6": true,
     "jquery": true
   },
   "globals": {
@@ -30,7 +36,13 @@
     ],
     "no-irregular-whitespace": 2,
     "no-nested-ternary": 0,
-    "linebreak-style": 0
+    "linebreak-style": 0,
+    "es5/no-block-scoping": ["error", { "const": true, "let": true }],
+    "es5/no-es6-methods": ["error", { "exceptMethods": ["find"] }],
+    "ie11/no-collection-args": [ "error" ],
+    "ie11/no-for-in-const": [ "error" ],
+    "ie11/no-loop-func": [ "error" ],
+    "ie11/no-weak-collections": [ "error" ]
   },
   "overrides": [
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3586,6 +3586,20 @@
       "integrity": "sha512-VDdRAIlNq1EM5P7J4JGQSCnZEIvIlNGGTUTCPT2wQNZ2GT69rsAwSIqZVcoiyZbwY7TaaMwLOxwSjqm+DEUjbA==",
       "dev": true
     },
+    "eslint-plugin-es5": {
+      "version": "git+https://github.com/skyway777/eslint-plugin-es5.git#470d588607ff0c9f98a9b570d182cdb708d134cf",
+      "from": "git+https://github.com/skyway777/eslint-plugin-es5.git#470d588607ff0c9f98a9b570d182cdb708d134cf",
+      "dev": true
+    },
+    "eslint-plugin-ie11": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-ie11/-/eslint-plugin-ie11-1.0.0.tgz",
+      "integrity": "sha512-PPv2Cbq5roUmoIZJfPWbEEILHvi2Yfp/cRVzaVKL/YJiYGGLJ0/Qrq1HKd2OZKb3RQQOXweCd/hh261bljEe8A==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.1.0"
+      }
+    },
     "eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -11121,6 +11135,12 @@
         "caller-path": "^0.1.0",
         "resolve-from": "^1.0.0"
       }
+    },
+    "requireindex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+      "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+      "dev": true
     },
     "requizzle": {
       "version": "0.2.3",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,8 @@
     "autoprefixer": "^10.2.5",
     "coffeescript": "^2.5.1",
     "eslint-config-jquery": "^3.0.0",
+    "eslint-plugin-es5": "git+https://github.com/skyway777/eslint-plugin-es5.git#470d588607ff0c9f98a9b570d182cdb708d134cf",
+    "eslint-plugin-ie11": "^1.0.0",
     "expect.js": "^0.3.1",
     "grunt": "^1.3.0",
     "grunt-assemble": "~0.6.3",


### PR DESCRIPTION
* Set ESLint's environment to ES6 to prevent ``let``/``const``/``Map`` from triggering errors
* Use eslint-plugin-es5 to disallow most of ES6's other features
  * Relies on a fork (nkt/eslint-plugin-es5#39) to exempt jQuery's ``find()`` method
    * The exemption also covers ES6's native ``find()`` methods (which are unsupported by IE11...)
* Use eslint-plugin-ie11 to detect unsupported use cases in IE11
* Related to #9146