### PR TITLE
Geomap - Working example, coded inline the thousand separator

### DIFF
--- a/src/plugins/geomap/geomap-en.hbs
+++ b/src/plugins/geomap/geomap-en.hbs
@@ -147,52 +147,52 @@
 									<tr data-geometry="POINT (-79.3847 43.6476)" data-type="wkt">
 										<td>1</td>
 										<td><a href="https://www.wikipedia.org/wiki/Toronto" title="Toronto">Toronto</a></td>
-										<td>2{{{i18n "info1000"}}}615{{{i18n "info1000"}}}060</td>
+										<td>2,615,060</td>
 									</tr>
 									<tr data-geometry="POINT (-73.56123 45.52927)" data-type="wkt">
 										<td>2</td>
 										<td><a href="https://www.wikipedia.org/wiki/Montreal" title="Montreal">Montreal</a></td>
-										<td>1{{{i18n "info1000"}}}649{{{i18n "info1000"}}}519</td>
+										<td>1,649,519</td>
 									</tr>
 									<tr data-geometry="POINT (-114.05879 51.04668)" data-type="wkt">
 										<td>3</td>
 										<td><a href="https://www.wikipedia.org/wiki/Calgary" title="Calgary">Calgary</a></td>
-										<td>1{{{i18n "info1000"}}}096{{{i18n "info1000"}}}833</td>
+										<td>1,096,833</td>
 									</tr>
 									<tr data-geometry="POINT (-75.68937 45.41072)" data-type="wkt">
 										<td>4</td>
 										<td><a href="https://www.wikipedia.org/wiki/Ottawa" title="Ottawa">Ottawa</a></td>
-										<td>883{{{i18n "info1000"}}}391</td>
+										<td>883,391</td>
 									</tr>
 									<tr data-geometry="POINT (-113.49590 53.53398)" data-type="wkt">
 										<td>5</td>
 										<td><a href="https://www.wikipedia.org/wiki/Edmonton" title="Edmonton">Edmonton</a></td>
-										<td>812{{{i18n "info1000"}}}201</td>
+										<td>812,201</td>
 									</tr>
 									<tr data-geometry="POINT (-79.65 43.60)" data-type="wkt">
 										<td>6</td>
 										<td><a href="https://www.wikipedia.org/wiki/Mississauga" title="Mississauga">Mississauga</a></td>
-										<td>713{{{i18n "info1000"}}}443</td>
+										<td>713,443</td>
 									</tr>
 									<tr data-geometry="POINT (-97.14352 49.89375)" data-type="wkt">
 										<td>7</td>
 										<td><a href="https://www.wikipedia.org/wiki/Winnipeg" title="Winnipeg">Winnipeg</a></td>
-										<td>663{{{i18n "info1000"}}}617</td>
+										<td>663,617</td>
 									</tr>
 									<tr data-geometry="POINT (-123.10091 49.26428)" data-type="wkt">
 										<td>8</td>
 										<td><a href="https://www.wikipedia.org/wiki/Vancouver" title="Vancouver">Vancouver</a></td>
-										<td>603{{{i18n "info1000"}}}502</td>
+										<td>603,502</td>
 									</tr>
 									<tr data-geometry="POINT (-79.76181 43.68686)" data-type="wkt">
 										<td>9</td>
 										<td><a href="https://www.wikipedia.org/wiki/Brampton" title="Brampton">Brampton</a></td>
-										<td>523{{{i18n "info1000"}}}911</td>
+										<td>523,911</td>
 									</tr>
 									<tr data-geometry="POINT (-79.86788 43.25717)" data-type="wkt">
 										<td>10</td>
 										<td><a href="https://www.wikipedia.org/wiki/Hamilton,_Ontario" title="Hamilton, Ontario">Hamilton</a></td>
-										<td>519{{{i18n "info1000"}}}949</td>
+										<td>519,949</td>
 									</tr>
 								</tbody>
 							</table>
