### PR TITLE
Equal height CSS - make col fullwidth on xs viewport

### DIFF
--- a/src/base/_wet-boew.scss
+++ b/src/base/_wet-boew.scss
@@ -138,6 +138,7 @@
 /* Extra-small view and under */
 @media screen and (max-width: $screen-xs-max) {
 	@import "views/screen-xs-max";
+	@import "../plugins/eqht-css/screen-xs-max";
 }
 
 /* Small view and under */

--- a/src/plugins/eqht-css/_screen-xs-max.scss
+++ b/src/plugins/eqht-css/_screen-xs-max.scss
@@ -1,0 +1,3 @@
+.wb-eqht-grd > [class*="col-"] {
+	width: 100%;
+}


### PR DESCRIPTION
**Que fait cette demande « pull » (PR)?**

Facilitates a glitch on xs viewport where a div with `col-*` class would take as much space as it's max content takes up creating a non-uniform look.

**Captures d'écrans**

Before:
<img width="573" alt="Screen Shot 2022-03-08 at 4 51 37 PM" src="https://user-images.githubusercontent.com/4353199/157331989-2005667f-0507-40f1-91b1-a4cde3fc5839.png">


After:
<img width="568" alt="Screen Shot 2022-03-08 at 4 52 05 PM" src="https://user-images.githubusercontent.com/4353199/157332007-30f4552d-2ea3-48b3-9e89-48164c33968c.png">

