### PR TITLE
Data Ajax: Use valid wb.init name if httpref doesn't match

### DIFF
--- a/src/plugins/data-ajax/data-ajax.js
+++ b/src/plugins/data-ajax/data-ajax.js
@@ -121,14 +121,16 @@ var componentName = "wb-data-ajax",
 				return {};
 			}
 
-			url = getURL( dtAttr.url, dtAttr.httpref );
-			if ( !url ) {
-				return {};
-			}
 			ajaxType = dtAttr.type;
 			if ( ajaxTypes.indexOf( ajaxType ) === -1 ) {
 				throw "Invalid ajax type";
 			}
+
+			url = getURL( dtAttr.url, dtAttr.httpref );
+			if ( !url ) {
+				return { "type": ajaxType };
+			}
+
 			nocache = dtAttr.nocache;
 			nocachekey = dtAttr.nocachekey;
 		}


### PR DESCRIPTION
Conditional filtering using HTTP referrer used to cause WET to try initializing "wb-data-ajax-undefined" if the current page's referrer didn't match.

If ``getAjxInfo()``'s call to ``getURL()`` returned an empty string (due to the current page's HTTP referrer not matching ``httpref``), a ``url`` variable would get set as such. An if condition would then detect the variable as falsy and return an empty object. The plugin's ``init()`` method would then try to retrieve an ``ajaxType`` string from the empty object ("undefined"), combine it with the plugin's name and pass it to ``wb.init()``.

This fixes it by making the following changes to ``getAjxInfo()``:
* Ensure ``ajaxType``'s value is known before the ``url`` variable's declaration/if condition
* If ``url`` turns out to be falsy, add ``ajaxType`` to the empty object that gets returned