### PR TITLE
WCAG SC 2.4.13 - Testing Script for page break

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -376,6 +376,7 @@ module.exports = (grunt) ->
 					"src/core/dep/modernizr-custom.js"
 					"src/core/wb.js"
 					"src/core/helpers.js"
+					"src/core/wcag.js"
 					"src/shims/**/*.js"
 					"src/plugins/**/*.js"
 					"!src/plugins/**/test.js"

--- a/src/core/wcag.js
+++ b/src/core/wcag.js
@@ -1,0 +1,29 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * @title WCAG Script for testing purposes
+ * @overview Test certain WCAG Success Criteria
+ * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ * @author @ricokola @duboisp
+ */
+
+function( $, wb ) {
+
+	// Execution of any action after WET is ready
+	wb.doc.one( "wb-ready.wb", setTimeout( function( ) {
+		var $pgbrk = $( ".pg-brk-aft" ),
+			msg = "WCAG SC 2.4.13 - The page break (.pg-brk-aft) is not ";
+
+		if ( $pgbrk.length > 0 ) {
+			$pgbrk.each( function() {
+				var id = $( this ).next().attr( "id" );
+				if ( id ) {
+					if ( !$( "a[href*=" + id + "]" ).length ) {
+						console.warn( msg + "linked in current page for id: " + id );
+					}
+				} else {
+					console.warn( msg + "linkable, no 'id' attribute found." );
+				}
+			} );
+		}
+	}, 250 );
+})( jQuery, wb );


### PR DESCRIPTION
Based on the change log of WCAG 2.2: [https://www.w3.org/TR/WCAG22/#changelog](https://www.w3.org/TR/WCAG22/#changelog), This success criterion has been removed on July 15 2022

Creation of new JS file (wcag.js) for testing Web pages against certain identified success criteria.