### PR TITLE
New: Details closed on mobile: Closes <details> elements on mobile

### DIFF
--- a/site/pages/docs/ref/details-close/details-close-en.hbs
+++ b/site/pages/docs/ref/details-close/details-close-en.hbs
@@ -1,0 +1,87 @@
+---
+{
+	"title": "Details closed on small views",
+	"language": "en",
+	"category": "Plugins",
+	"categoryfile": "plugins",
+	"description": "Keep selected details elements closed on defined viewport and under.",
+	"altLangPrefix": "details-close",
+	"dateModified": "2021-11-29"
+}
+---
+<div class="alert alert-warning">
+	<h2>Unstable feature</h2>
+	<p>To be used at <strong>your own risk</strong>. This feature described below can be removed in any subsequent minor/major release</p>
+	<p><small><a href="https://wet-boew.github.io/wet-boew-documentation/decision/7.html">Learn more about the design decision around provisional features.</a></small></p>
+	<p><small><a href="../provisional-en.html">Check other provisional features available.</a></small></p>
+</div>
+
+<h2>Purpose</h2>
+<p>Keep selected <code>details</code> elements closed on defined viewport and down if they were not engaged, default is small.</p>
+
+<h2>Working example</h2>
+<ul>
+	<li><a href="../../../demos/details-close/details-close-en.html">Default example</a></li>
+	<li><a href="../../../demos/details-close/details-close-md-en.html">Medium viewport example</a></li>
+</ul>
+
+<h2>Evaluation and report</h2>
+<p>There is no evaluation and report available for this component.</p>
+
+<h2>API (provisional)</h2>
+<dl class="dl-horizontal">
+	<dt>Function</dt>
+	<dd>provisional</dd>
+	<dt>Configuration</dt>
+	<dd>provisional</dd>
+</dl>
+
+<h3>Function</h3>
+<p>(Version provisional)</p>
+<table class="table">
+	<tr>
+		<th>Function type</th>
+		<th>Name</th>
+		<th>How to implement</th>
+		<th>What it does</th>
+	</tr>
+	<tr>
+		<td>jQuery Event</td>
+		<td><code>wb-init.wb-details-close</code></td>
+		<td>Triggered manually (e.g., <code>$( ".wb-details-close" ).trigger( "wb-init.wb-details-close" );</code>).</td>
+		<td>Initializes the details-close plugin. This plugin will be initialized automatically unless the <code>.wb-details-close</code> element is added after the page load and wet-boew was initialized.</td>
+	</tr>
+	<tr>
+		<td>jQuery Event</td>
+		<td><code>wb-ready.wb-details-close</code></td>
+		<td>Triggered automatically after the plugin initializes.</td>
+		<td>Used to identify when and where the plugin initializes (target of the event).
+			<pre><code>$( document ).on( "wb-ready.wb-details-close", ".wb-details-close", function( event ) {
+});</code></pre>
+			<pre><code>$elm.on( "wb-ready.wb-details-close", function( event ) {
+});</code></pre>
+		</td>
+	</tr>
+</table>
+
+<h3>Configuration</h3>
+<p>(Version provisional)</p>
+<table class="table">
+	<tr>
+		<th>Proprety name/type</th>
+		<th>Option</th>
+		<th>Description</th>
+		<th>How to configure</th>
+		<th>Values</th>
+	</tr>
+	<tr>
+		<td><code>[data-breakpoint]</code> String</td>
+		<td>Viewport abbreviation</td>
+		<td>defines highest viewport from which <code>details</code> are closed.</td>
+		<td>Valid Bootstrap 3 viewport</td>
+		<td>xs, sm, md, lg</td>
+	</tr>
+</table>
+
+<h2>Source code</h2>
+<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/details-close">Details closed on mobile source code on GitHub</a></p>

