### PR TITLE
When adding custom close button. Default one stay usable

### DIFF
--- a/src/plugins/overlay/overlay-en.hbs
+++ b/src/plugins/overlay/overlay-en.hbs
@@ -227,7 +227,7 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 		<p>Overlays/Modals through JavaScript are automatically updated with a close overlay/modal button. This button can be changed with the following code:</p>
 		<pre><code>&lt;div class=&quot;modal-footer&quot;&gt;
 ...
-&lt;button class=&quot;btn btn-primary popup-modal-dismiss&quot; type=&quot;button&quot;&gt;Close overlay/modal&lt;/button&gt;
+&lt;button class=&quot;btn btn-primary overlay-close&quot; type=&quot;button&quot;&gt;Close overlay/modal&lt;/button&gt;
 &lt;/div&gt;</code></pre>
 		<p><strong>Side Note:</strong> Close buttons must be inside the modal footer (a div with the class <code>modal-footer</code>).</p>
 	</section>

--- a/src/plugins/overlay/overlay-fr.hbs
+++ b/src/plugins/overlay/overlay-fr.hbs
@@ -229,7 +229,7 @@ wb.doc.on( "click vclick", "#overlay-open-btn", function( event ) {
 		<p>Overlays/Modals through JavaScript are automatically updated with a close overlay/modal button. This button can be changed with the following code:</p>
 		<pre><code>&lt;div class=&quot;modal-footer&quot;&gt;
 ...
-&lt;button class=&quot;btn btn-primary popup-modal-dismiss&quot; type=&quot;button&quot;&gt;Close overlay/modal&lt;/button&gt;
+&lt;button class=&quot;btn btn-primary overlay-close&quot; type=&quot;button&quot;&gt;Close overlay/modal&lt;/button&gt;
 &lt;/div&gt;</code></pre>
 		<p><strong>Side Note:</strong> Close buttons must be inside the modal footer (a div with the class <code>modal-footer</code>).</p>
 	</section>

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -60,7 +60,7 @@ var componentName = "wb-overlay",
 				footer = $elm.find( ".modal-footer" )[ 0 ];
 
 				var hasFooter = ( footer && footer.length !== 0 ) ? true : false,
-					hasButton = hasFooter && $( footer ).find( “.” + closeClass ).length !== 0,
+					hasButton = hasFooter && $( footer ).find( "." + closeClass ).length !== 0,
 					closeClassFtr = ( $elm.hasClass( "wb-panel-l" ) ? "pull-right " : "pull-left " )  + closeClass,
 					closeTextFtr = i18nText.close,
 					spanTextFtr = i18nText.closeOverlay,

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -60,7 +60,7 @@ var componentName = "wb-overlay",
 				footer = $elm.find( ".modal-footer" )[ 0 ];
 
 				var hasFooter = ( footer && footer.length !== 0 ) ? true : false,
-					hasButton = hasFooter && $( footer ).find( closeClass ).length !== 0,
+					hasButton = hasFooter && $( footer ).find( “.” + closeClass ).length !== 0,
 					closeClassFtr = ( $elm.hasClass( "wb-panel-l" ) ? "pull-right " : "pull-left " )  + closeClass,
 					closeTextFtr = i18nText.close,
 					spanTextFtr = i18nText.closeOverlay,


### PR DESCRIPTION
When we add a custom close button, it show 2 close buttons

## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Fix only class overlay-close is needed for overlay not lightbox



- [x ] Create/update documentation /// Créer/mettre à jour la documentation
- [x ] Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
- [ ] Validate changes against WCAG for accessibility /// Valider les changements avec WCAG pour l'accessibilité
- [ ] Ensure documentation is bilingual /// S'assurer que la documentation soit bilingue

**Screenshots / Captures d'écrans**
![image](https://user-images.githubusercontent.com/4562025/141179006-e6dca4d1-ea80-421b-ac3a-fbbba11c271b.png)

@duboisp 