### PR TITLE
Content - Add link to the WET core documentation

### DIFF
--- a/site/pages/demos/index-en.hbs
+++ b/site/pages/demos/index-en.hbs
@@ -153,3 +153,4 @@
 		</tr>
 	</tbody>
 </table>
+<p>Documentation of <a href="../docs/ref/core/core-en.html">WET 4 core</a></p>

--- a/site/pages/demos/index-fr.hbs
+++ b/site/pages/demos/index-fr.hbs
@@ -152,3 +152,4 @@
 		</tr>
 	</tbody>
 </table>
+<p>Documentation du <a href="../docs/ref/core/core-fr.html">coeur de la BOEW 4</a></p>

--- a/site/pages/docs/index-en.hbs
+++ b/site/pages/docs/index-en.hbs
@@ -4,7 +4,7 @@
 	"language": "en",
 	"description": "Documentation for the Web Experience Toolkit.",
 	"altLangPrefix": "index",
-	"dateModified": "2019-08-21"
+	"dateModified": "2022-06-14"
 }
 ---
 <p>WET operates on the principle of progressive enhancement, and implements well-established techniques increasing the accessibility and usability of web content. If you are new to WET, please begin with our <a href="start-en.html">Getting Started</a> section, which contains information on how to to download, use or contribute to the toolkit. Otherwise, see the Reference section below.</p>
@@ -28,6 +28,7 @@
 		<li><a href="ref/variants-en.html">Variants</a></li>
 		<li><a href="ref/provisional-en.html">Provisional features</a></li>
 		<li><a href="ref/other-en.html">Other components</a></li>
+		<li><a href="ref/core/core-en.html">WET 4 core</a></li>
 		<!-- <li><a href="https://wet-boew.github.io/v3.1-ci/docs/ref/external-en.html">External projects used in WET (v3.1)</a></li> -->
 	</ul>
 </section>

--- a/site/pages/docs/index-fr.hbs
+++ b/site/pages/docs/index-fr.hbs
@@ -4,7 +4,7 @@
 	"language": "fr",
 	"description": "Documentation de la Boîte à outils de l’expérience Web (BOEW).",
 	"altLangPrefix": "index",
-	"dateModified": "2019-08-21"
+	"dateModified": "2022-06-14"
 }
 ---
 <p>La BOEW fonctionne sur le principe d'amélioration progressive, et implémente des techniques bien établies pour accroître l'accessiblité et l'utilisabilité de contenu Web. Si vous êtes nouveau à la BOEW, veuillez commencer par notre section <a href="start-fr.html">Comment démarrer</a>, qui contient
@@ -29,6 +29,7 @@ de l'information comment télécharger, utiliser ou contribuer à la boîte d'ou
 		<li><a href="ref/variants-fr.html">Variants</a></li>
 		<li><a href="ref/provisional-fr.html">Fonctionnalités provisoires</a></li>
 		<li><a href="ref/other-fr.html">Autre composants</a></li>
+		<li><a href="ref/core/core-fr.html">Coeur de la BOEW 4</a></li>
 		<!-- <li><a href="https://wet-boew.github.io/v3.1-ci/docs/ref/external-fr.html">Projets externes utilisés par la BOEW (v3.1)</a></li> -->
 	</ul>
 </section>


### PR DESCRIPTION
Site content change - Added a link to the WET 4 core documentation from the main documentation page and from the working example page.