--- a/site/pages/docs/ref/details-close/details-close-fr.hbs
+++ b/site/pages/docs/ref/details-close/details-close-fr.hbs
@@ -1,0 +1,91 @@
+---
+{
+	"title": "Balise details fermée sur petits écrans",
+	"language": "fr",
+	"category": "Plugiciels",
+	"categoryfile": "plugins",
+	"description": "Garder les éléments details visés fermés sur écran défini et moins.",
+	"altLangPrefix": "details-close",
+	"dateModified": "2021-11-29"
+}
+---
+<div lang="en">
+<p><strong>Needs translation</strong></p>
+
+<div class="alert alert-warning">
+	<h2>Unstable feature</h2>
+	<p>To be used at <strong>your own risk</strong>. This feature described below can be removed in any subsequent minor/major release</p>
+	<p><small><a href="https://wet-boew.github.io/wet-boew-documentation/decision/7.html">Learn more about the design decision around provisional features.</a></small></p>
+	<p><small><a href="../provisional-en.html">Check other provisional features available.</a></small></p>
+</div>
+
+<h2>Purpose</h2>
+<p>Keep selected <code>details</code> elements closed on defined viewport and down if they were not engaged, default is small.</p>
+
+<h2>Working example</h2>
+<ul>
+	<li><a href="../../../demos/details-close/details-close-fr.html">Default example</a></li>
+	<li><a href="../../../demos/details-close/details-close-md-fr.html">Medium viewport example</a></li>
+</ul>
+
+<h2>Evaluation and report</h2>
+<p>There is no evaluation and report available for this component.</p>
+
+<h2>API (provisional)</h2>
+<dl class="dl-horizontal">
+	<dt>Function</dt>
+	<dd>provisional</dd>
+	<dt>Configuration</dt>
+	<dd>provisional</dd>
+</dl>
+
+<h3>Function</h3>
+<p>(provisional)</p>
+<table class="table">
+	<tr>
+		<th>Function type</th>
+		<th>Name</th>
+		<th>How to implement</th>
+		<th>What it does</th>
+	</tr>
+	<tr>
+		<td>jQuery Event</td>
+		<td><code>wb-init.wb-details-close</code></td>
+		<td>Triggered manually (e.g., <code>$( ".wb-details-close" ).trigger( "wb-init.wb-details-close" );</code>).</td>
+		<td>Initializes the details-close plugin. This plugin will be initialized automatically unless the <code>.wb-details-close</code> element is added after the page load and wet-boew was initialized.</td>
+	</tr>
+	<tr>
+		<td>jQuery Event</td>
+		<td><code>wb-ready.wb-details-close</code></td>
+		<td>Triggered automatically after the plugin initializes.</td>
+		<td>Used to identify when and where the plugin initializes (target of the event).
+			<pre><code>$( document ).on( "wb-ready.wb-details-close", ".wb-details-close", function( event ) {
+});</code></pre>
+			<pre><code>$elm.on( "wb-ready.wb-details-close", function( event ) {
+});</code></pre>
+		</td>
+	</tr>
+</table>
+
+<h3>Configuration</h3>
+<p>(Version provisional)</p>
+<table class="table">
+	<tr>
+		<th>Proprety name/type</th>
+		<th>Option</th>
+		<th>Description</th>
+		<th>How to configure</th>
+		<th>Values</th>
+	</tr>
+	<tr>
+		<td><code>[data-breakpoint]</code> String</td>
+		<td>Viewport abbreviation</td>
+		<td>defines highest viewport from which <code>details</code> are closed.</td>
+		<td>Valid Bootstrap 3 viewport</td>
+		<td>xs, sm, md, lg</td>
+	</tr>
+</table>
+
+<h2>Source code</h2>
+<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/details-close">Details closed on mobile source code on GitHub</a></p>
+</div>

--- a/site/pages/docs/ref/provisional-en.hbs
+++ b/site/pages/docs/ref/provisional-en.hbs
@@ -3,7 +3,7 @@
 	"title": "Provisional features",
 	"language": "en",
 	"altLangPrefix": "provisional",
-	"dateModified": "2021-05-19",
+	"dateModified": "2021-11-29",
 	"share": "true"
 }
 ---
@@ -95,7 +95,13 @@
 		<th>Plugin <code>.wb-addcal</code></th>
 		<td>This plugin add an event to a calendar (google, Apple, Android, Outlook and others).</td>
 		<td>v4.0.42.3</td>
-		<td><a href="../../docs/ref/add-cal/add-cal-fr.html">Detailed documentation</a></td>
+		<td><a href="../../docs/ref/add-cal/add-cal-en.html">Detailed documentation</a></td>
+	</tr>
+	<tr>
+		<th>Plugin <code>.wb-details-close</code></th>
+		<td>This plugin keeps selected details elements closed on defined viewport, default is small.</td>
+		<td>After v4.0.44.5 (STR)</td>
+		<td><a href="../../docs/ref/details-close/details-close-en.html">Detailed documentation</a></td>
 	</tr>
 </tbody>
 </table>
@@ -106,8 +112,4 @@
 
 <p>CSS provisional features must be accompanied by the class <code>.provisional</code> within his context of use.</p>
 
