### PR TITLE
Build: Bump grunt-html to ^15.2.2 and related changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -972,6 +972,22 @@ module.exports = (grunt) ->
 					"dist/unmin/demos/**/ajax/**/*.html"
 					"dist/unmin/assets/*.html"
 				]
+
+			lightbox:
+				options:
+					ignore: [
+						# TODO: Remove longdesc attributes without hindering user agents/screen readers that still support longdesc
+						"The “longdesc” attribute on the “img” element is obsolete. Use a regular “a” element to link to the description."
+						# TODO: Should be removed and fixed now that HTML5 specs updated
+						"The “main” role is unnecessary for element “main”."
+						"The “contentinfo” role is unnecessary for element “footer”."
+						"The “navigation” role is unnecessary for element “nav”."
+						"The “banner” role is unnecessary for element “header”."
+					]
+				src: [
+					"dist/unmin/demos/lightbox/*.html"
+				]
+
 			all:
 				options:
 					ignore: [
@@ -985,6 +1001,7 @@ module.exports = (grunt) ->
 					"dist/unmin/**/*.html"
 					"!dist/unmin/**/ajax/**/*.html"
 					"!dist/unmin/assets/**/*.html"
+					"!dist/unmin/demos/lightbox/*.html"
 					"!dist/unmin/demos/menu/demo/*.html"
 					"!dist/unmin/test/**/*.html"
 				]

--- a/package-lock.json
+++ b/package-lock.json
@@ -386,7 +386,7 @@
     "absolute": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/absolute/-/absolute-0.0.1.tgz",
