### PR TITLE
Footnote - Relink footer reference when multiple and not first

### DIFF
--- a/site/pages/docs/ref/footnotes/footnotes-en.hbs
+++ b/site/pages/docs/ref/footnotes/footnotes-en.hbs
@@ -126,6 +126,11 @@
 &lt;/dd&gt;</code></pre>
 		</section>
 	</section>
+
+	<section>
+		<h3>Quality control of footers references</h3>
+		<p>A workaround were implemented to ensure the footer items always refer to the first instance where the footnote is refered in the content. It is a best practice that the footers are property coded where their reference is pointing initially to the first instance. When this is not the case, the footnote plugin will fix the link and trigger a warning in the browser console. In such situation, it will show a warning like: <code>wb-fnote - Relink first reference of #myfoootnote for #fn4-1-rf</code></p>
+	</section>
 </section>
 
 <section>

--- a/site/pages/docs/ref/footnotes/footnotes-fr.hbs
+++ b/site/pages/docs/ref/footnotes/footnotes-fr.hbs
@@ -138,6 +138,11 @@
 &lt;/dd&gt;</code></pre>
 		</section>
 	</section>
+
+	<section>
+		<h3>Contrôle de la qualité des références de note de bas de page</h3>
+		<p>Une solution de contournement a été implémenté afin que les items dans la section de note de bas de page référe à la première instance de la note dans le contenu de la page courante. Il est une bonne pratique que le balisage à la source pointe vers la première référence. Lorsque cela n'est pas le cas, le plugiciel va émettre un averstissement dans la console du fureteur et affichera une message tel que: <code lang="en">wb-fnote - Relink first reference of #myfoootnote for #fn4-1-rf</code></p>
+	</section>
 </section>
 
 <div lang="en">

--- a/src/plugins/footnotes/footnotes-en.hbs
+++ b/src/plugins/footnotes/footnotes-en.hbs
@@ -22,14 +22,14 @@
 		<li>Progressive enhancement approach</li>
 		<li>Support for Firefox, Opera, Safari, Chrome, and IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup></li>
 		<li>Support for English and French</li>
-		<li>Configurable layout and design<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Footnote </span>3</a></sup></li>
+		<li>Configurable layout and design<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Footnote </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Footnote </span>3</a></sup>&#160;<sup id="fn4-0-rf"><a class="fn-lnk" href="#fn4"><span class="wb-inv">Footnote </span>4</a></sup></li>
 	</ul>
 </section>
 
 <section>
 	<h2>Recommended usage</h2>
 	<ul>
-		<li>Implementing footnotes in Web pages<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Footnote </span>*</a></sup></li>
+		<li>Implementing footnotes in Web pages<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Footnote </span>*</a></sup>&#160;<sup id="fn4-1-rf"><a class="fn-lnk" href="#fn4"><span class="wb-inv">Footnote </span>4</a></sup></li>
 	</ul>
 </section>
 
@@ -53,6 +53,11 @@
 			<p>Example of a footnote containing multiple paragraphs (third paragraph).</p>
 			<p class="fn-rtn"><a href="#fn3-rf"><span class="wb-inv">Return to footnote </span>3<span class="wb-inv"> referrer</span></a></p>
 		</dd>
+		<dt>Footnote 4</dt>
+		<dd id="fn4">
+			<p>Example of a footnote where first time clicked the user will get redirected to it's first instance of the footnote even if the coded link say otherwise. Prevent undesirable behaviour when footnote are added during a content review process.</p>
+			<p class="fn-rtn"><a href="#fn4-1-rf"><span class="wb-inv">Return to <span>first</span> footnote </span>4<span class="wb-inv"> referrer</span></a></p>
+		</dd>
 		<dt>Footnote *</dt>
 		<dd id="fn*">
 			<p>Example of a standard footnote, denoted by a symbol.</p>
