### PR TITLE
Form validation: Normalize required fieldsets

### DIFF
--- a/site/includes/alertfieldsetrequired.hbs
+++ b/site/includes/alertfieldsetrequired.hbs
@@ -1,0 +1,8 @@
+{{! Page content include}}
+<div class="alert alert-info">
+{{#contains language "en"}}
+	<p>It is recommended to use <code>data-rule-required="true"</code> vs <code>required="required"</code> in required <code>&lt;fieldset&gt;</code> elements as this avoids screen readers indicating that the first option is required.</p>
+{{else}}
+	<p>Il est recommandé d'utiliser <code>data-rule-required="true"</code> au lieu de <code>required="required"</code> dans les éléments <code>&lt;fieldset&gt;</code> obligatoires puisque cela permet d'éviter que les lecteurs d'écran indiquent que la première option est obligatoire.</p>
+{{/contains}}
+</div>

--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2025-02-26"
+	"dateModified": "2026-04-21"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -392,7 +392,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
-				<div class="alert alert-info"><p>It is recommended to use <code>data-rule-required="true"</code> vs <code>required="required"</code> as this avoids screen readers indicating that the first option is required.</p></div>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -430,7 +430,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
-				<div class="alert alert-info"><p>It is recommended to use <code>data-rule-required="true"</code> vs <code>required="required"</code> as this avoids screen readers indicating that the first option is required.</p></div>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -514,7 +514,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
-				{{>alertariahidden}}
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld required-no-asterisk"&gt;
 	&lt;form action="#" method="get" id="validation-example-4"&gt;
 		...
@@ -579,7 +579,7 @@
 				<legend class="required"><span class="field-name">Stacked checkboxes in a <code>&lt;li&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
 				<ul class="form-group list-unstyled">
 					<li class="checkbox">
-						<label for="example1a"><input type="checkbox" name="example1" value="1" id="example1a" required="required">Apple</label>
+						<label for="example1a"><input type="checkbox" name="example1" value="1" id="example1a" data-rule-required="true">Apple</label>
 					</li>
 					<li class="checkbox">
 						<label for="example1b"><input type="checkbox" name="example1" value="2" id="example1b">Orange</label>
@@ -594,6 +594,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -601,7 +602,7 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked checkboxes in a &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="example1a"&gt;&lt;input type="checkbox" name="example1" value="1" id="example1a" required="required"&gt;Apple&lt;/label&gt;
+					&lt;label for="example1a"&gt;&lt;input type="checkbox" name="example1" value="1" id="example1a" data-rule-required="true"&gt;Apple&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
 					&lt;label for="example1b"&gt;&lt;input type="checkbox" name="example1" value="2" id="example1b"&gt;Orange&lt;/label&gt;
@@ -622,7 +623,7 @@
 				<legend class="required"><span class="field-name">Stacked radio buttons in a <code>&lt;li&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
 				<ul class="form-group list-unstyled">
 					<li class="radio">
-						<label for="example2a"><input type="radio" name="example2" value="1" id="example2a" required="required">Apple</label>
+						<label for="example2a"><input type="radio" name="example2" value="1" id="example2a" data-rule-required="true">Apple</label>
 					</li>
 					<li class="radio">
 						<label for="example2b"><input type="radio" name="example2" value="2" id="example2b">Orange</label>
@@ -637,6 +638,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -644,7 +646,7 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked radio buttons in a &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="example2a"&gt;&lt;input type="radio" name="example2" value="1" id="example2a" required="required"&gt;Apple&lt;/label&gt;
+					&lt;label for="example2a"&gt;&lt;input type="radio" name="example2" value="1" id="example2a" data-rule-required="true"&gt;Apple&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
 					&lt;label for="example2b"&gt;&lt;input type="radio" name="example2" value="2" id="example2b"&gt;Orange&lt;/label&gt;
@@ -664,7 +666,7 @@
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Stacked checkboxes in a <code>&lt;div&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
 				<div class="checkbox">
-					<label for="example3a"><input type="checkbox" name="example3" value="1" id="example3a" required="required">Apple</label>
+					<label for="example3a"><input type="checkbox" name="example3" value="1" id="example3a" data-rule-required="true">Apple</label>
 				</div>
 				<div class="checkbox">
 					<label for="example3b"><input type="checkbox" name="example3" value="2" id="example3b">Orange</label>
@@ -678,13 +680,14 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked checkboxes in a &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="example3a"&gt;&lt;input type="checkbox" name="example3" value="1" id="example3a" required="required"&gt;Apple&lt;/label&gt;
+				&lt;label for="example3a"&gt;&lt;input type="checkbox" name="example3" value="1" id="example3a" data-rule-required="true"&gt;Apple&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
 				&lt;label for="example3b"&gt;&lt;input type="checkbox" name="example3" value="2" id="example3b"&gt;Orange&lt;/label&gt;
@@ -703,7 +706,7 @@
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Stacked radio buttons in a <code>&lt;div&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
 				<div class="radio">
-					<label for="example4a"><input type="radio" name="example4" value="1" id="example4a" required="required">Apple</label>
+					<label for="example4a"><input type="radio" name="example4" value="1" id="example4a" data-rule-required="true">Apple</label>
 				</div>
 				<div class="radio">
 					<label for="example4b"><input type="radio" name="example4" value="2" id="example4b">Orange</label>
@@ -717,13 +720,14 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked radio buttons in a &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="example4a"&gt;&lt;input type="radio" name="example4" value="1" id="example4a" required="required"&gt;Apple&lt;/label&gt;
+				&lt;label for="example4a"&gt;&lt;input type="radio" name="example4" value="1" id="example4a" data-rule-required="true"&gt;Apple&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="radio"&gt;
 				&lt;label for="example4b"&gt;&lt;input type="radio" name="example4" value="2" id="example4b"&gt;Orange&lt;/label&gt;
@@ -743,7 +747,7 @@
 				<legend class="required"><span class="field-name">Horizontal checkboxes in a <code>&lt;li&gt;</code> pattern with explicit labels</span> <strong class="required">(required)</strong></legend>
 				<ul class="form-inline list-unstyled">
 					<li class="label-inline">
-						<input type="checkbox" name="example5" value="1" id="example5a" required="required">
+						<input type="checkbox" name="example5" value="1" id="example5a" data-rule-required="true">
 						<label for="example5a">Apple</label>
 					</li>
 					<li class="label-inline">
@@ -762,6 +766,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -769,7 +774,7 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal checkboxes in a &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; pattern with explicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-inline list-unstyled"&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="checkbox" name="example5" value="1" id="example5a" required="required"&gt;
+					&lt;input type="checkbox" name="example5" value="1" id="example5a" data-rule-required="true"&gt;
 					&lt;label for="example5a"&gt;Apple&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="label-inline"&gt;
@@ -793,7 +798,7 @@
 				<legend class="required"><span class="field-name">Horizontal radio buttons in a <code>&lt;li&gt;</code> pattern with explicit labels</span> <strong class="required">(required)</strong></legend>
 				<ul class="form-inline list-unstyled">
 					<li class="label-inline">
-						<input type="radio" name="example6" value="1" id="example6a" required="required">
+						<input type="radio" name="example6" value="1" id="example6a" data-rule-required="true">
 						<label for="example6a">Apple</label>
 					</li>
 					<li class="label-inline">
@@ -812,6 +817,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -819,7 +825,7 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal radio buttons in a &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; pattern with explicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-inline list-unstyled"&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="radio" name="example6" value="1" id="example6a" required="required"&gt;
+					&lt;input type="radio" name="example6" value="1" id="example6a" data-rule-required="true"&gt;
 					&lt;label for="example6a"&gt;Apple&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="label-inline"&gt;
@@ -841,19 +847,20 @@
 			<!-- Checkboxes inline with implicit labels-->
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Horizontal checkboxes in a <code>&lt;label&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
-				<label for="example7a" class="checkbox-inline"><input type="checkbox" name="example7" value="1" id="example7a" required="required">Smartphone</label>
+				<label for="example7a" class="checkbox-inline"><input type="checkbox" name="example7" value="1" id="example7a" data-rule-required="true">Smartphone</label>
 				<label for="example7b" class="checkbox-inline"><input type="checkbox" name="example7" value="2" id="example7b">Laptop</label>
 				<label for="example7c" class="checkbox-inline"><input type="checkbox" name="example7" value="3" id="example7c">Voice assistant</label>
 				<label for="example7d" class="checkbox-inline"><input type="checkbox" name="example7" value="4" id="example7d">Fusion reactor</label>
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>View code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal checkboxes in a &lt;code&gt;&amp;lt;label&gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
-			&lt;label for="example7a" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="1" id="example7a" required="required"&gt;Smartphone&lt;/label&gt;
+			&lt;label for="example7a" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="1" id="example7a" data-rule-required="true"&gt;Smartphone&lt;/label&gt;
 			&lt;label for="example7b" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="2" id="example7b"&gt;Laptop&lt;/label&gt;
 			&lt;label for="example7c" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="3" id="example7c"&gt;Voice assistant&lt;/label&gt;
 			&lt;label for="example7d" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="4" id="example7d"&gt;Fusion reactor&lt;/label&gt;
@@ -863,19 +870,20 @@
 			<!-- Radio buttons inline with implicit labels-->
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Horizontal radio buttons in a <code>&lt;label&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
-				<label for="example8a" class="radio-inline"><input type="radio" name="example8" value="1" id="example8a" required="required">Smartphone</label>
+				<label for="example8a" class="radio-inline"><input type="radio" name="example8" value="1" id="example8a" data-rule-required="true">Smartphone</label>
 				<label for="example8b" class="radio-inline"><input type="radio" name="example8" value="2" id="example8b">Laptop</label>
 				<label for="example8c" class="radio-inline"><input type="radio" name="example8" value="3" id="example8c">Voice assistant</label>
 				<label for="example8d" class="radio-inline"><input type="radio" name="example8" value="4" id="example8d">Fusion reactor</label>
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>View code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal radio buttons in a &lt;code&gt;&amp;lt;label&gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
-			&lt;label for="example8a" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="1" id="example8a" required="required"&gt;Smartphone&lt;/label&gt;
+			&lt;label for="example8a" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="1" id="example8a" data-rule-required="true"&gt;Smartphone&lt;/label&gt;
 			&lt;label for="example8b" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="2" id="example8b"&gt;Laptop&lt;/label&gt;
 			&lt;label for="example8c" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="3" id="example8c"&gt;Voice assistant&lt;/label&gt;
 			&lt;label for="example8d" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="4" id="example8d"&gt;Fusion reactor&lt;/label&gt;
@@ -886,7 +894,7 @@
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Horizontal checkboxes in a <code>&lt;div&gt;</code> pattern with explicit labels</span> <strong class="required">(required)</strong></legend>
 				<div class="label-inline">
-					<input type="checkbox" name="example9" value="1" id="example9a" required="required">
+					<input type="checkbox" name="example9" value="1" id="example9a" data-rule-required="true">
 					<label for="example9a">Smartphone</label>
 				</div>
 				<div class="label-inline">
@@ -904,13 +912,14 @@
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>View code </summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal checkboxes in a &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; pattern with explicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="checkbox" name="example9" value="1" id="example9a" required="required"&gt;
+				&lt;input type="checkbox" name="example9" value="1" id="example9a" data-rule-required="true"&gt;
 				&lt;label for="example9a"&gt;Smartphone&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="label-inline"&gt;
@@ -932,7 +941,7 @@
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Horizontal radio buttons in a <code>&lt;div&gt;</code> pattern with explicit labels</span> <strong class="required">(required)</strong></legend>
 				<div class="label-inline">
-					<input type="radio" name="example10" value="1" id="example10a" required="required">
+					<input type="radio" name="example10" value="1" id="example10a" data-rule-required="true">
 					<label for="example10a">Smartphone</label>
 				</div>
 				<div class="label-inline">
@@ -950,13 +959,14 @@
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>View code </summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal radio buttons in a &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; pattern with explicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="radio" name="example10" value="1" id="example10a" required="required"&gt;
+				&lt;input type="radio" name="example10" value="1" id="example10a" data-rule-required="true"&gt;
 				&lt;label for="example10a"&gt;Smartphone&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="label-inline"&gt;

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2025-02-26"
+	"dateModified": "2026-04-21"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -392,7 +392,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
-				<div class="alert alert-info"><p>Il est recommandé d'utiliser <code>data-rule-required="true"</code> au lieu de <code>required="required"</code> puisque cela permet d'éviter que les lecteurs d'écran indiquent que la première option est obligatoire.</p></div>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -430,7 +430,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
-				<div class="alert alert-info"><p>Il est recommandé d'utiliser <code>data-rule-required="true"</code> au lieu de <code>required="required"</code> puisque cela permet d'éviter que les lecteurs d'écran indiquent que la première option est obligatoire.</p></div>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -514,7 +514,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>View code</summary>
-				{{>alertariahidden}}
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld required-no-asterisk"&gt;
 	&lt;form action="#" method="get" id="validation-example-4"&gt;
 		...
@@ -580,7 +580,7 @@
 				<legend class="required"><span class="field-name">Cases à cocher empilées dans un modèle d'éléments <code>&lt;li&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<ul class="form-group list-unstyled">
 					<li class="checkbox">
-						<label for="example1a"><input type="checkbox" name="example1" value="1" id="example1a" required="required">Pomme</label>
+						<label for="example1a"><input type="checkbox" name="example1" value="1" id="example1a" data-rule-required="true">Pomme</label>
 					</li>
 					<li class="checkbox">
 						<label for="example1b"><input type="checkbox" name="example1" value="2" id="example1b">Orange</label>
@@ -595,6 +595,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -602,7 +603,7 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher empilées dans un modèle d'éléments &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="example1a"&gt;&lt;input type="checkbox" name="example1" value="1" id="example1a" required="required"&gt;Pomme&lt;/label&gt;
+					&lt;label for="example1a"&gt;&lt;input type="checkbox" name="example1" value="1" id="example1a" data-rule-required="true"&gt;Pomme&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
 					&lt;label for="example1b"&gt;&lt;input type="checkbox" name="example1" value="2" id="example1b"&gt;Orange&lt;/label&gt;
@@ -623,7 +624,7 @@
 				<legend class="required"><span class="field-name">Boutons radio verticaux dans un modèle d'éléments <code>&lt;li&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<ul class="form-group list-unstyled">
 					<li class="radio">
-						<label for="example2a"><input type="radio" name="example2" value="1" id="example2a" required="required">Pomme</label>
+						<label for="example2a"><input type="radio" name="example2" value="1" id="example2a" data-rule-required="true">Pomme</label>
 					</li>
 					<li class="radio">
 						<label for="example2b"><input type="radio" name="example2" value="2" id="example2b">Orange</label>
@@ -638,6 +639,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -645,7 +647,7 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radio verticaux dans un modèle d'éléments &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="example2a"&gt;&lt;input type="radio" name="example2" value="1" id="example2a" required="required"&gt;Pomme&lt;/label&gt;
+					&lt;label for="example2a"&gt;&lt;input type="radio" name="example2" value="1" id="example2a" data-rule-required="true"&gt;Pomme&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
 					&lt;label for="example2b"&gt;&lt;input type="radio" name="example2" value="2" id="example2b"&gt;Orange&lt;/label&gt;
@@ -665,7 +667,7 @@
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Cases à cocher empilées dans un modèle d’éléments <code>&lt;div&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="checkbox">
-					<label for="example3a"><input type="checkbox" name="example3" value="1" id="example3a" required="required">Pomme</label>
+					<label for="example3a"><input type="checkbox" name="example3" value="1" id="example3a" data-rule-required="true">Pomme</label>
 				</div>
 				<div class="checkbox">
 					<label for="example3b"><input type="checkbox" name="example3" value="2" id="example3b">Orange</label>
@@ -679,13 +681,14 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher empilées dans un modèle d’éléments &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="example3a"&gt;&lt;input type="checkbox" name="example3" value="1" id="example3a" required="required"&gt;Pomme&lt;/label&gt;
+				&lt;label for="example3a"&gt;&lt;input type="checkbox" name="example3" value="1" id="example3a" data-rule-required="true"&gt;Pomme&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
 				&lt;label for="example3b"&gt;&lt;input type="checkbox" name="example3" value="2" id="example3b"&gt;Orange&lt;/label&gt;
@@ -704,7 +707,7 @@
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Boutons radios empilés dans un modèle d’éléments <code>&lt;div&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="radio">
-					<label for="example4a"><input type="radio" name="example4" value="1" id="example4a" required="required">Pomme</label>
+					<label for="example4a"><input type="radio" name="example4" value="1" id="example4a" data-rule-required="true">Pomme</label>
 				</div>
 				<div class="radio">
 					<label for="example4b"><input type="radio" name="example4" value="2" id="example4b">Orange</label>
@@ -718,13 +721,14 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radios empilés dans un modèle d’éléments &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="radio"&gt;
-				&lt;label for="example4a"&gt;&lt;input type="radio" name="example4" value="1" id="example4a" required="required"&gt;Pomme&lt;/label&gt;
+				&lt;label for="example4a"&gt;&lt;input type="radio" name="example4" value="1" id="example4a" data-rule-required="true"&gt;Pomme&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="radio"&gt;
 				&lt;label for="example4b"&gt;&lt;input type="radio" name="example4" value="2" id="example4b"&gt;Orange&lt;/label&gt;
@@ -744,7 +748,7 @@
 				<legend class="required"><span class="field-name">Cases à cocher horizontales dans un modèle d'éléments <code>&lt;li&gt;</code> comportant des étiquettes explicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<ul class="form-inline list-unstyled">
 					<li class="label-inline">
-						<input type="checkbox" name="example5" value="1" id="example5a" required="required">
+						<input type="checkbox" name="example5" value="1" id="example5a" data-rule-required="true">
 						<label for="example5a">Pomme</label>
 					</li>
 					<li class="label-inline">
@@ -763,6 +767,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -770,7 +775,7 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher horizontales dans un modèle d'éléments &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; comportant des étiquettes explicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-inline list-unstyled"&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="checkbox" name="example5" value="1" id="example5a" required="required"&gt;
+					&lt;input type="checkbox" name="example5" value="1" id="example5a" data-rule-required="true"&gt;
 					&lt;label for="example5a"&gt;Pomme&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="label-inline"&gt;
@@ -794,7 +799,7 @@
 				<legend class="required"><span class="field-name">Boutons radios horizontaux dans un modèle d'éléments <code>&lt;li&gt;</code> comportant des étiquettes explicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<ul class="form-inline list-unstyled">
 					<li class="label-inline">
-						<input type="radio" name="example6" value="1" id="example6a" required="required">
+						<input type="radio" name="example6" value="1" id="example6a" data-rule-required="true">
 						<label for="example6a">Pomme</label>
 					</li>
 					<li class="label-inline">
@@ -813,6 +818,7 @@
 			</fieldset>
 			<details class="mrgn-bttm-md">
 				<summary>Voir le code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
@@ -820,7 +826,7 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radios horizontaux dans un modèle d'éléments &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; comportant des étiquettes explicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-inline list-unstyled"&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="radio" name="example6" value="1" id="example6a" required="required"&gt;
+					&lt;input type="radio" name="example6" value="1" id="example6a" data-rule-required="true"&gt;
 					&lt;label for="example6a"&gt;Pomme&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="label-inline"&gt;
@@ -842,19 +848,20 @@
 			<!-- checkboxes inline with implicit labels-->
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Cases à cocher horizontales dans un modèle d'éléments <code>&lt;label&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
-				<label for="example7a" class="checkbox-inline"><input type="checkbox" name="example7" value="1" id="example7a" required="required">Téléphone intelligent</label>
+				<label for="example7a" class="checkbox-inline"><input type="checkbox" name="example7" value="1" id="example7a" data-rule-required="true">Téléphone intelligent</label>
 				<label for="example7b" class="checkbox-inline"><input type="checkbox" name="example7" value="2" id="example7b">Ordinateur portatif</label>
 				<label for="example7c" class="checkbox-inline"><input type="checkbox" name="example7" value="3" id="example7c">Système d’assistance vocale</label>
 				<label for="example7d" class="checkbox-inline"><input type="checkbox" name="example7" value="4" id="example7d">Réacteur à fusion</label>
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>Voir le code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher horizontales dans un modèle d'éléments &lt;code&gt;&amp;lt;label&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
-			&lt;label for="example7a" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="1" id="example7a" required="required"&gt;Téléphone intelligent&lt;/label&gt;
+			&lt;label for="example7a" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="1" id="example7a" data-rule-required="true"&gt;Téléphone intelligent&lt;/label&gt;
 			&lt;label for="example7b" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="2" id="example7b"&gt;Ordinateur portatif&lt;/label&gt;
 			&lt;label for="example7c" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="3" id="example7c"&gt;Système d’assistance vocale&lt;/label&gt;
 			&lt;label for="example7d" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="4" id="example7d"&gt;Réacteur à fusion&lt;/label&gt;
@@ -864,19 +871,20 @@
 			<!-- radio buttons inline with implicit labels-->
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Boutons radio horizontaux dans un modèle d'éléments <code>&lt;label&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
-				<label for="example8a" class="radio-inline"><input type="radio" name="example8" value="1" id="example8a" required="required">Téléphone intelligent</label>
+				<label for="example8a" class="radio-inline"><input type="radio" name="example8" value="1" id="example8a" data-rule-required="true">Téléphone intelligent</label>
 				<label for="example8b" class="radio-inline"><input type="radio" name="example8" value="2" id="example8b">Ordinateur portatif</label>
 				<label for="example8c" class="radio-inline"><input type="radio" name="example8" value="3" id="example8c">Système d’assistance vocale</label>
 				<label for="example8d" class="radio-inline"><input type="radio" name="example8" value="4" id="example8d">Réacteur à fusion</label>
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>Voir le code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radio horizontaux dans un modèle d'éléments &lt;code&gt;&amp;lt;label&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
-			&lt;label for="example8a" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="1" id="example8a" required="required"&gt;Téléphone intelligent&lt;/label&gt;
+			&lt;label for="example8a" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="1" id="example8a" data-rule-required="true"&gt;Téléphone intelligent&lt;/label&gt;
 			&lt;label for="example8b" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="2" id="example8b"&gt;Ordinateur portatif&lt;/label&gt;
 			&lt;label for="example8c" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="3" id="example8c"&gt;Système d’assistance vocale&lt;/label&gt;
 			&lt;label for="example8d" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="4" id="example8d"&gt;Réacteur à fusion&lt;/label&gt;
@@ -887,7 +895,7 @@
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Cases à cocher horizontales dans un modèle d’éléments <code>&lt;div&gt;</code> comportant des étiquettes explicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="label-inline">
-					<input type="checkbox" name="example9" value="1" id="example9a" required="required">
+					<input type="checkbox" name="example9" value="1" id="example9a" data-rule-required="true">
 					<label for="example9a">Téléphone intelligent</label>
 				</div>
 				<div class="label-inline">
@@ -905,13 +913,14 @@
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>Voir le code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher horizontales dans un modèle d’éléments &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; comportant des étiquettes explicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="checkbox" name="example9" value="1" id="example9a" required="required"&gt;
+				&lt;input type="checkbox" name="example9" value="1" id="example9a" data-rule-required="true"&gt;
 				&lt;label for="example9a"&gt;Téléphone intelligent&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="label-inline"&gt;
@@ -933,7 +942,7 @@
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Boutons radios horizontaux dans un modèle d’éléments <code>&lt;div&gt;</code> comportant des étiquettes explicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="label-inline">
-					<input type="radio" name="example10" value="1" id="example10a" required="required">
+					<input type="radio" name="example10" value="1" id="example10a" data-rule-required="true">
 					<label for="example10a">Téléphone intelligent</label>
 				</div>
 				<div class="label-inline">
@@ -951,13 +960,14 @@
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>Voir le code</summary>
+				{{>alertfieldsetrequired}}
 				<pre><code>&lt;div class="wb-frmvld"&gt;
 	&lt;form action="#" method="get" id="validation-example"&gt;
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radios horizontaux dans un modèle d’éléments &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; comportant des étiquettes explicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="radio" name="example10" value="1" id="example10a" required="required"&gt;
+				&lt;input type="radio" name="example10" value="1" id="example10a" data-rule-required="true"&gt;
 				&lt;label for="example10a"&gt;Téléphone intelligent&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="label-inline"&gt;

--- a/src/plugins/formvalid/formvalid-server-en.hbs
+++ b/src/plugins/formvalid/formvalid-server-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid-server",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid-server",
-	"dateModified": "2022-04-13"
+	"dateModified": "2026-04-21"
 }
 ---
 
@@ -27,6 +27,7 @@
 	<h2>Example</h2>
 
 	{{>alertariahidden}}
+	{{>alertfieldsetrequired}}
 
 	<p>After submitting your page, the server returned 7 server errors. Now if you try to resubmit your form with some
 		client errors, the component will add these errors to the existing server errors.</p>
@@ -86,7 +87,7 @@
 
 					<fieldset class="legend-brdr-bttm">
 						<legend class="required"><span class="field-name">Citizen Status</span> <strong class="required">(Required field)</strong></legend>
-						<div class="radio required"><label for="MainContent_wbRadioButtonList0_radioButtonList0_0"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_0" required="required" type="radio" checked="checked" value="radioButtonList0_0v"><span> Canadian citizen</span> </label></div>
+						<div class="radio required"><label for="MainContent_wbRadioButtonList0_radioButtonList0_0"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_0" data-rule-required="true" type="radio" checked="checked" value="radioButtonList0_0v"><span> Canadian citizen</span> </label></div>
 						<div class="radio">
 							<label for="MainContent_wbRadioButtonList0_radioButtonList0_1"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_1" type="radio" value="radioButtonList0_1v"><span> Permanent resident</span> </label></div>
 						<div class="radio">
@@ -96,7 +97,7 @@
 					<fieldset class="legend-brdr-bttm">
 						<legend class="required"><span class="field-name">Contact Information</span> <strong class="required">(Required field)</strong><span class="label label-danger wb-server-error" id="MainContent_wbCheckBoxList0Cv">You can't choose more than 2 checkboxes</span></legend>
 						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_0">
-								<input name="checkBoxList0" class="required_js valid" id="MainContent_wbCheckBoxList0_checkBoxList0_0" aria-invalid="false" required="required" type="checkbox" checked="checked" value="checkBoxList0_0v">
+								<input name="checkBoxList0" class="required_js valid" id="MainContent_wbCheckBoxList0_checkBoxList0_0" aria-invalid="false" data-rule-required="true" type="checkbox" checked="checked" value="checkBoxList0_0v">
 								<span> <span class="field-name">Contact me by email</span></span>
 							</label></div>
 						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_1"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_1" type="checkbox" checked="checked" value="checkBoxList0_1v"><span> <span class="field-name">Contact me by phone</span></span> </label></div>
@@ -105,7 +106,7 @@
 
 					<fieldset class="legend-brdr-bttm">
 						<legend class="required"><span class="field-name">Signature</span> <strong class="required">(Required field)</strong></legend>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_0"><input name="checkBoxList1" class="required_js valid" id="MainContent_wbCheckBoxList1_checkBoxList1_0" required="required" type="checkbox" checked="checked" value="checkBoxList1_0v"><span> <span class="field-name">Print this page</span></span> </label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_0"><input name="checkBoxList1" class="required_js valid" id="MainContent_wbCheckBoxList1_checkBoxList1_0" data-rule-required="true" type="checkbox" checked="checked" value="checkBoxList1_0v"><span> <span class="field-name">Print this page</span></span> </label></div>
 						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_1"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_1" type="checkbox" value="checkBoxList1_1v"><span> <span class="field-name">Please send me more information</span></span> </label></div>
 						<div class="checkbox required"><label for="MainContent_wbCheckBoxList1_checkBoxList1_2"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_2" aria-invalid="false" required="required" type="checkbox" value="checkBoxList1_2v"><span> <span class="field-name">I agree with the directives</span><strong class="required"> (Required field)</strong></span><span class="label label-danger wb-server-error" id="MainContent_wbCheckBoxList1_checkBoxList1_2Cv">This field is mandatory</span></label></div>
 					</fieldset>

--- a/src/plugins/formvalid/formvalid-server-fr.hbs
+++ b/src/plugins/formvalid/formvalid-server-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid-server",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid-server",
-	"dateModified": "2022-04-13"
+	"dateModified": "2026-04-21"
 }
 ---
 
