### PR TITLE
Multimedia player: Fix AJAX race condition in Firefox

### DIFF
--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -627,11 +627,13 @@ $document.on( "ajax-fetched.wb " + templateLoadedEvent, selector, function( even
 } );
 
 $document.on( initializedEvent, selector, function( event ) {
-	if ( event.namespace === componentName ) {
-		var $this = $( this ),
-			$media = $this.children( "audio, video" ).eq( 0 ),
-			captions = $media.children( "track[kind='captions']" ).attr( "src" ) || undef,
-			id = $this.attr( "id" ),
+	var $this = $( this ),
+		$media = $this.children( "audio, video" ).eq( 0 ),
+		media = $media.get( 0 );
+
+	if ( event.namespace === componentName && media ) {
+		var captions = $media.children( "track[kind='captions']" ).attr( "src" ) || undef,
+			id = $this.attr( "id" ) ? $this.attr( "id" ) : wb.getId(),
 			mId = $media.attr( "id" ) || id + "-md",
 			type = $media.is( "audio" ) ? "audio" : "video",
 			title = $media.attr( "title" ) || "",
@@ -648,7 +650,6 @@ $document.on( initializedEvent, selector, function( event ) {
 				height: height,
 				width: width
 			}, i18nText ),
-			media = $media.get( 0 ),
 			youTube = window.youTube,
 			url;
 
@@ -683,7 +684,7 @@ $document.on( initializedEvent, selector, function( event ) {
 				load: "https://www.youtube.com/iframe_api"
 			} );
 
-		} else if ( media.error === null && media.currentSrc !== "" && media.currentSrc !== undef ) {
+		} else if ( media.error === null ) {
 			$this.trigger( renderUIEvent, [ type, data ] );
 		} else {
 


### PR DESCRIPTION
Players brought in via the Data Ajax plugin sometimes tried initializing themselves twice in Firefox.

When it happened, the first attempt occurred before the AJAXed-in player had received a "wb-auto-*" ID - resulting in the player and media element's IDs getting set to "undefined" and "undefined-md" respectively.

The second attempt then treated the player's transformed HTML markup as if it was the initial markup. That caused several issues, such as a "video" class getting added to audio players (producing a large play icon overlapping the player controls), ID mismatches and a JavaScript console error related to the ``media`` variable being undefined.

This resolves it via the following changes:
* Add a check to ensure the ``media`` variable is truthy before proceeding with initialization
* Move most variable declarations after the ``media`` check
* Get an ID from ``wb.getId()`` if the player doesn't already have one
  * Note: Getting an ID at this point will prevent the second initialization from occurring. But the ``media`` check is still necessary for players that use hardcoded IDs.
* Don't check ``media.currentSrc`` in the condition that triggers ``renderUIEvent`` (speeds things up by triggering it on the first init instead of the second, higher-level ``media`` check makes this one redundant)