### PR TITLE
Toggle: Fix open details elements in accordions

### DIFF
--- a/src/plugins/toggle/toggle.js
+++ b/src/plugins/toggle/toggle.js
@@ -109,7 +109,7 @@ var componentName = "wb-toggle",
 					// Check if the element is toggled on based on the
 					// open attribute or "on" CSS class
 					isOpen = elm.nodeName.toLowerCase() === "details" ?
-						!!elm.getAttribute( "open" ) :
+						!!elm.hasAttribute( "open" ) :
 						( " " + tab.className + " " ).indexOf( " " + data.stateOn + " " );
 					if ( isOpen ) {
 						hasOpen = true;


### PR DESCRIPTION
The toggle plugin's accordion implementation previously checked whether the value of the ``details`` element's ``open`` attribute value was truthy. As a result, void ``open`` attributes were treated as falsy, causing the plugin to:
* Set the ``tgl-tab`` ``div``'s ``aria-selected`` attribute to ``false``
* Set the ``tgl-panel`` ``div``'s ARIA attributes as follows:
  * ``aria-expanded="false"``
  * ``aria-hidden="true"``

That had negative repercussions on screen reader users since, among other things, ``aria-hidden="true"`` completely hid the open ``details`` element's inner content.

This resolves it by adjusting the plugin to only check whether the ``open`` attribute exists.

CC @fsnoddy