### PR TITLE
Rakefile: Update HTMLProofer options for v4

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ task :default => [:test]
 
 task :test do
 	HTMLProofer.check_directory("dist/", {
-		:url_ignore => [
+		:ignore_urls => [
 			"#",
 			# The additional anchor link is picked up from the Geomap JSON, but shouldn't be flagged
 			"\\\"#\\\"",
@@ -20,8 +20,8 @@ task :test do
 			"texthighlight/texthighlight-fr.html?txthl=influenza%20aviaire+monde+suffis+symptômes%20semblables%20à%20ceux%20de%20l'influenza+À%20titre%20de%20rappel...+À%20de%20rares%20occasions,%20des%20humains%20ont%20été%20infectés%20par%20ce%20virus.",
 			"../../../demos/texthighlight/texthighlight-en.html?txthl=influenza%20aviaire+monde+suffis+sympt%C3%B4mes%20semblables%20%C3%A0%20ceux%20de%20l'influenza+%C3%80%20titre%20de%20rappel...+%C3%80%20de%20rares%20occasions,%20des%20humains%20ont%20%C3%A9t%C3%A9%20infect%C3%A9s%20par%20ce%20virus.#exemple"
 		],
+		:allow_missing_href => true,
 		:disable_external => true,
-		:empty_alt_ignore => true,
-		:ext => ".html"
+		:enforce_https => false
 	}).run
 end


### PR DESCRIPTION
* Rename ``url_ignore`` to ``ignore_urls``
* Add ``allow_missing_href`` and set it to ``true`` (suppresses "'a' tag is missing a reference" errors on JSON manager and data JSON templates)
* Add ``enforce_https`` and set it to ``false`` (suppresses "* is not an HTTPS link" errors on HTTP links... might be possible to update some to HTTPS, but many of them are literally HTTP-only)
* Remove ``empty_alt_ignore`` (renamed to ``ignore_missing_alt`` in v4, but WET no longer needs it)
* Remove ``ext`` (renamed to ``extensions`` in v4, isn't needed in practice since the default extension is already ".html")