### PR TITLE
helpers: findPotentialPii changes

### DIFF
--- a/site/pages/docs/ref/core/core-en.hbs
+++ b/site/pages/docs/ref/core/core-en.hbs
@@ -63,6 +63,65 @@
 </section>
 
 <section>
+	<h2>JS API</h2>
+	<h3>wb.findPotentialPII(str, scope, opts) - Find most common Personal Identifiable Information (PII) in a string</h3>
+	<p>Find most common Personal Identifiable Information (PII) in a string and return either the cleaned string either true/false</p>
+	<p>This function can have the following parameters</p>
+	<ul>
+		<li>
+			<code>str</code> (required) - string representing the content that needs to be verified
+		</li>
+		<li>
+			<code>scope</code> this parameter can be:
+			<ul>
+				<li>either a boolean (required) - If passed as true will scrub the content</li>
+				<li>either an object (optional) - having the following properties (optional):
+					<ul>
+						<li>{string} any key name of the default patterns e.g. <code>email</code>, <code>digits</code>, etc. with the value 1. The function will only scrub the content that match the regex of the default patterns passed in this object
+						<p>The list of the regular expressions that will be applied by default:</p>
+						<ul>
+							<li>digits</li>
+							<li>passport</li>
+							<li>email</li>
+							<li>postalCode</li>
+							<li>username</li><li>password</li>
+						</ul>
+						</li>
+						<li>{regex} <code>customCase</code> - this param is a regular expression. It will search and replace the values corresponding that pattern</li>
+					</ul>
+				</li>
+			</ul>
+		</li>
+		<li>
+			<code>opts</code> (optional) - the 3rd param of the function is an object that can contain the following properties (optional):
+			<ul>
+				<li>{boolean} <code>isCustomExclusive</code> - if the value is 1(true), it will scrubb only the custom regex if the regex is the only property of the <code>scope</code> object
+</li>
+				<li>{string} <code>replaceWith</code> - this string will replace the scrubbed content</li>
+				<li>{bolean} <code>useFullBlock</code> - if the is value 1(true), it will replace the scrubbed characters with the "█" symbol;</li>
+			</ul>
+		</li>
+	</ul>
+	<p>Working example</p>
+<pre><code>
+wb.findPotentialPII( "email:test@test.com, phone:123 123 1234", true )
+</code></pre>
+<p>It will return: "email:, phone:" </p>
+<pre><code>
+	wb.findPotentialPII( "email:test@test.com, phone:123 123 1234", false )
+</code></pre>
+<p>It will return: <code>true</code> </p>
+<pre><code>
+wb.findPotentialPII( "email:test@test.com, phone:123 123 1234", { email:1 }{ replaceWith: [REDACTED/CAVIARDÉ] } )
+</code></pre>
+<p>It will return:"email:[REDACTED/CAVIARDÉ], phone:123 123 1234" </p>
+<pre><code>
+wb.findPotentialPII( "email:test@test.com, phone:123 123 1234, numéro de cas 12345678", { "customCase":/\b(?:case[\s-]?number[\s\-\\.]?(?:\d{5,10}))|(?:numéro[\s-]?de[\s-]?cas[\s\-\\.]?(?:\d{5,10}))/ig }, { useFullBlock:1})
+</code></pre>
+<p>It will return: "phone:████████████, email:█████████████, postalCode:██████, ██████████████████████"</p>
+</section>
+
+<section>
 	<h2>Source code</h2>
 	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/core">WET core source code on GitHub</a></p>
 </section>

--- a/site/pages/docs/ref/core/core-fr.hbs
+++ b/site/pages/docs/ref/core/core-fr.hbs
@@ -64,7 +64,66 @@
 		</table>
 	</div>
 </section>
+<section>
+	<h2>JS API</h2>
+	<h3>wb.findPotentialPII(str, scope, opts) - Find most common Personal Identifiable Information (PII) in a string </h3>
+	<p>Find most common Personal Identifiable Information (PII) in a string and return either the cleaned string either true/false</p>
+	<p>This function can have the following parameters</p>
+	<ul>
+		<li>
+			<code>str</code> (required) - string representing the content that needs to be verified
+		</li>
+		<li>
+			<code>scope</code> this parameter can be:
+			<ul>
+				<li>either a boolean (required) - If passed as true will scrub the content</li>
+				<li>either an object (optional) - having the following properties (optional):
+					<ul>
+						<li>{string} any key name of the default patterns e.g. <code>email</code>, <code>digits</code>, etc. with the value 1. The function will only scrub the content that match the regex of the default patterns passed in this object
+						<p>The list of the regular expressions that will be applied by default:</p>
+						<ul>
+							<li>digits</li>
+							<li>passport</li>
+							<li>email</li>
+							<li>postalCode</li>
+							<li>username</li><li>password</li>
+						</ul>
+						</li>
 