@@ -1008,52 +1008,52 @@ var wet_boew_geomap = {
 							<tr data-geometry="POINT (-79.3847 43.6476)" data-type="wkt">
 								<td>1</td>
 								<td><a href="https://www.wikipedia.org/wiki/Toronto" title="Toronto">Toronto</a></td>
-								<td>2{{{i18n "info1000"}}}615{{{i18n "info1000"}}}060</td>
+								<td>2,615,060</td>
 							</tr>
 							<tr data-geometry="POINT (-73.56123 45.52927)" data-type="wkt">
 								<td>2</td>
 								<td><a href="https://www.wikipedia.org/wiki/Montreal" title="Montreal">Montreal</a></td>
-								<td>1{{{i18n "info1000"}}}649{{{i18n "info1000"}}}519</td>
+								<td>1,649,519</td>
 							</tr>
 							<tr data-geometry="POINT (-114.05879 51.04668)" data-type="wkt">
 								<td>3</td>
 								<td><a href="https://www.wikipedia.org/wiki/Calgary" title="Calgary">Calgary</a></td>
-								<td>1{{{i18n "info1000"}}}096{{{i18n "info1000"}}}833</td>
+								<td>1,096,833</td>
 							</tr>
 							<tr data-geometry="POINT (-75.68937 45.41072)" data-type="wkt">
 								<td>4</td>
 								<td><a href="https://www.wikipedia.org/wiki/Ottawa" title="Ottawa">Ottawa</a></td>
-								<td>883{{{i18n "info1000"}}}391</td>
+								<td>883,391</td>
 							</tr>
 							<tr data-geometry="POINT (-113.49590 53.53398)" data-type="wkt">
 								<td>5</td>
 								<td><a href="https://www.wikipedia.org/wiki/Edmonton" title="Edmonton">Edmonton</a></td>
-								<td>812{{{i18n "info1000"}}}201</td>
+								<td>812,201</td>
 							</tr>
 							<tr data-geometry="POINT (-79.65 43.60)" data-type="wkt">
 								<td>6</td>
 								<td><a href="https://www.wikipedia.org/wiki/Mississauga" title="Mississauga">Mississauga</a></td>
-								<td>713{{{i18n "info1000"}}}443</td>
+								<td>713,443</td>
 							</tr>
 							<tr data-geometry="POINT (-97.14352 49.89375)" data-type="wkt">
 								<td>7</td>
 								<td><a href="https://www.wikipedia.org/wiki/Winnipeg" title="Winnipeg">Winnipeg</a></td>
-								<td>663{{{i18n "info1000"}}}617</td>
+								<td>663,617</td>
 							</tr>
 							<tr data-geometry="POINT (-123.10091 49.26428)" data-type="wkt">
 								<td>8</td>
 								<td><a href="https://www.wikipedia.org/wiki/Vancouver" title="Vancouver">Vancouver</a></td>
-								<td>603{{{i18n "info1000"}}}502</td>
+								<td>603,502</td>
 							</tr>
 							<tr data-geometry="POINT (-79.76181 43.68686)" data-type="wkt">
 								<td>9</td>
 								<td><a href="https://www.wikipedia.org/wiki/Brampton" title="Brampton">Brampton</a></td>
-								<td>523{{{i18n "info1000"}}}911</td>
+								<td>523,911</td>
 							</tr>
 							<tr data-geometry="POINT (-79.86788 43.25717)" data-type="wkt">
 								<td>10</td>
 								<td><a href="https://www.wikipedia.org/wiki/Hamilton,_Ontario" title="Hamilton, Ontario">Hamilton</a></td>
-								<td>519{{{i18n "info1000"}}}949</td>
+								<td>519,949</td>
 							</tr>
 						</tbody>
 					</table>
@@ -1247,52 +1247,52 @@ var wet_boew_geomap = {
 						&lt;tr data-geometry="POINT (-79.3847 43.6476)" data-type="wkt"&gt;
 							&lt;td&gt;1&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Toronto" title="Toronto"&gt;Toronto&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;2{{{i18n "info1000"}}}615{{{i18n "info1000"}}}060&lt;/td&gt;
+							&lt;td&gt;2,615,060&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-73.56123 45.52927)" data-type="wkt"&gt;
 							&lt;td&gt;2&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Montreal" title="Montreal"&gt;Montreal&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;1{{{i18n "info1000"}}}649{{{i18n "info1000"}}}519&lt;/td&gt;
+							&lt;td&gt;1,649,519&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-114.05879 51.04668)" data-type="wkt"&gt;
 							&lt;td&gt;3&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Calgary" title="Calgary"&gt;Calgary&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;1{{{i18n "info1000"}}}096{{{i18n "info1000"}}}833&lt;/td&gt;
