### PR TITLE
Forms: Use global variable for asterisk width

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -110,6 +110,12 @@ $wb-so-text-align: right !default;
 $wb-so-padding: 1em 0 0 !default;
 
 
+//== Forms
+//
+// WET Custom
+$wb-forms-asterisk-width: .67em !default; // Asterisk offset for required field labels.
+
+
 //== Tables
 //
 //## Customizes the `.table` component with basic values, each used across all table variations.

--- a/src/base/forms/_base.scss
+++ b/src/base/forms/_base.scss
@@ -3,8 +3,6 @@
   @title: Form additions to WET-BOEW
  */
 
-$asterisk-width: .67em;
-
 %forms-color-red-bold {
 	color: #d3080c;
 	font-weight: 700;
@@ -17,7 +15,7 @@ legend,
 		&:before {
 			@extend %forms-color-red-bold;
 			content: "* ";
-			margin-left: -$asterisk-width;
+			margin-left: -$wb-forms-asterisk-width;
 			vertical-align: top;
 		}
 
@@ -51,7 +49,7 @@ legend,
 		&.required {
 			&:before {
 				margin-left: auto;
-				margin-right: -$asterisk-width;
+				margin-right: -$wb-forms-asterisk-width;
 			}
 		}
 	}


### PR DESCRIPTION
* Rename ``$asterisk-width`` to ``$wb-forms-asterisk-width``
* Declare ``$wb-forms-asterisk-width`` as a global SCSS variable to allow other WET themes to override it
* **Note:** The asterisk's width can vary based on font face. The default width isn't suitable for themes that use wider fonts.