### PR TITLE
Navcurrent: Make current page's footer link bold

### DIFF
--- a/theme/footer/_base.scss
+++ b/theme/footer/_base.scss
@@ -5,4 +5,8 @@
 	li {
 		margin-bottom: .75em;
 	}
+
+	.wb-navcurr {
+		font-weight: 700;
+	}
 }

--- a/theme/footer/_base.scss
+++ b/theme/footer/_base.scss
@@ -6,7 +6,7 @@
 		margin-bottom: .75em;
 	}
 
-	.wb-navcurr {
+	a.wb-navcurr {
 		font-weight: 700;
 	}
 }


### PR DESCRIPTION
The "wb-navcurr" class changes colour schemes in the mega and secondary menus to visually-emphasize the current page.

This adds a similar effect to footer links via bolding. It wouldn't of been practical to change text/background colours in that context since WET's footer links don't resemble buttons.