### PR TITLE
Build: Use browserslists and overrideBrowserslist

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -712,14 +712,7 @@ module.exports = (grunt) ->
 			modern:
 				options:
 					processors: [
-						require("autoprefixer")(
-							browsers: [
-								"last 2 versions"
-								"bb >= 10"
-								"Firefox ESR"
-								"ie > 10"
-							]
-						)
+						require("autoprefixer")()
 					]
 				files: [
 					{
@@ -747,14 +740,7 @@ module.exports = (grunt) ->
 			mixed:
 				options:
 					processors: [
-						require("autoprefixer")(
-							browsers: [
-								"last 2 versions"
-								"bb >= 10"
-								"Firefox ESR"
-								"ie > 10"
-							]
-						)
+						require("autoprefixer")()
 					]
 				files: [
 					cwd: "<%= coreDist %>/css/polyfills"
@@ -776,8 +762,12 @@ module.exports = (grunt) ->
 			# Only IE8 support
 			oldIE:
 				options:
-					browsers: [
-						"ie 8"
+					processors: [
+						require("autoprefixer")(
+							overrideBrowserslist: [
+								"ie 8"
+							]
+						)
 					]
 				cwd: "dist"
 				src: [

--- a/package.json
+++ b/package.json
@@ -32,6 +32,12 @@
   ],
   "author": "",
   "license": "MIT",
+  "browserslist": [
+    "last 2 versions",
+    "bb >= 10",
+    "Firefox ESR",
+    "ie > 10"
+  ],
   "dependencies": {
     "bootstrap-sass": "3.4.1",
     "code-prettify": "^0.1.0",


### PR DESCRIPTION
* Move the browsers from Autoprefixer's ``browsers`` option (deprecated, repeated twice) into a ``browserslists`` key in package.json
* Use the ``browserslists`` key for the ``postscss:mixed`` and ``postcss:modern`` tasks
* Add Autoprefixer to the ``postcss:oldIE`` task and make it use the ``overrideBrowserslist`` option
  * Side effect: PostCSS now actually does something as a part of this task... Removes irrelevant prefixes from ie8-theme.css
* Resolve PostCSS and Autoprefixer deprecation/configuration warnings