+						<li>{regex} <code>customCase</code> - this param is a regular expression. It will search and replace the values corresponding that pattern</li>
+					</ul>
+				</li>
+			</ul>
+
+		</li>
+		<li>
+			<code>opts</code> (optional) - the 3rd param of the function is an object that can contain the following properties (optional):
+			<ul>
+				<li>{boolean} <code>isCustomExclusive</code> - if the value is 1(true), it will scrubb only the custom regex if the regex is the only property of the <code>scope</code> object
+</li>
+				<li>{string} <code>replaceWith</code> - this string will replace the scrubbed content</li>
+				<li>{bolean} <code>useFullBlock</code> - if the is value 1(true), it will replace the scrubbed characters with the "█" symbol;</li>
+			</ul>
+		</li>
+	</ul>
+	<p>Working example</p>
+<pre><code>
+wb.findPotentialPII( "email:test@test.com, phone:123 123 1234", true )
+</code></pre>
+<p>It will return: "email:, phone:" </p>
+<pre><code>
+	wb.findPotentialPII( "email:test@test.com, phone:123 123 1234", false )
+</code></pre>
+<p>It will return: <code>true</code> </p>
+<pre><code>
+wb.findPotentialPII( "email:test@test.com, phone:123 123 1234", { email:1 }{ replaceWith: [REDACTED/CAVIARDÉ] } )
+</code></pre>
+<p>It will return:"email:[REDACTED/CAVIARDÉ], phone:123 123 1234" </p>
+<pre><code>
+wb.findPotentialPII( "email:test@test.com, phone:123 123 1234, numéro de cas 12345678", { "customCase":/\b(?:case[\s-]?number[\s\-\\.]?(?:\d{5,10}))|(?:numéro[\s-]?de[\s-]?cas[\s\-\\.]?(?:\d{5,10}))/ig }, { useFullBlock:1})
+</code></pre>
+<p>It will return: "phone:████████████, email:█████████████, postalCode:██████, ██████████████████████"</p>
+</section>
 <section>
 	<h2>Source code</h2>
 	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/core">WET core source code on GitHub</a></p>

--- a/src/core/test.js
+++ b/src/core/test.js
@@ -56,6 +56,36 @@ describe( "findPotentialPII test suite", function() {
 		it( "should match password = value", function() {
 			expect( wb.findPotentialPII( "password:P123456, password=P123456, pass:P123456, pass=P123456", true ) ).to.equal( ", , , " );
 		} );
+
+		it( "should return true", function() {
+			expect( wb.findPotentialPII( "phone:514-514-5144, email:1@example.com" ) ).to.equal( true );
+		} );
+
+		it( "should return false", function() {
+			expect( wb.findPotentialPII( "date:2022-02-02, case number:1234" ) ).to.equal( false );
+		} );
+
+		it( "should match the all the default patterns and the custom case passed as parameter", function() {
+			expect( wb.findPotentialPII( "email:1@example.com, phone:514-514-5144, postal code:K2C-3N2, my-custom-rule: case number:123456", { myCustomRule: /\b(?:case[\s-]?number[\s\-\\.:]?(?:\d{5,10}))/ig }, { useFullBlock: 1 } ) ).to.equal( "email:█████████████, phone:████████████, postal code:███████, my-custom-rule: ██████████████████" );
+		} );
+
+		it( "should match only the custom case passed as parameter", function() {
+			expect( wb.findPotentialPII( "email:1@example.com, phone:514-514-5144, postal code:K2C-3N2, my-custom-rule: case number:123456", { myCustomRule: /\b(?:case[\s-]?number[\s\-\\.:]?(?:\d{5,10}))/ig }, { isCustomExclusive: 1, useFullBlock: 1 } ) ).to.equal( "email:1@example.com, phone:514-514-5144, postal code:K2C-3N2, my-custom-rule: ██████████████████" );
+		} );
+
+		it( "should replace removed content with this string: [REDACTED/CAVIARDÉ]", function() {
+			expect( wb.findPotentialPII( "email:1@example.com, phone:514-514-5144, postal code:K2C-3N2", true, { replaceWith: "[REDACTED/CAVIARDÉ]" } ) ).to.equal( "email:[REDACTED/CAVIARDÉ], phone:[REDACTED/CAVIARDÉ], postal code:[REDACTED/CAVIARDÉ]" );
+		} );
+
+		it( "should replace the scrubbed characters with the █ symbol", function() {
+			expect( wb.findPotentialPII( "email:1@example.com, phone:514-514-5144, postal code:K2C-3N2", true, { useFullBlock: 1 } ) ).to.equal( "email:█████████████, phone:████████████, postal code:███████" );
+		} );
+
+		it( "should find and replace content matching a specific pattern e.g 'email' and 'postalCode' that is present in the list of the default patterns", function() {
+			expect( wb.findPotentialPII( "email:1@example.com, phone:514-514-5144, postal code:K2C-3N2, case number:123456", { email: 1, postalCode: 1 }, { useFullBlock: 1 } ) ).to.equal( "email:█████████████, phone:514-514-5144, postal code:███████, case number:123456" );
+		} );
+
+
 	} );
 
 } );


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Update: 2022-06-14:

WET wb.findPotentialPII() function is updated to:

- Switch 8-digit wildcard to a 9-digit wildcard;
- New parameters added : 

   1.  `scope`  - can be:
        - a Boolean - if true, it will scrub the content that match the patterns;
        - an object (optional) that will the define the scope of replacing the content. Can have the following properties:
           - {string} any key name of the default patterns e.g. email, digits, etc. with the value 1. The function will only scrub the content that match the regex of the default patterns passed in this object;
           - {regex} customCase - this param is a regex. It will search and replace the values corresponding that pattern

   2. `opts` (optional) - an object that can have the following properties:
       - {boolean} isCustomExclusive - if true, it will scrub only the custom regex if the regex is the only property of the "scope" object
       - {bolean} useFullBlock - if true, it will replace the scrubbed characters with the "█" symbol;
       - {string} useString - this string will replace the scrubbed content        

