### PR TITLE
Core: Set WET's lang to first 2 chars of page lang

### DIFF
--- a/site/pages/docs/ref/core/core-en.hbs
+++ b/site/pages/docs/ref/core/core-en.hbs
@@ -1,0 +1,68 @@
+---
+{
+	"title": "WET core",
+	"language": "en",
+	"category": "Other",
+	"categoryfile": "other",
+	"description": "Core WET object.",
+	"altLangPrefix": "core",
+	"dateModified": "2022-04-20"
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<div class="alert alert-warning mrgn-tp-lg">
+	<h2>Work in progress</h2>
+	<p>This page is a work in progress.</p>
+</div>
+
+<section>
+	<h2>Purpose</h2>
+	<p>Core WET object.</p>
+</section>
+
+<section>
+	<h2>Language (<code>wb.lang</code>)</h2>
+	<p>WET's language is derived from the <code>html</code> element's <code>lang</code> attribute. A formatted version of the page's language code is stored in the <code>wb.lang</code> variable.</p>
+	<p>By default, the variable's value will be derived from the first two characters of the page's language code. If a longer code is specified, it'll be re-used as the variable's value so long as it corresponds to one of WET's built-in languages (i.e. <code>pt-BR</code> for Portuguese [Brazilian] or <code>zh-Hans</code> for Chinese [Simplified]).</p>
+	<p>Implementations that want to provide custom i18n files for longer language codes (e.g. <code>en-CA</code>, <code>en-US</code>, etc) can do so by adding <code>data-wb-core</code> and <code>lang-lang-long=""</code> attributes to WET's <code>script</code> element.</p>
+	<p>WET will also attempt to load an i18n file named after the variable. Plugins won't initialize if the i18n file fails to load.</p>
+</section>
+
+<section>
+	<h2>Configuration</h2>
+	<div class="table-responsive">
+		<table class="table">
+			<thead>
+				<tr>
+					<th>Type</th>
+					<th>Option</th>
+					<th>Description</th>
+					<th>How to configure</th>
+					<th>Values</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>HTML attribue</td>
+					<td><code>data-wb-core</code></td>
+					<td>Customizes WET's core variables. Use with other <code>data-*</code> attributes.</td>
+					<td>Add a <code>data-wb-core</code> attribute to WET's <code>script</code> element</td>
+					<td>None</td>
+				</tr>
+				<tr>
+					<td>HTML attribue</td>
+					<td><code>data-lang-long</code></td>
+					<td>Extends <code>wb.lang</code>'s support for long language codes (&gt; 2 characters). Use with the <code>data-wb-core</code> attribute.</td>
+					<td>Add a <code>data-wb-core</code> attribute to WET's <code>script</code> element</td>
+					<td>Space-separated <a href="https://www.rfc-editor.org/info/bcp47" rel="external">BCP 47</a> language codes</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</section>
+
+<section>
+	<h2>Source code</h2>
+	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/core">WET core source code on GitHub</a></p>
+</section>

--- a/site/pages/docs/ref/core/core-fr.hbs
+++ b/site/pages/docs/ref/core/core-fr.hbs
@@ -1,0 +1,71 @@
+---
+{
+	"title": "Base de la BOEW",
+	"language": "fr",
+	"category": "Autre",
+	"categoryfile": "other",
+	"description": "Objet principal de la BOEW.",
+	"altLangPrefix": "core",
+	"dateModified": "2022-04-20"
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<div class="alert alert-warning mrgn-tp-lg">
+	<h2>Travail en cours</h2>
+	<p>Cette page est un travail en cours.</p>
+</div>
+
+<p lang="en"><strong>Needs translation</strong></p>
+
+<section>
+	<h2>But</h2>
+	<p>Objet principal de la BOEW.</p>
+</section>
+
+<div lang="en">
+<section>
+	<h2>Language (<code>wb.lang</code>)</h2>
+	<p>WET's language is derived from the <code>html</code> element's <code>lang</code> attribute. A formatted version of the page's language code is stored in the <code>wb.lang</code> variable.</p>
+	<p>By default, the variable's value will be derived from the first two characters of the page's language code. If a longer code is specified, it'll be re-used as the variable's value so long as it corresponds to one of WET's built-in languages (i.e. <code>pt-BR</code> for Portuguese [Brazilian] or <code>zh-Hans</code> for Chinese [Simplified]).</p>
+	<p>Implementations that want to provide custom i18n files for longer language codes (e.g. <code>en-CA</code>, <code>en-US</code>, etc) can do so by adding <code>data-wb-core</code> and <code>lang-lang-long=""</code> attributes to WET's <code>script</code> element.</p>
+	<p>WET will also attempt to load an i18n file named after the variable. Plugins won't initialize if the i18n file fails to load.</p>
+</section>
+
+<section>
+	<h2>Configuration</h2>
+	<div class="table-responsive">
+		<table class="table">
+			<thead>
+				<tr>
+					<th>Type</th>
+					<th>Option</th>
+					<th>Description</th>
+					<th>How to configure</th>
+					<th>Values</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>HTML attribue</td>
+					<td><code>data-wb-core</code></td>
+					<td>Customizes WET's core variables. Use with other <code>data-*</code> attributes.</td>
+					<td>Add a <code>data-wb-core</code> attribute to WET's <code>script</code> element</td>
+					<td>None</td>
+				</tr>
+				<tr>
+					<td>HTML attribue</td>
+					<td><code>data-lang-long</code></td>
+					<td>Extends <code>wb.lang</code>'s support for long language codes (&gt; 2 characters). Use with the <code>data-wb-core</code> attribute.</td>
+					<td>Add a <code>data-wb-core</code> attribute to WET's <code>script</code> element</td>
+					<td>Space-separated <a href="https://www.rfc-editor.org/info/bcp47" rel="external">BCP 47</a> language codes</td>
+				</tr>
+			</tbody>
+		</table>
+	</div>
+</section>
+
+<section>
+	<h2>Source code</h2>
+	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/core">WET core source code on GitHub</a></p>
+</section>

--- a/site/pages/docs/ref/other-en.hbs
+++ b/site/pages/docs/ref/other-en.hbs
@@ -4,7 +4,7 @@
 	"language": "en",
 	"description": "Other components - Documentation - Web Experience Toolkit (WET)",
 	"altLangPrefix": "other",
-	"dateModified": "2014-07-28"
+	"dateModified": "2022-04-20"
 }
 ---
 <p>These WET components provide various types of information and functionality that is useful to developing and managing websites.</p>
@@ -16,4 +16,5 @@
 	<li><a href="tablevalidator/tablevalidator-en.html">Table Validator</a> - Web editor tool that helps to produce tables that conform to WCAG 2.0</li>
 	<li><a href="transitions/transitions-en.html">Transitions</a> - CSS-based transitions</li>
 	<li><a href="wamethod/wamethod-en.html">Web Accessibility Assessment Methodology</a> - Provides an assessment methodology that assists with measuring conformance to the Web Content Accessibility Guidelines (WCAG) 2.0 Level A, AA, and AAA Success Criteria.</li>
+	<li><a href="core/core-en.html">WET core</a> - Core WET object.</li>
 </ul>

--- a/site/pages/docs/ref/other-fr.hbs
+++ b/site/pages/docs/ref/other-fr.hbs
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"description": "Autres composants - Documentation - Boîte à outils de l'expérience Web (BOEW)",
 	"altLangPrefix": "other",
-	"dateModified": "2014-07-28"
+	"dateModified": "2022-04-20"
 }
 ---
 <p lang="en"><strong>Needs translation</strong> These WET components provide various types of information and functionality that is useful to developing and managing websites.</p>
