### PR TITLE
Fixed a typo (solves #9325)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ If this is your first time contributing on GitHub, don't worry! Here are some gu
 
 ## Fixing or improving WET as a developer
 
-Refer to the [get started rubric for deveopers](https://wet-boew.github.io/wet-boew/docs/start-en.html#develop).
+Refer to the [get started rubric for developers](https://wet-boew.github.io/wet-boew/docs/start-en.html#develop).
 
 ## Create or edit WET features
 


### PR DESCRIPTION
This PR corrects a typo in `CONTRIBUTING.md` from `Refer to the [get started rubric for deveopers](https://wet-boew.github.io/wet-boew/docs/start-en.html#develop).` to `Refer to the [get started rubric for developers](https://wet-boew.github.io/wet-boew/docs/start-en.html#develop).`

![image](https://user-images.githubusercontent.com/67518620/165590181-d781cd3b-d294-4666-8859-bc15b67218af.png)

Fixes #9325