### PR TITLE
Merge server-client errors: Remove noscript block

### DIFF
--- a/src/plugins/formvalid/formvalid-server-en.hbs
+++ b/src/plugins/formvalid/formvalid-server-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid-server",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid-server",
-	"dateModified": "2021-08-11"
+	"dateModified": "2021-11-03"
 }
 ---
 
@@ -50,24 +50,6 @@
 							the directives - This field is mandatory - (Correct and resubmit) </a></li>
 				</ul>
 			</section>
-
-			<noscript>
-				&lt;section class="alert alert-danger" &gt;
-				&lt;h2&gt;This is user control wbDisplayErrors (It appears when JavaScript is disabled)&lt;/h2&gt;
-				&lt;ul&gt;
-				&lt;li&gt;&lt;a href="#MainContent_BeneficiaryName"&gt;&lt;span class='prefix'&gt;Error&amp;nbsp;1:
-				&lt;/span&gt;Beneficiary name - The name should begin with "Super" - (Correct and resubmit)&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href="#MainContent_BeneficiaryAge"&gt;&lt;span class='prefix'&gt;Error&amp;nbsp;2:
-				&lt;/span&gt;Beneficiary age is mandatory - Age should be between 64 and 200 for a Retirement benefit - (Correct
-				and resubmit)&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href="#MainContent_wbCheckBoxList0_checkBoxList0_0"&gt;&lt;span class='prefix'&gt;Error&amp;nbsp;3:
-				&lt;/span&gt;Contact Information - You can't choose more than 2 checkboxes - (Correct and
-				resubmit)&lt;/a&gt;&lt;/li&gt;
-				&lt;li&gt;&lt;a href="#MainContent_wbCheckBoxList1_checkBoxList1_2"&gt;&lt;span class='prefix'&gt;Error&amp;nbsp;4:
-				&lt;/span&gt;I agree with the directives - This field is mandatory - (Correct and resubmit)&lt;/a&gt;&lt;/li&gt;
-				&lt;/ul&gt;
-				&lt;/section&gt;
-			</noscript>
 
 			<section class="panel panel-info">
 				<header class="panel-heading">


### PR DESCRIPTION
Issues with what was removed:
* Was only present in the English demo page
* Duplicated the errors alert (which is already visible to all users in JS/basic HTML/noscript modes)
* Used escaped HTML tags (wasn't presented to users as rendered HTML)

CC @StdGit @duboisp