-<h2>Provisional working examples</h2>
-
-<ul>
-	<li><a href="../../docs/ref/stepsform/stepsform-en.html">Detailed documentation</a></li>
-</ul>
+<!-- <h2>Provisional working examples</h2> -->

--- a/site/pages/docs/ref/provisional-fr.hbs
+++ b/site/pages/docs/ref/provisional-fr.hbs
@@ -3,7 +3,7 @@
 	"title": "Fonctionnalités provisoires",
 	"language": "fr",
 	"altLangPrefix": "provisional",
-	"dateModified": "2020-08-18",
+	"dateModified": "2021-11-29",
 	"share": "true"
 }
 ---
@@ -99,6 +99,12 @@
 		<td>v4.0.42.3</td>
 		<td><a href="../../docs/ref/add-cal/add-cal-en.html">Detailed documentation</a></td>
 	</tr>
+	<tr>
+		<th>Plugin <code>.wb-details-close</code></th>
+		<td>This plugin keeps selected details elements closed on defined viewport, default is small.</td>
+		<td>After v4.0.44.5 (STR)</td>
+		<td><a href="../../docs/ref/details-close/details-close-fr.html">Detailed documentation</a></td>
+	</tr>
 </tbody>
 </table>
 
@@ -108,10 +114,5 @@
 
 <p>CSS provisional features must be accompanied by the class <code>.provisional</code> within his context of use.</p>
 
-
-<h2>Provisional working examples</h2>
-
-<ul>
-	<li><a href="../../docs/ref/stepsform/stepsform-fr.html">Detailed documentation</a></li>
-</ul>
+<!-- <h2>Provisional working examples</h2> -->
 </div>

--- a/src/plugins/details-close/details-close-en.hbs
+++ b/src/plugins/details-close/details-close-en.hbs
@@ -1,0 +1,47 @@
+---
+{
+	"title": "Details closed on small views",
+	"language": "en",
+	"category": "Plugins",
+	"description": "Keep selected details elements closed on small view and down.",
+	"tag": "details-close",
+	"parentdir": "details-close",
+	"altLangPrefix": "details-close",
+	"dateModified": "2021-11-29"
+}
+---
+<div class="alert alert-warning">
+	<h2>Unstable feature</h2>
+	<p>To be used at <strong>your own risk</strong>. This feature described below can be removed in any subsequent minor/major release</p>
+	<p><small><a href="https://wet-boew.github.io/wet-boew-documentation/decision/7.html">Learn more about the design decision around provisional features.</a></small></p>
+	<p><small><a href="../../docs/ref/provisional-en.html">Check other provisional features available.</a></small></p>
+</div>
+
+<h2>Other example</h2>
+<ul>
+	<li><a href="details-close-md-en.html">Medium viewport example</a></li>
+</ul>
+
+<h2>Example of <code>details</code> element kept closed on small viewport and down (sm, xs and xxs)</h2>
+<p>Resize your browser to view the plugin at play.</p>
+<div class="row">
+	<div class="col-md-6">
+		<details class="provisional wb-details-close" open>
+			<summary>I am closed on mobile (uses plugin)</summary>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.</p>
+		</details>
+	</div>
+	<div class="col-md-6">
+		<details open>
+			<summary>I am opened on mobile (regular)</summary>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.</p>
+		</details>
+	</div>
+</div>
+
+<h3>Source code</h3>
+<pre><code>&lt;details class="provisional wb-details-close" open&gt;
+	&lt;summary&gt;I am closed on mobile (uses plugin)&lt;/summary&gt;
+	&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.&lt;/p&gt;
+&lt;/details&gt;
+</code></pre>

