### PR TITLE
Theme: Don't redeclare %accessible-invisible

### DIFF
--- a/theme/_defaults.scss
+++ b/theme/_defaults.scss
@@ -9,12 +9,3 @@
 	content: "";
 	display: table;
 }
-
-%accessible-invisible {
-	clip: rect(1px, 1px, 1px, 1px);
-	height: 1px;
-	margin: 0;
-	overflow: hidden;
-	position: absolute;
-	width: 1px;
-}


### PR DESCRIPTION
That placeholder selector already exists in src/base/_wet-boew.scss with identical properties.

Redeclaring it caused all of its generated selectors to appear twice in theme.css:
* Theme's version at the very beginning
* Base's version half-way in

Removing theme's version shouldn't cause any issues with specificity since the base version always overrode it.