### PR TITLE
Overlay - Prevent background content to scroll

### DIFF
--- a/src/plugins/overlay/_base.scss
+++ b/src/plugins/overlay/_base.scss
@@ -90,6 +90,8 @@
 }
 
 .wb-overlay-dlg {
+	overflow: hidden;
+	
 	.overlay-bg {
 		box-shadow: 0 0 1000px 1000px black;
 	}

--- a/src/plugins/overlay/_base.scss
+++ b/src/plugins/overlay/_base.scss
@@ -91,7 +91,7 @@
 
 .wb-overlay-dlg {
 	overflow: hidden;
-	
+
 	.overlay-bg {
 		box-shadow: 0 0 1000px 1000px black;
 	}


### PR DESCRIPTION

_(Pick the language of your choice to fill out the following information. / Choisissez la langue de votre choix pour remplir l'information ci-dessous.)_

## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Adds style to body for overlay [mid-screen, full-screen, full-screen hidden-header, mid-screen with background] in order to remove scrollbar of content behind the overlay when active.  This will avoid the user from scrolling the background content while navigating the overlay content. 