+							&lt;td&gt;1,096,833&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-75.68937 45.41072)" data-type="wkt"&gt;
 							&lt;td&gt;4&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Ottawa" title="Ottawa"&gt;Ottawa&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;883{{{i18n "info1000"}}}391&lt;/td&gt;
+							&lt;td&gt;883,391&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-113.49590 53.53398)" data-type="wkt"&gt;
 							&lt;td&gt;5&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Edmonton" title="Edmonton"&gt;Edmonton&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;812{{{i18n "info1000"}}}201&lt;/td&gt;
+							&lt;td&gt;812,201&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-79.65 43.60)" data-type="wkt"&gt;
 							&lt;td&gt;6&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Mississauga" title="Mississauga"&gt;Mississauga&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;713{{{i18n "info1000"}}}443&lt;/td&gt;
+							&lt;td&gt;713,443&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-97.14352 49.89375)" data-type="wkt"&gt;
 							&lt;td&gt;7&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Winnipeg" title="Winnipeg"&gt;Winnipeg&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;663{{{i18n "info1000"}}}617&lt;/td&gt;
+							&lt;td&gt;663,617&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-123.10091 49.26428)" data-type="wkt"&gt;
 							&lt;td&gt;8&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Vancouver" title="Vancouver"&gt;Vancouver&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;603{{{i18n "info1000"}}}502&lt;/td&gt;
+							&lt;td&gt;603,502&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-79.76181 43.68686)" data-type="wkt"&gt;
 							&lt;td&gt;9&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Brampton" title="Brampton"&gt;Brampton&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;523{{{i18n "info1000"}}}911&lt;/td&gt;
+							&lt;td&gt;523,911&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-79.86788 43.25717)" data-type="wkt"&gt;
 							&lt;td&gt;10&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Hamilton,_Ontario" title="Hamilton, Ontario"&gt;Hamilton&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;519{{{i18n "info1000"}}}949&lt;/td&gt;
+							&lt;td&gt;519,949&lt;/td&gt;
 						&lt;/tr&gt;
 					&lt;/tbody&gt;
 				&lt;/table&gt;

--- a/src/plugins/geomap/geomap-fr.hbs
+++ b/src/plugins/geomap/geomap-fr.hbs
@@ -146,52 +146,52 @@
 									<tr data-geometry="POINT (-79.3847 43.6476)" data-type="wkt">
 										<td>1</td>
 										<td><a href="https://www.wikipedia.org/wiki/Toronto" title="Toronto">Toronto</a></td>
-										<td>2{{{i18n "info1000"}}}615{{{i18n "info1000"}}}060</td>
+										<td>2&#160;615&#160;060</td>
 									</tr>
 									<tr data-geometry="POINT (-73.56123 45.52927)" data-type="wkt">
 										<td>2</td>
 										<td><a href="https://www.wikipedia.org/wiki/Montreal" title="Montreal">Montreal</a></td>
-										<td>1{{{i18n "info1000"}}}649{{{i18n "info1000"}}}519</td>
+										<td>1&#160;649&#160;519</td>
 									</tr>
 									<tr data-geometry="POINT (-114.05879 51.04668)" data-type="wkt">
 										<td>3</td>
 										<td><a href="https://www.wikipedia.org/wiki/Calgary" title="Calgary">Calgary</a></td>
-										<td>1{{{i18n "info1000"}}}096{{{i18n "info1000"}}}833</td>
+										<td>1&#160;096&#160;833</td>
 									</tr>
 									<tr data-geometry="POINT (-75.68937 45.41072)" data-type="wkt">
 										<td>4</td>
 										<td class="select"><a href="https://www.wikipedia.org/wiki/Ottawa" title="Ottawa">Ottawa</a></td>
-										<td>883{{{i18n "info1000"}}}391</td>
+										<td>883&#160;391</td>
 									</tr>
 									<tr data-geometry="POINT (-113.49590 53.53398)" data-type="wkt">
 										<td>5</td>
 										<td><a href="https://www.wikipedia.org/wiki/Edmonton" title="Edmonton">Edmonton</a></td>
-										<td>812{{{i18n "info1000"}}}201</td>
+										<td>812&#160;201</td>
 									</tr>
 									<tr data-geometry="POINT (-79.65 43.60)" data-type="wkt">
 										<td>6</td>
 										<td><a href="https://www.wikipedia.org/wiki/Mississauga" title="Mississauga">Mississauga</a></td>
