### PR TITLE
Release v4.0.45.1 - Update GCWeb to v10.2.0

### DIFF
--- a/site/pages/docs/versions/dwnld-en.hbs
+++ b/site/pages/docs/versions/dwnld-en.hbs
@@ -30,8 +30,8 @@
 			</tr>
 			<tr>
 				<td>Canada.ca (GCWeb)</td>
-				<td>v10.1.1 (STR)</td>
-				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Download<span class="wb-inv"> - v10.1.1 (STR) - Canada.ca theme</span></a></td>
+				<td>v10.2.0 (STR)</td>
+				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Download<span class="wb-inv"> - v10.2.0 (STR) - Canada.ca theme</span></a></td>
 			</tr>
 		</tbody>
 	</table>

--- a/site/pages/docs/versions/dwnld-fr.hbs
+++ b/site/pages/docs/versions/dwnld-fr.hbs
@@ -30,8 +30,8 @@
 			</tr>
 			<tr>
 				<td>Canada.ca (GCWeb)</td>
-				<td>v10.1.1 (DCT)</td>
-				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Télécharger<span class="wb-inv"> - v10.1.1 (DCT) - Thème Canada.ca</span></a></td>
+				<td>v10.2.0 (DCT)</td>
+				<td class="text-center"><a class="btn btn-default" href="https://github.com/wet-boew/GCWeb/releases/latest">Télécharger<span class="wb-inv"> - v10.2.0 (DCT) - Thème Canada.ca</span></a></td>
 			</tr>
 		</tbody>
 	</table>


### PR DESCRIPTION
Update the version of GCWeb to v10.2.0 in the following files:

- site/pages/docs/versions/dwnld-en.hbs
- site/pages/docs/versions/dwnld-fr.hbs