@@ -27,6 +27,7 @@
 	<h2>Exemple</h2>
 
 	{{>alertariahidden}}
+	{{>alertfieldsetrequired}}
 
 	<p>Après avoir soumis votre page, le serveur retourne 7 erreurs serveur. Maintenant si vous essayez de resoumettre
 		votre formulaire avec des erreurs clients, ce composant ajoutera ces erreurs aux erreurs serveur déjà existantes.</p>
@@ -93,7 +94,7 @@
 
 					<fieldset class="legend-brdr-bttm">
 						<legend class="required"><span class="field-name">Statut de citoyen</span> <strong class="required">(Champ requis)</strong></legend>
-						<div class="radio required"><label for="MainContent_wbRadioButtonList0_radioButtonList0_0"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_0" required="required" type="radio" checked="checked" value="radioButtonList0_0v"><span> Citoyen canadien</span> </label></div>
+						<div class="radio required"><label for="MainContent_wbRadioButtonList0_radioButtonList0_0"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_0" data-rule-required="true" type="radio" checked="checked" value="radioButtonList0_0v"><span> Citoyen canadien</span> </label></div>
 						<div class="radio"><label for="MainContent_wbRadioButtonList0_radioButtonList0_1"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_1" type="radio" value="radioButtonList0_1v"><span> Résident permanent</span> </label></div>
 						<div class="radio"><label for="MainContent_wbRadioButtonList0_radioButtonList0_2"><input name="radioButtonList0" id="MainContent_wbRadioButtonList0_radioButtonList0_2" type="radio" value="radioButtonList0_2v"><span> Permis de travail</span> </label></div>
 					</fieldset>