@@ -16,4 +16,5 @@
 	<li><a href="arb-rra/arb-rra-fr.html">Répartition des responsabilités d'accessibilité (WCAG 2.0)</a> - Une répartition des responsabilités associées aux critères de succès pour WCAG 2.0 sur l’ensemble de la chaîne de production Web.</li>
 	<li><a href="transitions/transitions-fr.html">Transitions</a> - Transitions CSS</li>
 	<li><a href="tablevalidator/tablevalidator-fr.html">Validateur de tableau</a> - Outils pour les éditeur web qui fourni une assistance afin de produire des tableaux conforme au norme WCAG</li>
+	<li><a href="core/core-fr.html">Base de la BOEW</a> - Objet principal de la BOEW.</li>
 </ul>

--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -57,9 +57,33 @@ var getUrlParts = function( url ) {
 
 	/**
 	 * @variable i18n
-	 * @return {string} of HTML document language
+	 * @return {string} of WET document language
 	 */
-	lang = document.documentElement.lang,
+	lang = ( function( ele ) {
+		let lang = document.documentElement.lang;
+		const shortLangLength = 2;
+
+		// Perform extra checks if the page uses a long language code
+		if ( lang.length > shortLangLength ) {
+			let longLangs = [ "pt-BR", "zh-Hans" ]; // Built-in long language codes
+
+			// Check if any custom long language codes have been specified
+			// Specify by adding data-wb-core and data-lang-long="en-CA en-US etc" attributes to WET's script element (e.g. wet-boew.js or wet-boew.min.js)
+			if ( ele[ 0 ].hasAttribute( "data-wb-core" ) &&  ele[ 0 ].hasAttribute( "data-lang-long" ) ) {
+				const longLangsCustom = ele.attr( "data-lang-long" ).split( " " );
+
+				// Add extra language codes to the beginning of the longLangs array to match them more quickly
+				longLangs = longLangsCustom.concat( longLangs );
+			}
+
+			// Shorten the language code if it doesn't exist in the longLangs array
+			if ( longLangs.indexOf( lang ) === -1 ) {
+				lang = lang.substring( 0, shortLangLength );
+			}
+		}
+
+		return lang;
+	}( $src ) ),
 
 	paths = ( function( ele ) {
 		var paths = {};


### PR DESCRIPTION
Certain web app platforms (e.g. Microsoft PowerApps) can only be configured to use country language codes. So they end up generating HTML elements that use lang attributes along the lines of "en-CA" or "fr-CA". By comparison, most of WET's built-in i18n languages use two-letter language codes such as "en" or "fr".

That's a recipe for disaster. WET sets its language based on the current page's HTML lang attribute, then tries loading a namesake i18n file. If WET fails to load its i18n file, plugins don't get initialized. So users end up with broken pages.

This change reconciles the differences by deriving WET's language from the HTML lang attribute's first two characters, unless:
* The page's language is built-into WET and uses a longer language code (i.e. "pt-BR" and "zh-Hans")
* WET's ``script`` element (e.g. wet-boew.js or wet-boew.min.js) contains both of the following attributes:
  * ``data-wb-core`` (doesn't need a value)
  * ``data-lang-long="[longer language codes, space-separated]"`` (in case a site wants to use custom i18n files for longer language codes)

A core documentation page has also been added to document how WET will handle language codes going forward.

Fixes #8842.

Co-authored-by:
* @fsnoddy
* @duboisp