### PR TITLE
Ajax-fetch - fetchData pointer option was empty

### DIFF
--- a/src/plugins/ajax-fetch/ajax-fetch.js
+++ b/src/plugins/ajax-fetch/ajax-fetch.js
@@ -26,7 +26,8 @@ $document.on( "ajax-fetch.wb", function( event ) {
 		urlSubParts = url.split( "#" ),
 		urlHash = urlSubParts[ 1 ],
 		selector = urlParts[ 1 ] || ( urlHash ? "#" + urlHash : false ),
-		fetchData, callerId, fetchNoCacheURL, urlSub,
+		fetchData = {},
+		callerId, fetchNoCacheURL, urlSub,
 		fetchNoCache = fetchOpts.nocache,
 		fetchNoCacheKey = fetchOpts.nocachekey || wb.cacheBustKey || "wbCacheBust";
 
@@ -75,18 +76,18 @@ $document.on( "ajax-fetch.wb", function( event ) {
 
 				if ( selector ) {
 					response = $( "<div>" + response + "</div>" ).find( selector );
-				} else {
-					response = $( response );
 				}
+
+				fetchData.pointer = $( "<div id='" + wb.getId() + "' data-type='" + responseType + "'></div>" )
+					.append( responseType === "string" ? response : "" );
+
+				response = $( response );
 
 				fetchData = {
 					response: response,
 					status: status,
 					xhr: xhr
 				};
-
-				fetchData.pointer = $( "<div id='" + wb.getId() + "' data-type='" + responseType + "'></div>" )
-					.append( responseType === "string" ? response : "" );
 
 				$( "#" + callerId ).trigger( {
 					type: "ajax-fetched.wb",


### PR DESCRIPTION
Fix a issue that prevented the megamenu to load when the data-ajax-replace is used with the mega menu plugin.

Note: The data-ajax-replace plugin work fine when it is used inside page content.