-										<td>713{{{i18n "info1000"}}}443</td>
+										<td>713&#160;443</td>
 									</tr>
 									<tr data-geometry="POINT (-97.14352 49.89375)" data-type="wkt">
 										<td>7</td>
 										<td><a href="https://www.wikipedia.org/wiki/Winnipeg" title="Winnipeg">Winnipeg</a></td>
-										<td>663{{{i18n "info1000"}}}617</td>
+										<td>663&#160;617</td>
 									</tr>
 									<tr data-geometry="POINT (-123.10091 49.26428)" data-type="wkt">
 										<td>8</td>
 										<td><a href="https://www.wikipedia.org/wiki/Vancouver" title="Vancouver">Vancouver</a></td>
-										<td>603{{{i18n "info1000"}}}502</td>
+										<td>603&#160;502</td>
 									</tr>
 									<tr data-geometry="POINT (-79.76181 43.68686)" data-type="wkt">
 										<td>9</td>
 										<td><a href="https://www.wikipedia.org/wiki/Brampton" title="Brampton">Brampton</a></td>
-										<td>523{{{i18n "info1000"}}}911</td>
+										<td>523&#160;911</td>
 									</tr>
 									<tr data-geometry="POINT (-79.86788 43.25717)" data-type="wkt">
 										<td>10</td>
 										<td><a href="https://www.wikipedia.org/wiki/Hamilton,_Ontario" title="Hamilton, Ontario">Hamilton</a></td>
-										<td>519{{{i18n "info1000"}}}949</td>
+										<td>519&#160;949</td>
 									</tr>
 								</tbody>
 							</table>
