### PR TITLE
Footnotes: Remove outdated comment

### DIFF
--- a/src/plugins/footnotes/footnotes.js
+++ b/src/plugins/footnotes/footnotes.js
@@ -36,7 +36,7 @@ var componentName = "wb-fnote",
 			footnoteDd = elm.getElementsByTagName( "dd" );
 			footnoteDt = elm.getElementsByTagName( "dt" );
 
-			// Apply aria-labelledby and set initial event handlers for return to referrer links
+			// Set initial event handlers for return to referrer links
 			len = footnoteDd.length;
 			for ( i = 0; i !== len; i += 1 ) {
 				dd = footnoteDd[ i ];


### PR DESCRIPTION
The footnotes plugin used to automatically add ``aria-describedby`` attributes onto ``dd`` elements. But it was found to be pointless in #8826 and was subsequently removed by #8835.

This removes a leftover comment that was still mentioning ``aria-describedby``. Should help reduce potential confusion for anyone that looks through the plugin's source code.