@@ -103,14 +104,14 @@
 								requis)</strong>
 							<span class="label label-danger wb-server-error" id="MainContent_wbCheckBoxList0Cv">Vous ne pouvez sélectionner plus de 2 cases à cocher</span>
 						</legend>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_0"><input name="checkBoxList0" class="required_js valid" id="MainContent_wbCheckBoxList0_checkBoxList0_0" aria-invalid="false" required="required" type="checkbox" checked="checked" value="checkBoxList0_0v"><span> <span class="field-name">Contactez-moi par courrier électronique</span></span> </label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_0"><input name="checkBoxList0" class="required_js valid" id="MainContent_wbCheckBoxList0_checkBoxList0_0" aria-invalid="false" data-rule-required="true" type="checkbox" checked="checked" value="checkBoxList0_0v"><span> <span class="field-name">Contactez-moi par courrier électronique</span></span> </label></div>
 						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_1"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_1" type="checkbox" checked="checked" value="checkBoxList0_1v"><span> <span class="field-name">Contactez-moi par téléphone</span></span> </label></div>
 						<div class="checkbox"><label for="MainContent_wbCheckBoxList0_checkBoxList0_2"><input name="checkBoxList0" id="MainContent_wbCheckBoxList0_checkBoxList0_2" type="checkbox" checked="checked" value="checkBoxList0_2v"><span> <span class="field-name">Contactez-moi par message texte</span></span> </label></div>
 					</fieldset>
 
 					<fieldset class="legend-brdr-bttm">
 						<legend class="required"><span class="field-name">Signature</span> <strong class="required">(Champ requis)</strong></legend>