@@ -75,14 +80,14 @@
 		&lt;li&gt;Progressive enhancement approach&lt;/li&gt;
 		&lt;li&gt;Support for Firefox, Opera, Safari, Chrome, and IE 7+&lt;sup id=&quot;fn2-2-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;li&gt;Support for English and French&lt;/li&gt;
-		&lt;li&gt;Configurable layout and design&lt;sup id=&quot;fn2-3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id=&quot;fn3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn3&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;3&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Configurable layout and design&lt;sup id=&quot;fn2-3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id=&quot;fn3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn3&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;3&lt;/a&gt;&lt;/sup&gt;&amp;#160;&lt;sup id=&quot;fn4-0-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn4&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;4&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/section&gt;
 
 &lt;section&gt;
 	&lt;h2&gt;Recommended usage&lt;/h2&gt;
 	&lt;ul&gt;
-		&lt;li&gt;Implementing footnotes in Web pages&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Implementing footnotes in Web pages&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&amp;#160;&lt;sup id=&quot;fn4-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn4&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;4&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/section&gt;
 
@@ -105,6 +110,11 @@
 			&lt;p&gt;Example of a footnote containing multiple paragraphs (second paragraph).&lt;/p&gt;
 			&lt;p&gt;Example of a footnote containing multiple paragraphs (third paragraph).&lt;/p&gt;
 			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn3-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to footnote &lt;/span&gt;3&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
+		&lt;/dd&gt;
+		&lt;dt&gt;Footnote 4&lt;/dt&gt;
+		&lt;dd id=&quot;fn4&quot;&gt;
+			&lt;p&gt;Example of a footnote where first time clicked the user will get redirected to it's first instance of the footnote even if the coded link say otherwise. Prevent undesirable behaviour when footnote are added during a content review process.&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn4-1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Return to &lt;span&gt;first&lt;/span&gt; footnote &lt;/span&gt;4&lt;span class=&quot;wb-inv&quot;&gt; referrer&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Footnote *&lt;/dt&gt;
 		&lt;dd id=&quot;fn*&quot;&gt;

--- a/src/plugins/footnotes/footnotes-fr.hbs
+++ b/src/plugins/footnotes/footnotes-fr.hbs
@@ -22,14 +22,14 @@
 		<li>Approche d'amélioration progressive</li>
 		<li>Soutien pour Firefox, Opera, Safari, Chrome et IE 7+<sup id="fn2-2-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup></li>
 		<li>Soutien pour l'anglais et le français</li>
-		<li>Mise en page et conception configurable<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Note de bas de page </span>3</a></sup></li>
+		<li>Mise en page et conception configurable<sup id="fn2-3-rf"><a class="fn-lnk" href="#fn2"><span class="wb-inv">Note de bas de page </span>2</a></sup>&#160;<sup id="fn3-rf"><a class="fn-lnk" href="#fn3"><span class="wb-inv">Note de bas de page </span>3</a></sup>&#160;<sup id="fn4-0-rf"><a class="fn-lnk" href="#fn4"><span class="wb-inv">Note de bas de page </span>4</a></sup></li>
 	</ul>
 </section>
 
 <section>
 	<h2>Utilisation recommandée</h2>
 		<ul>
-			<li>Exécuter les notes de bas de page dans les pages Web<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Note de bas de page </span>*</a></sup></li>
+			<li>Exécuter les notes de bas de page dans les pages Web<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Note de bas de page </span>*</a></sup>&#160;<sup id="fn4-1-rf"><a class="fn-lnk" href="#fn4"><span class="wb-inv">Note de bas de page </span>4</a></sup></li>
 		</ul>
 </section>
 
@@ -53,6 +53,11 @@
 			<p>Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).</p>
 			<p class="fn-rtn"><a href="#fn3-rf"><span class="wb-inv">Retour à la référence de la note de bas de page </span>3</a></p>
 		</dd>
