### PR TITLE
add new plugin: Data Scrub

### DIFF
--- a/site/pages/docs/ref/wb-data-scrub/wb-data-scrub-en.hbs
+++ b/site/pages/docs/ref/wb-data-scrub/wb-data-scrub-en.hbs
@@ -1,0 +1,105 @@
+---
+{
+	"title": "Data Scrub",
+	"language": "en",
+	"category": "Plugins",
+	"categoryfile": "plugins",
+	"description": "Delete Personal Identifiable Information (PII) before form submit.",
+	"altLangPrefix": "wb-data-scrub",
+	"dateModified": "2022-02-24"
+}
+---
+<span class="wb-prettify all-pre hide"></span>
+
+
+<section>
+	<h2>Purpose</h2>
+	<p>This component provides the ability to delete the Personal Identifiable Information (PII) from a form fields before submit.</p>
+	<p>Here is the list of the PII that the plugin will search and remove:</p>
+	<ul>
+		<li>All the combinations of 8 digits and more</li>
+		<li>Canadian serial passport number</li>
+		<li>Email</li>
+		<li>Canadian postal code</li>
+		<li>Any potential user name values added in this format username=theUserValue, username:theUserValue, user=theUserValue, user:theUserValue</li>
+		<li>Any potential password values added in this format password=thePassValue, password: thePassValue pass=thePassValue, pass:thePassValue</li>
+	</ul>
+	<p>For more details about the scrubbing PII behaviour please check on the wet-boew core helper <code>wb.findPotentialPII</code></p>
+</section>
+
+<section>
+	<h2>Use when</h2>
+	<ul>
+		<li>forms might contain Personal Identifiable Information (PII), this plugin will identify and delete this information before form submit.</li>
+	</ul>
+</section>
+
+<section>
+	<h2>Do not use when</h2>
+	<ul>
+		<li>a form is using Form validation plugin</li>
+		<li>a form is using Postback plugin</li>
+	</ul>
+</section>
+
+<section>
+	<h2>Working example</h2>
+	<ul>
+		<li><a href="../../../demos/wb-data-scrub/wb-data-scrub-en.html">English example</a></li>
+		<li><a hreflang="fr" href="../../../demos/wb-data-scrub/wb-data-scrub-fr.html">French example</a></li>
+	</ul>
+</section>
+
+<section>
+	<h2>How to implement</h2>
+	<ol>
+		<li>Add the following data attribute <code>data-rule-wbscrub</code> for each form element that might contain personal information.
+			<pre><code>&lt;input id="email" name="email" type="email" <strong>data-rule-wbscrub</strong> /&gt;</code></pre>
+		</li>
+		<li>
+			Optionally, if you want the form to submit a parameter whenever a PII is found and removed, create an hidden input with the attribute<code>data-wbscrub-flag</code> with the name and value of your choice.
+			<pre><code>&lt;input name="scrub" value="1" data-wbscrub-flag /&gt;</code></pre>
+		</li>
+	</ol>
+</section>
+
+<section>
+	<h2>Events</h2>
+	<p>Document the public events that can be used by implementers or developers.</p>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Event</th>
+				<th>Trigger</th>
+				<th>What it does</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>wb-init.wb-data-scrub</code></td>
+				<td>Triggered manually (e.g., <code>$( ".wb-data-scrub" ).trigger( "wb-init.wb-data-scrub" );</code>).</td>
+				<td>Used to manually initialize the wb-data-scrub plugin</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb-data-scrub</code> (v4.0.24+)</td>
+				<td>Triggered automatically after wb-data-scrub initializes.</td>
+				<td>Used to identify the element where steps form has initialized (target of the event)
+					<pre><code>$( document ).on( "wb-ready.wb-data-scrub", ".wb-data-scrub", function( event ) {});</code></pre>
+					<pre><code>$( ".wb-data-scrub" ).on( "wb-ready.wb-data-scrub", function( event ) {});</code></pre>
+				</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb</code> (v4.0.24+)</td>
+				<td>Triggered automatically when WET has finished loading and executing.</td>
+				<td>Used to identify when all WET plugins and polyfills have finished loading and executing.
+					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {});</code></pre>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+
+<section>
+	<h2>Source code</h2>
+	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/wb-data-scrub">Data Scrub source code on GitHub</a></p>
+</section>

