### PR TITLE
Theme: Add colcount-xxs-1 proximity class

### DIFF
--- a/src/base/proximity/_base.scss
+++ b/src/base/proximity/_base.scss
@@ -255,6 +255,10 @@
 	}
 }
 
+.colcount-xxs-1 {
+	column-count: 1;
+}
+
 .colcount-xxs-2 {
 	column-count: 2;
 }


### PR DESCRIPTION
Meant to be used alongside any ``colcount-xs-*`` class. Makes it possible to revert a multi-column layout intended for extra-small view into a single-column layout in extra-extra-small view.