### PR TITLE
ESLint: Set environment to ES6

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,7 @@
   ],
   "env": {
     "browser": true,
+    "es6": true,
     "jquery": true
   },
   "globals": {


### PR DESCRIPTION
* Prevents ``let``/``const``/``Map``/etc from triggering errors
* Supersedes and closes #9159
* Related to #9146