+		<dt>Note de bas de page 4</dt>
+		<dd id="fn4">
+			<p>Exemple de note de bas de page lorsqu'il est initialement cliqué et que l'utilisateur est redirigé vers la première instance de la note de base de page. Ceci même si cela a été codifié autrement. Cela prévient un comportement indésirable lorsqu'une note de bas de page est ajouté durant une revue du contenu.</p>
+			<p class="fn-rtn"><a href="#fn4-1-rf"><span class="wb-inv">Retour à la <span>première</span> référence de la note de bas de page </span>4</a></p>
+		</dd>
 		<dt>Note de bas de page *</dt>
 		<dd id="fn*">
 			<p>Exemple de note de bas de page standard, représentée par un symbole.</p>
@@ -75,14 +80,14 @@
 		&lt;li&gt;Approche d'amélioration progressive&lt;/li&gt;
 		&lt;li&gt;Soutien pour Firefox, Opera, Safari, Chrome et IE 7+&lt;sup id=&quot;fn2-2-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;li&gt;Soutien pour l'anglais et le français&lt;/li&gt;
-		&lt;li&gt;Mise en page et conception configurable&lt;sup id=&quot;fn2-3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id=&quot;fn3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn3&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;3&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Mise en page et conception configurable&lt;sup id=&quot;fn2-3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn2&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;2&lt;/a&gt;&lt;/sup&gt;&#160;&lt;sup id=&quot;fn3-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn3&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;3&lt;/a&gt;&lt;/sup&gt;&amp;#160;&lt;sup id=&quot;fn4-0-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn4&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;4&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/section&gt;
 
 &lt;section&gt;
 	&lt;h2&gt;Utilisation recommandée&lt;/h2&gt;
 		&lt;ul&gt;
-			&lt;li&gt;Exécuter les notes de bas de page dans les pages Web&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+			&lt;li&gt;Exécuter les notes de bas de page dans les pages Web&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&amp;#160;&lt;sup id=&quot;fn4-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn4&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;4&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;/ul&gt;
 &lt;/section&gt;
 
@@ -105,6 +110,11 @@
 			&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (deuxième paragraphe).&lt;/p&gt;
 			&lt;p&gt;Exemple de note de bas de page qui compte plusieurs paragraphes (troisième paragraphe).&lt;/p&gt;
 			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn3-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la référence de la note de bas de page &lt;/span&gt;3&lt;/a&gt;&lt;/p&gt;
+		&lt;/dd&gt;
+		&lt;dt&gt;Note de bas de page 4&lt;/dt&gt;
+		&lt;dd id=&quot;fn4&quot;&gt;
+			&lt;p&gt;Exemple de note de bas de page lorsqu'il est initialement cliqué et que l'utilisateur est redirigé vers la première instance de la note de base de page. Ceci même si cela a été codifié autrement. Cela prévient un comportement indésirable lorsqu'une note de bas de page est ajouté durant une revue du contenu.&lt;/p&gt;
+			&lt;p class=&quot;fn-rtn&quot;&gt;&lt;a href=&quot;#fn4-1-rf&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Retour à la &lt;span&gt;première&lt;/span&gt; référence de la note de bas de page &lt;/span&gt;4&lt;/a&gt;&lt;/p&gt;
 		&lt;/dd&gt;
 		&lt;dt&gt;Note de bas de page *&lt;/dt&gt;
 		&lt;dd id=&quot;fn*&quot;&gt;

--- a/src/plugins/footnotes/footnotes.js
+++ b/src/plugins/footnotes/footnotes.js
@@ -92,11 +92,12 @@ var componentName = "wb-fnote",
 						refIdDashIdx = refId.indexOf( "-" );
 						if ( refIdDashIdx !== -1 && !$elmTarget.attr( modFlag ) ) {
 							searchRefId = refId.substring( 0, refIdDashIdx + 1 );
-							refIdSrc = $( "sup[id^='" + searchRefId + "']:first()" ).attr( "id" );
+							refIdSrc = wb.jqEscape( $( "sup[id^='" + searchRefId + "']:first()" ).attr( "id" ) );
 							if ( !refIdSrc || refId !== refIdSrc ) {
 								console.warn( componentName + " - Relink first reference of " + ref + " for #" + refIdSrc );
+								refId = refIdSrc;
 								$elmTarget
-									.attr( "href", "#" + refIdSrc )
+									.attr( "href", "#" + refId )
 									.attr( modFlag, true );
 							}
 						}

