### PR TITLE
Site: Update more HTTP links to HTTPS

### DIFF
--- a/site/pages/docs/opt-en.hbs
+++ b/site/pages/docs/opt-en.hbs
@@ -111,7 +111,7 @@ console.log( ( new Date() ).getTime() - test );</code></pre>
 		<h3>Additional techniques</h3>
 		<ul>
 			<li><a rel="external" href="https://www.queness.com/post/588/15-ways-to-optimize-css-and-reduce-css-file-size">15 Ways to Optimize CSS and Reduce CSS File Size</a></li>
-			<li><a rel="external" href="http://www.dailycoding.com/Posts/top_7_tip_for_optimizing_css.aspx">Top 7 Tip for Optimizing CSS</a></li>
+			<li><a rel="external" href="https://web.archive.org/web/20190119144722/http://www.dailycoding.com/Posts/top_7_tip_for_optimizing_css.aspx">Top 7 Tip for Optimizing CSS</a></li>
 			<li><a rel="external" href="https://perishablepress.com/how-to-micro-optimize-your-css/">How to Micro-Optimize Your CSS]</a></li>
 		</ul>
 	</section>

--- a/site/pages/docs/opt-fr.hbs
+++ b/site/pages/docs/opt-fr.hbs
@@ -150,7 +150,7 @@ console.log( ( new Date() ).getTime() - test );</code></pre>
 		<h3>Techniques aditionelles</h3>
 		<ul lang="en">
 			<li><a rel="external" href="https://www.queness.com/post/588/15-ways-to-optimize-css-and-reduce-css-file-size">15 Ways to Optimize CSS and Reduce CSS File Size</a></li>
-			<li><a rel="external" href="http://www.dailycoding.com/Posts/top_7_tip_for_optimizing_css.aspx">Top 7 Tip for Optimizing CSS</a></li>
+			<li><a rel="external" href="https://web.archive.org/web/20190119144722/http://www.dailycoding.com/Posts/top_7_tip_for_optimizing_css.aspx">Top 7 Tip for Optimizing CSS</a></li>
 			<li><a rel="external" href="https://perishablepress.com/how-to-micro-optimize-your-css/">How to Micro-Optimize Your CSS]</a></li>
 		</ul>
 	</section>

--- a/site/pages/docs/ref/accolades-en.hbs
+++ b/site/pages/docs/ref/accolades-en.hbs
@@ -124,7 +124,7 @@
 				<td>DigitalGov</td>
 			</tr>
 			<tr>
-				<td><a href="http://www.myplanetdigital.com/article/wetkit-steals-show-drupalcamp-ottawa">WetKit steals the show at DrupalCamp Ottawa</a></td>
+				<td><a href="https://web.archive.org/web/20130819222440/http://www.myplanetdigital.com/article/wetkit-steals-show-drupalcamp-ottawa">WetKit steals the show at DrupalCamp Ottawa</a></td>
 				<td><time>2013-04-19</time></td>
 				<td>Andrea Sigritz</td>
 				<td>DigitalGov</td>
@@ -136,7 +136,7 @@
 				<td>Wired</td>
 			</tr>
 			<tr>
-				<td><a href="http://roberto-montero.com/blog/web-experience-toolkit-distribution">The day I discovered Web Experience Toolkit Distribution</a></td>
+				<td><a href="https://roberto-montero.com/blog/web-experience-toolkit-distribution">The day I discovered Web Experience Toolkit Distribution</a></td>
 				<td><time>2012-11-30</time></td>
 				<td>Roberto Montero</td>
 				<td>Personal blog</td>

--- a/site/pages/docs/ref/accolades-fr.hbs
+++ b/site/pages/docs/ref/accolades-fr.hbs
@@ -124,7 +124,7 @@
 				<td lang="en">DigitalGov</td>
 			</tr>
 			<tr>
-				<td lang="en"><a href="http://www.myplanetdigital.com/article/wetkit-steals-show-drupalcamp-ottawa">WetKit steals the show at DrupalCamp Ottawa</a></td>
+				<td lang="en"><a href="https://web.archive.org/web/20130819222440/http://www.myplanetdigital.com/article/wetkit-steals-show-drupalcamp-ottawa">WetKit steals the show at DrupalCamp Ottawa</a></td>
 				<td><time>2013-04-19</time></td>
 				<td>Andrea Sigritz</td>
 				<td lang="en">DigitalGov</td>
@@ -136,7 +136,7 @@
 				<td lang="en">Wired</td>
 			</tr>
 			<tr>
-				<td lang="en"><a href="http://roberto-montero.com/blog/web-experience-toolkit-distribution">The day I discovered Web Experience Toolkit Distribution</a></td>
+				<td lang="en"><a href="https://roberto-montero.com/blog/web-experience-toolkit-distribution">The day I discovered Web Experience Toolkit Distribution</a></td>
 				<td><time>2012-11-30</time></td>
 				<td>Roberto Montero</td>
 				<td>Blogue personnel</td>

--- a/site/pages/docs/ref/cal-events/cal-events-en.hbs
+++ b/site/pages/docs/ref/cal-events/cal-events-en.hbs
@@ -132,7 +132,7 @@
 			&lt;/li&gt;
 			&lt;li class="cal-disp-onshow"&gt;
 				&lt;section&gt;
-					&lt;h5&gt;&lt;a href="http://gcpedia.gc.ca"&gt;Event 4&lt;/a&gt;&lt;/h5&gt;
+					&lt;h5&gt;&lt;a href="https://www.gcpedia.gc.ca/"&gt;Event 4&lt;/a&gt;&lt;/h5&gt;
 					&lt;p&gt;&lt;time datetime="2011-03-24"&gt;March 24th 2011&lt;/time&gt;&lt;/p&gt;
 				&lt;/section&gt;
 			&lt;/li&gt;

--- a/site/pages/docs/ref/cal-events/cal-events-fr.hbs
+++ b/site/pages/docs/ref/cal-events/cal-events-fr.hbs
@@ -131,7 +131,7 @@
 			&lt;/li&gt;
 			&lt;li class="cal-disp-onshow"&gt;
 				&lt;section&gt;
-					&lt;h5&gt;&lt;a href="http://gcpedia.gc.ca"&gt;Événement 4&lt;/a&gt;&lt;/h5&gt;
+					&lt;h5&gt;&lt;a href="https://www.gcpedia.gc.ca/"&gt;Événement 4&lt;/a&gt;&lt;/h5&gt;
 					&lt;p&gt;&lt;time datetime="2011-03-24"&gt;24 mars 2011&lt;/time&gt;&lt;/p&gt;
 				&lt;/section&gt;
 			&lt;/li&gt;

--- a/site/pages/docs/ref/charts/charts-en.hbs
+++ b/site/pages/docs/ref/charts/charts-en.hbs
@@ -268,7 +268,7 @@ window[ "wb-charts" ] = {
 };
 &lt;/script&gt;</code></pre>
 
-		<p>The key for the <code>fn</code> object is similar to the JSON pointer defined in <a href="http://tools.ietf.org/html/rfc6901">RFC 6901</a>. The key identifies what should be overwritten with the function.</p>
+		<p>The key for the <code>fn</code> object is similar to the JSON pointer defined in <a href="https://datatracker.ietf.org/doc/html/rfc6901">RFC 6901</a>. The key identifies what should be overwritten with the function.</p>
 
 		<p>You can rename "custom" by anything you want, just keep in mind of that placeholder name will be the same name for your CSS custom option.</p>
 

--- a/site/pages/docs/ref/charts/charts-fr.hbs
+++ b/site/pages/docs/ref/charts/charts-fr.hbs
@@ -272,7 +272,7 @@ window[ "wb-charts" ] = {
 };
 &lt;/script&gt;</code></pre>
 
-		<p>The key for the <code>fn</code> object is similar to the JSON pointer defined in <a href="http://tools.ietf.org/html/rfc6901">RFC 6901</a>. The key identifies what should be overwritten with the function.</p>
+		<p>The key for the <code>fn</code> object is similar to the JSON pointer defined in <a href="https://datatracker.ietf.org/doc/html/rfc6901">RFC 6901</a>. The key identifies what should be overwritten with the function.</p>
 
 		<p>You can rename "custom" by anything you want, just keep in mind of that placeholder name will be the same name for your CSS custom option.</p>
 

--- a/site/pages/docs/ref/session-timeout/session-timeout-en.hbs
+++ b/site/pages/docs/ref/session-timeout/session-timeout-en.hbs
@@ -37,7 +37,7 @@
 	<ol>
 		<li>
 			Add a <code>class="wb-sessto"</code> element to the web page (only required once). You must set the <code>logouturl</code>, which controls where the user is redirected if their session expires:
