### PR TITLE
Navcurrent: Add aria-current="page" attribute

### DIFF
--- a/src/plugins/navcurrent/navcurrent.js
+++ b/src/plugins/navcurrent/navcurrent.js
@@ -121,6 +121,7 @@ var componentName = "wb-navcurr",
 
 				if ( match ) {
 					link.className += " " + className;
+					link.setAttribute( "aria-current", "page" );
 					if ( menu.className.indexOf( "wb-menu" ) !== -1 && link.className.indexOf( "item" ) === -1 ) {
 						$( link ).closest( ".sm" ).parent().children( "a" ).addClass( className );
 					}


### PR DESCRIPTION
The navcurrent plugin is a perfect fit for the `aria-current` attribute. The former adds a class ("wb-navcurr") to visually-denote links to the current page, whereas the latter represents it in semantics.

**Scenarios this covers:**
* Any links to the current page the plugin tries adding the "wb-navcurr" class to

**Scenarios this won't cover:**
* Top-level mega menu links that point to dropdown IDs (`aria-current` is inappropriate in those scenarios)