--- a/src/plugins/details-close/details-close-fr.hbs
+++ b/src/plugins/details-close/details-close-fr.hbs
@@ -1,0 +1,49 @@
+---
+{
+	"title": "Balise details fermée sur petits écrans",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Garder les éléments details visés fermés sur petits écrans et moins.",
+	"tag": "details-close",
+	"parentdir": "details-close",
+	"altLangPrefix": "details-close",
+	"dateModified": "2021-11-29"
+}
+---
+<div lang="en">
+	<div class="alert alert-warning">
+		<h2>Unstable feature</h2>
+		<p>To be used at <strong>your own risk</strong>. This feature described below can be removed in any subsequent minor/major release</p>
+		<p><small><a href="https://wet-boew.github.io/wet-boew-documentation/decision/7.html">Learn more about the design decision around provisional features.</a></small></p>
+		<p><small><a href="../../docs/ref/provisional-en.html">Check other provisional features available.</a></small></p>
+	</div>
+
+	<h2>Other example</h2>
+	<ul>
+		<li><a href="details-close-md-en.html">Medium viewport example</a></li>
+	</ul>
+
+	<h2>Example of <code>details</code> element kept closed on small viewport and down (sm, xs and xxs)</h2>
+	<p>Resize your browser to view the plugin at play.</p>
+	<div class="row">
+		<div class="col-md-6">
+			<details class="provisional wb-details-close" open>
+				<summary>I am closed on mobile (uses plugin)</summary>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.</p>
+			</details>
+		</div>
+		<div class="col-md-6">
+			<details open>
+				<summary>I am opened on mobile (regular)</summary>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.</p>
+			</details>
+		</div>
+	</div>
+
+	<h3>Source code</h3>
+	<pre><code>&lt;details class="provisional wb-details-close" open&gt;
+		&lt;summary&gt;I am closed on mobile (uses plugin)&lt;/summary&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.&lt;/p&gt;
+	&lt;/details&gt;
+	</code></pre>
+</div>

--- a/src/plugins/details-close/details-close-md-en.hbs
+++ b/src/plugins/details-close/details-close-md-en.hbs
@@ -1,0 +1,47 @@
+---
+{
+	"title": "Details closed on medium view and down",
+	"language": "en",
+	"category": "Plugins",
+	"description": "Keep selected details elements closed on medium view and smaller.",
+	"tag": "details-close",
+	"parentdir": "details-close",
+	"altLangPrefix": "details-close",
+	"dateModified": "2021-11-29"
+}
+---
+<div class="alert alert-warning">
+	<h2>Unstable feature</h2>
+	<p>To be used at <strong>your own risk</strong>. This feature described below can be removed in any subsequent minor/major release</p>
+	<p><small><a href="https://wet-boew.github.io/wet-boew-documentation/decision/7.html">Learn more about the design decision around provisional features.</a></small></p>
+	<p><small><a href="../../docs/ref/provisional-en.html">Check other provisional features available.</a></small></p>
+</div>
+
+<h2>Other example</h2>
+<ul>
+	<li><a href="details-close-en.html">Default example</a></li>
+</ul>
+
+<h2>Example of <code>details</code> element kept closed on medium viewport and down (md, sm, xs and xxs)</h2>
+<p>Resize your browser to view the plugin at play. Note that setting a different viewport than default on the first instance of <code>.wb-details-close</code> will repeat same setting for all instances of the plugin on the page.</p>
+<div class="row">
+	<div class="col-md-6">
+		<details class="provisional wb-details-close" data-breakpoint="md" open>
+			<summary>I am closed on medium view and down</summary>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.</p>
+		</details>
+	</div>
+	<div class="col-md-6">
+		<details class="provisional wb-details-close" open>
+			<summary>I follow same settings as the first instance</summary>
+			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.</p>
+		</details>
+	</div>
+</div>
+
+<h3>Source code</h3>
+<pre><code>&lt;details class="provisional wb-details-close" data-breakpoint="md" open&gt;
+	&lt;summary&gt;I am closed on medium view and down&lt;/summary&gt;
+	&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.&lt;/p&gt;
+&lt;/details&gt;
+</code></pre>