--- a/src/plugins/footnotes/footnotes.js
+++ b/src/plugins/footnotes/footnotes.js
@@ -15,6 +15,7 @@
  */
 var componentName = "wb-fnote",
 	selector = "." + componentName,
+	modFlag = "data-" + componentName,
 	initEvent = "wb-init" + selector,
 	setFocusEvent = "setfocus.wb",
 	$document = wb.doc,
@@ -49,7 +50,7 @@ var componentName = "wb-fnote",
 			$elm.find( "dd p.fn-rtn a span span" ).remove();
 
 			// Listen for footnote reference links that get clicked
-			$document.on( "click vclick", "main :not(" + selector + ") sup a.fn-lnk", function( event ) {
+			$document.on( "click", "main :not(" + selector + ") sup a.fn-lnk", function( event ) {
 				var eventTarget = event.target,
 					which = event.which,
 					refId, $refLinkDest;
@@ -60,7 +61,8 @@ var componentName = "wb-fnote",
 					$refLinkDest = $document.find( refId );
 
 					$refLinkDest.find( "p.fn-rtn a" )
-						.attr( "href", "#" + eventTarget.parentNode.id );
+						.attr( "href", "#" + eventTarget.parentNode.id )
+						.attr( modFlag, true );
 
 					// Assign focus to $refLinkDest
 					$refLinkDest.trigger( setFocusEvent );
@@ -69,21 +71,38 @@ var componentName = "wb-fnote",
 			} );
 
 			// Listen for footnote return links that get clicked
-			$document.on( "click vclick", selector + " dd p.fn-rtn a", function( event ) {
+			$document.on( "click", selector + " dd p.fn-rtn a", function( event ) {
 				var which = event.which,
+					$elmTarget = $( event.target ),
 					ref,
-					refId;
+					refId,
+					refIdSrc,
+					refIdDashIdx,
+					searchRefId;
 
 				// Ignore middle/right mouse button
 				if ( !which || which === 1 ) {
-					ref = event.target.getAttribute( "href" );
+					ref = $elmTarget.attr( "href" );
 
 					// Focus on associated referrer link (if the return link points to an ID)
 					if ( ref.charAt( 0 ) === "#" ) {
-						refId = "#" + wb.jqEscape( ref.substring( 1 ) );
+						refId = wb.jqEscape( ref.substring( 1 ) );
+
+						// When first clicked, ensure we send the user on the first instance when the id follow the recommend pattern
+						refIdDashIdx = refId.indexOf( "-" );
+						if ( refIdDashIdx !== -1 && !$elmTarget.attr( modFlag ) ) {
+							searchRefId = refId.substring( 0, refIdDashIdx + 1 );
+							refIdSrc = $( "sup[id^='" + searchRefId + "']:first()" ).attr( "id" );
+							if ( !refIdSrc || refId !== refIdSrc ) {
+								console.warn( componentName + " - Relink first reference of " + ref + " for #" + refIdSrc );
+								$elmTarget
+									.attr( "href", "#" + refIdSrc )
+									.attr( modFlag, true );
+							}
+						}
 
 						// Assign focus to the link
-						$document.find( refId + " a" ).trigger( setFocusEvent );
+						$document.find( "#" + refId + " a" ).trigger( setFocusEvent );
 						return false;
 					}
 				}


### PR DESCRIPTION
Relink footer reference when multiple and not first.

Rational: A similar JS code was added into all pages in Canada.ca and we are removing those. 

Purpose: Fix an editing issue when a footnote is added later during a review step and that new footnote is before the one that already exist when the footnote ID match the wet-boew footnote example. This ensure to provide a consistent user experience.

---
For Principal Publisher: This request is related to MWS-2053