### PR TITLE
Tables - Skip column when ordering not available

### DIFF
--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -142,7 +142,7 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 	$elm.find( "th" ).each( function( index ) {
 		var $th = $( this ),
 			$btn = $th.find( "button" );
-		if ( order && order[ 0 ][ 0 ] === index ) {
+		if ( order && order.length && order[ 0 ][ 0 ] === index ) {
 			var label = ( order[ 0 ][ 1 ] === "desc" ) ? i18nText.aria.sortAscending : i18nText.aria.sortDescending;
 			label = $btn.text() + label;
 			$btn.attr( "title", label );


### PR DESCRIPTION
An error was identified when using Tables plugin in Geomap. Since Geomap generates a first and last `th` for checkboxes and magnified glass icon for zoom, these columns are set to be not sortable, when they are read by the table JS, the order length is 0. 

Based on this logic, when the Geomap table was generated, the console was showing the following error for the first and last column: `order[ 0 ]` 

In order to resolve this issue, a new condition for handling sorting/ordering validating `order.length`  has been added to the tables.js file:

```
// Handle sorting/ordering
	var order = $elm.dataTable( { "retrieve": true } ).api().order();
	$elm.find( "th" ).each( function( index ) {
		var $th = $( this ),
			$btn = $th.find( "button" );
		if ( order && order.length && order[ 0 ][ 0 ] === index ) {
			var label = ( order[ 0 ][ 1 ] === "desc" ) ? i18nText.aria.sortAscending : i18nText.aria.sortDescending;
			label = $btn.text() + label;
			$btn.attr( "title", label );
		}
		$th.removeAttr( "aria-label" );
	} );
```
 