--- a/site/pages/docs/ref/wb-data-scrub/wb-data-scrub-fr.hbs
+++ b/site/pages/docs/ref/wb-data-scrub/wb-data-scrub-fr.hbs
@@ -1,0 +1,104 @@
+---
+{
+	"title": "Data Scrub",
+	"language": "fr",
+	"category": "Plugiciels",
+	"categoryfile": "plugins",
+	"description": "Supprimer les informations personnelles identifiables (IPI) avant de soumettre le formulaire",
+	"altLangPrefix": "wb-data-scrub",
+	"dateModified": "2022-02-24"
+}
+---
+<span class="wb-prettify all-pre hide"></span>
+
+<section>
+	<h2>But</h2>
+	<p>Ce composant offre la possibilité de supprimer les informations personnelles identifiables (PII) dans les champs d'un formulaire avant de le soumettre.</p>
+	<p>Voici la liste des IPI que le plugiciel recherchera et supprimera:</p>
+	<ul>
+		<li>Toutes les combinaisons de 8 chiffres et plus</li>
+		<li>Numéro de série du passeport canadien</li>
+		<li>E-mail</li>
+		<li>Code postal canadien</li>
+		<li>Toute valeur de nom d'utilisateur potentielle ajoutée dans ce format username=theUserValue, username:theUserValue, user=theUserValue, user:theUserValue</li>
+		<li>Toute valeur de mot de passe potentielle ajoutée dans ce format password=thePassValue, mot de passe:thePassValue pass=thePassValue, pass:thePassValue</li>
+	</ul>
+	<p>Pour plus de détails sur le comportement de nettoyage des PII, veuillez consulter l'assistant de base wet-boew:<code>wb.findPotentialPII</code></p>
+</section>
+
+<section>
+	<h2>Utiliser lorsque</h2>
+	<ul>
+		<li>les formulaires peuvent contenir des informations personnelles identifiables (PII), ce plugiciel identifiera et supprimera ces informations avant la soumission du formulaire.</li>
+	</ul>
+</section>
+
+<section>
+	<h2>Ne pas utiliser lorsque</h2>
+	<ul>
+		<li>un formulaire utilise le plugiciel Validation de formulaires</li>
+		<li>un formulaire utilise le plugiciel Envoie via Ajax</li>
+	</ul>
+</section>
+
+<section>
+	<h2>Exemple pratique</h2>
+	<ul>
+		<li><a href="../../../demos/wb-data-scrub/wb-data-scrub-en.html">Exemple anglais</a></li>
+		<li><a hreflang="fr" href="../../../demos/wb-data-scrub/wb-data-scrub-fr.html">Exemple français</a></li>
+	</ul>
+</section>
+
+<section>
+	<h2>Comment implémenter le plugiciel</h2>
+	<ol>
+		<li>Ajoutez l'attribut de données suivant <code>data-rule-wbscrub</code> pour chaque élément du formulaire susceptible de contenir des informations personnelles.
+			<pre><code>&lt;input id="email" name="email" type="email" <strong>data-rule-wbscrub</strong> /&gt;</code></pre>
+		</li>
+		<li>
+			Optionnellement, si vous souhaitez que le formulaire soumette un paramètre chaque fois qu'un PII est trouvé et supprimé, créer un champs de type  masquée avec  <code>data-wbscrub-flag</code> avec une valeur et un nom de votre choix
+			<pre><code>&lt;input name="scrub" value="1" data-wbscrub-flag /&gt;</code></pre>
+		</li>
+	</ol>
+</section>
+
+<section>
+	<h2>Événements</h2>
+	<p>Documentez les événements publics qui peuvent être utilisés par les implémenteurs ou les développeurs.</p>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Événement</th>
+				<th>Déclencheur</th>
+				<th>Effet déclenché</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>wb-init.wb-data-scrub</code></td>
+				<td>Déclenché manuellement (e.g., <code>$( ".wb-data-scrub" ).trigger( "wb-init.wb-data-scrub" );</code>).</td>
+				<td>Utilisé pour initialisé manuellement le plugiciel Supprime-IPI.</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb-data-scrub</code> (v4.0.24+)</td>
+				<td>Déclenché automatiquement après l'initialisation du plugiciel Supprime-IPI.</td>
+				<td>Utilisé afin d'identifié l'élément sur lequel le plugiciel Supprime-IPI a été initialisé (la cible de l'événement)
+					<pre><code>$( document ).on( "wb-ready.wb-data-scrub", ".wb-data-scrub", function( event ) {});</code></pre>
+					<pre><code>$( ".wb-data-scrub" ).on( "wb-ready.wb-data-scrub", function( event ) {});</code></pre>
+				</td>
+			</tr>
+			<tr>
+				<td><code>wb-ready.wb</code> (v4.0.24+)</td>
+				<td>Déclenché automatiquement lorsque la WET-BOEW a terminé son chargement et son exécution.</td>
+				<td>Utilisé pour identifié le moment lorsque tous les plugiciels et tous les polyfills de la WET-BOEW ont terminés de charger et de s'exécuter.
+					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {});</code></pre>
+				</td>
+			</tr>
+		</tbody>
+	</table>
+</section>
+
+<section>
+	<h2>Code source</h2>
+	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/plugins/wb-data-scrub">Code source du plugiciel Data Scrub sur GitHub</a></p>
+</section>

