### PR TITLE
Update form validations English document: url2

### DIFF
--- a/site/pages/docs/ref/formvalid/formvalid-en.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-en.hbs
@@ -250,7 +250,7 @@
 					<td>URL (IPv6)</td>
 				</tr>
 				<tr>
-					<td><code>type="url" data-rule-url2="true"</code></td>
+					<td><code>type="text" data-rule-url2="true"</code></td>
 					<td>URL (TLD optional)</td>
 				</tr>
 				<tr>

--- a/site/pages/docs/ref/formvalid/formvalid-fr.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-fr.hbs
@@ -253,7 +253,7 @@
 					<td>URL (IPv6)</td>
 				</tr>
 				<tr>
-					<td><code>type="url" data-rule-url2="true"</code></td>
+					<td><code>type="text" data-rule-url2="true"</code></td>
 					<td>URL (TLD optional)</td>
 				</tr>
 				<tr>


### PR DESCRIPTION
` data-rule-url2="true"` only works with `type="text"` and not `type="url"`