-      "integrity": "sha512-Zs3Sz3lmEIH76fvnc4jto4CpuI5bhU2TD+jtBYVIfXnjFm+49y1opKxNy4gtNF+xSLBL7hXRpLwypc+o2MzBIQ==",
+      "integrity": "sha1-wigi+H4ck59XmIdQTZwQnEFzgp0=",
       "dev": true
     },
     "accepts": {
@@ -498,7 +498,7 @@
     "align-text": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha512-GrTZLRpmp6wIC2ztrWW9MjjTgSKccffgFagbNDOX95/dcjEcYZibYTeaOntySQLcdw1ztBoFkviiUvTMbb9MYg==",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -528,7 +528,7 @@
     "ansi-red": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ansi-red/-/ansi-red-0.1.1.tgz",
-      "integrity": "sha512-ewaIr5y+9CUTGFwZfpECUbFlGcC0GCw1oqR9RI6h1gQCd9Aj2GxSckCnPsVJnmfMZbwFYE+leZGASgkWl06Jow==",
+      "integrity": "sha1-jGOPnRCAgAo1PJwoyKgcpHBdlGw=",
       "dev": true,
       "requires": {
         "ansi-wrap": "0.1.0"
@@ -549,7 +549,7 @@
     "ansi-wrap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
-      "integrity": "sha512-ZyznvL8k/FZeQHr2T6LzcJ/+vBApDnMNZvfVFy3At0knswWd6rJ3/0Hhmpu8oqa6C92npmozs890sX9Dl6q+Qw==",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
     "anymatch": {
@@ -617,7 +617,7 @@
     "array-differ": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
-      "integrity": "sha512-LeZY+DZDRnvP7eMuQ6LHfCzUGxAAIViUBliK24P3hWXL6y4SortgR6Nim6xrkfSLlmH0+k+9NYNwVC2s53ZrYQ==",
+      "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
     },
     "array-each": {
@@ -716,7 +716,7 @@
     "assert": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.3.0.tgz",
-      "integrity": "sha512-5aKcpD+XnHpZ7EGxsuo6uoILNh0rvm0Ypa17GlkrF2CNSPhvdgi3ft9XsL2ajdVOI2I3xuGZnHvlXAeqTZYvXg==",
+      "integrity": "sha1-A5OaYiWCqBLMICMgoLmlbJuBWEk=",
       "dev": true,
       "requires": {
         "util": "0.10.3"
@@ -931,7 +931,7 @@
     "bluebird": {
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-      "integrity": "sha512-iD3898SR7sWVRHbiQv+sHUtHnMvC1o3nW5rAcqnq3uOn07DSAppZYUkIGslDz6gXC7HfunPe7YVBgoEJASPcHA==",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
       "dev": true
     },
     "bn.js": {
@@ -1122,7 +1122,7 @@
     "brorand": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-      "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
     "browser-pack": {
@@ -1165,7 +1165,7 @@
     "browserify": {
       "version": "13.1.1",
       "resolved": "https://registry.npmjs.org/browserify/-/browserify-13.1.1.tgz",
-      "integrity": "sha512-/a2iFDn8tc6FIU9v4fqB3SX4fFOPLZqA9BeUS1A+SWSsnzKRfL2gZkBwy01msbArQOOxypfr8v92UFq9BYgZ2A==",
+      "integrity": "sha1-cqIxDi9wbth9uSnPDuc6Xhldm7A=",
       "dev": true,
       "requires": {
         "JSONStream": "^1.0.3",
@@ -1361,7 +1361,7 @@
     "browserify-zlib": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-      "integrity": "sha512-19OEpq7vWgsH6WkvkBJQDFvJS1uPcbFOQ4v9CU839dO+ZZXUZO6XpE6hNCqvlIIj+4fZvRiJ6DsAQ382GwiyTQ==",
+      "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
       "dev": true,
       "requires": {
         "pako": "~0.2.0"
@@ -1434,13 +1434,13 @@
     "buffer-xor": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ==",
+      "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
       "dev": true
     },
     "builtin-status-codes": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
-      "integrity": "sha512-HpGFw18DgFWlncDfjTa2rcQ4W88O1mC8e8yZ2AvQY5KDaktSTwo+KRf6nHK6FRI5FyRyb/5T6+TSxfP7QyGsmQ==",
+      "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
     },
     "bytes": {
@@ -1554,7 +1554,7 @@
     "center-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha512-Baz3aNe2gd2LP2qk5U+sDk/m4oSuwSDcBfayTCTBoWpfIGO5XFxPmjILQII4NGiZjD6DoDI6kf7gKaxkf7s3VQ==",
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2025,7 +2025,7 @@
     "colors": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+      "integrity": "sha512-ENwblkFQpqqia6b++zLD/KUWafYlVY/UNnAp7oz7LY7E924wmpye416wBOmvv/HMWzl8gL1kJlfvId/1Dg176w==",
       "dev": true
     },
     "combine-source-map": {
@@ -2667,13 +2667,13 @@
         "acorn": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.12.0.tgz",
-          "integrity": "sha512-itM1P1dPZymI8PCDR/eU0Q1KyIoPv1o7XqsjiEDHuQMZ0X6gPC79OpJScw4a8ZgzDQ8dvnRi99kBEPVcvJX99A==",
+          "integrity": "sha1-M3sLspPf1iOdfmbJLHJ8VqCNQD4=",
           "dev": true
         },
         "camelcase": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-          "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
           "dev": true
         },
         "cliui": {
@@ -3746,7 +3746,7 @@
     "eventemitter2": {
       "version": "0.4.14",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
-      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "integrity": "sha512-K7J4xq5xAD5jHsGM5ReWXRTFa3JRGofHiMcVgQ8PRwgWxzjHpMWCIzsmyf60+mh8KLsqYPcjUMa0AC4hd6lPyQ==",
       "dev": true
     },
     "events": {
@@ -3768,7 +3768,7 @@
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
       "dev": true
     },
     "exit-hook": {
@@ -4267,7 +4267,7 @@
     "for-own": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
-      "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
+      "integrity": "sha512-0OABksIGrxKK8K4kynWkQ7y1zounQxP+CWnyclVwj81KW3vlLlGUx57DKGcP/LH216GzqnstnPocF16Nxs0Ycg==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.1"
@@ -4854,7 +4854,7 @@
         "findup-sync": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
-          "integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
+          "integrity": "sha512-z8Nrwhi6wzxNMIbxlrTzuUW6KWuKkogZ/7OdDVq+0+kxn77KUH1nipx8iU6suqkHqc4y6n7a9A8IpmxY/pTjWg==",
           "dev": true,
           "requires": {
             "glob": "~5.0.0"
@@ -4863,7 +4863,7 @@
             "glob": {
               "version": "5.0.15",
               "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-              "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
+              "integrity": "sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==",
               "dev": true,
               "requires": {
                 "inflight": "^1.0.4",
@@ -5492,70 +5492,21 @@
       }
     },
     "grunt-html": {
-      "version": "14.3.0",
-      "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-14.3.0.tgz",
-      "integrity": "sha512-QGivDYsvXxgScin5wMicPOV4KkJ7b42KpPci7StllHusvJraY5QgHrmgCnIJMpZO1xJJR523stiJQnBAO4Ei0A==",
+      "version": "15.2.2",
+      "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-15.2.2.tgz",
+      "integrity": "sha512-/Zm1bMzmDcZtfBwtlGVkNimSRHP5OuuzajJ3+4S92TSfwcUi2iTIin7RLGNpW9Egmni66+SmEM+vI56JzTNInQ==",
       "dev": true,
       "requires": {
-        "async": "^3.2.0",
-        "chalk": "^4.1.0",
-        "vnu-jar": "21.2.5"
+        "async": "^3.2.3",
+        "picocolors": "^1.0.0",
+        "vnu-jar": "21.10.12"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
         "async": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-3.2.0.tgz",
-          "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
+          "version": "3.2.4",
+          "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
+          "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
           "dev": true
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },
@@ -7414,7 +7365,7 @@
     "interpret": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "integrity": "sha512-CLM8SNMDu7C5psFCn6Wg/tgpj/bKAg7hc2gWqcuR9OD5Ft9PhBpIu8PLicPeis+xDd6YX2ncI8MCA64I9tftIA==",
       "dev": true
     },
     "invert-kv": {
@@ -7780,7 +7731,7 @@
         "acorn": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
-          "integrity": "sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
           "dev": true
         },
         "espree": {
@@ -8853,7 +8804,7 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
         }
       }
@@ -9783,13 +9734,13 @@
         "ansi-styles": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz",
-          "integrity": "sha512-3iF4FIKdxaVYT3JqQuY3Wat/T2t7TRbbQ94Fu50ZUCbLy4TFbTzr90NOHQodQkNqmeEGCw8WbeP78WNi6SKYUA==",
+          "integrity": "sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=",
           "dev": true
         },
         "chalk": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
-          "integrity": "sha512-sQfYDlfv2DGVtjdoQqxS0cEZDroyG8h6TamA6rvxwlrU5BaSLDx9xhatBYl2pxZ7gmpNaPFVwBtdGdu5rQ+tYQ==",
+          "integrity": "sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=",
           "dev": true,
           "requires": {
             "ansi-styles": "~1.0.0",
@@ -9814,7 +9765,7 @@
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
       "dev": true,
       "requires": {
         "abbrev": "1"
@@ -10027,7 +9978,7 @@
     "object.defaults": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/object.defaults/-/object.defaults-1.1.0.tgz",
-      "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
+      "integrity": "sha512-c/K0mw/F11k4dEUBMW8naXUuBuhxRCfG7W+yFy8EcijU/rSmazOUd1XAEEe6bC0OuXY4HUKjTJv7xbxIMqdxrA==",
       "dev": true,
       "requires": {
         "array-each": "^1.0.1",
@@ -10039,7 +9990,7 @@
     "object.map": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object.map/-/object.map-1.0.1.tgz",
-      "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
+      "integrity": "sha512-3+mAJu2PLfnSVGHwIWubpOFLscJANBKuB/6A4CxBstc4aqwQY0FWcsppuy4jU5GSB95yES5JHSI+33AWuS4k6w==",
       "dev": true,
       "requires": {
         "for-own": "^1.0.0",
@@ -10118,7 +10069,7 @@
         "async": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
-          "integrity": "sha512-ZAxi5cea9DNM37Ld7lIj7c8SmOVaK/ns1pTiNI8vnQbyGsS5WuL+ImnU5UVECiIw43wlx9Wnr9iXn7MJymXacA==",
+          "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
           "dev": true,
           "requires": {
             "lodash": "^4.14.0"
@@ -10127,7 +10078,7 @@
         "camelcase": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
-          "integrity": "sha512-wzLkDa4K/mzI1OSITC+DUyjgIl/ETNHE9QvYgy6J6Jvqyyz4C0Xfd+lQhb19sX2jMpZV4IssUn0VDVmglV+s4g==",
+          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "dev": true,
           "optional": true
         },
@@ -10172,7 +10123,7 @@
             "async": {
               "version": "1.5.2",
               "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-              "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+              "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
               "dev": true
             }
           }
@@ -10418,7 +10369,7 @@
     "parse-filepath": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
-      "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
+      "integrity": "sha512-FwdRXKCohSVeXqwtYonZTXtbGJKrn+HNyWDYVcp5yuJlesTwNH4rsmRZ+GrKAPJ5bLpRxESMeS+Rl0VCHRvB2Q==",
       "dev": true,
       "requires": {
         "is-absolute": "^1.0.0",
@@ -10513,7 +10464,7 @@
     "path-root": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/path-root/-/path-root-0.1.1.tgz",
-      "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
+      "integrity": "sha512-QLcPegTHF11axjfojBIoDygmS2E3Lf+8+jI6wOVmNVenrKSo3mFdSGiIgdSHenczw3wPtlVMQaFVwGmM7BJdtg==",
       "dev": true,
       "requires": {
         "path-root-regex": "^0.1.0"
@@ -10522,7 +10473,7 @@
     "path-root-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/path-root-regex/-/path-root-regex-0.1.2.tgz",
-      "integrity": "sha1-v8zcjfWxLcUsi0PsONGNcsBLqW0=",
+      "integrity": "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ==",
       "dev": true
     },
     "path-to-regexp": {
@@ -14518,9 +14469,9 @@
       }
     },
     "vnu-jar": {
-      "version": "21.2.5",
-      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-21.2.5.tgz",
-      "integrity": "sha512-mVBXRui9jAkZwXyiqofprrDIAB91F5S0xRic49elb5sutx/L3JFICVut4rMlOoX5Jwqv7lAMHGnl7RMOFdSkVA==",
+      "version": "21.10.12",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-21.10.12.tgz",
+      "integrity": "sha512-tC+BEIWbLW0duLlQl75j9jWcrkPH+hSNGOe5D/FhT21c+JBqVk7Zc7gkDswT6VRlt7skJe4e31wnoAFoLDSg0Q==",
       "dev": true
     },
     "void-elements": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "grunt-cssmin-ie8-clean": "0.0.1",
     "grunt-eslint": "^23.0.0",
     "grunt-gh-pages": "^4.0.0",
-    "grunt-html": "^14.3.0",
+    "grunt-html": "^15.2.2",
     "grunt-i18n-csv": "^0.1.0",
     "grunt-lintspaces": "^0.9.0",
     "grunt-markdownlint": "^3.1.2",

--- a/site/pages/Licence-fr.hbs
+++ b/site/pages/Licence-fr.hbs
@@ -8,4 +8,4 @@
 }
 ---
 
-<p id="licence">Voir <a href="Voir https://github.com/wet-boew/wet-boew/blob/master/LICENSE" data-proofer-ignore>LICENSE</a></p>
+<p id="licence">Voir <a href="https://github.com/wet-boew/wet-boew/blob/master/LICENSE">LICENSE</a></p>

--- a/site/pages/License-en.hbs
+++ b/site/pages/License-en.hbs
@@ -8,4 +8,4 @@
 }
 ---
 
-<p id="license">See <a href="See https://github.com/wet-boew/wet-boew/blob/master/LICENSE" data-proofer-ignore>LICENSE</a></p>
+<p id="license">See <a href="https://github.com/wet-boew/wet-boew/blob/master/LICENSE">LICENSE</a></p>

--- a/site/pages/docs/ref/bgimg/bgimg-en.hbs
+++ b/site/pages/docs/ref/bgimg/bgimg-en.hbs
@@ -82,7 +82,6 @@
 <p>(Version 1.0)</p>
 <table class="table">
 	<tr>
-		<th>Proprety name/type</th>
 		<th>Option</th>
 		<th>Description</th>
 		<th>How to configure</th>
@@ -93,7 +92,6 @@
 		<td>Address of the <a href="https://html.spec.whatwg.org/multipage/links.html#hyperlink">hyperlinks</a></td>
 		<td>Sets the background image URL to specified.</td>
 		<td>Valid URL pointing to a valid image ressource</td>
-		<td></td>
 	</tr>
 	<tr>
 		<td><code>[data-bgimg-srcset]</code> String</td>

--- a/site/pages/docs/ref/bgimg/bgimg-fr.hbs
+++ b/site/pages/docs/ref/bgimg/bgimg-fr.hbs
@@ -84,7 +84,6 @@
 <p>(Version 1.0)</p>
 <table class="table">
 	<tr>
-		<th>Proprety name/type</th>
 		<th>Option</th>
 		<th>Description</th>
 		<th>How to configure</th>
@@ -95,7 +94,6 @@
 		<td>Address of the <a href="https://html.spec.whatwg.org/multipage/links.html#hyperlink">hyperlinks</a></td>
 		<td>Sets the background image URL to specified.</td>
 		<td>Valid URL pointing to a valid image ressource</td>
-		<td></td>
 	</tr>
 	<tr>
 		<td><code>[data-bgimg-srcset]</code> String</td>

--- a/site/pages/docs/ref/core/core-fr.hbs
+++ b/site/pages/docs/ref/core/core-fr.hbs
@@ -69,3 +69,4 @@
 	<h2>Source code</h2>
 	<p><a href="https://github.com/wet-boew/wet-boew/tree/master/src/core">WET core source code on GitHub</a></p>
 </section>
+</div>

--- a/site/pages/docs/ref/exitscript/exitscript-en.hbs
+++ b/site/pages/docs/ref/exitscript/exitscript-en.hbs
@@ -71,8 +71,7 @@
 				<td>Add <code>"i18n":{ "cancelBtn": "Nope"}</code> to the <code>data-wb-exitscript</code> attribute.</td>
 				<td>Your custom label</td>
 			</tr>
-				</tr>
-				<tr>
+			<tr>
 				<td><code>.wb-exitscript-urlparam</code></td>
 				<td>Retrieves the original URL</td>
 				<td>Add class <code>.wb-exitscript-urlparam</code> to the container <code><span class="wb-exitscript wb-exitscript-urlparam"></span></code>.</td>

--- a/site/pages/docs/ref/exitscript/exitscript-fr.hbs
+++ b/site/pages/docs/ref/exitscript/exitscript-fr.hbs
@@ -78,8 +78,7 @@
 				<td>Add <code>"i18n":{ "cancelBtn": "Nope"}</code> to the <code>data-wb-exitscript</code> attribute.</td>
 				<td>Your custom label</td>
 			</tr>
-				</tr>
-				<tr>
+			<tr>
 				<td><code>.wb-exitscript-urlparam</code></td>
 				<td>Retrieves the original URL</td>
 				<td>Add class <code>.wb-exitscript-urlparam</code> to the container <code><span class="wb-exitscript wb-exitscript-urlparam"></span></code>.</td>

--- a/site/pages/docs/ref/plugins-fr.hbs
+++ b/site/pages/docs/ref/plugins-fr.hbs
@@ -32,7 +32,7 @@
 	<li><a href="share/share-fr.html">Gadget de partage</a> - Permet à l'utilisateur de partager un contenu Web sur les plateformes de médias sociaux.</li>
 	<li><a href="geomap/geomap-fr.html">Géocarte</a> - Affiche une carte dynamique sur laquelle des informations de sources supplémentaires peuvent être superposées.</li>
 	<li><a href="charts/charts-fr.html">Graphiques</a> - Génère des graphiques à partir de données d’un tableau.</li>
-	<li><a href="bgimg/bgimg-fr.html">Image d'arrière plan - Défini une image d'arrière plan pour l'URL passé en paramètre ou tel que spécifier par l'information du group d'image.</li>
+	<li><a href="bgimg/bgimg-fr.html">Image d'arrière plan</a> - Défini une image d'arrière plan pour l'URL passé en paramètre ou tel que spécifier par l'information du group d'image.</li>
 	<li><a href="tabs/tabs-fr.html">Interface à onglets</a> - Comprime plusieurs sections de contenu dans le même espace physique et fourni des onglets qui permettent à l'utilisateur de choisi la section de contenu à afficher.</li>
 	<li><a href="multimedia/multimedia-fr.html">Lecteur multimédia</a> - Un lecteur multimédia accessible permettant d'intégrer des contenus vidéo et audio sur les pages Web.</li>
 	<li><a href="lightbox/lightbox-fr.html">Lightbox</a> - Crée une galerie photo sur une page Web.</li>

--- a/src/other/utility/utility-fr.hbs
+++ b/src/other/utility/utility-fr.hbs
@@ -178,7 +178,7 @@
 <pre><code>&lt;p class="<strong>position-relative</strong>"&gt;Ceci est un paragraphe relativement positionné.&lt;/p&gt;</code></pre>
 
 <h2 id="divers">Divers</h2>
-<h3><code>max-content</code></h3
+<h3><code>max-content</code></h3>
 <p>Limite la largeur d'un élément à la largeur de son contenu le plus grand.</p>
 <h4>Example pratique:</h4>
 <details class="max-content">

--- a/src/plugins/data-fusion-query/data-fusion-query-en.hbs
+++ b/src/plugins/data-fusion-query/data-fusion-query-en.hbs
@@ -17,7 +17,7 @@
 <ul>
 	<li><a href="?text=this+is+a+test">Text, setting the following value "this is a test" (<code>?text=this+is+a+test</code>)</a></li>
 	<li><a href="?select=ipsum">Select, setting the following value "ipsum" (<code>?select=ipsum</code>)</a></li>
-	<li><a href="?multiline=This+is+a+multiline+<strong>emphasis</strong>">Multiline text, setting the following value "This is a multiline &lt;strong&gt;emphasis&lt;/strong&gt;" (<code>?multiline=This+is+a+multiline+&lt;strong&gt;emphasis&lt;/strong&gt;</code>)</a></li>
+	<li><a href="?multiline=This+is+a+multiline+%3Cstrong%3Eemphasis%3C/strong%3E">Multiline text, setting the following value "This is a multiline &lt;strong&gt;emphasis&lt;/strong&gt;" (<code>?multiline=This+is+a+multiline+%3Cstrong%3Eemphasis%3C/strong%3E</code>)</a></li>
 </ul>
 
 <div class="form-group">

--- a/src/plugins/data-fusion-query/data-fusion-query-fr.hbs
+++ b/src/plugins/data-fusion-query/data-fusion-query-fr.hbs
@@ -17,7 +17,7 @@
 <ul>
 	<li><a href="?text=Ceci+est+un+test">Zone de texte, attribuer la valeur "Ceci est un test" (<code>?text=Ceci+est+un+test</code>)</a></li>
 	<li><a href="?select=ipsum">Liste déroulante, attribuer la valeur "ipsum" (<code>?select=ipsum</code>)</a></li>
-	<li><a href="?multiline=Ceci+est+multiligne+<strong>emphase</strong>">Zone de texte multiligne, attribuer la valeur "Ceci est multiligne &lt;strong&gt;emphase&lt;/strong&gt;" (<code>?multiline=Ceci+est+multiligne+&lt;strong&gt;emphase&lt;/strong&gt;</code>)</a></li>
+	<li><a href="?multiline=Ceci+est+multiligne+%3Cstrong%3Eemphase%3C/strong%3E">Zone de texte multiligne, attribuer la valeur "Ceci est multiligne &lt;strong&gt;emphase&lt;/strong&gt;" (<code>?multiline=Ceci+est+multiligne+%3Cstrong%3Eemphase%3C/strong%3E</code>)</a></li>
 </ul>
 
 <div class="form-group">

--- a/src/plugins/exitscript/exitscript-en.hbs
+++ b/src/plugins/exitscript/exitscript-en.hbs
@@ -58,7 +58,7 @@
 	<pre><code>
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-en.html"}'&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
-</details
+</details>
 <p>This example shows a custom message</p>
 <p><a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"i18n": { "exitMsg": "This is a custom message.", "cancelBtn": "Nope", "yesBtn": "Sure" }}'>http://csszengarden.com/219</a></p>
 <details class="mrgn-bttm-md">

--- a/src/plugins/exitscript/exitscript-fr.hbs
+++ b/src/plugins/exitscript/exitscript-fr.hbs
@@ -58,7 +58,7 @@
 	<pre><code>
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
-</details
+</details>
 <p>This example shows a custom message</p>
 <p><a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"i18n": { "exitMsg": "This is a custom message.", "cancelBtn": "Nope", "yesBtn": "Sure" }}'>http://csszengarden.com/219</a></p>
 <details class="mrgn-bttm-md">

--- a/src/plugins/wb-postback/wb-postback-en.hbs
+++ b/src/plugins/wb-postback/wb-postback-en.hbs
@@ -19,20 +19,20 @@
 <form action="wb-postback-en.html" class="wb-postback" data-wb-postback='{"success":".success-message","failure":".failure-message","content":".form-content"}'>
 	<div class="form-content">
 		<div class="form-group">
-			<label for="firstname"><span class="field-name">First Name</span></label>
-			<input class="form-control" id="firstname" name="firstname" type="text" data-rule-minlength="2" />
+			<label for="firstname1"><span class="field-name">First Name</span></label>
+			<input class="form-control" id="firstname1" name="firstname" type="text" data-rule-minlength="2" />
 		</div>
 		<div class="form-group">
-			<label for="lastname"><span class="field-name">Last Name</span></label>
-			<input class="form-control" id="lastname" name="lastname" type="text" data-rule-minlength="2" />
+			<label for="lastname1"><span class="field-name">Last Name</span></label>
+			<input class="form-control" id="lastname1" name="lastname" type="text" data-rule-minlength="2" />
 		</div>
 		<div class="form-group">
-			<label for="preferredNumber">Preferred: <span class="field-name">Phone Number</span></label>
-			<input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-phoneUS="true" />
+			<label for="preferredNumber1">Preferred: <span class="field-name">Phone Number</span></label>
+			<input class="form-control" id="preferredNumber1" name="preferredNumber" type="tel" data-rule-phoneUS="true" />
 		</div>
 		<div class="form-group">
-			<label for="email"><span class="field-name">Email Address</span> (test@domaine)</label>
-			<input class="form-control" id="email" name="email" type="email" />
+			<label for="email1"><span class="field-name">Email Address</span> (test@domaine)</label>
+			<input class="form-control" id="email1" name="email" type="email" />
 		</div>
 		<button type="submit" class="btn btn-primary">Submit</button>
 	</div>
@@ -44,20 +44,20 @@
 	<pre><code>&lt;form action="wb-postback-en.html" class="wb-postback" data-wb-postback="{&amp;quot;success&amp;quot;:&amp;quot;success-message&amp;quot;,&amp;quot;failure&amp;quot;:&amp;quot;failure-message&amp;quot;}"&gt;
 	&lt;div class="form-content"&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="firstname"&gt;&lt;span class="field-name"&gt;First Name&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="firstname" name="firstname" type="text" data-rule-minlength="2" /&gt;
+			&lt;label for="firstname1"&gt;&lt;span class="field-name"&gt;First Name&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="firstname1" name="firstname" type="text" data-rule-minlength="2" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="lastname"&gt;&lt;span class="field-name"&gt;Last Name&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="lastname" name="lastname" type="text" data-rule-minlength="2" /&gt;
+			&lt;label for="lastname1"&gt;&lt;span class="field-name"&gt;Last Name&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="lastname1" name="lastname" type="text" data-rule-minlength="2" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="preferredNumber"&gt;Preferred: &lt;span class="field-name"&gt;Phone Number&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-phoneUS="true" /&gt;
+			&lt;label for="preferredNumber1"&gt;Preferred: &lt;span class="field-name"&gt;Phone Number&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="preferredNumber1" name="preferredNumber" type="tel" data-rule-phoneUS="true" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="email"&gt;&lt;span class="field-name"&gt;Email Address&lt;/span&gt; (test@domaine)&lt;/label&gt;
-			&lt;input class="form-control" id="email" name="email" type="email" /&gt;
+			&lt;label for="email1"&gt;&lt;span class="field-name"&gt;Email Address&lt;/span&gt; (test@domaine)&lt;/label&gt;
+			&lt;input class="form-control" id="email1" name="email" type="email" /&gt;
 		&lt;/div&gt;
 		&lt;button type="submit" class="btn btn-primary"&gt;Submit&lt;/button&gt;
 	&lt;/div&gt;
@@ -74,20 +74,20 @@
 <form action="wb-postback-en.html" class="wb-postback" data-wb-postback='{"success":".success-message-2","failure":".failure-message-2","content":".form-content"}'>
 	<div class="form-content">
 		<div class="form-group">
-			<label for="firstname" class="required"><span class="field-name">First name</span> <strong class="required">(required)</strong></label>
-			<input class="form-control" id="firstname" name="firstname" type="text" data-rule-minlength="2" required="required" />
+			<label for="firstname2" class="required"><span class="field-name">First name</span> <strong class="required">(required)</strong></label>
+			<input class="form-control" id="firstname2" name="firstname" type="text" data-rule-minlength="2" required="required" />
 		</div>
 		<div class="form-group">
-			<label for="lastname" class="required"><span class="field-name">Last Name</span> <strong class="required">(required)</strong></label>
-			<input class="form-control" id="lastname" name="lastname" type="text" data-rule-minlength="2" required="required" />
+			<label for="lastname2" class="required"><span class="field-name">Last Name</span> <strong class="required">(required)</strong></label>
+			<input class="form-control" id="lastname2" name="lastname" type="text" data-rule-minlength="2" required="required" />
 		</div>
 		<div class="form-group">
-			<label for="preferredNumber">Preferred: <span class="field-name">Phone Number</span></label>
-			<input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-phoneUS="true" />
+			<label for="preferredNumber2">Preferred: <span class="field-name">Phone Number</span></label>
+			<input class="form-control" id="preferredNumber2" name="preferredNumber" type="tel" data-rule-phoneUS="true" />
 		</div>
 		<div class="form-group">
-			<label for="email"><span class="field-name">Email Address</span> (test@domaine)</label>
-			<input class="form-control" id="email" name="email" type="email" />
+			<label for="email2"><span class="field-name">Email Address</span> (test@domaine)</label>
+			<input class="form-control" id="email2" name="email" type="email" />
 		</div>
 		<button type="submit" class="btn btn-primary">Submit</button>
 	</div>
@@ -103,20 +103,20 @@
 		&lt;form action="wb-postback-en.html" class="wb-postback" data-wb-postback="{&amp;quot;success&amp;quot;:&amp;quot;success-message-2&amp;quot;,&amp;quot;failure&amp;quot;:&amp;quot;failure-message-2&amp;quot;}"&gt;
 	&lt;div class="form-content"&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="firstname" class="required"&gt;&lt;span class="field-name"&gt;First Name&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="firstname" name="firstname" type="text" data-rule-minlength="2" required="required" /&gt;
+			&lt;label for="firstname2" class="required"&gt;&lt;span class="field-name"&gt;First Name&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="firstname2" name="firstname" type="text" data-rule-minlength="2" required="required" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="lastname" class="required"&gt;&lt;span class="field-name"&gt;Last Name&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="lastname" name="lastname" type="text" data-rule-minlength="2" required="required"/&gt;
+			&lt;label for="lastname2" class="required"&gt;&lt;span class="field-name"&gt;Last Name&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="lastname2" name="lastname" type="text" data-rule-minlength="2" required="required" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="preferredNumber"&gt;Preferred: &lt;span class="field-name"&gt;Phone Number&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-phoneUS="true" /&gt;
+			&lt;label for="preferredNumber2"&gt;Preferred: &lt;span class="field-name"&gt;Phone Number&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="preferredNumber2" name="preferredNumber" type="tel" data-rule-phoneUS="true" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="email"&gt;&lt;span class="field-name"&gt;Email Address&lt;/span&gt; (test@domaine)&lt;/label&gt;
-			&lt;input class="form-control" id="email" name="email" type="email" /&gt;
+			&lt;label for="email2"&gt;&lt;span class="field-name"&gt;Email Address&lt;/span&gt; (test@domaine)&lt;/label&gt;
+			&lt;input class="form-control" id="email2" name="email" type="email" /&gt;
 		&lt;/div&gt;
 		&lt;button type="submit" class="btn btn-primary"&gt;Submit&lt;/button&gt;
 	&lt;/div&gt;

--- a/src/plugins/wb-postback/wb-postback-fr.hbs
+++ b/src/plugins/wb-postback/wb-postback-fr.hbs
@@ -18,20 +18,20 @@
 <form action="wb-postback-fr.html" class="wb-postback" data-wb-postback='{"success":".success-message","failure":".failure-message"}'>
 	<div class="form-content">
 		<div class="form-group">
-			<label for="firstname"><span class="field-name">Prénom</span></label>
-			<input class="form-control" id="firstname" name="firstname" type="text" data-rule-minlength="2" />
+			<label for="firstname1"><span class="field-name">Prénom</span></label>
+			<input class="form-control" id="firstname1" name="firstname" type="text" data-rule-minlength="2" />
 		</div>
 		<div class="form-group">
-			<label for="lastname"><span class="field-name">Nom de famille</span></label>
-			<input class="form-control" id="lastname" name="lastname" type="text" data-rule-minlength="2" />
+			<label for="lastname1"><span class="field-name">Nom de famille</span></label>
+			<input class="form-control" id="lastname1" name="lastname" type="text" data-rule-minlength="2" />
 		</div>
 		<div class="form-group">
-			<label for="preferredNumber"><span class="field-name">Numéro de téléphone</span></label>
-			<input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-phoneUS="true" />
+			<label for="preferredNumber1"><span class="field-name">Numéro de téléphone</span></label>
+			<input class="form-control" id="preferredNumber1" name="preferredNumber" type="tel" data-rule-phoneUS="true" />
 		</div>
 		<div class="form-group">
-			<label for="email"><span class="field-name">Addresse courriel</span> (test@domaine)</label>
-			<input class="form-control" id="email" name="email" type="email" />
+			<label for="email1"><span class="field-name">Addresse courriel</span> (test@domaine)</label>
+			<input class="form-control" id="email1" name="email" type="email" />
 		</div>
 		<button type="submit" class="btn btn-primary">Soumettre</button>
 	</div>
@@ -44,20 +44,20 @@
 	<pre><code>&lt;form action="wb-postback-fr.html" class="wb-postback" data-wb-postback="{&amp;quot;success&amp;quot;:&amp;quot;success-message&amp;quot;,&amp;quot;failure&amp;quot;:&amp;quot;failure-message&amp;quot;}"&gt;
 	&lt;div class="form-content"&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="firstname"&gt;&lt;span class="field-name"&gt;Prénom&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="firstname" name="firstname" type="text" data-rule-minlength="2" /&gt;
+			&lt;label for="firstname1"&gt;&lt;span class="field-name"&gt;Prénom&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="firstname1" name="firstname" type="text" data-rule-minlength="2" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="lastname"&gt;&lt;span class="field-name"&gt;Nom de famille&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="lastname" name="lastname" type="text" data-rule-minlength="2" /&gt;
+			&lt;label for="lastname1"&gt;&lt;span class="field-name"&gt;Nom de famille&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="lastname1" name="lastname" type="text" data-rule-minlength="2" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="preferredNumber"&gt;&lt;span class="field-name"&gt;Numéro de téléphone&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-phoneUS="true" /&gt;
+			&lt;label for="preferredNumber1"&gt;&lt;span class="field-name"&gt;Numéro de téléphone&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="preferredNumber1" name="preferredNumber" type="tel" data-rule-phoneUS="true" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="email"&gt;&lt;span class="field-name"&gt;Addresse courriel&lt;/span&gt; (test@domaine)&lt;/label&gt;
-			&lt;input class="form-control" id="email" name="email" type="email" /&gt;
+			&lt;label for="email1"&gt;&lt;span class="field-name"&gt;Addresse courriel&lt;/span&gt; (test@domaine)&lt;/label&gt;
+			&lt;input class="form-control" id="email1" name="email" type="email" /&gt;
 		&lt;/div&gt;
 		&lt;button type="submit" class="btn btn-primary"&gt;Soumettre&lt;/button&gt;
 	&lt;/div&gt;
@@ -73,20 +73,20 @@
 <form action="wb-postback-fr.html" class="wb-postback" data-wb-postback='{"success":".success-message-2","failure":".failure-message-2"}'>
 	<div class="form-content">
 		<div class="form-group">
-			<label for="firstname" class="required"><span class="field-name">Prénom</span> <strong class="required">(obligatoire)</strong></label>
-			<input class="form-control" id="firstname" name="firstname" type="text" data-rule-minlength="2" required="required"/>
+			<label for="firstname2" class="required"><span class="field-name">Prénom</span> <strong class="required">(obligatoire)</strong></label>
+			<input class="form-control" id="firstname2" name="firstname" type="text" data-rule-minlength="2" required="required" />
 		</div>
 		<div class="form-group">
-			<label for="lastname" class="required"><span class="field-name">Nom de famille</span> <strong class="required">(obligatoire)</strong></label>
-			<input class="form-control" id="lastname" name="lastname" type="text" data-rule-minlength="2" required="required"/>
+			<label for="lastname2" class="required"><span class="field-name">Nom de famille</span> <strong class="required">(obligatoire)</strong></label>
+			<input class="form-control" id="lastname2" name="lastname" type="text" data-rule-minlength="2" required="required" />
 		</div>
 		<div class="form-group">
-			<label for="preferredNumber"><span class="field-name">Numéro de téléphone</span></label>
-			<input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-phoneUS="true" />
+			<label for="preferredNumber2"><span class="field-name">Numéro de téléphone</span></label>
+			<input class="form-control" id="preferredNumber2" name="preferredNumber" type="tel" data-rule-phoneUS="true" />
 		</div>
 		<div class="form-group">
-			<label for="email"><span class="field-name">Addresse courriel</span> (test@domaine)</label>
-			<input class="form-control" id="email" name="email" type="email" />
+			<label for="email2"><span class="field-name">Addresse courriel</span> (test@domaine)</label>
+			<input class="form-control" id="email2" name="email" type="email" />
 		</div>
 		<button type="submit" class="btn btn-primary">Soumettre</button>
 	</div>
@@ -95,27 +95,27 @@
 <p class="failure-message-2 hide">Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.</p>
 </div>
 <details class="mrgn-tp-md mrgn-bttm-md">
-	{{>alertariahidden}}
 	<summary>View code</summary>
+	{{>alertariahidden}}
 	<pre><code>
 		&lt;div class="wb-frmvld"&gt;
 		&lt;form action="wb-postback-fr.html" class="wb-postback" data-wb-postback="{&amp;quot;success&amp;quot;:&amp;quot;success-message-2&amp;quot;,&amp;quot;failure&amp;quot;:&amp;quot;failure-message-2&amp;quot;}"&gt;
 	&lt;div class="form-content"&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="firstname" class="required"&gt;&lt;span class="field-name"&gt;Prénom&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="firstname" name="firstname" type="text" data-rule-minlength="2" required="required"/&gt;
+			&lt;label for="firstname2" class="required"&gt;&lt;span class="field-name"&gt;Prénom&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="firstname2" name="firstname" type="text" data-rule-minlength="2" required="required" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="lastname" class="required"&gt;&lt;span class="field-name"&gt;Nom de famille&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="lastname" name="lastname" type="text" data-rule-minlength="2" required="required" /&gt;
+			&lt;label for="lastname2" class="required"&gt;&lt;span class="field-name"&gt;Nom de famille&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="lastname2" name="lastname" type="text" data-rule-minlength="2" required="required" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="preferredNumber"&gt;&lt;span class="field-name"&gt;Numéro de téléphone&lt;/span&gt;&lt;/label&gt;
-			&lt;input class="form-control" id="preferredNumber" name="preferredNumber" type="tel" data-rule-phoneUS="true" /&gt;
+			&lt;label for="preferredNumber2"&gt;&lt;span class="field-name"&gt;Numéro de téléphone&lt;/span&gt;&lt;/label&gt;
+			&lt;input class="form-control" id="preferredNumber2" name="preferredNumber" type="tel" data-rule-phoneUS="true" /&gt;
 		&lt;/div&gt;
 		&lt;div class="form-group"&gt;
-			&lt;label for="email"&gt;&lt;span class="field-name"&gt;Addresse courriel&lt;/span&gt; (test@domaine)&lt;/label&gt;
-			&lt;input class="form-control" id="email" name="email" type="email" /&gt;
+			&lt;label for="email2"&gt;&lt;span class="field-name"&gt;Addresse courriel&lt;/span&gt; (test@domaine)&lt;/label&gt;
+			&lt;input class="form-control" id="email2" name="email" type="email" /&gt;
 		&lt;/div&gt;
 		&lt;button type="submit" class="btn btn-primary"&gt;Soumettre&lt;/button&gt;
 	&lt;/div&gt;


### PR DESCRIPTION
* Bump ``grunt-html`` dependency to ^15.2.2
  * Many pre-existing ``htmllint`` errors weren't being reported due to a bug in ^14.3.0 (validator/grunt-html#152)... ``grunt-html`` 15.0.0 fixed it
* Drop node 10.x from GitHub Actions (``grunt-html`` 15.0.0 and up require node 12.x at minimum)
* Fix various ``htmllint`` errors:
  * License:
    * Remove "See " / "Voir " from an ``href`` attribute's value
    * Remove ``data-proofer-ignore`` attributes (no longer needed, botched ``href`` attributes were causing ``html-proofer``'s errors)
  * Demos:
    * Exit script:
      * Add ``>`` (greater than sign) to the end of a closing ``</details>`` tag
    * Lightbox:
      * Add an extra ``htmllint`` task that ignores lightbox's ``longdesc`` attributes... removing them might necessitate other changes to the plugin
    * Postback:
      * Add number suffixes to field IDs to make them unique
      * Add a space character before ``/`` (forward slash) in ``<input>`` tags
    * Postback (French version):
      * Move ``aria-hidden="true"`` alert after ``summary`` element
    * Utilities (French version):
      * Add ``>`` (greater than sign) to the end of a closing </h3> tag
  * Docs:
    * Background image:
      * Remove "Proprety name/type" column header... no content existed for it in data rows and its presence was causing a mismatch in the number of thead/tbody columns
      * Remove empty ``td`` element from the end of the ``data-bgimg`` attribute's row
    * Exit script:
      * Remove stray closing ``</tr>`` tag
      * Adjust indentation of an opening ``<tr>`` tag
    * Plugins (French version):
      * Add closing ``</a>`` tag after "Image d'arrière plan"
    * WET core (French version):
      * Add closing ``</div>`` tag for untranslated English content

Spinoff of #9146.

CC @GormFrank