--- a/src/plugins/wb-data-scrub/wb-data-scrub-en.hbs
+++ b/src/plugins/wb-data-scrub/wb-data-scrub-en.hbs
@@ -1,0 +1,67 @@
+---
+{
+	"title": "Data Scrub",
+	"language": "en",
+	"category": "Plugins",
+	"description": "Delete Personal Identifiable Information (PII) from the form flagged fields before submit",
+	"tag": "wb-data-scrub",
+	"parentdir": "wb-data-scrub",
+	"altLangPrefix": "wb-data-scrub",
+	"dateModified": "2022-02-24"
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<h2>Example</h2>
+
+<p>Delete Personal Identifiable Information (PII) from the form flagged fields before submit.</p>
+
+<form action="wb-data-scrub-en.html" method="GET">
+	<input type="hidden" name="scrub" value="1" data-wbscrub-flag />
+	<div class="form-content">
+		<div class="form-group">
+			<label for="firstname"><span class="field-name">First Name</span></label>
+			<input class="form-control" id="firstname" name="firstname" type="text"/>
+		</div>
+		<div class="form-group">
+			<label for="lastname"><span class="field-name">Last Name</span></label>
+			<input class="form-control" id="lastname" name="lastname" type="text" />
+		</div>
+		<div class="form-group">
+			<label for="preferredNumber">Preferred: <span class="field-name">Phone Number</span></label>
+			<input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-wbscrub />
+		</div>
+		<div class="form-group">
+			<label for="email"><span class="field-name">Email Address</span> (test@domaine)</label>
+			<input class="form-control" id="email" name="email" type="email" data-rule-wbscrub />
+		</div>
+		<button type="submit" class="btn btn-primary">Submit</button>
+	</div>
+</form>
+
+
+<details class="mrgn-tp-md mrgn-bttm-md">
+	<summary>View code</summary>
+	<pre><code>&lt;form action="wb-data-scrub-en.html" &gt;
+		&lt;input type="hidden" name="scrub" value="1" data-wbscrub-flag /&gt;
+	&lt;div class="form-content"&gt;
+		&lt;div class="form-group"&gt;
+			&lt;label for="firstname"&gt;&lt;span class="field-name"&gt;First Name&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="firstname" name="firstname" type="text" /&gt;
+		&lt;/div&gt;
+		&lt;div class="form-group"&gt;
+			&lt;label for="lastname"&gt;&lt;span class="field-name"&gt;Last Name&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="lastname" name="lastname" type="text" /&gt;
+		&lt;/div&gt;
+		&lt;div class="form-group"&gt;
+			&lt;label for="preferredNumber"&gt;Preferred: &lt;span class="field-name"&gt;Phone Number&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-wbscrub /&gt;
+		&lt;/div&gt;
+		&lt;div class="form-group"&gt;
+			&lt;label for="email"&gt;&lt;span class="field-name"&gt;Email Address&lt;/span&gt; (test@domaine)&lt;/label&gt;
+			&lt;input class="form-control" id="email" name="email" type="email" data-rule-wbscrub /&gt;
+		&lt;/div&gt;
+		&lt;button type="submit" class="btn btn-primary"&gt;Submit&lt;/button&gt;
+	&lt;/div&gt;
+&lt;/form&gt;</code></pre>
+</details>

--- a/src/plugins/wb-data-scrub/wb-data-scrub-fr.hbs
+++ b/src/plugins/wb-data-scrub/wb-data-scrub-fr.hbs
@@ -1,0 +1,67 @@
+---
+{
+	"title": "Data Scrub",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Supprimer les informations personnelles identifiables (IPI) avant de soumettre le formulaire",
+	"tag": "wb-data-scrub",
+	"parentdir": "wb-data-scrub",
+	"altLangPrefix": "wb-data-scrub",
+	"dateModified": "2022-02-24"
+}
+---
+<div class="wb-prettify all-pre hide"></div>
+
+<h2>Exemple</h2>
+
+<p>Supprimez les informations personnelles identifiables (PII) des champs marqués du formulaire avant de les soumettre.</p>
+
+<form action="wb-data-scrub-fr.html">
+	<input type="hidden" name="scrub" value="1" data-wbscrub-flag />
+	<div class="form-content">
+		<div class="form-group">
+			<label for="firstname"><span class="field-name">Prénom</span></label>
+			<input class="form-control" id="firstname" name="firstname" type="text" />
+		</div>
+		<div class="form-group">
+			<label for="lastname"><span class="field-name">Nom de famille</span></label>
+			<input class="form-control" id="lastname" name="lastname" type="text" />
+		</div>
+		<div class="form-group">
+			<label for="preferredNumber"><span class="field-name">Numéro de téléphone</span></label>
+			<input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-wbscrub />
+		</div>
+		<div class="form-group">
+			<label for="email"><span class="field-name">Addresse courriel</span> (test@domaine)</label>
+			<input class="form-control" id="email" name="email" type="email" data-rule-wbscrub />
+		</div>
+		<button type="submit" class="btn btn-primary">Soumettre</button>
+	</div>
+</form>
+
+<details class="mrgn-tp-md mrgn-bttm-md">
+	<summary>View code</summary>
+	<pre><code>&lt;form action="wb-data-scrub-fr.html" &gt;
+	&lt;input type="hidden" name="scrub" value="1" data-wbscrub-flag /&gt;
+	&lt;div class="form-content"&gt;
+		&lt;div class="form-group"&gt;
+			&lt;label for="firstname"&gt;&lt;span class="field-name"&gt;Prénom&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="firstname" name="firstname" type="text" /&gt;
+		&lt;/div&gt;
+		&lt;div class="form-group"&gt;
+			&lt;label for="lastname"&gt;&lt;span class="field-name"&gt;Nom de famille&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="lastname" name="lastname" type="text" /&gt;
+		&lt;/div&gt;
+		&lt;div class="form-group"&gt;
+			&lt;label for="preferredNumber"&gt;&lt;span class="field-name"&gt;Numéro de téléphone&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-wbscrub /&gt;
+		&lt;/div&gt;
+		&lt;div class="form-group"&gt;
+			&lt;label for="email"&gt;&lt;span class="field-name"&gt;Addresse courriel&lt;/span&gt; (test@domaine)&lt;/label&gt;
+			&lt;input class="form-control" id="email" name="email" type="email" data-rule-wbscrub /&gt;
+		&lt;/div&gt;
+		&lt;button type="submit" class="btn btn-primary"&gt;Soumettre&lt;/button&gt;
+	&lt;/div&gt;
+&lt;/form&gt;
+</code></pre>
+</details>

--- a/src/plugins/wb-data-scrub/wb-data-scrub.js
+++ b/src/plugins/wb-data-scrub/wb-data-scrub.js
@@ -1,0 +1,60 @@
+/**
+ * @title WET-BOEW wb-data-scrub
+ * @overview This plugin delete Personal Identifiable Information (PII) from the flagged form fields before form submit
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @polmih, @duboisp, @GormFrank
+ **/
+( function( $, wb ) {
+"use strict";
+
+var $document = wb.doc,
+	componentName = "wb-data-scrub",
+	selector = "[data-rule-wbscrub]",
+	initEvent = "wb-init" + componentName,
+
+	init = function( event ) {
+		var elm = wb.init( event, componentName, selector );
+
+		if ( elm && $( elm.form ).data( "scrub-inited" ) !== "" ) {
+
+			var	form = elm.form;
+
+			$( elm.form ).data( "scrub-inited", "" );
+
+			form.addEventListener( "submit", function() {
+				var isScrubbed = false,
+					$inputScrubEngaged = $( "input[data-wbscrub-flag]", elm.form );
+
+				// identify form elements that were assigned to be scrubbed
+				$( selector, form ).each( function() {
+
+					var $elmInput = $( this ),
+						elmInputVal = $elmInput.val(),
+						inpValLenght = elmInputVal.length;
+
+					// if the helper find any PII values clean the PII and assign new value to the form element with the output string
+					$elmInput.val( wb.findPotentialPII( elmInputVal, true ) === false ? elmInputVal : wb.findPotentialPII( elmInputVal, true ) );
+
+					//if the output is not the same as the initial value, PII was deleted
+					if ( $elmInput.val().length !== inpValLenght ) {
+						isScrubbed = true;
+					}
+				} );
+
+				// if the publisher added the input with inputScrubEngaged and no PII was found/removed, do not submit that input
+				if ( $inputScrubEngaged ) {
+					$inputScrubEngaged.prop( "disabled", !isScrubbed );
+				}
+			} );
+
+			wb.ready( $( elm ), componentName );
+		}
+	};
+
+// Bind the init event of the plugin
+$document.on( "timerpoke.wb " + initEvent, selector, init );
+
+// Add the timer poke to initialize the plugin
+wb.add( selector );
+
+} )( jQuery, wb );


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

this plugin will delete the potential Personal Identifiable Information (PII) before a form submit.

This plugin will work with any standard form. 
This plugin **will not support** Form validation plugin or Postback plugin to be executed on the same form.

In order to activate this plugin on a form:

- the form fields that needs to be scrubbed should have the following data attribute : `data-rule-wbscrub` ;

Optionally, if you want the form to submit a parameter whenever a PII is found and removed, create an hidden input with the attribute<code>data-wbscrub-flag</code> with the name and value of your choice: 	
`<input name="scrubb" value="1" data-wbscrub-flag />` .


