### PR TITLE
Wrap Overlay and Lightbox plugins popup in Dialog for screen reader c…

### DIFF
--- a/src/plugins/lightbox/_base.scss
+++ b/src/plugins/lightbox/_base.scss
@@ -127,7 +127,7 @@ body {
 	}
 }
 
-.mfp-wrap {
+.wb-modal {
 	dialog{
 		background-color: transparent;
 		border: none;

--- a/src/plugins/lightbox/_base.scss
+++ b/src/plugins/lightbox/_base.scss
@@ -126,3 +126,10 @@ body {
 		@extend %global-display-block-important;
 	}
 }
+
+.mfp-wrap {
+	dialog{
+		background-color:transparent;
+		border:none;
+	 }
+}

--- a/src/plugins/lightbox/_base.scss
+++ b/src/plugins/lightbox/_base.scss
@@ -131,5 +131,5 @@ body {
 	dialog{
 		background-color:transparent;
 		border:none;
-	 }
+	}
 }

--- a/src/plugins/lightbox/_base.scss
+++ b/src/plugins/lightbox/_base.scss
@@ -131,12 +131,5 @@ body {
 	dialog{
 		background-color: transparent;
 		border: none;
-		height: 100%;
-		left: 0;
-		padding: 0px;
-		position: absolute;
-		text-align: center;
-		top: 0;
-		width: 100%;
 	}
 }

--- a/src/plugins/lightbox/_base.scss
+++ b/src/plugins/lightbox/_base.scss
@@ -129,7 +129,14 @@ body {
 
 .mfp-wrap {
 	dialog{
-		background-color:transparent;
-		border:none;
+		background-color: transparent;
+		border: none;
+		height: 100%;
+		left: 0;
+		padding: 0px;
+		position: absolute;
+		text-align: center;
+		top: 0;
+		width: 100%;
 	}
 }

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -144,7 +144,7 @@ var componentName = "wb-lbx",
 					var $item = this.currItem,
 						$content = this.contentContainer,
 						$wrap = this.wrap,
-						$container = $wrap.find('.mfp-container'),
+						$container = $wrap.find( ".mfp-container" ),
 						$modal = $wrap.find( ".modal-dialog" ),
 						$buttons = $wrap.find( ".mfp-close, .mfp-arrow" ),
 						len = $buttons.length,
@@ -169,7 +169,7 @@ var componentName = "wb-lbx",
 
 					trapTabbing( $wrap );
 
-					if ( $container.html().trim() != '' ) {
+					if ( $container.html().trim() !== "" ) {
 						var contentHtml = $container.html();
 						$container.empty().html( "<dialog class='mfp-content' open>" + contentHtml + "</dialog>" );
 					}

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -144,6 +144,7 @@ var componentName = "wb-lbx",
 					var $item = this.currItem,
 						$content = this.contentContainer,
 						$wrap = this.wrap,
+						$container = $wrap.find('.mfp-container'),
 						$modal = $wrap.find( ".modal-dialog" ),
 						$buttons = $wrap.find( ".mfp-close, .mfp-arrow" ),
 						len = $buttons.length,
@@ -167,10 +168,17 @@ var componentName = "wb-lbx",
 					this.contentContainer.attr( "data-pgtitle", document.getElementsByTagName( "H1" )[ 0 ].textContent );
 
 					trapTabbing( $wrap );
+
+					if ( $container.html().trim() != '' ) {
+						var contentHtml = $container.html();
+						$container.empty().html( "<dialog class='mfp-content' open>" + contentHtml + "</dialog>" );
+					}
 				},
 				close: function() {
 					$document.find( "body" ).removeClass( "wb-modal" );
 					$document.find( modalHideSelector ).removeAttr( "aria-hidden" );
+					this.wrap.find( "dialog" ).removeAttr( "open" );
+
 				},
 				change: function() {
 					var $item = this.currItem,

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -169,10 +169,7 @@ var componentName = "wb-lbx",
 
 					trapTabbing( $wrap );
 
-					if ( $container.html().trim() !== "" ) {
-						var contentHtml = $container.html();
-						$container.empty().html( "<dialog class='mfp-content' open>" + contentHtml + "</dialog>" );
-					}
+					$container.wrap( "<dialog class='mfp-content' open='open'></dialog>" );
 				},
 				close: function() {
 					$document.find( "body" ).removeClass( "wb-modal" );

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -145,6 +145,7 @@ var componentName = "wb-lbx",
 						$content = this.contentContainer,
 						$wrap = this.wrap,
 						$container = $wrap.find( ".mfp-container" ),
+						$containerParent = $container.parent(),
 						$modal = $wrap.find( ".modal-dialog" ),
 						$buttons = $wrap.find( ".mfp-close, .mfp-arrow" ),
 						len = $buttons.length,
@@ -169,7 +170,11 @@ var componentName = "wb-lbx",
 
 					trapTabbing( $wrap );
 
-					$container.wrap( "<dialog class='mfp-content' open='open'></dialog>" );
+					if ( !$containerParent.is( "dialog" ) ) {
+						$container.wrap( "<dialog open='open'></dialog>" );
+					} else {
+						$containerParent.attr( "open", "open" );
+					}
 				},
 				close: function() {
 					$document.find( "body" ).removeClass( "wb-modal" );

--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -171,7 +171,7 @@ var componentName = "wb-lbx",
 					trapTabbing( $wrap );
 
 					if ( !$containerParent.is( "dialog" ) ) {
-						$container.wrap( "<dialog open='open'></dialog>" );
+						$container.wrap( "<dialog class='mfp-container' open='open'></dialog>" );
 					} else {
 						$containerParent.attr( "open", "open" );
 					}

--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -115,6 +115,7 @@ var componentName = "wb-overlay",
 
 		$overlay
 			.addClass( "open" )
+			.attr( "role", "dialog" )
 			.attr( "aria-hidden", "false" );
 
 		if ( $overlay.hasClass( "wb-popup-full" ) || $overlay.hasClass( "wb-popup-mid" ) ) {
@@ -145,6 +146,7 @@ var componentName = "wb-overlay",
 
 		$overlay
 			.removeClass( "open" )
+			.removeAttr( "role" )
 			.attr( "aria-hidden", "true" );
 
 		if ( $overlay.hasClass( "wb-popup-full" ) || $overlay.hasClass( "wb-popup-mid" ) ) {


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Wrap Overlay and Lightbox plugins popup in Dialog for screen reader compatibility

## Additional information (optional) / Information additionnelle (optionel)
I recently assessed an application using the WET4 light boxes (Lightbox) for the Session Timeout and some informational messages. The developer says they are using WET4 correctly. 
The issue is that I can navigate to the background of the Lightbox using the arrow keys on screen readers (JAWS 2020 and NVDA) in their application. 
I tested the Lightbox and Session Timeout on WET4, and I correctly am not able to navigate to the background while using a screen reader.
In my research, I discovered that adding `<div role="dialog">` around the `<div role="document">` will prevent the screen reader user from navigating to the background using the arrow keys.

**General checklist / Liste de contrôle générale**
Make your own list for the purpose of your Pull request. /// Faites votre propre liste en fonction des besoins de votre demande « pull ».

- [x] Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
- [x] Validate changes against WCAG for accessibility /// Valider les changements avec WCAG pour l'accessibilité

**Related issues / Requêtes associées**


**Screenshots / Captures d'écrans**

