### PR TITLE
Build: Add htmllint/bootlint tasks to GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,7 @@ jobs:
       # - run: grunt dist
       - if: ${{ !env.ACT }}
         run: grunt test
+      - run: grunt htmllint
+      - run: grunt bootlint
       - run: npm test
       - run: rake


### PR DESCRIPTION
These tasks are called by grunt dist, but were missing from GitHub Actions. End result was that contributors could technically send in pull requests that introduced HTML and/or Bootlint validation errors that could slip under the radar.

* Spinoff of #9146
* Depends on #9332

C @GormFrank