-			<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"logouturl": "http://app.gc.ca/logout"}'&gt;&lt;/span&gt;</code></pre>
+			<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"logouturl": "https://app.gc.ca/logout"}'&gt;&lt;/span&gt;</code></pre>
 		</li>
 		<li>Configure the plugin using the <code>data-wb-sessto</code> attribute of the element:
 			<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{

--- a/site/pages/docs/ref/session-timeout/session-timeout-fr.hbs
+++ b/site/pages/docs/ref/session-timeout/session-timeout-fr.hbs
@@ -43,7 +43,7 @@
 		<ol>
 			<li>
 				Add a <code>class="wb-sessto"</code> element to the web page (only required once). You must set the <code>logouturl</code>, which controls where the user is redirected if their session expires:
-				<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"logouturl": "http://app.gc.ca/logout"}'&gt;&lt;/span&gt;</code></pre>
+				<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"logouturl": "https://app.gc.ca/logout"}'&gt;&lt;/span&gt;</code></pre>
 			</li>
 			<li>Configure the plugin using the <code>data-wb-sessto</code> attribute of the element:
 				<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{

--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -3,7 +3,7 @@
  * @overview Helper methods for WET
  * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  * @author WET Community
- * Credits: http://kaibun.net/blog/2013/04/19/a-fully-fledged-coffeescript-boilerplate-for-jquery-plugins/
+ * Credits: https://web.archive.org/web/20130826230640/http://kaibun.net/blog/2013/04/19/a-fully-fledged-coffeescript-boilerplate-for-jquery-plugins/
  */
 ( function( $, wb ) {
 

--- a/src/other/checklist/checklist-en.hbs
+++ b/src/other/checklist/checklist-en.hbs
@@ -72,7 +72,7 @@
 		</li>
 		<li>
 			<fieldset>
-				<legend>Is <a href="http://www.iheni.com/using-opera-10-beta-with-voiceover/">pinch zoom supported (HTML only)</a>?</legend>
+				<legend>Is <a href="https://web.archive.org/web/20130509175512/http://www.iheni.com/using-opera-10-beta-with-voiceover/">pinch zoom supported (HTML only)</a>?</legend>
 				<input id="ap124" type="radio" name="a124" value="pass"><label for="ap124">&nbsp;Pass</label>&nbsp;
 				<input id="af124" type="radio" name="a124" value="fail"><label for="af124">&nbsp;Fail</label>&nbsp;
 				<input id="an124" type="radio" name="a124" value="na"><label for="an124"><abbr title="Not applicable">&nbsp;N/A</abbr></label>&nbsp;
@@ -159,7 +159,7 @@
 		</li>
 		<li>
 			<fieldset>
-				<legend>Is the <a href="http://www.iheni.com/content-order-on-touch-screens/">content order logical</a>?</legend>
+				<legend>Is the <a href="https://web.archive.org/web/20150907093348/http://www.iheni.com/content-order-on-touch-screens/">content order logical</a>?</legend>
 				<input id="bp122" type="radio" name="b122" value="pass"><label for="bp122">&nbsp;Pass</label>&nbsp;
 				<input id="bf122" type="radio" name="b122" value="fail"><label for="bf122">&nbsp;Fail</label>&nbsp;
 				<input id="bn122" type="radio" name="b122" value="na"><label for="bn122"><abbr title="Not applicable">&nbsp;N/A</abbr></label>&nbsp;
@@ -167,7 +167,7 @@
 		</li>
 		<li>
 			<fieldset>
-				<legend>Are <a href="http://www.iheni.com/usable-landmarks-across-desktop-and-mobile/">landmarks</a> labelled or have the appropriate headings been announced with them?</legend>
+				<legend>Are <a href="https://web.archive.org/web/20180402210727/http://www.iheni.com:80/usable-landmarks-across-desktop-and-mobile/">landmarks</a> labelled or have the appropriate headings been announced with them?</legend>
 				<input id="bp123" type="radio" name="b123" value="pass"><label for="bp123">&nbsp;Pass</label>&nbsp;
 				<input id="bf123" type="radio" name="b123" value="fail"><label for="bf123">&nbsp;Fail</label>&nbsp;
 				<input id="bn123" type="radio" name="b123" value="na"><label for="bn123"><abbr title="Not applicable">&nbsp;N/A</abbr></label>&nbsp;
@@ -231,7 +231,7 @@
 		</li>
 		<li>
 			<fieldset>
-				<legend>Are <a href="http://www.spotlessinteractive.com/articles/accessibility/handling-repeated-adjacent-links.php">images and links to the same target grouped into one touchzone</a>?</legend>
+				<legend>Are <a href="https://web.archive.org/web/20130218204846/http://www.spotlessinteractive.com/articles/accessibility/handling-repeated-adjacent-links.php">images and links to the same target grouped into one touchzone</a>?</legend>
 				<input id="bp131" type="radio" name="b131" value="pass"><label for="bp131">&nbsp;Pass</label>&nbsp;
 				<input id="bf131" type="radio" name="b131" value="fail"><label for="bf131">&nbsp;Fail</label>&nbsp;
 				<input id="bn131" type="radio" name="b131" value="na"><label for="bn131"><abbr title="Not applicable">&nbsp;N/A</abbr></label>&nbsp;
@@ -458,9 +458,9 @@
 <section>
 	<h2 id="about">About:</h2>
 	<p>Inspired by Al Duggin’s <strong>browser based tests for accessibility</strong> in his kick ass post <a onclick="javascript:_gaq.push(['_trackPageview', '/out/alistairduggin.co.uk/blog/accessibile-interoperable-webpage-1']);" href="https://alistairduggin.co.uk/blog/accessibile-interoperable-webpage-1">building a web page with accessibility and interoperability in mind</a>, I thought I’d put some tests together for mobile. This is intended as a guide you can use in day-to-day testing – you should be able to answer ‘yes’ to each question.</p>
-	<p>Tests should be carried out in the <a href="http://www.iheni.com/talk-is-cheap-screen-reader-testing-on-mobile/">native browser in iOS Android</a> or any other of your <a href="http://www.iheni.com/getting-to-grips-with-a-mobile-accessibility-strategy/">supported devices</a> without any accessibility settings or support running as well as a combination of settings and support running i.e. zoom, voice output, inverse colours etc.</p>
-	<p>It’s worth also checking content in <a href="http://www.iheni.com/accessible-firefox-chrome-android-ios/">Firefox and Chrome on iOS and Android</a> which both have voice output support and various zoom functions. I find this especially useful when I need to establish whether the content, voice output or browser is buggy.</p>
+	<p>Tests should be carried out in the <a href="https://web.archive.org/web/20160408173132/http://www.iheni.com/talk-is-cheap-screen-reader-testing-on-mobile/">native browser in iOS Android</a> or any other of your <a href="https://web.archive.org/web/20180225031631/http://www.iheni.com:80/getting-to-grips-with-a-mobile-accessibility-strategy/">supported devices</a> without any accessibility settings or support running as well as a combination of settings and support running i.e. zoom, voice output, inverse colours etc.</p>
+	<p>It’s worth also checking content in <a href="https://web.archive.org/web/20160810040135/http://www.iheni.com/accessible-firefox-chrome-android-ios/">Firefox and Chrome on iOS and Android</a> which both have voice output support and various zoom functions. I find this especially useful when I need to establish whether the content, voice output or browser is buggy.</p>
 	<p>Finally this is a general list of core tests. Different devices will offer different accessibility settings and support ranging from anything including external braille displays and keyboards to different types of zoom. It’s important to be aware of these and include them in your testing where possible.</p>
 	<p>Henny Swan</p>
-	<small>Sourced from this <a href="http://www.iheni.com/mobile-accessibility-tests">blog</a>.</small>
+	<small>Sourced from this <a href="https://web.archive.org/web/20180129002224/http://www.iheni.com:80/mobile-accessibility-tests/">blog</a>.</small>
 </section><!-- /h2 -->

--- a/src/other/checklist/checklist-fr.hbs
+++ b/src/other/checklist/checklist-fr.hbs
@@ -104,7 +104,7 @@ There is no hard-coded value inside the html file it manipulates and variables a
 		</li>
 		<li>
 			<fieldset>
-				<legend>Is <a href="http://www.iheni.com/using-opera-10-beta-with-voiceover/">pinch zoom supported (HTML only)</a>?</legend>
+				<legend>Is <a href="https://web.archive.org/web/20130509175512/http://www.iheni.com/using-opera-10-beta-with-voiceover/">pinch zoom supported (HTML only)</a>?</legend>
 				<input id="ap124" type="radio" name="a124" value="pass"><label for="ap124">&nbsp;Pass</label>&nbsp;
 				<input id="af124" type="radio" name="a124" value="fail"><label for="af124">&nbsp;Fail</label>&nbsp;
 				<input id="an124" type="radio" name="a124" value="na"><label for="an124"><abbr title="Not applicable">&nbsp;N/A</abbr></label>&nbsp;
@@ -191,7 +191,7 @@ There is no hard-coded value inside the html file it manipulates and variables a
 		</li>
 		<li>
 			<fieldset>
-				<legend>Is the <a href="http://www.iheni.com/content-order-on-touch-screens/">content order logical</a>?</legend>
+				<legend>Is the <a href="https://web.archive.org/web/20150907093348/http://www.iheni.com/content-order-on-touch-screens/">content order logical</a>?</legend>
 				<input id="bp122" type="radio" name="b122" value="pass"><label for="bp122">&nbsp;Pass</label>&nbsp;
 				<input id="bf122" type="radio" name="b122" value="fail"><label for="bf122">&nbsp;Fail</label>&nbsp;
 				<input id="bn122" type="radio" name="b122" value="na"><label for="bn122"><abbr title="Not applicable">&nbsp;N/A</abbr></label>&nbsp;
@@ -199,7 +199,7 @@ There is no hard-coded value inside the html file it manipulates and variables a
 		</li>
 		<li>
 			<fieldset>
-				<legend>Are <a href="http://www.iheni.com/usable-landmarks-across-desktop-and-mobile/">landmarks</a> labelled or have the appropriate headings been announced with them?</legend>
+				<legend>Are <a href="https://web.archive.org/web/20180402210727/http://www.iheni.com:80/usable-landmarks-across-desktop-and-mobile/">landmarks</a> labelled or have the appropriate headings been announced with them?</legend>
 				<input id="bp123" type="radio" name="b123" value="pass"><label for="bp123">&nbsp;Pass</label>&nbsp;
 				<input id="bf123" type="radio" name="b123" value="fail"><label for="bf123">&nbsp;Fail</label>&nbsp;
 				<input id="bn123" type="radio" name="b123" value="na"><label for="bn123"><abbr title="Not applicable">&nbsp;N/A</abbr></label>&nbsp;
@@ -263,7 +263,7 @@ There is no hard-coded value inside the html file it manipulates and variables a
 		</li>
 		<li>
 			<fieldset>
-				<legend>Are <a href="http://www.spotlessinteractive.com/articles/accessibility/handling-repeated-adjacent-links.php">images and links to the same target grouped into one touchzone</a>?</legend>
+				<legend>Are <a href="https://web.archive.org/web/20130218204846/http://www.spotlessinteractive.com/articles/accessibility/handling-repeated-adjacent-links.php">images and links to the same target grouped into one touchzone</a>?</legend>
 				<input id="bp131" type="radio" name="b131" value="pass"><label for="bp131">&nbsp;Pass</label>&nbsp;
 				<input id="bf131" type="radio" name="b131" value="fail"><label for="bf131">&nbsp;Fail</label>&nbsp;
 				<input id="bn131" type="radio" name="b131" value="na"><label for="bn131"><abbr title="Not applicable">&nbsp;N/A</abbr></label>&nbsp;
@@ -490,10 +490,10 @@ There is no hard-coded value inside the html file it manipulates and variables a
 <section>
 	<h2 id="about">About:</h2>
 	<p>Inspired by Al Duggin’s <strong>browser based tests for accessibility</strong> in his kick ass post <a onclick="javascript:_gaq.push(['_trackPageview', '/out/alistairduggin.co.uk/blog/accessibile-interoperable-webpage-1']);" href="https://alistairduggin.co.uk/blog/accessibile-interoperable-webpage-1">building a web page with accessibility and interoperability in mind</a>, I thought I’d put some tests together for mobile. This is intended as a guide you can use in day-to-day testing – you should be able to answer ‘yes’ to each question.</p>
-	<p>Tests should be carried out in the <a href="http://www.iheni.com/talk-is-cheap-screen-reader-testing-on-mobile/">native browser in iOS Android</a> or any other of your <a href="http://www.iheni.com/getting-to-grips-with-a-mobile-accessibility-strategy/">supported devices</a> without any accessibility settings or support running as well as a combination of settings and support running i.e. zoom, voice output, inverse colours etc.</p>
-	<p>It’s worth also checking content in <a href="http://www.iheni.com/accessible-firefox-chrome-android-ios/">Firefox and Chrome on iOS and Android</a> which both have voice output support and various zoom functions. I find this especially useful when I need to establish whether the content, voice output or browser is buggy.</p>
+	<p>Tests should be carried out in the <a href="https://web.archive.org/web/20160408173132/http://www.iheni.com/talk-is-cheap-screen-reader-testing-on-mobile/">native browser in iOS Android</a> or any other of your <a href="https://web.archive.org/web/20180225031631/http://www.iheni.com:80/getting-to-grips-with-a-mobile-accessibility-strategy/">supported devices</a> without any accessibility settings or support running as well as a combination of settings and support running i.e. zoom, voice output, inverse colours etc.</p>
+	<p>It’s worth also checking content in <a href="https://web.archive.org/web/20160810040135/http://www.iheni.com/accessible-firefox-chrome-android-ios/">Firefox and Chrome on iOS and Android</a> which both have voice output support and various zoom functions. I find this especially useful when I need to establish whether the content, voice output or browser is buggy.</p>
 	<p>Finally this is a general list of core tests. Different devices will offer different accessibility settings and support ranging from anything including external braille displays and keyboards to different types of zoom. It’s important to be aware of these and include them in your testing where possible.</p>
 	<p>Henny Swan</p>
-	<small>Sourced from this <a href="http://www.iheni.com/mobile-accessibility-tests">blog</a>.</small>
+	<small>Sourced from this <a href="https://web.archive.org/web/20180129002224/http://www.iheni.com:80/mobile-accessibility-tests/">blog</a>.</small>
 </section><!-- /h2 -->
 </div><!-- /lang en -->

--- a/src/plugins/feeds/test.js
+++ b/src/plugins/feeds/test.js
@@ -42,7 +42,7 @@ describe( "Feeds test suite", function() {
 											},
 											{
 												title: "Test entry 2",
-												link: "http://bar.com",
+												link: "https://bar.com",
 												publishedDate: "Wed, 29 Jan 2014 21:00:00 -0500"
 											},
 											{

--- a/src/plugins/multimedia/multimedia-youtube-en.hbs
+++ b/src/plugins/multimedia/multimedia-youtube-en.hbs
@@ -28,7 +28,7 @@
 				<source type="video/youtube" src="https://www.youtube.com/watch?v=9znKJqnFuuY" />
 			</video>
 			<figcaption>
-				<p>Suspect (<a href="http://healthycanadians.gc.ca/video/suspect-eng.php#trans">Transcript</a>)</p>
+				<p>Suspect (<a href="https://www.canada.ca/en/health-canada/services/video/suspect.html#trans">Transcript</a>)</p>
 			</figcaption>
 		</figure>
 
@@ -59,7 +59,7 @@
 				<source type="video/youtube" src="https://www.youtube.com/watch?v=9znKJqnFuuY" />
 			</video>
 			<figcaption>
-				<p>Suspect (<a href="http://healthycanadians.gc.ca/video/suspect-eng.php#trans">Transcript</a>)</p>
+				<p>Suspect (<a href="https://www.canada.ca/en/health-canada/services/video/suspect.html#trans">Transcript</a>)</p>
 			</figcaption>
 		</figure>
 	</div>
@@ -78,7 +78,7 @@
 				&lt;source type="video/youtube" src="https://www.youtube.com/watch?v=9znKJqnFuuY" /&gt;
 			&lt;/video&gt;
 			&lt;figcaption&gt;
-				&lt;p&gt;Suspect (&lt;a href="http://healthycanadians.gc.ca/video/suspect-eng.php#trans"&gt;Transcript&lt;/a&gt;)&lt;/p&gt;
+				&lt;p&gt;Suspect (&lt;a href="https://www.canada.ca/en/health-canada/services/video/suspect.html#trans"&gt;Transcript&lt;/a&gt;)&lt;/p&gt;
 			&lt;/figcaption&gt;
 		&lt;/figure&gt;
 	&lt;/div&gt;

--- a/src/plugins/multimedia/multimedia-youtube-fr.hbs
+++ b/src/plugins/multimedia/multimedia-youtube-fr.hbs
@@ -27,7 +27,7 @@
 				<source type="video/youtube" src="https://www.youtube.com/watch?v=LLg-UsTr7us" />
 			</video>
 			<figcaption>
-				<p>Suspect (<a href="http://canadiensensante.gc.ca/video/suspect-fra.php#trans">Transcription</a>)</p>
+				<p>Suspect (<a href="https://www.canada.ca/fr/sante-canada/services/video/suspect.html#trans">Transcription</a>)</p>
 			</figcaption>
 		</figure>
 
@@ -58,7 +58,7 @@
 				<source type="video/youtube" src="https://www.youtube.com/watch?v=LLg-UsTr7us" />
 			</video>
 			<figcaption>
-				<p>Suspect (<a href="http://canadiensensante.gc.ca/video/suspect-fra.php#trans">Transcription</a>)</p>
+				<p>Suspect (<a href="https://www.canada.ca/fr/sante-canada/services/video/suspect.html#trans">Transcription</a>)</p>
 			</figcaption>
 		</figure>
 	</div>
@@ -77,7 +77,7 @@
 				&lt;source type="video/youtube" src="https://www.youtube.com/watch?v=LLg-UsTr7us" /&gt;
 			&lt;/video&gt;
 			&lt;figcaption&gt;
-				&lt;p&gt;Suspect (&lt;a href="http://canadiensensante.gc.ca/video/suspect-fra.php#trans"&gt;Transcription&lt;/a&gt;)&lt;/p&gt;
+				&lt;p&gt;Suspect (&lt;a href="https://www.canada.ca/fr/sante-canada/services/video/suspect.html#trans"&gt;Transcription&lt;/a&gt;)&lt;/p&gt;
 			&lt;/figcaption&gt;
 		&lt;/figure&gt;
 	&lt;/div&gt;

--- a/src/plugins/tables/ajax/datasource.json
+++ b/src/plugins/tables/ajax/datasource.json
@@ -1,6 +1,6 @@
 {
   "data": [{
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Biomass Program Continues to Support Transition to Renewable Energy in Manitoba</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Biomass Program Continues to Support Transition to Renewable Energy in Manitoba</a>",
     "TEASER": "The governments of Canada and Manitoba are supporting a greener, more sustainable economy through the $1 million Biomass Energy Support Program, Federal Agriculture Minister Lawrence MacAulay and Manitoba Agriculture Minister Ralph Eichler announced today.",
     "PUBDATE": "2016-07-30",
     "TYPE": "News Releases",
@@ -10,7 +10,7 @@
     "AUDIENCE": "Media,Farmers,General Public",
     "LOCATION": "Manitoba"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">MP Rodger Cuzner to make announcement in Broad Cove</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">MP Rodger Cuzner to make announcement in Broad Cove</a>",
     "TEASER": "Rodger Cuzner, Member of Parliament for Cape Breton – Canso, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency, will make a funding announcement at the Broad Cove Scottish Concert.",
     "PUBDATE": "2016-07-30 12:07:00",
     "TYPE": "Media Advisories",
@@ -20,7 +20,7 @@
     "AUDIENCE": "Media,Rural Community,Travellers,Visitors,General Public",
     "LOCATION": "Canada,Nova Scotia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">An Exhibition Dedicated to the Caribou and Other Animals Like It</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">An Exhibition Dedicated to the Caribou and Other Animals Like It</a>",
     "TEASER": "The Government of Canada supports the Musée du Fjord",
     "PUBDATE": "2016-07-29",
     "TYPE": "News Releases",
@@ -30,7 +30,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Backgrounder: Government of Canada delivers $109 million to Alberta for community infrastructure projects</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Backgrounder: Government of Canada delivers $109 million to Alberta for community infrastructure projects</a>",
     "TEASER": "The Government of Canada delivered the first of two federal Gas Tax Fund installments for 2016-17 to all the provinces and territories benefitting 364 municipalities in Alberta.",
     "PUBDATE": "2016-07-29 11:07:00",
     "TYPE": "Backgrounders",
@@ -40,7 +40,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Canada,Alberta"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government of Canada delivers $109 million to Alberta for community infrastructure projects</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government of Canada delivers $109 million to Alberta for community infrastructure projects</a>",
     "TEASER": "Modern and up-to-date community infrastructure helps ensure that Canadians live the quality of life that they want and expect. Community infrastructure helps connect people to jobs and provides access to better community services, attracts new businesses and creates economic growth opportunities.",
     "PUBDATE": "2016-07-29",
     "TYPE": "News Releases",
@@ -50,7 +50,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Canada,Alberta"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Carr to Make an Announcement About the Winnipeg Art Gallery</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Carr to Make an Announcement About the Winnipeg Art Gallery</a>",
     "TEASER": "WINNIPEG – The Honourable Jim Carr, Minister of Natural Resources...",
     "PUBDATE": "2016-07-29 11:07:00",
     "TYPE": "Media Advisories",
@@ -60,7 +60,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a>",
     "TEASER": "What an honour to be at the University of Toronto-my alma mater-for this tremendous announcement.",
     "PUBDATE": "2016-07-29",
     "TYPE": "Speeches",
@@ -70,7 +70,7 @@
     "AUDIENCE": "Business,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Post-Secondary Institutions Strategic Investment Fund Announcement at the University of Toronto</a>",
     "TEASER": "Thank you, Meric [Meric S. Gertler, President, University of Toronto]. And thank you to the University of Toronto for being such great hosts today. I'm delighted to be here with my friend and colleague Kirsty Duncan, Minister of Science.",
     "PUBDATE": "2016-07-29 10:07:00",
     "TYPE": "Speeches",
@@ -80,7 +80,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">The Royal 22e Régiment Takes On Tough Competition at Leapfest</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">The Royal 22e Régiment Takes On Tough Competition at Leapfest</a>",
     "TEASER": "Ten members of 3rd Battalion, Royal 22e Régiment will be testing their parachuting abilities at Leapfest from August 1 to 9.",
     "PUBDATE": "2016-07-29",
     "TYPE": "News Releases",
@@ -90,7 +90,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Best summer ever: Record number of jobs and opportunities in Newfoundland and Labrador through Canada Summer Jobs program</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Best summer ever: Record number of jobs and opportunities in Newfoundland and Labrador through Canada Summer Jobs program</a>",
     "TEASER": "More Newfoundland and Labrador students than ever before will be working under the Canada Summer Jobs (CSJ) program this year, thanks to unprecedented interest shown by employers and students across the province. Ken McDonald, Member of Parliament for Avalon, made the announcement today on behalf of the Honourable MaryAnn Mihychuk, Minister of Employment, Workforce Development and Labour.",
     "PUBDATE": "2016-07-29 08:07:00",
     "TYPE": "News Releases",
@@ -100,7 +100,7 @@
     "AUDIENCE": "Media,Students,Parents,Youth,Employers,General Public,Job Seekers",
     "LOCATION": "Newfoundland and Labrador"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">UPDATE: Address by Minister Dion on the occasion of a joint press conference with Sri Lankan Minister of Foreign Affairs Samaraweera</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">UPDATE: Address by Minister Dion on the occasion of a joint press conference with Sri Lankan Minister of Foreign Affairs Samaraweera</a>",
     "TEASER": "I'm touched by the warmth and smiles that have greeted the Canadian delegation since our arrival in Sri Lanka last night. Minister Samaraweera, thank you very much for your invitation and the exceptional hospitality we've been shown.",
     "PUBDATE": "2016-07-29",
     "TYPE": "Speeches",
@@ -110,7 +110,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Announcing the new president of the National Research Council of Canada</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Announcing the new president of the National Research Council of Canada</a>",
     "TEASER": "The Honourable Kirsty Duncan, Minister of Science, made the following announcement today: I am pleased to announce the appointment of Mr. Iain Stewart as President of the National Research Council of Canada (NRC), effective August 24, 2016.",
     "PUBDATE": "2016-07-28 19:07:00",
     "TYPE": "Statements",
@@ -120,7 +120,7 @@
     "AUDIENCE": "Business,General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Statement from the Vice Chief of the Defence Staff Regarding the 1974 Valcartier Grenade Incident</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Statement from the Vice Chief of the Defence Staff Regarding the 1974 Valcartier Grenade Incident</a>",
     "TEASER": "Lieutenant-General Guy Thibault, Vice Chief of the Defence Staff, today issued the following statement:",
     "PUBDATE": "2016-07-28",
     "TYPE": "Statements",
@@ -130,7 +130,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government of Canada invests in project to bring high speed Internet to all Manitoba First Nations</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government of Canada invests in project to bring high speed Internet to all Manitoba First Nations</a>",
     "TEASER": "Canada is working in partnership with First Nations to improve the quality of life on reserves and in remote and isolated communities.",
     "PUBDATE": "2016-07-28 16:07:00",
     "TYPE": "News Releases",
@@ -140,7 +140,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Building the Manitoba First Nations Network of the Future</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Building the Manitoba First Nations Network of the Future</a>",
     "TEASER": "Manitoba has some of the poorest Internet connectivity in the country south of 60. Of Manitoba's 63 First Nations, less than a third of communities have sufficient Internet capability for email, texting, or online applications.",
     "PUBDATE": "2016-07-28",
     "TYPE": "Backgrounders",
@@ -150,7 +150,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Les Brasseurs du Petit-Sault Inc. Gears up to Increase Productivity</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Les Brasseurs du Petit-Sault Inc. Gears up to Increase Productivity</a>",
     "TEASER": "Les Brasseurs du Petit-Sault Inc. Gears up to Increase Productivity New equipment will help microbrewery meet growing demand for its products",
     "PUBDATE": "2016-07-28 16:07:00",
     "TYPE": "News Releases",
@@ -160,7 +160,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "New Brunswick"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canadian Soldiers headed to Exercise PANAMAX</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canadian Soldiers headed to Exercise PANAMAX</a>",
     "TEASER": "The newly enlarged Panama Canal will be the focus of Exercise PANAMAX, led by Chile, Colombia and Peru. Canadian participation in the U.S. Southern Command- sponsored exercise consists of 10 Regular and Reserve Force members from 5th Canadian Division from July 29 to August 5.",
     "PUBDATE": "2016-07-28",
     "TYPE": "News Releases",
@@ -170,7 +170,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">2016-2017 Annual Plan focuses on strengthening competition to drive innovation</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">2016-2017 Annual Plan focuses on strengthening competition to drive innovation</a>",
     "TEASER": "The Competition Bureau's priorities for the current year include supporting innovation by deterring anti\u2011competitive conduct that discourages new entrants in the digital economy and using data screening to detect bid\u2011rigging in public infrastructure projects.",
     "PUBDATE": "2016-07-28 15:07:00",
     "TYPE": "News Releases",
@@ -180,7 +180,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government of Canada Supports Mississauga Biotech Innovator</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government of Canada Supports Mississauga Biotech Innovator</a>",
     "TEASER": "Minister of Innovation, Science and Economic Development Navdeep Bains, on behalf of the Minister of Agriculture and Agri-Food Canada, Lawrence MacAulay, will be in Mississauga, Ontario, on Friday, July 29th, to make an announcement in support of a Mississauga-based biotechnology company, AbCelex Technologies Inc.",
     "PUBDATE": "2016-07-28",
     "TYPE": "Media Advisories",
@@ -190,7 +190,7 @@
     "AUDIENCE": "Media,Farmers,General Public",
     "LOCATION": "Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">AC Crystal wheat to move to Canada Northern Hard Red class in 2019</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">AC Crystal wheat to move to Canada Northern Hard Red class in 2019</a>",
     "TEASER": "As of August 1, 2019, the Canadian Grain Commission will designate the wheat variety AC Crystal to the Canada Northern Hard Red class.",
     "PUBDATE": "2016-07-28 14:07:00",
     "TYPE": "News Releases",
@@ -200,7 +200,7 @@
     "AUDIENCE": "Farmers",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canadian Energy in a Global Marketplace</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canadian Energy in a Global Marketplace</a>",
     "TEASER": "The past two years in energy markets have been a wild ride, to say the least. This has been a time of unprecedented uncertainty",
     "PUBDATE": "2016-07-28",
     "TYPE": "Speeches",
@@ -210,7 +210,7 @@
     "AUDIENCE": "Business,General Public,Government",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">New Machinery Readies Sea Cucumbers for Export</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">New Machinery Readies Sea Cucumbers for Export</a>",
     "TEASER": "Today Atlantic Sea Cucumber Ltd. celebrated the grand opening of their newly renovated seafood processing facility in Hackett's Cove. The Government of Canada provided the company with a $500,000 repayable contribution, through the Atlantic Canada Opportunities Agency's Business Development Program (BDP), to help modernize the facility.",
     "PUBDATE": "2016-07-28 13:07:00",
     "TYPE": "News Releases",
@@ -220,7 +220,7 @@
     "AUDIENCE": "Media,Rural Community,Business,General Public",
     "LOCATION": "Nova Scotia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Recreational Improvements in Stratford</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Recreational Improvements in Stratford</a>",
     "TEASER": "The Town of Stratford will soon see many of its recreational assets undergo important infrastructure upgrades. Locations include Kelly's Pond, MacNeill Community Centre and the adjacent MacNeill Ball Field, Robert L. Cotton Centre, and Bunbury Ball Field.",
     "PUBDATE": "2016-07-28",
     "TYPE": "News Releases",
@@ -230,7 +230,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">CRTC launches review of the Wireless Code of Conduct</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">CRTC launches review of the Wireless Code of Conduct</a>",
     "TEASER": "The Canadian Radio-television and Telecommunications Commission (CRTC) today invited Canadians to participate in its review of the Wireless Code. The review will also include a public hearing that will begin on February 6, 2017, in the National Capital Region.",
     "PUBDATE": "2016-07-28 12:07:00",
     "TYPE": "News Releases",
@@ -240,7 +240,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">The Government of Canada takes action to eliminate known Sex-Based Discrimination in the Indian Act</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">The Government of Canada takes action to eliminate known Sex-Based Discrimination in the Indian Act</a>",
     "TEASER": "Today, the Honourable Carolyn Bennett, Minister of Indigenous and Northern Affairs, provided details on the Government of Canada's two-staged approach in the context of the response to the Superior Court of Quebec decision in the case of Descheneaux et al., v. Canada",
     "PUBDATE": "2016-07-28",
     "TYPE": "News Releases",
@@ -250,7 +250,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Message from the Minister of Health - World Hepatitis Day</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Message from the Minister of Health - World Hepatitis Day</a>",
     "TEASER": "July 28th marks World Hepatitis Day, and is an opportunity to draw attention to the impact of viral hepatitis in Canada and the efforts to eliminate this disease around the world.",
     "PUBDATE": "2016-07-28 11:07:00",
     "TYPE": "Statements",
@@ -260,7 +260,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government of Canada investing in innovation at Cape Breton University</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government of Canada investing in innovation at Cape Breton University</a>",
     "TEASER": "Rodger Cuzner, Member of Parliament for Cape Breton – Canso, was joined by the Honourable Mark Eyking, Member of Parliament for Sydney – Victoria, today to announce a more than $1.1 million investment to the Cape Breton University's Verschuren Centre for Sustainability in Energy and Environment for a project that supports research and development to degrade organic matter commonly found in food processing wastewater. The funding is being provided through ACOA's Atlantic Innovation Fund.",
     "PUBDATE": "2016-07-28",
     "TYPE": "News Releases",
@@ -270,7 +270,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canada and Ontario invest in infrastructure at University of Toronto</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canada and Ontario invest in infrastructure at University of Toronto</a>",
     "TEASER": "Canadians will be better equipped for the well-paying middle-class jobs of today and tomorrow as a result of a $98 million investment in the University of Toronto.",
     "PUBDATE": "2016-07-28 10:07:00",
     "TYPE": "News Releases",
@@ -280,7 +280,7 @@
     "AUDIENCE": "Business,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Post-Secondary Institutions Strategic Investment Fund</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Post-Secondary Institutions Strategic Investment Fund</a>",
     "TEASER": "The Post-Secondary Institutions Strategic Investment Fund is a $2-billion initiative designed to modernize research and commercialization facilities at Canadian universities, colleges and polytechnics.",
     "PUBDATE": "2016-07-28",
     "TYPE": "Backgrounders",
@@ -290,7 +290,7 @@
     "AUDIENCE": "Business,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Making post-secondary education more affordable</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Making post-secondary education more affordable</a>",
     "TEASER": "For too many Canadians, rising costs have made post-secondary education less affordable. Fewer are able to save for education, and those who receive financial assistance often find it difficult to repay their loans. Increases to Canada Student Grants and changes to the Repayment Assistance Plan offer real help to Canada's middle-class and those working hard to join it.",
     "PUBDATE": "2016-07-28 10:07:00",
     "TYPE": "News Releases",
@@ -300,7 +300,7 @@
     "AUDIENCE": "Media,Students,Youth,General Public,Government",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Media Advisory - Martensville, Saskatchewan</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Media Advisory - Martensville, Saskatchewan</a>",
     "TEASER": "Martensville, Saskatchewan July 28, 2016 – Members of the media are invited to attend an important infrastructure event regarding Highways 11 and 12 with the Honourable Ralph Goodale, Minister of Public Safety and Emergency Preparedness and the Honourable Nancy Heppner, Minister of Highways and Infrastructure.",
     "PUBDATE": "2016-07-28",
     "TYPE": "Media Advisories",
@@ -310,7 +310,7 @@
     "AUDIENCE": "Media,General Public,Government",
     "LOCATION": "Canada,Saskatchewan"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Media Advisory - Whitecap, Saskatchewan</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Media Advisory - Whitecap, Saskatchewan</a>",
     "TEASER": "Members of the media are invited to attend an important event regarding water and wastewater infrastructure in Whitecap, with the Honourable Ralph Goodale, Minister of Public Safety and Emergency Preparedness, the Honourable Jim Reiter, Minister of Government Relations, and Darcy Bear, Chief of the Whitecap Dakota First Nation.",
     "PUBDATE": "2016-07-28 10:07:00",
     "TYPE": "Media Advisories",
@@ -320,7 +320,7 @@
     "AUDIENCE": "Media,General Public,Government",
     "LOCATION": "Canada,Saskatchewan"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Member of Parliament Denis Lemieux to Make an Announcement About the Musée du Fjord</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Member of Parliament Denis Lemieux to Make an Announcement About the Musée du Fjord</a>",
     "TEASER": "SAGUENAY, Quebec – Denis Lemieux, Member of Parliament (Chicoutimi–Le Fjord)...",
     "PUBDATE": "2016-07-28",
     "TYPE": "Media Advisories",
@@ -330,7 +330,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Lockdown and search at Mountain Institution</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Lockdown and search at Mountain Institution</a>",
     "TEASER": "On July 26, 2016 at about 7:00 p.m., a lockdown was put in place at Mountain Institution, a medium security federal institution, to enable staff members to conduct a general search.",
     "PUBDATE": "2016-07-28 09:07:00",
     "TYPE": "News Releases",
@@ -340,7 +340,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "British Columbia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Ottawa River Designated a Canadian Heritage River</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Ottawa River Designated a Canadian Heritage River</a>",
     "TEASER": "Today, the Ontario Minister of Natural Resources and Forestry, Kathryn McGarry, and the Minister of Environment and Climate Change and Minister responsible for Parks Canada, Catherine McKenna, designated the Ontario portion of the Ottawa River as a Canadian Heritage River for its outstanding cultural heritage values.",
     "PUBDATE": "2016-07-28",
     "TYPE": "News Releases",
@@ -350,7 +350,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Ottawa River Designated into the Canadian Heritage Rivers System</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Ottawa River Designated into the Canadian Heritage Rivers System</a>",
     "TEASER": "The Ottawa River",
     "PUBDATE": "2016-07-28 09:07:00",
     "TYPE": "Backgrounders",
@@ -360,7 +360,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Veterans Affairs Canada office in Charlottetown to reopen November, 2016</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Veterans Affairs Canada office in Charlottetown to reopen November, 2016</a>",
     "TEASER": "Government of Canada committed to doing more for Veterans",
     "PUBDATE": "2016-07-28",
     "TYPE": "News Releases",
@@ -370,7 +370,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Statement from the Minister of Health on the Opioid Crisis</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Statement from the Minister of Health on the Opioid Crisis</a>",
     "TEASER": "Canada is facing a growing crisis related to opioid overdoses and deaths across the country, and our government is committed to addressing this issue.",
     "PUBDATE": "2016-07-27 21:07:00",
     "TYPE": "Statements",
@@ -380,7 +380,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Parliamentary Secretary Alghabra to attend presidential inauguration in Peru</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Parliamentary Secretary Alghabra to attend presidential inauguration in Peru</a>",
     "TEASER": "Omar Alghabra, Parliamentary Secretary to the Minister of Foreign Affairs (Consular Affairs), today announced that he will attend the inauguration of president-elect Pedro Pablo Kuczynski in Lima, Peru, on July 28, 2016.",
     "PUBDATE": "2016-07-27",
     "TYPE": "News Releases",
@@ -390,7 +390,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">National Strategy Advocates Inuit-led Approach to Suicide Prevention</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">National Strategy Advocates Inuit-led Approach to Suicide Prevention</a>",
     "TEASER": "Inuit Tapiriit Kanatami (ITK) and Health Canada are committed to working together and with other Inuit leaders and provincial and territorial governments to provide effective, sustainable, and culturally appropriate health programs and services to improve the health of Inuit.",
     "PUBDATE": "2016-07-27 18:07:00",
     "TYPE": "News Releases",
@@ -400,7 +400,7 @@
     "AUDIENCE": "Employers",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Bains and Minister Duncan to announce infrastructure funding at University of Toronto</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Bains and Minister Duncan to announce infrastructure funding at University of Toronto</a>",
     "TEASER": "Event date: <span class=doe>July 28, 2016</span> - The Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development, the Honourable Kirsty Duncan, Minister of Science, and the Honourable Deb Matthews, Ontario Minister of Advanced Education and Skills Development, will be joined by Parliamentary Assistant to the Minister of Advanced Education and Skills Development Han Dong at the University of Toronto on July 28 to announce infrastructure funding for the University of Toronto and to highlight the benefits of the new Post-Secondary Institutions Strategic Investment Fund.",
     "PUBDATE": "2016-07-27",
     "TYPE": "Media Advisories",
@@ -410,7 +410,7 @@
     "AUDIENCE": "Business,General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">NFB Indigenous films showcased at Présence autochtone. 2015 award winner Red Path also debuts at NFB.ca, starting Aug. 4</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">NFB Indigenous films showcased at Présence autochtone. 2015 award winner Red Path also debuts at NFB.ca, starting Aug. 4</a>",
     "TEASER": "Five National Film Board of Canada Indigenous short films will be featured at the 2016 Festival Présence autochtone/Montreal First Peoples Festival (Aug. 3–10).",
     "PUBDATE": "2016-07-27 17:07:00",
     "TYPE": "News Releases",
@@ -420,7 +420,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Free streaming of Thérèse Ottawa's Red Path at NFB.ca, starting Aug. 4. NFB short received two special mentions at last year's Festival Présence autochtone/Montreal First Peoples Festival.</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Free streaming of Thérèse Ottawa's Red Path at NFB.ca, starting Aug. 4. NFB short received two special mentions at last year's Festival Présence autochtone/Montreal First Peoples Festival.</a>",
     "TEASER": "As the Festival Présence autochtone/Montreal First Peoples Festival kicks off its new season, one of the National Film Board of Canada's hits from the 2015 edition will premiere at NFB.ca, with Atikamekw filmmaker Thérèse Ottawa's acclaimed short Red Path (Le chemin rouge) debuting online August 4.",
     "PUBDATE": "2016-07-27",
     "TYPE": "News Releases",
@@ -430,7 +430,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Statement on Network Disruption Affecting Access to Phoenix System</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Statement on Network Disruption Affecting Access to Phoenix System</a>",
     "TEASER": "Early this morning one of the Government of Canada data centres experienced an automatic emergency shutdown due to its smoke detection sensors being activated. Power was immediately restored and staff have worked through the night to restore services to the data centre.",
     "PUBDATE": "2016-07-27 15:07:00",
     "TYPE": "Statements",
@@ -440,7 +440,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">FedDev Ontario Supports Expansion Activities for Belleville Clean Technology Manufacturer</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">FedDev Ontario Supports Expansion Activities for Belleville Clean Technology Manufacturer</a>",
     "TEASER": "Today, Neil R. Ellis, Member of Parliament for Bay of Quinte, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for FedDev Ontario, announced an investment of up to $1.95 million to Strathcona Energy Group Inc. (SEG) to expand production capacity for its core solar panel business in Belleville.",
     "PUBDATE": "2016-07-27",
     "TYPE": "News Releases",
@@ -450,7 +450,7 @@
     "AUDIENCE": "Business,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Federal and Provincial Governments to Make an Announcement in Edmundston</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Federal and Provincial Governments to Make an Announcement in Edmundston</a>",
     "TEASER": "René Arseneault, Member of Parliament for Madawaska – Restigouche, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency; and the Honourable Francine Landry, Minister of Economic Development and Minister responsible for Opportunities NB, will be in Edmundston on Thursday, July 28, 2016.",
     "PUBDATE": "2016-07-27 15:07:00",
     "TYPE": "Media Advisories",
@@ -460,7 +460,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "New Brunswick"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">McKay Memorial Library Opens New Chapter of Community Support</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">McKay Memorial Library Opens New Chapter of Community Support</a>",
     "TEASER": "The McKay Memorial Library is opening up a new chapter in its book; one where it will be better equipped to support the needs of its community. The Library will be receiving renovations that will expand their programming space in order to enhance non-traditional library services such as workshops, training, specialized programming, artisan's displays and community space.",
     "PUBDATE": "2016-07-27",
     "TYPE": "News Releases",
@@ -470,7 +470,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Nova Scotia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Lockdown and search at Bowden Institution – Medium security unit</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Lockdown and search at Bowden Institution – Medium security unit</a>",
     "TEASER": "On July 26, 2016, at about 3:40 p.m., a lockdown was put in place in the medium security unit at Bowden Institution to enable staff members to conduct a general search.",
     "PUBDATE": "2016-07-27 14:07:00",
     "TYPE": "News Releases",
@@ -480,7 +480,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Alberta"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government of Canada invests in southern Ontario</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government of Canada invests in southern Ontario</a>",
     "TEASER": "Ontarians will benefit from well­paying jobs for the middle class and those working hard to join it as a result of a series of investments made this week by the Government of Canada to commercialize new technologies, diversify regional economies and accelerate the growth of small businesses.",
     "PUBDATE": "2016-07-27",
     "TYPE": "News Releases",
@@ -490,7 +490,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Health Minister to speak at the MyHealthNS Personal Health Record launch</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Health Minister to speak at the MyHealthNS Personal Health Record launch</a>",
     "TEASER": "The Honourable Jane Philpott, Federal Minister of Health, will present remarks at the launch of the MyHealthNS Personal Health Record along with the Honourable Stephen McNeil, Nova Scotia Premier.",
     "PUBDATE": "2016-07-27 14:07:00",
     "TYPE": "Media Advisories",
@@ -500,7 +500,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canada Announces Improved Additions to Reserve Process to Advance Reconciliation with First Nations and Promote Economic Development</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canada Announces Improved Additions to Reserve Process to Advance Reconciliation with First Nations and Promote Economic Development</a>",
     "TEASER": "The Government of Canada is committed to improving the process for creating new reserves and adding land to existing reserves.",
     "PUBDATE": "2016-07-27",
     "TYPE": "News Releases",
@@ -510,7 +510,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">TransCanada Highway getting safety improvements near Malahat, BC</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">TransCanada Highway getting safety improvements near Malahat, BC</a>",
     "TEASER": "The Trans-Canada Highway is the main north-south corridor on Vancouver Island and serves as a critical route for moving goods, linking communities, and supporting a thriving tourism industry in the region.",
     "PUBDATE": "2016-07-27 13:07:00",
     "TYPE": "News Releases",
@@ -520,7 +520,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "British Columbia,Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Enforcement Advisory - Notice for businesses and individuals on how to keep records of consent</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Enforcement Advisory - Notice for businesses and individuals on how to keep records of consent</a>",
     "TEASER": "Commission staff has published this advisory, directed to businesses and individuals in Canada sending commercial electronic messages (CEMs) as part of their commercial activities.",
     "PUBDATE": "2016-07-27",
     "TYPE": "Media Advisories",
@@ -530,7 +530,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">MP Cuzner and MP Eyking to make innovation funding announcement</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">MP Cuzner and MP Eyking to make innovation funding announcement</a>",
     "TEASER": "Members of the media are invited to attend an event where Rodger Cuzner, Member of Parliament for Cape Breton - Canso, alongside the Honourable Mark Eyking, Member of Parliament for Sydney – Victoria, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency (ACOA), will make an official announcement concerning a major investment in innovation in Atlantic Canada under ACOA's Atlantic Innovation Fund.",
     "PUBDATE": "2016-07-27 11:07:00",
     "TYPE": "Media Advisories",
@@ -540,7 +540,7 @@
     "AUDIENCE": "Media,Students,Scientists,General Public,Government,Job Seekers",
     "LOCATION": "Nova Scotia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Hehr to make announcement regarding office opening in Charlottetown, Prince Edward Island</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Hehr to make announcement regarding office opening in Charlottetown, Prince Edward Island</a>",
     "TEASER": "The Honourable Kent Hehr, Minister of Veterans Affairs and Associate Minister of National Defence, will announce plans to reopen the Veterans Affairs Canada office in Charlottetown, Prince Edward Island, and speak to Budget 2016 measures which improve support for Canadian Armed Forces members, Veterans and their families",
     "PUBDATE": "2016-07-27",
     "TYPE": "Media Advisories",
@@ -550,7 +550,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Hehr Marks Korean War Veterans Day</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Hehr Marks Korean War Veterans Day</a>",
     "TEASER": "The Honourable Kent Hehr, Minister of Veterans Affairs and Associate Minister of National Defence, today issued the following statement on Korean War Veterans Day",
     "PUBDATE": "2016-07-27 10:07:00",
     "TYPE": "Statements",
@@ -560,7 +560,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canadian Army trains with Allied Forces in Romania during Exercise SABER GUARDIAN</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canadian Army trains with Allied Forces in Romania during Exercise SABER GUARDIAN</a>",
     "TEASER": "Starting today until August 7, approximately 45 Canadian Army soldiers will be participating in Exercise SABER GUARDIAN 2016, a U.S.-led joint, multinational, regional exercise, in Cincu, Romania. In support of allied and partner nations, more than 2,500 soldiers from 11 countries will partake in the exercise designed to improve interoperability within a multinational brigade.",
     "PUBDATE": "2016-07-27",
     "TYPE": "News Releases",
@@ -570,7 +570,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Visits temporarily cancelled at Saskatchewan Penitentiary</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Visits temporarily cancelled at Saskatchewan Penitentiary</a>",
     "TEASER": "Due to water supply concerns following the recent oil spill in the North Saskatchewan River, all visits are temporarily cancelled at Saskatchewan Penitentiary, a multi-level security federal institution.",
     "PUBDATE": "2016-07-27 09:07:00",
     "TYPE": "News Releases",
@@ -580,7 +580,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Saskatchewan"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Veterans Affairs Canada office in Sydney to reopen November 2016</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Veterans Affairs Canada office in Sydney to reopen November 2016</a>",
     "TEASER": "Government of Canada committed to doing more for Veterans",
     "PUBDATE": "2016-07-27",
     "TYPE": "News Releases",
@@ -590,7 +590,7 @@
     "AUDIENCE": "Veterans,General Public",
     "LOCATION": "Canada,Nova Scotia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Dion to visit Sri Lanka following successful visit to Lao People's Democratic Republic</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Dion to visit Sri Lanka following successful visit to Lao People's Democratic Republic</a>",
     "TEASER": "The Honourable Stéphane Dion, Minister of Foreign Affairs, today concluded his first visit to Vientiane, Lao People's Democratic Republic (PDR). Minister Dion met with Association of Southeast Asian Nations (ASEAN) foreign ministers during the annual ASEAN-Canada Post-Ministerial Conference and took part in the ASEAN Regional Forum. During his trip, the Minister announced nine new initiatives, together worth more than $18 million, aimed at promoting regional security and stability in Southeast Asia. Of these, two in particular will strengthen the Laotian government's ability to respond to natural disasters and counter human-smuggling and -trafficking networks.",
     "PUBDATE": "2016-07-26 18:07:00",
     "TYPE": "News Releases",
@@ -600,7 +600,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Backgrounder - Southeast Asia security and stability project announcements</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Backgrounder - Southeast Asia security and stability project announcements</a>",
     "TEASER": "This initiative will assist the Lao People's Democratic Republic (PDR) in developing ways to track public expenditures related to disaster risk management. The initiative will also assist the governments of the Lao PDR and Cambodia in developing disaster-loss databases for the road sector to ensure risk-informed decision making in the construction and repair of roads.",
     "PUBDATE": "2016-07-26",
     "TYPE": "Backgrounders",
@@ -610,7 +610,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Highway 905 - All Weather Roadway - Stony Rapids to Lake Athabasca near Fond-du-Lac: Public Comments Invited</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Highway 905 - All Weather Roadway - Stony Rapids to Lake Athabasca near Fond-du-Lac: Public Comments Invited</a>",
     "TEASER": "The Canadian Environmental Assessment Agency is conducting a federal environmental assessment of the proposed Highway 905 - All Weather Roadway - Stony Rapids to Lake Athabasca near Fond-du-Lac, located in northern Saskatchewan.",
     "PUBDATE": "2016-07-26 16:07:00",
     "TYPE": "News Releases",
@@ -620,7 +620,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Saskatchewan"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Ontario and Canada Investing in Barrie Area Agricultural Projects</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Ontario and Canada Investing in Barrie Area Agricultural Projects</a>",
     "TEASER": "The provincial and federal governments have invested over $1 million in 24 projects in Barrie and the surrounding area of Dufferin County and Simcoe County to help grow the area's food and beverage sector and the local economy.",
     "PUBDATE": "2016-07-26",
     "TYPE": "News Releases",
@@ -630,7 +630,7 @@
     "AUDIENCE": "Media,Farmers,General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Des Joachims Bridge - lane reduction</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Des Joachims Bridge - lane reduction</a>",
     "TEASER": "Public Services and Procurement Canada (PSPC) wishes to advise motorists of the following lane reduction on the Des Joachims Bridge.",
     "PUBDATE": "2016-07-26 15:07:00",
     "TYPE": "Media Advisories",
@@ -640,7 +640,7 @@
     "AUDIENCE": "Travellers,Visitors,General Public",
     "LOCATION": "Canada,Quebec,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">FedDev Ontario Invests in Biomedical Engineering and Advanced Manufacturing Centre</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">FedDev Ontario Invests in Biomedical Engineering and Advanced Manufacturing Centre</a>",
     "TEASER": "Hamilton residents will benefit from well-paying jobs for the middle class and those working hard to join it as a result of an $11.96-million investment to establish a biomedical engineering and advanced manufacturing facility. The products developed as a result of this investment have the potential to change diagnostics and treatment, which could improve the quality of life of Canadians as well as people living in countries around the world.",
     "PUBDATE": "2016-07-26",
     "TYPE": "News Releases",
@@ -650,7 +650,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">FedDev Ontario Invests in Biomedical Engineering and Advanced Manufacturing Centre</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">FedDev Ontario Invests in Biomedical Engineering and Advanced Manufacturing Centre</a>",
     "TEASER": "The Government of Canada supports the development of new health technologies that have the potential to improve the quality of life of all Canadians, while creating well-paying jobs for the middle class and those working hard to join it. As part of this program, McMaster University will receive an investment of up to $11.96 million.",
     "PUBDATE": "2016-07-26 14:07:00",
     "TYPE": "Backgrounders",
@@ -660,7 +660,7 @@
     "AUDIENCE": "Business,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">MP Jordan to make announcement in Shelburne</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">MP Jordan to make announcement in Shelburne</a>",
     "TEASER": "Members of the media are invited to join Bernadette Jordan, Member of Parliament for South Shore – St. Margarets, on behalf of the Honorable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency, for a funding announcement in Shelburne.",
     "PUBDATE": "2016-07-26",
     "TYPE": "Media Advisories",
@@ -670,7 +670,7 @@
     "AUDIENCE": "Media,Rural Community,Seniors,Students,Parents,Business,General Public",
     "LOCATION": "Nova Scotia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">New crop year reminders for western producers and industry</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">New crop year reminders for western producers and industry</a>",
     "TEASER": "The Canadian Grain Commission reminds the grain industry and producers about grain grading changes that come into effect on August 1, 2016 in western Canada",
     "PUBDATE": "2016-07-26 14:07:00",
     "TYPE": "News Releases",
@@ -680,7 +680,7 @@
     "AUDIENCE": "Farmers",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Fisheries and Oceans Canada announces new round of funding for Canadian researchers to study contaminants</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Fisheries and Oceans Canada announces new round of funding for Canadian researchers to study contaminants</a>",
     "TEASER": "Ottawa, Ontario – Research that studies the effects of contaminants on our aquatic ecosystems helps improve decision-making on the use and protection of our marine and freshwater environments. It contributes to Fisheries and Oceans Canada's overall advice on sustainable aquaculture, resource development and emergency response measures.",
     "PUBDATE": "2016-07-26",
     "TYPE": "News Releases",
@@ -690,7 +690,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Backgrounder: Seventeen Infrastructure Projects in Yukon Get Joint Government Funding</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Backgrounder: Seventeen Infrastructure Projects in Yukon Get Joint Government Funding</a>",
     "TEASER": "The governments of Canada and Yukon are announcing funding for infrastructure improvement projects in communities across the territory under the Small Communities Fund. The Government of Canada will provide up to $58,596,772 through the Small Communities Fund for the 17 projects and the Government of Yukon will cover any remaining costs.",
     "PUBDATE": "2016-07-26 14:07:00",
     "TYPE": "Backgrounders",
@@ -700,7 +700,7 @@
     "AUDIENCE": "Media,General Public,Government",
     "LOCATION": "Yukon Territory,Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government Of Canada Investing in Innovation at QRA Corp</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government Of Canada Investing in Innovation at QRA Corp</a>",
     "TEASER": "The Honourable Scott Brison, President of the Treasury Board of Canada and Member of Parliament for Kings-Hants, was joined by Andy Fillmore, Member of Parliament for Halifax, today to announce an investment of $2,994,928 for the development of QRA Corp's QVtrace analysis tool. The announcement was made on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency (ACOA). Minister Brison and MP Fillmore were joined by Dr. Jordan Kyriakidis, Co-founder and CEO of QRA Corp, and Greg Phipps, Managing Director of Investment for Innovacorp.",
     "PUBDATE": "2016-07-26",
     "TYPE": "News Releases",
@@ -710,7 +710,7 @@
     "AUDIENCE": "Media,Scientists,Business,Employers,General Public",
     "LOCATION": "Canada,Nova Scotia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Seventeen Infrastructure Projects in Yukon Get Joint Government Funding</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Seventeen Infrastructure Projects in Yukon Get Joint Government Funding</a>",
     "TEASER": "Providing community residents and businesses with modern, reliable and sustainable public infrastructure opens doors to good jobs, helps create economic growth and foster a strong middle class, and provides opportunities for a better quality of life to everyone.",
     "PUBDATE": "2016-07-26 14:07:00",
     "TYPE": "News Releases",
@@ -720,7 +720,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Yukon Territory,Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">MP Ellis to Announce Support for Business Growth and Productivity in Belleville</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">MP Ellis to Announce Support for Business Growth and Productivity in Belleville</a>",
     "TEASER": "Neil R. Ellis, Member of Parliament for Bay of Quinte, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for FedDev Ontario, will make an announcement supporting a Belleville-based clean technology manufacturer.",
     "PUBDATE": "2016-07-26",
     "TYPE": "Media Advisories",
@@ -730,7 +730,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">TEACH Magazine Profiles Key Milestone Anniversaries in 2016</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">TEACH Magazine Profiles Key Milestone Anniversaries in 2016</a>",
     "TEASER": "National educational publisher receives federal funding to create new resources",
     "PUBDATE": "2016-07-26 13:07:00",
     "TYPE": "News Releases",
@@ -740,7 +740,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Hehr to make announcement regarding office reopening in Sydney, Nova Scotia</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Hehr to make announcement regarding office reopening in Sydney, Nova Scotia</a>",
     "TEASER": "The Honourable Kent Hehr, Minister of Veterans Affairs and Associate Minister of National Defence, will announce plans to reopen the Veterans Affairs Canada office in Sydney, Nova Scotia, and speak to Budget 2016 measures which improve support for Canadian Armed Forces members, Veterans and their families",
     "PUBDATE": "2016-07-26",
     "TYPE": "Media Advisories",
@@ -750,7 +750,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Contract awarded for survey of the shipwrecked MV <em>Manolis L</em></a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Contract awarded for survey of the shipwrecked MV <em>Manolis L</em></a>",
     "TEASER": "An assessment to be conducted this summer of the MV Manolis L, a shipwreck in Notre Dame Bay off the coast of Newfoundland and Labrador, will inform the development of Canadian Coast Guard plans for the recovery of the vessel's cargo of an estimated 462 tons of fuel, 60 tons of diesel and removal of the vessel.",
     "PUBDATE": "2016-07-26 11:07:00",
     "TYPE": "News Releases",
@@ -760,7 +760,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Newfoundland and Labrador"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government funding brings high-speed internet to Southwestern Ontario communities</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government funding brings high-speed internet to Southwestern Ontario communities</a>",
     "TEASER": "The governments of Canada and Ontario are committed to supporting innovation and encouraging economic activity that contributes to growing the middle class. That is why the federal and provincial governments are providing up to $180 million in joint funding to improve high-speed internet connectivity to over 300 communities in Southwestern Ontario.",
     "PUBDATE": "2016-07-26",
     "TYPE": "News Releases",
@@ -770,7 +770,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Dr. Steven J. Hoffman appointed Scientific Director of the CIHR Institute of Population and Public Health</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Dr. Steven J. Hoffman appointed Scientific Director of the CIHR Institute of Population and Public Health</a>",
     "TEASER": "Dr. Alain Beaudet, President of the Canadian Institutes of Health Research (CIHR), along with CIHR's Governing Council, announced today the appointment of Dr. Steven J. Hoffman, a leading international lawyer and global health researcher at the University of Ottawa, as incoming Scientific Director of CIHR's Institute of Population and Public Health and as CIHR's lead for global health. This appointment is effective August 1, 2016.",
     "PUBDATE": "2016-07-26 10:07:00",
     "TYPE": "News Releases",
@@ -780,7 +780,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Chair Kathy Fox statement on the expedited removal of legacy tank cars for crude oil transport</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Chair Kathy Fox statement on the expedited removal of legacy tank cars for crude oil transport</a>",
     "TEASER": "TSB issues statement on expedited removal of legacy tank cars.",
     "PUBDATE": "2016-07-26",
     "TYPE": "News Releases",
@@ -790,7 +790,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">New Opportunities for Play at Queens County Fair</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">New Opportunities for Play at Queens County Fair</a>",
     "TEASER": "The Queens County Fair Association is upgrading the fairground playground thanks to support from the Government of Canada. A $10,000 non-repayable contribution through the Canada 150 Community Infrastructure Program (CIP150) will help to install equipment that will appeal to a larger age range of children in the area.",
     "PUBDATE": "2016-07-26 10:07:00",
     "TYPE": "News Releases",
@@ -800,7 +800,7 @@
     "AUDIENCE": "Media,Rural Community,Parents,Visitors,Children,Educators,General Public",
     "LOCATION": "Canada,Nova Scotia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government of Canada Supports Stella's Circle Building Upgrades</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government of Canada Supports Stella's Circle Building Upgrades</a>",
     "TEASER": "Plans are underway to upgrade the Stella's Circle building on Cabot Street, thanks in part to a contribution from the Government of Canada. Seamus O'Regan, Member of Parliament for St. John's South-Mount Pearl, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency (ACOA), today announced funding of $32,500 for the project through the Canada 150 Community Infrastructure Program (CIP 150).",
     "PUBDATE": "2016-07-26",
     "TYPE": "News Releases",
@@ -810,7 +810,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Improvements to Montague Waterfront</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Improvements to Montague Waterfront</a>",
     "TEASER": "Montague the Beautiful, well-known for its picturesque waterfront, will soon see infrastructure improvements that will further enhance the area's appeal to visitors and locals alike.",
     "PUBDATE": "2016-07-26 10:07:00",
     "TYPE": "News Releases",
@@ -820,7 +820,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Prince Edward Island"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Lockdown and search at Matsqui Institution</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Lockdown and search at Matsqui Institution</a>",
     "TEASER": "On July 24, 2016, at about 4:00 p.m., a lockdown was put in place at Matsqui Institution, a medium security federal institution, to enable staff members to conduct an exceptional search.",
     "PUBDATE": "2016-07-26",
     "TYPE": "News Releases",
@@ -830,7 +830,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "British Columbia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">End of lockdown and search at Joyceville Institution - Medium security unit</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">End of lockdown and search at Joyceville Institution - Medium security unit</a>",
     "TEASER": "The lockdown put in place at the medium-security unit at Joyceville Institution on July 21, 2016, has ended and an exceptional search has been completed. The institution has resumed its normal operations.",
     "PUBDATE": "2016-07-25 17:07:00",
     "TYPE": "News Releases",
@@ -840,7 +840,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">End of lockdown and search at Warkworth Institution</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">End of lockdown and search at Warkworth Institution</a>",
     "TEASER": "The lockdown put in place at Warkworth Institution on July 20, 2016, has ended. The institution has resumed its normal operations.",
     "PUBDATE": "2016-07-25",
     "TYPE": "News Releases",
@@ -850,7 +850,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Notice of participant funding offering for Ontario Power Generation's Western Waste Management Facility licence renewal</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Notice of participant funding offering for Ontario Power Generation's Western Waste Management Facility licence renewal</a>",
     "TEASER": "The Canadian Nuclear Safety Commission (CNSC) is offering participant funding to assist members of the public, Aboriginal groups and other stakeholders in participating in the licence application review and Commission hearing process for Ontario Power Generation's Western Waste Management Facility licence renewal. Participant funding of up to $75,000 is being offered for the provision of new, distinctive and valuable information, through informed and topic-specific interventions to the Commission.",
     "PUBDATE": "2016-07-25 16:07:00",
     "TYPE": "News Releases",
@@ -860,7 +860,7 @@
     "AUDIENCE": "Aboriginal Peoples,Scientists,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Faster timeline for phasing out DOT-111 tank cars</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Faster timeline for phasing out DOT-111 tank cars</a>",
     "TEASER": "In 2015, more than 146,000 carloads of crude oil were shipped throughout Canada by rail.",
     "PUBDATE": "2016-07-25",
     "TYPE": "News Releases",
@@ -870,7 +870,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Media Advisory - Whitehorse, Yukon</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Media Advisory - Whitehorse, Yukon</a>",
     "TEASER": "Members of the media are invited to attend an important infrastructure funding announcement with the Honourable Larry Bagnell, Member of Parliament for Yukon, along with the Honourable Currie Dixon, Minister of Community Services and Minister of the Public Service Commission for the Government of Yukon.",
     "PUBDATE": "2016-07-25 14:07:00",
     "TYPE": "Media Advisories",
@@ -880,7 +880,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Yukon Territory,Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Brison to speak about the Government of Canada's plan for the middle class</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Brison to speak about the Government of Canada's plan for the middle class</a>",
     "TEASER": "President of the Treasury Board and Member of Parliament for Kings-Hants Scott Brison will be speaking about the Government of Canada's plan to strengthen Canada's middle class and help the families who need it most.",
     "PUBDATE": "2016-07-25",
     "TYPE": "Media Advisories",
@@ -890,7 +890,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Nova Scotia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Backgrounder - Canada promotes regional security and safety in Southeast Asia</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Backgrounder - Canada promotes regional security and safety in Southeast Asia</a>",
     "TEASER": "Canada announced a total of more than $17 million in new funding through its security-related capacity-building programs.",
     "PUBDATE": "2016-07-25 13:07:00",
     "TYPE": "Backgrounders",
@@ -900,7 +900,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canada promotes regional security and safety in Southeast Asia</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canada promotes regional security and safety in Southeast Asia</a>",
     "TEASER": "The Honourable Stéphane Dion, Minister of Foreign Affairs, today announced seven new security and safety initiatives worth more than $17 million during his participation at the Association of Southeast Asian Nations (ASEAN)-Canada Post-Ministerial Conference in Vientiane, the Lao People's Democratic Republic (PDR).",
     "PUBDATE": "2016-07-25",
     "TYPE": "News Releases",
@@ -910,7 +910,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government of Canada Recognizes Westmount for its National Historic Significance</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government of Canada Recognizes Westmount for its National Historic Significance</a>",
     "TEASER": "Government of Canada Recognizes Westmount for its National Historic Significance",
     "PUBDATE": "2016-07-25 13:07:00",
     "TYPE": "News Releases",
@@ -920,7 +920,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Westmount District</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Westmount District</a>",
     "TEASER": "Westmount District",
     "PUBDATE": "2016-07-25",
     "TYPE": "Backgrounders",
@@ -930,7 +930,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">The Government of Canada Invests $68.2 Million in Small Craft Harbours Infrastructure in the Province of Newfoundland and Labrador</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">The Government of Canada Invests $68.2 Million in Small Craft Harbours Infrastructure in the Province of Newfoundland and Labrador</a>",
     "TEASER": "Small craft harbours play an important role in providing coastal communities and the commercial fishing industry with safe and accessible facilities. With more than 76,000 Canadians employed in this sector, the Government of Canada is making investments that will continue to support the growth of this industry and provide economic opportunities for middle-class Canadians.",
     "PUBDATE": "2016-07-25 12:07:00",
     "TYPE": "News Releases",
@@ -940,7 +940,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Newfoundland and Labrador"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Backgrounder: 27 Manitoba Infrastructure Projects Approved Under New Federal Funding Programs</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Backgrounder: 27 Manitoba Infrastructure Projects Approved Under New Federal Funding Programs</a>",
     "TEASER": "Canada and Manitoba approved 27 community infrastructure projects today under two new federal infrastructure programs introduced as part of Phase 1 of the 10-year Investing in Canada plan. The Public Transit Infrastructure Fund and the Canadian Water and Wastewater Fund, are both aimed at addressing priority projects and focuses on repairing and upgrading existing facilities and assets. Phase 1 will help lay the foundation for the longer-term federal investment strategy. Details on Phase 2 of Investing in Canada will be announced over the next year.",
     "PUBDATE": "2016-07-25",
     "TYPE": "Backgrounders",
@@ -950,7 +950,7 @@
     "AUDIENCE": "Media,General Public,Government",
     "LOCATION": "Canada,Manitoba"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canada and Manitoba Reach Agreement Under New Federal Infrastructure Funding Programs</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canada and Manitoba Reach Agreement Under New Federal Infrastructure Funding Programs</a>",
     "TEASER": "Investing in local infrastructure helps ensure that Canadian communities have access to high-quality municipal water and wastewater systems that families can rely on, and efficient and modern public transit systems so that people can get to work on time and back home safely at the end of a long day.",
     "PUBDATE": "2016-07-25 12:07:00",
     "TYPE": "News Releases",
@@ -960,7 +960,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Canada,Manitoba"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canada 150 Community Infrastructure Program Investments for Montague</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canada 150 Community Infrastructure Program Investments for Montague</a>",
     "TEASER": "Members of the media are invited to attend an infrastructure announcement in Montague. The Honourable Lawrence MacAulay, Minister of Agriculture and Agri-Food, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency, will join officials from the Town of Montague and the Montague Waterfront Development Corporation to make the announcement.",
     "PUBDATE": "2016-07-25",
     "TYPE": "Media Advisories",
@@ -970,7 +970,7 @@
     "AUDIENCE": "Media",
     "LOCATION": "Prince Edward Island"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government of Canada Invests $12M to Support Bio-Based Innovation in Sarnia</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government of Canada Invests $12M to Support Bio-Based Innovation in Sarnia</a>",
     "TEASER": "Residents of the Sarnia-Lambton region will benefit from more jobs for the middle class – and those working hard to join it – as a result of a $12-million investment to support the sustainable chemistry and bio-based industrial sector.",
     "PUBDATE": "2016-07-25 12:07:00",
     "TYPE": "News Releases",
@@ -980,7 +980,7 @@
     "AUDIENCE": "Business,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Media Advisory - London, Ontario</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Media Advisory - London, Ontario</a>",
     "TEASER": "Members of the media are invited to attend an important infrastructure event regarding internet connectivity with the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development, on behalf of the Honourable Amarjeet Sohi, Minister of Infrastructure and Communities; and the Honourable Bob Chiarelli, Ontario Minister of Infrastructure.",
     "PUBDATE": "2016-07-25",
     "TYPE": "Media Advisories",
@@ -990,7 +990,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Bains to Announce Support for Commercialization Partnerships in Hamilton</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Bains to Announce Support for Commercialization Partnerships in Hamilton</a>",
     "TEASER": "Event date: <span class=doe>July 26, 2016</span>-The Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development, and Minister responsible for FedDev Ontario, along with Filomena Tassi, Member of Parliament for Hamilton West–Ancaster–Dundas, and Bob Bratina, Member of Parliament for Hamilton East&#8722;Stoney Creek, will make an announcement supporting commercialization partnerships in Hamilton.",
     "PUBDATE": "2016-07-25 11:07:00",
     "TYPE": "Media Advisories",
@@ -1000,7 +1000,7 @@
     "AUDIENCE": "Business,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Brison and MP Fillmore to make innovation funding announcement</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Brison and MP Fillmore to make innovation funding announcement</a>",
     "TEASER": "Members of the media are invited to attend an event where the Honourable Scott Brison, President of the Treasury Board of Canada and Member of Parliament for Kings-Hants, along with Andy Fillmore, Member of Parliament for Halifax, on behalf of the Honourable Navdeep Bains, Minister of Innovation, Science and Economic Development and Minister responsible for the Atlantic Canada Opportunities Agency (ACOA), will make an official announcement concerning a major investment in innovation in Atlantic Canada under ACOA's Atlantic Innovation Fund.",
     "PUBDATE": "2016-07-25",
     "TYPE": "Media Advisories",
@@ -1010,7 +1010,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada,Nova Scotia"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Parliamentary Secretary Gould to visit Honduras and Guatemala</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Parliamentary Secretary Gould to visit Honduras and Guatemala</a>",
     "TEASER": "Karina Gould, Parliamentary Secretary to the Minister of International Development and la Francophonie, announced today that she will travel to Honduras and Guatemala from July 25 to 29, 2016.",
     "PUBDATE": "2016-07-25 10:07:00",
     "TYPE": "News Releases",
@@ -1020,7 +1020,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canadians recognized for their dedication to Veterans</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canadians recognized for their dedication to Veterans</a>",
     "TEASER": "Minister of Veterans Affairs Commendation presented at a ceremony in Halifax",
     "PUBDATE": "2016-07-25",
     "TYPE": "News Releases",
@@ -1030,7 +1030,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Media Advisory - West St. Paul, Manitoba</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Media Advisory - West St. Paul, Manitoba</a>",
     "TEASER": "West St. Paul, Manitoba, July 22, 2016 – Members of the media are invited to attend an important infrastructure event regarding federal infrastructure commitments with the Honourable MaryAnn Mihychuk, Minister of Employment, Workforce Development and Labour, and Member of Parliament for Kildonan-St. Paul, on behalf of Amarjeet Sohi, Minister of Infrastructure and Communities; Eileen Clarke, Minister of Indigenous and Municipal Relations; and Chris Goertzen, President of the Association of Manitoba Municipalities.",
     "PUBDATE": "2016-07-25 09:07:00",
     "TYPE": "Media Advisories",
@@ -1040,7 +1040,7 @@
     "AUDIENCE": "Media,General Public,Government",
     "LOCATION": "Canada,Manitoba"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canada took strong stance at United Nations meetings on climate warming HFCs</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canada took strong stance at United Nations meetings on climate warming HFCs</a>",
     "TEASER": "Canada is taking action on climate change at home and abroad. Environment and Climate Change Minister, Catherine McKenna, today wrapped up a series of UN meetings in Vienna, where Canada pushed for international action to phase down climate-warming hydrofluorocarbons (HFCs) as quickly as possible.",
     "PUBDATE": "2016-07-24",
     "TYPE": "News Releases",
@@ -1050,7 +1050,7 @@
     "AUDIENCE": "General Public,Government",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Camp Hughes</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Camp Hughes</a>",
     "TEASER": "This former military training camp is the most intact First World War battlefield terrain, created for training purposes, remaining in Canada and one of a dwindling number worldwide. It retains – in whole or in part – many key features including the training trenches (approximately ten kilometres of the main battalion trench system), rifle range, grenade training grounds, artillery observation posts, building foundations, and a camp cemetery.",
     "PUBDATE": "2016-07-24 15:07:00",
     "TYPE": "Backgrounders",
@@ -1060,7 +1060,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Camp Hughes, WWI Military Training Camp, Recognized for its National Historic Significance</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Camp Hughes, WWI Military Training Camp, Recognized for its National Historic Significance</a>",
     "TEASER": "Camp Hughes, WWI Military Training Camp, Recognized for its National Historic Significance",
     "PUBDATE": "2016-07-24",
     "TYPE": "News Releases",
@@ -1070,7 +1070,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Morneau Again Earns G20 Support for Canada's Plan for Middle Class Growth</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Morneau Again Earns G20 Support for Canada's Plan for Middle Class Growth</a>",
     "TEASER": "Minister Morneau Again Earns G20 Support for Canada's Plan for Middle Class Growth",
     "PUBDATE": "2016-07-24 11:07:00",
     "TYPE": "News Releases",
@@ -1080,7 +1080,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Minister Dion to travel to the Lao People's Democratic Republic, establish new diplomatic mission and participate in Association of Southeast Asian Nations meetings</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Minister Dion to travel to the Lao People's Democratic Republic, establish new diplomatic mission and participate in Association of Southeast Asian Nations meetings</a>",
     "TEASER": "The Honourable Stéphane Dion, Minister of Foreign Affairs, today announced that he will travel to Vientiane, the Lao People's Democratic Republic (PDR), for the annual Association of Southeast Asian Nations (ASEAN)-Canada Post-Ministerial Conference and the ASEAN Regional Forum, scheduled, respectively, for July 25 and 26, 2016.",
     "PUBDATE": "2016-07-23",
     "TYPE": "News Releases",
@@ -1090,7 +1090,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">The Government of Canada supports a community project in Lac-Drolet</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">The Government of Canada supports a community project in Lac-Drolet</a>",
     "TEASER": "Municipal skating rink converted to accommodate sports enthusiasts all year round.",
     "PUBDATE": "2016-07-19 16:07:00",
     "TYPE": "News Releases",
@@ -1100,7 +1100,7 @@
     "AUDIENCE": "Non-Governmental Organizations,Media,Business,General Public",
     "LOCATION": "Quebec"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Federal and Provincial Governments Celebrate the Grand Opening of Revitalized Bridge Street</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Federal and Provincial Governments Celebrate the Grand Opening of Revitalized Bridge Street</a>",
     "TEASER": "Completed restoration project will enhance business, community and tourism activities",
     "PUBDATE": "2016-07-19",
     "TYPE": "News Releases",
@@ -1110,7 +1110,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "New Brunswick"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canada appalled by depraved attack in Munich, Germany</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canada appalled by depraved attack in Munich, Germany</a>",
     "TEASER": "We condemn this attack, and we offer our deepest condolences to the families and friends of those killed and a quick recovery to those injured. Canadians are deeply saddened by these tragic events, especially the targeting of children, and our thoughts are with the people of Germany during this stressful period.",
     "PUBDATE": "2016-07-19 21:07:00",
     "TYPE": "Statements",
@@ -1120,7 +1120,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government of Canada, provinces and territories reach unprecedented agreement-in-principle on internal trade</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government of Canada, provinces and territories reach unprecedented agreement-in-principle on internal trade</a>",
     "TEASER": "In an increasingly global economy, Canada must have a free trade agreement that lowers barriers within our own country. An open Canadian market creates well-paying jobs for the middle class and those working hard to join it. It drives economic growth and provides consumers with more choice. It also enables Canadian businesses to be as competitive at home as they are abroad.",
     "PUBDATE": "2016-07-16",
     "TYPE": "News Releases",
@@ -1130,7 +1130,7 @@
     "AUDIENCE": "Business,General Public",
     "LOCATION": "Canada,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Federal and Provincial Governments Support Youth Entrepreneurship at UNB's Summer Institute Program</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Federal and Provincial Governments Support Youth Entrepreneurship at UNB's Summer Institute Program</a>",
     "TEASER": "Inspired youth demonstrate their creative business ideas",
     "PUBDATE": "2016-07-16 18:07:00",
     "TYPE": "News Releases",
@@ -1140,7 +1140,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "New Brunswick"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Defence Minister Concludes Visit to RIMPAC 2016</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Defence Minister Concludes Visit to RIMPAC 2016</a>",
     "TEASER": "As part of the Government of Canada's commitment to maintaining strong, multilateral ties with allies in the Asia-Pacific region, Defence Minister Harjit S. Sajjan today concluded a successful visit with Canadian Armed Forces (CAF) personnel and international partners in the region of the Hawaiian Islands during the world's largest international maritime exercise, Rim of the Pacific (RIMPAC) 2016.",
     "PUBDATE": "2016-07-15",
     "TYPE": "News Releases",
@@ -1150,7 +1150,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Yacht club convicted of killing migratory birds in attempt to scare them away</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Yacht club convicted of killing migratory birds in attempt to scare them away</a>",
     "TEASER": "On July 6, the Club nautique de Baie-Comeau Inc., on the North Shore, pleaded guilty to killing or injuring a dozen Ring-Billed Gulls by trying to scare them, in violation of the Migratory Birds Regulations. The Club nautique was fined 2,500 dollars, which will be paid to the Environmental Damages Fund. This sentence is the first conviction in Canada for this type of offence under the Migratory Birds Convention Act, 1994 (MBCA).",
     "PUBDATE": "2016-07-15 17:07:00",
     "TYPE": "News Releases",
@@ -1160,7 +1160,7 @@
     "AUDIENCE": "General Public,Government",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Statement from Minister MacAulay on Federal, Provincial and Territorial Ministers of Agriculture Annual Conference</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Statement from Minister MacAulay on Federal, Provincial and Territorial Ministers of Agriculture Annual Conference</a>",
     "TEASER": "The Honourable Lawrence MacAulay, Minister of Agriculture and Agri-Food, today issued the following statement regarding the annual conference of federal, provincial and territorial (FPT) Ministers of Agriculture.",
     "PUBDATE": "2016-07-12",
     "TYPE": "Statements",
@@ -1170,7 +1170,7 @@
     "AUDIENCE": "Media,Farmers,General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Federal, Provincial and Territorial Ministers Set the Direction for the Next Agricultural Framework</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Federal, Provincial and Territorial Ministers Set the Direction for the Next Agricultural Framework</a>",
     "TEASER": "Canada's federal, provincial and territorial (FPT) Ministers of Agriculture today concluded their annual conference with Ministers issuing the Calgary Statement \u2015 representing a consensus among Ministers regarding the key priorities to develop the next agricultural policy framework, set to launch in April 2018.",
     "PUBDATE": "2016-07-12 16:07:00",
     "TYPE": "News Releases",
@@ -1180,7 +1180,7 @@
     "AUDIENCE": "Media,Farmers,General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Government of Canada Announces Re-evaluation Decision for Pesticides Containing Boric Acid</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Government of Canada Announces Re-evaluation Decision for Pesticides Containing Boric Acid</a>",
     "TEASER": "Today, the Government of Canada published a final pesticide re-evaluation decision for boric acid, a naturally occurring substance that is commonly used in a wide range of pesticide products in Canada to control insects and fungi.",
     "PUBDATE": "2016-07-09",
     "TYPE": "News Releases",
@@ -1190,7 +1190,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">The JAG Launches Comprehensive Review of Court Martial System</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">The JAG Launches Comprehensive Review of Court Martial System</a>",
     "TEASER": "The Judge Advocate General (JAG), Major-General Blaise Cathcart, has launched a proactive comprehensive review of the Canadian Armed Forces' (CAF) court martial system.",
     "PUBDATE": "2016-07-09 16:07:00",
     "TYPE": "News Releases",
@@ -1200,7 +1200,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Canadian Armed Forces teams complete the 2016 Nijmegen Marches</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Canadian Armed Forces teams complete the 2016 Nijmegen Marches</a>",
     "TEASER": "Today marks the end of the 100th annual International Four Days Marches Nijmegen in the Netherlands. This year, more than 200 Canadian Armed Forces (CAF) members from across Canada and Formation Europe participated in the marching event, and were awarded a special 100th anniversary edition of the Four Day Marches Cross.",
     "PUBDATE": "2016-07-08",
     "TYPE": "News Releases",
@@ -1210,7 +1210,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Des Allumettes Bridge - lane closures</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Des Allumettes Bridge - lane closures</a>",
     "TEASER": "Public Services and Procurement Canada wishes to advise motorists of the following alternate lane closures on the Des Allumettes Bridge.",
     "PUBDATE": "2016-07-08 15:07:00",
     "TYPE": "Media Advisories",
@@ -1220,7 +1220,7 @@
     "AUDIENCE": "Travellers,General Public",
     "LOCATION": "Quebec,Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">New Leader at the Helm of Maritime Forces Pacific</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">New Leader at the Helm of Maritime Forces Pacific</a>",
     "TEASER": "Rear-Admiral (RAdm) Art McDonald officially assumed command of Maritime Forces Pacific (MARPAC) and Joint Task Force (Pacific) (JTF(P)) from RAdm Gilles Couturier during a ceremony held today at CFB Esquimalt. Presiding over the ceremony was Vice-Admiral Ron Lloyd, Commander Royal Canadian Navy.",
     "PUBDATE": "2016-07-08",
     "TYPE": "News Releases",
@@ -1230,7 +1230,7 @@
     "AUDIENCE": "General Public",
     "LOCATION": "Canada"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Death of an inmate at Collins Bay Institution - Minimum-security unit</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Death of an inmate at Collins Bay Institution - Minimum-security unit</a>",
     "TEASER": "On July 21, 2016, Christopher Leach, an inmate at Collins Bay Institution died at the regional hospital in Bath, Ontario.",
     "PUBDATE": "2016-07-05 14:07:00",
     "TYPE": "News Releases",
@@ -1240,7 +1240,7 @@
     "AUDIENCE": "Media,General Public",
     "LOCATION": "Ontario"
   }, {
-    "TITLE": "<a href=\"http://news.gc.ca/web/index-en.do\">Department of Finance Releases Legislative and Regulatory Proposals Relating to the Goods and Services Tax/Harmonized Sales Tax</a>",
+    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Department of Finance Releases Legislative and Regulatory Proposals Relating to the Goods and Services Tax/Harmonized Sales Tax</a>",
     "TEASER": "Department of Finance Releases Legislative and Regulatory Proposals Relating to the Goods and Services Tax/Harmonized Sales Tax",
     "PUBDATE": "2016-07-05",
     "TYPE": "News Releases",

--- a/src/polyfills/slider/slider.js
+++ b/src/polyfills/slider/slider.js
@@ -25,7 +25,7 @@ var fdSlider = (function() {
             // Does a JSON (native or not) Object exist
             if(typeof JSON === "object" && typeof(JSON.parse) === "function") {
                 return JSON.parse(str);
-            // Genious code taken from: http://kentbrewster.com/badges/
+            // Genious code taken from: https://web.archive.org/web/20140715200301/http://kentbrewster.com/badges/
             } else if(/mousewheelenabled|fullaria|describedby|norangebar|html5animation|varsetrules/.test(str.toLowerCase())) {
                 var f = Function(['var document,top,self,window,parent,Number,Date,Object,Function,',
                     'Array,String,Math,RegExp,Image,ActiveXObject;',


### PR DESCRIPTION
* Update links to HTTP sites that now support HTTPS and/or redirect to new locations on HTTPS sites
* Change links to HTTP sites that no longer exist to point towards Wayback Machine mirrors
* Spinoff of #9395's review comment
* Successor to #8674

CC @GormFrank @duboisp