@@ -998,52 +998,52 @@ var wet_boew_geomap = {
 							<tr data-geometry="POINT (-79.3847 43.6476)" data-type="wkt">
 								<td>1</td>
 								<td><a href="https://www.wikipedia.org/wiki/Toronto" title="Toronto">Toronto</a></td>
-								<td>2{{{i18n "info1000"}}}615{{{i18n "info1000"}}}060</td>
+								<td>2&#160;615&#160;060</td>
 							</tr>
 							<tr data-geometry="POINT (-73.56123 45.52927)" data-type="wkt">
 								<td>2</td>
 								<td><a href="https://www.wikipedia.org/wiki/Montreal" title="Montreal">Montreal</a></td>
-								<td>1{{{i18n "info1000"}}}649{{{i18n "info1000"}}}519</td>
+								<td>1&#160;649&#160;519</td>
 							</tr>
 							<tr data-geometry="POINT (-114.05879 51.04668)" data-type="wkt">
 								<td>3</td>
 								<td><a href="https://www.wikipedia.org/wiki/Calgary" title="Calgary">Calgary</a></td>
-								<td>1{{{i18n "info1000"}}}096{{{i18n "info1000"}}}833</td>
+								<td>1&#160;096&#160;833</td>
 							</tr>
 							<tr data-geometry="POINT (-75.68937 45.41072)" data-type="wkt">
 								<td>4</td>
 								<td class="select"><a href="https://www.wikipedia.org/wiki/Ottawa" title="Ottawa">Ottawa</a></td>
-								<td>883{{{i18n "info1000"}}}391</td>
+								<td>883&#160;391</td>
 							</tr>
 							<tr data-geometry="POINT (-113.49590 53.53398)" data-type="wkt">
 								<td>5</td>
 								<td><a href="https://www.wikipedia.org/wiki/Edmonton" title="Edmonton">Edmonton</a></td>
-								<td>812{{{i18n "info1000"}}}201</td>
+								<td>812&#160;201</td>
 							</tr>
 							<tr data-geometry="POINT (-79.65 43.60)" data-type="wkt">
 								<td>6</td>
 								<td><a href="https://www.wikipedia.org/wiki/Mississauga" title="Mississauga">Mississauga</a></td>
-								<td>713{{{i18n "info1000"}}}443</td>
+								<td>713&#160;443</td>
 							</tr>
 							<tr data-geometry="POINT (-97.14352 49.89375)" data-type="wkt">
 								<td>7</td>
 								<td><a href="https://www.wikipedia.org/wiki/Winnipeg" title="Winnipeg">Winnipeg</a></td>
-								<td>663{{{i18n "info1000"}}}617</td>
+								<td>663&#160;617</td>
 							</tr>
 							<tr data-geometry="POINT (-123.10091 49.26428)" data-type="wkt">
 								<td>8</td>
 								<td><a href="https://www.wikipedia.org/wiki/Vancouver" title="Vancouver">Vancouver</a></td>
-								<td>603{{{i18n "info1000"}}}502</td>
+								<td>603&#160;502</td>
 							</tr>
 							<tr data-geometry="POINT (-79.76181 43.68686)" data-type="wkt">
 								<td>9</td>
 								<td><a href="https://www.wikipedia.org/wiki/Brampton" title="Brampton">Brampton</a></td>
-								<td>523{{{i18n "info1000"}}}911</td>
+								<td>523&#160;911</td>
 							</tr>
 							<tr data-geometry="POINT (-79.86788 43.25717)" data-type="wkt">
 								<td>10</td>
 								<td><a href="https://www.wikipedia.org/wiki/Hamilton,_Ontario" title="Hamilton, Ontario">Hamilton</a></td>
-								<td>519{{{i18n "info1000"}}}949</td>
+								<td>519&#160;949</td>
 							</tr>
 						</tbody>
 					</table>
@@ -1235,52 +1235,52 @@ var wet_boew_geomap = {
 						&lt;tr data-geometry="POINT (-79.3847 43.6476)" data-type="wkt"&gt;
 							&lt;td&gt;1&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Toronto" title="Toronto"&gt;Toronto&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;2{{{i18n "info1000"}}}615{{{i18n "info1000"}}}060&lt;/td&gt;
+							&lt;td&gt;2&#160;615&#160;060&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-73.56123 45.52927)" data-type="wkt"&gt;
 							&lt;td&gt;2&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Montreal" title="Montreal"&gt;Montreal&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;1{{{i18n "info1000"}}}649{{{i18n "info1000"}}}519&lt;/td&gt;
+							&lt;td&gt;1&#160;649&#160;519&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-114.05879 51.04668)" data-type="wkt"&gt;
 							&lt;td&gt;3&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Calgary" title="Calgary"&gt;Calgary&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;1{{{i18n "info1000"}}}096{{{i18n "info1000"}}}833&lt;/td&gt;
+							&lt;td&gt;1&#160;096&#160;833&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-75.68937 45.41072)" data-type="wkt"&gt;
 							&lt;td&gt;4&lt;/td&gt;
 							&lt;td class="select"&gt;&lt;a href="https://www.wikipedia.org/wiki/Ottawa" title="Ottawa"&gt;Ottawa&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;883{{{i18n "info1000"}}}391&lt;/td&gt;
+							&lt;td&gt;883&#160;391&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-113.49590 53.53398)" data-type="wkt"&gt;
 							&lt;td&gt;5&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Edmonton" title="Edmonton"&gt;Edmonton&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;812{{{i18n "info1000"}}}201&lt;/td&gt;
+							&lt;td&gt;812&#160;201&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-79.65 43.60)" data-type="wkt"&gt;
 							&lt;td&gt;6&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Mississauga" title="Mississauga"&gt;Mississauga&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;713{{{i18n "info1000"}}}443&lt;/td&gt;
+							&lt;td&gt;713&#160;443&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-97.14352 49.89375)" data-type="wkt"&gt;
 							&lt;td&gt;7&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Winnipeg" title="Winnipeg"&gt;Winnipeg&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;663{{{i18n "info1000"}}}617&lt;/td&gt;
+							&lt;td&gt;663&#160;617&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-123.10091 49.26428)" data-type="wkt"&gt;
 							&lt;td&gt;8&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Vancouver" title="Vancouver"&gt;Vancouver&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;603{{{i18n "info1000"}}}502&lt;/td&gt;
+							&lt;td&gt;603&#160;502&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-79.76181 43.68686)" data-type="wkt"&gt;
 							&lt;td&gt;9&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Brampton" title="Brampton"&gt;Brampton&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;523{{{i18n "info1000"}}}911&lt;/td&gt;
+							&lt;td&gt;523&#160;911&lt;/td&gt;
 						&lt;/tr&gt;
 						&lt;tr data-geometry="POINT (-79.86788 43.25717)" data-type="wkt"&gt;
 							&lt;td&gt;10&lt;/td&gt;
 							&lt;td&gt;&lt;a href="https://www.wikipedia.org/wiki/Hamilton,_Ontario" title="Hamilton, Ontario"&gt;Hamilton&lt;/a&gt;&lt;/td&gt;
-							&lt;td&gt;519{{{i18n "info1000"}}}949&lt;/td&gt;
+							&lt;td&gt;519&#160;949&lt;/td&gt;
 						&lt;/tr&gt;
 					&lt;/tbody&gt;
 				&lt;/table&gt;

--- a/src/plugins/geomap/geomap-v4.0.30-en.hbs
+++ b/src/plugins/geomap/geomap-v4.0.30-en.hbs
@@ -130,52 +130,52 @@
 								<tr data-geometry="POINT (-79.3847, 43.6476)" data-type="wkt">
 									<td>1</td>
 									<td><a href="https://www.wikipedia.org/wiki/Toronto" title="Toronto">Toronto</a></td>
-									<td>2{{{i18n "info1000"}}}615{{{i18n "info1000"}}}060</td>
+									<td>2,615,060</td>
 								</tr>
 								<tr data-geometry="POINT (-73.56123, 45.52927)" data-type="wkt">
 									<td>2</td>
 									<td><a href="https://www.wikipedia.org/wiki/Montreal" title="Montreal">Montreal</a></td>
-									<td>1{{{i18n "info1000"}}}649{{{i18n "info1000"}}}519</td>
+									<td>1,649,519</td>
 								</tr>
 								<tr data-geometry="POINT (-114.05879, 51.04668)" data-type="wkt">
 									<td>3</td>
 									<td><a href="https://www.wikipedia.org/wiki/Calgary" title="Calgary">Calgary</a></td>
-									<td>1{{{i18n "info1000"}}}096{{{i18n "info1000"}}}833</td>
+									<td>1,096,833</td>
 								</tr>
 								<tr data-geometry="POINT (-75.68937, 45.41072)" data-type="wkt">
 									<td>4</td>
 									<td><a href="https://www.wikipedia.org/wiki/Ottawa" title="Ottawa">Ottawa</a></td>
-									<td>883{{{i18n "info1000"}}}391</td>
+									<td>883,391</td>
 								</tr>
 								<tr data-geometry="POINT (-113.49590, 53.53398)" data-type="wkt">
 									<td>5</td>
 									<td><a href="https://www.wikipedia.org/wiki/Edmonton" title="Edmonton">Edmonton</a></td>
-									<td>812{{{i18n "info1000"}}}201</td>
+									<td>812,201</td>
 								</tr>
 								<tr data-geometry="POINT (-79.65, 43.60)" data-type="wkt">
 									<td>6</td>
 									<td><a href="https://www.wikipedia.org/wiki/Mississauga" title="Mississauga">Mississauga</a></td>
-									<td>713{{{i18n "info1000"}}}443</td>
+									<td>713,443</td>
 								</tr>
 								<tr data-geometry="POINT (-97.14352, 49.89375)" data-type="wkt">
 									<td>7</td>
 									<td><a href="https://www.wikipedia.org/wiki/Winnipeg" title="Winnipeg">Winnipeg</a></td>
-									<td>663{{{i18n "info1000"}}}617</td>
+									<td>663,617</td>
 								</tr>
 								<tr data-geometry="POINT (-123.10091, 49.26428)" data-type="wkt">
 									<td>8</td>
 									<td><a href="https://www.wikipedia.org/wiki/Vancouver" title="Vancouver">Vancouver</a></td>
-									<td>603{{{i18n "info1000"}}}502</td>
+									<td>603,502</td>
 								</tr>
 								<tr data-geometry="POINT (-79.76181, 43.68686)" data-type="wkt">
 									<td>9</td>
 									<td><a href="https://www.wikipedia.org/wiki/Brampton" title="Brampton">Brampton</a></td>
-									<td>523{{{i18n "info1000"}}}911</td>
+									<td>523,911</td>
 								</tr>
 								<tr data-geometry="POINT (-79.86788, 43.25717)" data-type="wkt">
 									<td>10</td>
 									<td><a href="https://www.wikipedia.org/wiki/Hamilton,_Ontario" title="Hamilton, Ontario">Hamilton</a></td>
-									<td>519{{{i18n "info1000"}}}949</td>
+									<td>519,949</td>
 								</tr>
 							</tbody>
 						</table>

--- a/src/plugins/geomap/geomap-v4.0.30-fr.hbs
+++ b/src/plugins/geomap/geomap-v4.0.30-fr.hbs
@@ -129,52 +129,52 @@
 								<tr data-geometry="POINT (-79.3847, 43.6476)" data-type="wkt">
 									<td>1</td>
 									<td><a href="https://www.wikipedia.org/wiki/Toronto" title="Toronto">Toronto</a></td>
-									<td>2{{{i18n "info1000"}}}615{{{i18n "info1000"}}}060</td>
+									<td>2&#160;615&#160;060</td>
 								</tr>
 								<tr data-geometry="POINT (-73.56123, 45.52927)" data-type="wkt">
 									<td>2</td>
 									<td><a href="https://www.wikipedia.org/wiki/Montreal" title="Montreal">Montreal</a></td>
-									<td>1{{{i18n "info1000"}}}649{{{i18n "info1000"}}}519</td>
+									<td>1&#160;649&#160;519</td>
 								</tr>
 								<tr data-geometry="POINT (-114.05879, 51.04668)" data-type="wkt">
 									<td>3</td>
 									<td><a href="https://www.wikipedia.org/wiki/Calgary" title="Calgary">Calgary</a></td>
-									<td>1{{{i18n "info1000"}}}096{{{i18n "info1000"}}}833</td>
+									<td>1&#160;096&#160;833</td>
 								</tr>
 								<tr data-geometry="POINT (-75.68937, 45.41072)" data-type="wkt">
 									<td>4</td>
 									<td class="select"><a href="https://www.wikipedia.org/wiki/Ottawa" title="Ottawa">Ottawa</a></td>
-									<td>883{{{i18n "info1000"}}}391</td>
+									<td>883&#160;391</td>
 								</tr>
 								<tr data-geometry="POINT (-113.49590, 53.53398)" data-type="wkt">
 									<td>5</td>
 									<td><a href="https://www.wikipedia.org/wiki/Edmonton" title="Edmonton">Edmonton</a></td>
-									<td>812{{{i18n "info1000"}}}201</td>
+									<td>812&#160;201</td>
 								</tr>
 								<tr data-geometry="POINT (-79.65, 43.60)" data-type="wkt">
 									<td>6</td>
 									<td><a href="https://www.wikipedia.org/wiki/Mississauga" title="Mississauga">Mississauga</a></td>
-									<td>713{{{i18n "info1000"}}}443</td>
+									<td>713&#160;443</td>
 								</tr>
 								<tr data-geometry="POINT (-97.14352, 49.89375)" data-type="wkt">
 									<td>7</td>
 									<td><a href="https://www.wikipedia.org/wiki/Winnipeg" title="Winnipeg">Winnipeg</a></td>
-									<td>663{{{i18n "info1000"}}}617</td>
+									<td>663&#160;617</td>
 								</tr>
 								<tr data-geometry="POINT (-123.10091, 49.26428)" data-type="wkt">
 									<td>8</td>
 									<td><a href="https://www.wikipedia.org/wiki/Vancouver" title="Vancouver">Vancouver</a></td>
-									<td>603{{{i18n "info1000"}}}502</td>
+									<td>603&#160;502</td>
 								</tr>
 								<tr data-geometry="POINT (-79.76181, 43.68686)" data-type="wkt">
 									<td>9</td>
 									<td><a href="https://www.wikipedia.org/wiki/Brampton" title="Brampton">Brampton</a></td>
-									<td>523{{{i18n "info1000"}}}911</td>
+									<td>523&#160;911</td>
 								</tr>
 								<tr data-geometry="POINT (-79.86788, 43.25717)" data-type="wkt">
 									<td>10</td>
 									<td><a href="https://www.wikipedia.org/wiki/Hamilton,_Ontario" title="Hamilton, Ontario">Hamilton</a></td>
-									<td>519{{{i18n "info1000"}}}949</td>
+									<td>519&#160;949</td>
 								</tr>
 							</tbody>
 						</table>


### PR DESCRIPTION
This was generating Jekyll liquid warning when the geomap working example was rendered with the GCWeb theme.
