### PR TITLE
Details/Sum: Utility to limit width to max content

### DIFF
--- a/site/pages/docs/ref/add-cal/add-cal-en.hbs
+++ b/site/pages/docs/ref/add-cal/add-cal-en.hbs
@@ -108,5 +108,8 @@
 
 <p>The propery "datemodified" must be present in the web page.</p>
 
+<h3>View and style</h3>
+<p>Add to calendar details/summary uses the <code>.max-content</code> utility class, which limits the width of the element to the width of its largest content inside.</p>
+
 <h2>Source code</h2>
 <p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/add-cal">Add to Calendar source code on GitHub</a></p>

--- a/site/pages/docs/ref/add-cal/add-cal-fr.hbs
+++ b/site/pages/docs/ref/add-cal/add-cal-fr.hbs
@@ -111,6 +111,9 @@
 
 	<p>The propery "datemodified" must be present in the web page.</p>
 
+	<h3>View and style</h3>
+	<p>Add to calendar details/summary uses the <code>.max-content</code> utility class, which limits the width of the element to the width of its largest content inside.</p>
+
 	<h2>Source code</h2>
 	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/add-cal">Add to Calendar source code on GitHub</a></p>
 </div>

--- a/src/base/details/_base.scss
+++ b/src/base/details/_base.scss
@@ -39,4 +39,8 @@ details {
 	&[open] {
 		padding-bottom: 1em;
 	}
+
+	&.max-content {
+		max-width: max-content;
+	}
 }


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

Mostly used for Add to calendar at the moment. Details/summary with the .max-content class will have its width take up to the maximum of its own content and not stretch to the entirety of the container.
