### PR TITLE
Country content: Fix plugin... again

### DIFF
--- a/src/plugins/country-content/country-content-en.hbs
+++ b/src/plugins/country-content/country-content-en.hbs
@@ -3,11 +3,11 @@
 	"title": "Country Content",
 	"language": "en",
 	"category": "Plugins",
-	"description": "A basic AjaxLoader wrapper that inserts AJAXed-in content based on a visitor's country as determined by freegeoip.app",
+	"description": "A basic AjaxLoader wrapper that inserts AJAXed-in content based on a visitor's country as determined by country.is",
 	"tag": "country-content",
 	"parentdir": "country-content",
 	"altLangPrefix": "country-content",
-	"dateModified": "2020-09-10"
+	"dateModified": "2022-07-18"
 }
 ---
 <p>{{description}}</p>

--- a/src/plugins/country-content/country-content-fr.hbs
+++ b/src/plugins/country-content/country-content-fr.hbs
@@ -3,11 +3,11 @@
 	"title": "Contenu par pays",
 	"language": "fr",
 	"category": "Plugiciels",
-	"description": "Un enveloppeur de AjaxLoader qui insère de contenu télécharger via AJAX. Le contenu est basée sur l'emplacement des visiteurs comme déterminé par freegeoip.app",
+	"description": "Un enveloppeur de AjaxLoader qui insère de contenu télécharger via AJAX. Le contenu est basée sur l'emplacement des visiteurs comme déterminé par country.is",
 	"tag": "country-content",
 	"parentdir": "country-content",
 	"altLangPrefix": "country-content",
-	"dateModified": "2020-09-10"
+	"dateModified": "2022-07-18"
 }
 ---
 <p>{{description}}</p>

--- a/src/plugins/country-content/country-content.js
+++ b/src/plugins/country-content/country-content.js
@@ -65,12 +65,12 @@ var componentName = "wb-ctrycnt",
 
 			// From https://github.com/aFarkas/webshim/blob/master/src/shims/geolocation.js#L89-L127
 			$.ajax( {
-				url: "https://freegeoip.app/json/",
+				url: "https://api.country.is/",
 				dataType: "json",
 				cache: true,
 				success: function( data ) {
 					if ( data ) {
-						countryCode = data.country_code;
+						countryCode = data.country;
 						try {
 							localStorage.setItem( "countryCode", countryCode );
 						} catch ( error ) {

--- a/src/plugins/country-content/test.js
+++ b/src/plugins/country-content/test.js
@@ -23,10 +23,10 @@ describe( "Country Content test suite", function() {
 
 		before( function() {
 
-			// Stub the $.ajax method to return data.country_code = "CA" on success.
+			// Stub the $.ajax method to return data.country = "CA" on success.
 			// This must be used instead of Sinon's fakeServer because the plugin uses
 			// JSON-P for the request: https://sinonjs.org/docs/#json-p
-			stubs.ajax = sandbox.stub( $, "ajax" ).yieldsTo( "success", { country_code: "CA" } );
+			stubs.ajax = sandbox.stub( $, "ajax" ).yieldsTo( "success", { country: "CA" } );
 			stubs.load = sandbox.stub( $.prototype, "load" );
 
 			// Clear out any previously saved country code
@@ -57,7 +57,7 @@ describe( "Country Content test suite", function() {
 
 			for ( ; i !== len && !isLookup; i += 1 ) {
 				if ( args[ i ] instanceof Array ) {
-					isLookup = args[ i ].length && args[ i ][ 0 ].url === "https://freegeoip.app/json/";
+					isLookup = args[ i ].length && args[ i ][ 0 ].url === "https://api.country.is/";
 				}
 			}
 			expect( isLookup ).to.equal( true );


### PR DESCRIPTION
* Replace all references to [freegeoip.app](https://freegeoip.app/) (which stopped working in late April) with [country.is](https://country.is/) and [api.country.is](https://api.country.is/)
* Rename ``country_code`` JSON key to ``country``
* Overview of [country.is](https://country.is/):
  * Has existed since 2014-2015
  * Site claims not to collect request logs
  * Doesn't have any usage limits according to hakanensari/country#17
  * Discovered it in [public-apis/public-apis#geocoding](https://github.com/public-apis/public-apis#geocoding)
* Successor to #8928