### PR TITLE
Transitions: Fix placeholder links for images (documentation)

### DIFF
--- a/src/other/transitions/transitions-en.hbs
+++ b/src/other/transitions/transitions-en.hbs
@@ -21,15 +21,15 @@
 	<section>
 		<h3>Fade-in</h3>
 		<p>Hover mouse over space below to trigger fade-in (300ms)</p>
-		<img src="https://placehold.it/350x150&amp;text=fade-in+test" class="wb-fade-in-test" alt="placeholder" tabindex="0" />
-		<img src="https://placehold.it/350x150&amp;text=fade-in+test" class="" alt="placeholder" />
+		<img src="https://via.placeholder.com/350x150&amp;text=fade-in+test" class="wb-fade-in-test" alt="placeholder" tabindex="0" />
+		<img src="https://via.placeholder.com/350x150&amp;text=fade-in+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
 		<h3>Fade-out</h3>
 		<p>Hover mouse over space below to trigger fade-out (500ms)</p>
-		<img src="https://placehold.it/350x150&amp;text=fade-out+test" class="wb-fade-out-test" alt="placeholder" tabindex="0" />
-		<img src="https://placehold.it/350x150&amp;text=fade-out+test" class="" alt="placeholder" />
+		<img src="https://via.placeholder.com/350x150&amp;text=fade-out+test" class="wb-fade-out-test" alt="placeholder" tabindex="0" />
+		<img src="https://via.placeholder.com/350x150&amp;text=fade-out+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
@@ -45,15 +45,15 @@
 	<section>
 		<h3>Slide-left</h3>
 		<p>Hover mouse over space below to trigger slide-left (300ms)</p>
-		<img src="https://placehold.it/350x150&amp;text=slide-left+test" class="wb-slide-left-test" alt="placeholder" tabindex="0" />
-		<img src="https://placehold.it/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
+		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="wb-slide-left-test" alt="placeholder" tabindex="0" />
+		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
 		<h3>Slide-right</h3>
 		<p>Hover mouse over space below to trigger slide-right (500ms)</p>
-		<img src="https://placehold.it/350x150&amp;text=slide-right+test" class="wb-slide-right-test" alt="placeholder" tabindex="0" />
-		<img src="https://placehold.it/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
+		<img src="https://via.placeholder.com/350x150&amp;text=slide-right+test" class="wb-slide-right-test" alt="placeholder" tabindex="0" />
+		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
 	</section>
 
 	<section>

--- a/src/other/transitions/transitions-fr.hbs
+++ b/src/other/transitions/transitions-fr.hbs
@@ -22,15 +22,15 @@
 	<section>
 		<h3>Fade-in</h3>
 		<p>Hover mouse over space below to trigger fade-in (300ms)</p>
-		<img src="https://placehold.it/350x150&amp;text=fade-in+test" class="wb-fade-in-test" alt="placeholder" tabindex="0" />
-		<img src="https://placehold.it/350x150&amp;text=fade-in+test" class="" alt="placeholder" />
+		<img src="https://via.placeholder.com/350x150&amp;text=fade-in+test" class="wb-fade-in-test" alt="placeholder" tabindex="0" />
+		<img src="https://via.placeholder.com/350x150&amp;text=fade-in+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
 		<h3>Fade-out</h3>
 		<p>Hover mouse over space below to trigger fade-out (500ms)</p>
-		<img src="https://placehold.it/350x150&amp;text=fade-out+test" class="wb-fade-out-test" alt="placeholder" tabindex="0" />
-		<img src="https://placehold.it/350x150&amp;text=fade-out+test" class="" alt="placeholder" />
+		<img src="https://via.placeholder.com/350x150&amp;text=fade-out+test" class="wb-fade-out-test" alt="placeholder" tabindex="0" />
+		<img src="https://via.placeholder.com/350x150&amp;text=fade-out+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
@@ -46,15 +46,15 @@
 	<section>
 		<h3>Slide-left</h3>
 		<p>Hover mouse over space below to trigger slide-left (300ms)</p>
-		<img src="https://placehold.it/350x150&amp;text=slide-left+test" class="wb-slide-left-test" alt="placeholder" tabindex="0" />
-		<img src="https://placehold.it/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
+		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="wb-slide-left-test" alt="placeholder" tabindex="0" />
+		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
 		<h3>Slide-right</h3>
 		<p>Hover mouse over space below to trigger slide-right (500ms)</p>
-		<img src="https://placehold.it/350x150&amp;text=slide-right+test" class="wb-slide-right-test" alt="placeholder" tabindex="0" />
-		<img src="https://placehold.it/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
+		<img src="https://via.placeholder.com/350x150&amp;text=slide-right+test" class="wb-slide-right-test" alt="placeholder" tabindex="0" />
+		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
 	</section>
 
 	<section>


### PR DESCRIPTION
## Que fait cette demande « pull » (PR)?
Règle des liens brisés vers les images "placeholders" dans la documentation des transitions CSS.