-						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_0"><input name="checkBoxList1" class="required_js valid" id="MainContent_wbCheckBoxList1_checkBoxList1_0" required="required" type="checkbox" checked="checked" value="checkBoxList1_0v"><span> <span class="field-name">Imprimer cette page</span></span> </label></div>
+						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_0"><input name="checkBoxList1" class="required_js valid" id="MainContent_wbCheckBoxList1_checkBoxList1_0" data-rule-required="true" type="checkbox" checked="checked" value="checkBoxList1_0v"><span> <span class="field-name">Imprimer cette page</span></span> </label></div>
 						<div class="checkbox"><label for="MainContent_wbCheckBoxList1_checkBoxList1_1"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_1" type="checkbox" value="checkBoxList1_1v"><span> <span class="field-name">Veuillez m'envoyer de l'information complémentaire</span></span> </label></div>
 						<div class="checkbox required"><label for="MainContent_wbCheckBoxList1_checkBoxList1_2"><input name="checkBoxList1" id="MainContent_wbCheckBoxList1_checkBoxList1_2" aria-invalid="false" required="required" type="checkbox" value="checkBoxList1_2v"><span> <span class="field-name">Je suis en accord avec les directives</span><strong class="required"> (Champ requis)</strong></span><span class="label label-danger wb-server-error" id="MainContent_wbCheckBoxList1_checkBoxList1_2Cv">Ce champs est obligatoire</span></label></div>
 					</fieldset>


### PR DESCRIPTION
#9091 changed some of the form validation demo page's required fieldsets to use ``data-rule-required="true"`` attributes on their first fields (instead of ``required="required"``). But it left out the stacked/horizontal fieldset examples and the server demo page.

This changes the leftovers to use ``data-rule-required="true"`` for consistency. Also adds its alert nearby.

Related changes:
* Made the alert's wording more specific... now specifically mentions required fieldsets (it was previously ambiguous - which might've caused confusion when the ``aria-hidden="true"`` alert was nearby)
* Changed the alert into an include (similar to what's already being done with the ``aria-hidden="true"`` alert)
* Replaced the ``aria-hidden="true"`` alert with the ``data-rule-required="true"`` alert in #9866's no asterisk fieldset example (should've used the latter in the first place but overlooked it)

CC @thekodester @StdGit @delisma