--- a/src/plugins/details-close/details-close-md-fr.hbs
+++ b/src/plugins/details-close/details-close-md-fr.hbs
@@ -1,0 +1,49 @@
+---
+{
+	"title": "Balise details fermée sur écran moyen et moins",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Garder les éléments details visés fermés sur moyens écrans ou plus petits.",
+	"tag": "details-close",
+	"parentdir": "details-close",
+	"altLangPrefix": "details-close-md",
+	"dateModified": "2021-11-29"
+}
+---
+<div lang="en">
+	<div class="alert alert-warning">
+		<h2>Unstable feature</h2>
+		<p>To be used at <strong>your own risk</strong>. This feature described below can be removed in any subsequent minor/major release</p>
+		<p><small><a href="https://wet-boew.github.io/wet-boew-documentation/decision/7.html">Learn more about the design decision around provisional features.</a></small></p>
+		<p><small><a href="../../docs/ref/provisional-en.html">Check other provisional features available.</a></small></p>
+	</div>
+
+	<h2>Other example</h2>
+	<ul>
+		<li><a href="details-close-en.html">Default example</a></li>
+	</ul>
+
+	<h2>Example of <code>details</code> element kept closed on medium viewport and down (md, sm, xs and xxs)</h2>
+	<p>Resize your browser to view the plugin at play. Note that setting a different viewport than default on the first instance of <code>.wb-details-close</code> will repeat same setting for all instances of the plugin on the page.</p>
+	<div class="row">
+		<div class="col-md-6">
+			<details class="provisional wb-details-close" data-breakpoint="md" open>
+				<summary>I am closed on medium view and down</summary>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.</p>
+			</details>
+		</div>
+		<div class="col-md-6">
+			<details class="provisional wb-details-close" open>
+				<summary>I follow same settings as the first instance</summary>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.</p>
+			</details>
+		</div>
+	</div>
+
+	<h3>Source code</h3>
+	<pre><code>&lt;details class="provisional wb-details-close" data-breakpoint="md" open&gt;
+		&lt;summary&gt;I am closed on medium view and down&lt;/summary&gt;
+		&lt;p&gt;Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum rhoncus, neque accumsan faucibus ultricies, libero massa mollis neque, et mollis libero enim a ligula. Ut dictum tempor luctus. Ut convallis vehicula sapien a facilisis. Morbi eget lectus efficitur, finibus metus eu, feugiat felis. Praesent sodales elit sed finibus pharetra. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Praesent quis sem lacinia, accumsan sem et, lacinia turpis.&lt;/p&gt;
+	&lt;/details&gt;
+	</code></pre>
+</div>

--- a/src/plugins/details-close/details-close.js
+++ b/src/plugins/details-close/details-close.js
@@ -1,0 +1,81 @@
+/**
+ * @title WET-BOEW Details closed on small screen
+ * @overview Closes details on defined viewport and down if they were not engaged, default is small
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @thomasgohard
+ */
+( function( $, wb ) {
+"use strict";
+
+/*
+* Variable and function definitions.
+* These are global to the plugin - meaning that they will be initialized once per page,
+* not once per instance of plugin on the page. So, this is a good place to define
+* variables that are common to all instances of the plugin on a page.
+*/
+var componentName = "wb-details-close",
+	selector = ".provisional." + componentName,
+	initEvent = "wb-init" + selector,
+	$document = wb.doc,
+	views = [ "xxs", "xs", "sm", "md", "lg", "xl" ],
+	viewsClass = [ "xxsmallview", "xsmallview", "smallview", "mediumview", "largeview", "xlargeview" ],
+	breakpoint,
+
+	/**
+	 * @method init
+	 * @param {jQuery Event} event Event that triggered the function call
+	 */
+	init = function( event ) {
+
+		// Start initialization
+		// returns DOM object = proceed with init
+		// returns undefined = do not proceed with init (e.g., already initialized)
+		var elm = wb.init( event, componentName, selector ),
+			$elm, i;
+
+		if ( elm ) {
+			$elm = $( elm );
+
+			// Get the plugin JSON configuration set on attribute data-wb-details-close
+			// Will define one set settings for all .wb-details-close on the page
+			breakpoint = $elm.data( "breakpoint" ) || "sm";
+
+			// reset breakpoint if config is passed
+			if ( views.length === viewsClass.length ) {
+				i = views.indexOf( breakpoint );
+				viewsClass = viewsClass.slice( 0, i + 1 );
+			}
+
+			hideOnBreakpoint();
+
+			// Identify that initialization has completed
+			wb.ready( $elm, componentName );
+		}
+	},
+
+	/**
+	 * Toggle details depending on breakpoint
+	 * @method hideOnBreakpoint
+	 * @param {jQuery DOM element | jQuery Event} $elm Element targetted by this plugin, which is the details
+	 */
+	hideOnBreakpoint = function() {
+		var $elm = $( selector ),
+			viewsSelector = "html." + viewsClass.join( ", html." );
+
+		// If within the targetted views, keep details closed
+		if ( $( viewsSelector ).length ) {
+			$elm.removeAttr( "open" );
+		} else {
+
+			// If not, keep opened
+			$elm.attr( "open", "" );
+		}
+	};
+
+// Bind the init event of the plugin
+$document.on( "timerpoke.wb " + initEvent, selector, init );
+
+// Add the timer poke to initialize the plugin
+wb.add( selector );
+
+} )( jQuery, wb );


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Keep selected details elements closed on small view and down, such as filters besides tables, in order to dive right into the relevant content on mobile and not be distracted by details/summary purposely used to enhance content only.