### PR TITLE
Calevt: Adding redraw feature and small fixes

### DIFF
--- a/site/pages/docs/ref/cal-events/cal-events-en.hbs
+++ b/site/pages/docs/ref/cal-events/cal-events-en.hbs
@@ -33,21 +33,25 @@
 	<h2>How to implement</h2>
 	<ol>
 		<li>Add a div element to the Web page with a <code>class</code> attribute containing "wb-calevt" and a unique name in a <code>data-calevt-src</code> attribute (e.g.: <code>&lt;div class="wb-calevt" data-calevt-src="unique-name"&gt;&lt;/div&gt;</code>).</li>
-		<li>Include in the div element a ordered list of events (ol element) with the following structure for each event:
+		<li>Include in the div element an unordered list of events (ul element) with the following structure for each event:
 			<ol>
 				<li>The list element must start with a heading element (<code>h2</code> to <code>h6</code>, depending on the context of the page).</li>
 				<li>The heading element must include a link to the event description with the event title for the link text.</li>
 				<li>The event date must be provided in an HTML5 <code>time</code> element contained within a paragraph element (following the heading element). The date to be displayed is contained in the <code>time</code> element and an ISO-8601 date (e.g., 2010-03-11) is provided in the <code>datetime</code> attribute.</li>
+				<li>Note: to exclude an item from being shown on the calendar and in the list, simply add the CSS class <code>wb-fltr-out</code> to the list element (<code>&lt;li&gt;</code>).</li>
 			</ol>
 		</li>
 		<li>Add a second <code>div</code> element to the Web page with an <code>id</code> attribute containing your <code>data-calevt-src</code> attribute's unique name from above (e.g., <code>&lt;div id="unique-name"&gt;&lt;/div&gt;</code>). This will hold the calendar interface.</li>
 	</ol>
+	<div class="alert alert-info">
+		<p><strong>Note</strong>: the plugin still supports <code>&lt;ul&gt;</code> and <code>&lt;ol&gt;</code>, but, as of October 4th 2022, we recommend using a <code>&lt;ul&gt;</code> since items numbers in a <code>&lt;ol&gt;</code> will always start at 1, even when some items are hidden.</p>
+	</div>
 
 	<h3>Example Code</h3>
 	<pre><code>&lt;div id="calendar1"&gt;&lt;/div&gt;
 
 &lt;div class="wb-calevt" data-calevt-src="calendar1"&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href="https://www.canada.gc.ca"&gt;Single-Day Event&lt;/a&gt;&lt;/h4&gt;
@@ -62,7 +66,7 @@
 				&lt;p&gt;Event Description&lt;/p&gt;
 			&lt;/section&gt;
 		&lt;/li&gt;
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
 	<section>
@@ -71,7 +75,7 @@
 		<pre><code>&lt;div id="calendar2"&gt;&lt;/div&gt;
 
 &lt;div class="wb-calevt evt-anchor" data-calevt-src="calendar2"&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;Single-Day Event&lt;/h4&gt;
@@ -96,7 +100,7 @@
 				&lt;/ul&gt;
 			&lt;/section&gt;
 		&lt;/li&gt;
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 	</section>
 
@@ -109,7 +113,7 @@
 &lt;div class="wb-calevt evt-anchor" data-calevt-src="calendar3"&gt;
 	&lt;section&gt;
 		&lt;h4&gt;Events List 1&lt;/h4&gt;
-		&lt;ol&gt;
+		&lt;ul&gt;
 			&lt;li class="cal-disp-onshow"&gt;
 				&lt;section&gt;
 					&lt;h5&gt;&lt;a href="https://www.ec.gc.ca"&gt;Event 1&lt;/a&gt;&lt;/h5&gt;
@@ -154,7 +158,7 @@
 					&lt;p&gt;&lt;time datetime="2011-04-23"&gt;April 23rd 2011&lt;/time&gt;&lt;/p&gt;
 				&lt;/section&gt;
 			&lt;/li&gt;
-		&lt;/ol&gt;
+		&lt;/ul&gt;
 	&lt;/section&gt;
 &lt;/div&gt;</code></pre>
 	</section>
@@ -203,6 +207,11 @@
 					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
 });</code></pre>
 				</td>
+			</tr>
+			<tr>
+				<td><code>wb-redraw.wb-calevt</code> (v4.0.??)</td>
+				<td>Triggered manually (e.g., <code>$elm.trigger( "wb-redraw.wb-calevt" );</code>).</td>
+				<td>Used to manually redraw the Calendar widget. For example, when events have been changed dynamically after page load.</td>
 			</tr>
 		</tbody>
 	</table>

--- a/site/pages/docs/ref/cal-events/cal-events-fr.hbs
+++ b/site/pages/docs/ref/cal-events/cal-events-fr.hbs
@@ -33,20 +33,23 @@
 	<h2>Mise en œuvre</h2>
 	<ol>
 		<li>Ajouter un élément div à la page Web avec un attribut <code>class</code> contenant "wb-calevt" et un nom unique dans un attribut <code>data-calevt-src</code> (e.g.: <code>&lt;div class="wb-calevt" data-calevt-src="unique-name"&gt;&lt;/div&gt;</code>).</li>
-		<li>Inclure dans l’élément div une liste ordonnée des événements (élément ol) en utilisant la structure suivante pour chaque événement :
+		<li>Inclure dans l’élément div une liste non-ordonnée des événements (élément ul) en utilisant la structure suivante pour chaque événement :
 			<ol>
 				<li>L’élément de liste doit commencer par un élément d’en-tête (de <code>h2</code> à <code>h6</code>, selon le contexte de la page).</li>
 				<li>L’élément d’en-tête doit inclure un lien vers la description de l’événement, avec le titre de l’événement comme hyperlien.</li>
 				<li>La date de l’événement doit être fournie dans un élément <code>time</code> en HTML5 contenu au sein d’un élément de paragraphe (à la suite de l’élément d’en-tête). La date à afficher est contenue dans l’élément <code>time</code> et une date de norme ISO-8601 (p. ex., 2010-03-11) est indiquée dans l’attribut <code>datetime</code>.</li>
+				<li>Remarque : pour empêcher un élément de s'afficher dans le calendrier ainsi que dans la liste, ajoutez simplement la classe CSS <code>wb-fltr-out</code> à l'élément de liste (<code>&lt;li&gt;</code>).</li>
 			</ol>
 		</li>
 		<li>Ajouter un deuxième élément <code>div</code> à la page Web avec le nom unique de l’attribut <code>data-calevt-src</code> ci-haut (p.ex., <code>&lt;div id="unique-name"&gt;&lt;/div&gt;</code>). Cela permettra de maintenir en place l’interface de calendrier.</li>
 	</ol>
+	<p><strong>Note</strong>: ce plugiciel prend toujours en charge <code>&lt;ul&gt;</code> et <code>&lt;ol&gt;</code>, mais, en date du 4 octobre 2022, nous recommandons d'utiliser un <code>&lt;ul&gt;</code> car les numéros d'éléments dans un <code>&lt;ol&gt;</code> commencerons toujours à 1, même lorsque certains éléments sont masqués.</p>
+
 	<p>Exemple code :</p>
 	<pre><code>&lt;div id="calendar1"&gt;&lt;/div&gt;
 
 &lt;div class="wb-calevt" data-calevt-src="calendar1"&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href="https://www.canada.gc.ca"&gt;Événement de seul-jour&lt;/a&gt;&lt;/h4&gt;
@@ -61,7 +64,7 @@
 				&lt;p&gt;Description de l'événement&lt;/p&gt;
 			&lt;/section&gt;
 		&lt;/li&gt;
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 
 	<section>
@@ -70,7 +73,7 @@
 		<pre><code>&lt;div id="calendar2"&gt;&lt;/div&gt;
 
 &lt;div class="wb-calevt evt-anchor" data-calevt-src="calendar2"&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;Événement de seul-jour&lt;/h4&gt;
@@ -95,7 +98,7 @@
 				&lt;/ul&gt;
 			&lt;/section&gt;
 		&lt;/li&gt;
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 	</section>
 
@@ -108,7 +111,7 @@
 &lt;div class="wb-calevt evt-anchor" data-calevt-src="calendar3"&gt;
 	&lt;section&gt;
 		&lt;h4&gt;Événements - Liste 1&lt;/h4&gt;
-		&lt;ol&gt;
+		&lt;ul&gt;
 			&lt;li class="cal-disp-onshow"&gt;
 				&lt;section&gt;
 					&lt;h5&gt;&lt;a href="https://www.ec.gc.ca"&gt;Événement 1&lt;/a&gt;&lt;/h5&gt;
@@ -153,7 +156,7 @@
 					&lt;p&gt;&lt;time datetime="2011-04-23"&gt;23 avril 2011&lt;/time&gt;&lt;/p&gt;
 				&lt;/section&gt;
 			&lt;/li&gt;
-		&lt;/ol&gt;
+		&lt;/ul&gt;
 	&lt;/section&gt;
 &lt;/div&gt;</code></pre>
 	</section>
@@ -203,6 +206,11 @@
 					<pre><code>$( document ).on( "wb-ready.wb", function( event ) {
 });</code></pre>
 				</td>
+			</tr>
+			<tr>
+				<td><code>wb-redraw.wb-calevt</code> (v4.0.??)</td>
+				<td>Triggered manually (e.g., <code>$elm.trigger( "wb-redraw.wb-calevt" );</code>).</td>
+				<td>Used to manually redraw the Calendar widget. For example, when events have been changed dynamically after page load.</td>
 			</tr>
 		</tbody>
 	</table>

--- a/src/plugins/cal-events/cal-events-en.hbs
+++ b/src/plugins/cal-events/cal-events-en.hbs
@@ -21,7 +21,7 @@
 		<div id="calendar1"></div>
 
 		<div class="wb-calevt" data-calevt-src="calendar1">
-			<ol>
+			<ul>
 				<li>
 					<section>
 						<h4><a href="https://www.canada.ca" rel="external">Single-Day Event</a></h4>
@@ -36,7 +36,7 @@
 						<p>Event Description</p>
 					</section>
 				</li>
-			</ol>
+			</ul>
 		</div>
 
 		<section>
@@ -46,7 +46,7 @@
 				<pre><code>&lt;div id=&quot;calendar1&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt&quot; data-calevt-src=&quot;calendar1&quot;&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Single-Day Event&lt;/a&gt;&lt;/h4&gt;
@@ -58,7 +58,7 @@
 			...
 		&lt;/li&gt;
 		...
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 			</details>
 		</section>
@@ -71,7 +71,7 @@
 		<div id="calendar2"></div>
 
 		<div class="wb-calevt evt-anchor" data-calevt-src="calendar2">
-			<ol>
+			<ul>
 				<li>
 					<section>
 						<h4>Single-Day Event</h4>
@@ -96,7 +96,7 @@
 						</ul>
 					</section>
 				</li>
-			</ol>
+			</ul>
 		</div>
 
 		<section>
@@ -105,7 +105,7 @@
 				<summary>View code</summary>
 				<pre><code>&lt;div id=&quot;calendar2&quot;&gt;&lt;/div&gt;
 &lt;div class=&quot;wb-calevt evt-anchor&quot; data-calevt-src=&quot;calendar2&quot;&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;Single-Day Event&lt;/h4&gt;
@@ -122,7 +122,7 @@
 			...
 		&lt;/li&gt;
 		...
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 			</details>
 		</section>
@@ -135,7 +135,7 @@
 		<div id="cal-ajax"></div>
 
 		<div class="wb-calevt evt-anchor" data-calevt-src="cal-ajax">
-			<ol data-calevt="ajax/cal-include1-en.html ajax/cal-include2-en.html ajax/cal-include3-en.html"></ol>
+			<ul data-calevt="ajax/cal-include1-en.html ajax/cal-include2-en.html ajax/cal-include3-en.html"></ul>
 		</div>
 
 		<section>
@@ -147,7 +147,7 @@
 					<pre><code>&lt;div id=&quot;cal-ajax&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt evt-anchor&quot; data-calevt-src=&quot;cal-ajax&quot;&gt;
-	&lt;ol data-calevt=&quot;ajax/cal-include1-en.html ajax/cal-include2-en.html ajax/cal-include3-en.html&quot;&gt;&lt;/ol&gt;
+	&lt;ul data-calevt=&quot;ajax/cal-include1-en.html ajax/cal-include2-en.html ajax/cal-include3-en.html&quot;&gt;&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 				</section>
 
@@ -216,7 +216,7 @@
 		<div class="wb-calevt evt-anchor" data-calevt-src="calendar3">
 			<section>
 				<h4>Events List 1</h4>
-				<ol>
+				<ul>
 					<li class="cal-disp-onshow">
 						<section>
 							<h5><a href="https://www.ec.gc.ca" rel="external">Event 1</a></h5>
@@ -261,7 +261,7 @@
 							<p><time datetime="2013-04-23">April 23rd, 2013</time></p>
 						</section>
 					</li>
-				</ol>
+				</ul>
 			</section>
 		</div>
 
@@ -274,7 +274,7 @@
 &lt;div class=&quot;wb-calevt evt-anchor&quot; data-calevt-src=&quot;calendar3&quot;&gt;
 	&lt;section&gt;
 		&lt;h4&gt;Events List 1&lt;/h4&gt;
-		&lt;ol&gt;
+		&lt;ul&gt;
 			&lt;li class=&quot;cal-disp-onshow&quot;&gt;
 				&lt;section&gt;
 					&lt;h5&gt;&lt;a href=&quot;https://www.ec.gc.ca&quot; rel=&quot;external&quot;&gt;Event 1&lt;/a&gt;&lt;/h5&gt;
@@ -285,7 +285,7 @@
 				...
 			&lt;/li&gt;
 			...
-		&lt;/ol&gt;
+		&lt;/ul&gt;
 	&lt;/section&gt;
 &lt;/div&gt;</code></pre>
 			</details>
@@ -300,7 +300,7 @@
 		<div class="wb-calevt evt-anchor" data-wb-calevt='{"year": 2013, "month": 2}' data-calevt-src="calendar4">
 			<section>
 				<h4>Events List 1</h4>
-				<ol>
+				<ul>
 					<li class="cal-disp-onshow">
 						<section>
 							<h5><a href="https://www.ec.gc.ca" rel="external">Event 1</a></h5>
@@ -345,7 +345,7 @@
 							<p><time datetime="2013-04-23">April 23rd, 2013</time></p>
 						</section>
 					</li>
-				</ol>
+				</ul>
 			</section>
 		</div>
 
@@ -357,7 +357,7 @@
 &lt;div class=&quot;wb-calevt evt-anchor&quot; data-wb-calevt='{"year": 2013, "month": 2}' data-calevt-src=&quot;calendar4&quot;&gt;
 	&lt;section&gt;
 		&lt;h4&gt;Events List 1&lt;/h4&gt;
-		&lt;ol&gt;
+		&lt;ul&gt;
 			&lt;li class=&quot;cal-disp-onshow&quot;&gt;
 				&lt;section&gt;
 					&lt;h5&gt;&lt;a href=&quot;https://www.ec.gc.ca&quot; rel=&quot;external&quot;&gt;Event 1&lt;/a&gt;&lt;/h5&gt;
@@ -368,7 +368,126 @@
 				...
 			&lt;/li&gt;
 			...
-		&lt;/ol&gt;
+		&lt;/ul&gt;
+	&lt;/section&gt;
+&lt;/div&gt;</code></pre>
+			</details>
+		</section>
+	</section>
+
+	<section>
+		<h3>Exclude items</h3>
+		<p>In this example, some items are hidden in the list and in the calendar widget by using the <code>wb-fltr-out</code> CSS class.</p>
+
+		<div id="cal-exclude"></div>
+
+		<div class="wb-calevt evt-anchor" data-calevt-src="cal-exclude">
+			<section>
+				<h4>Events List 1</h4>
+				<ul>
+					<li>
+						<section>
+							<h5><a href="https://www.ec.gc.ca" rel="external">Event 1</a></h5>
+							<p><time datetime="2013-03-11">March 11th, 2013</time></p>
+						</section>
+					</li>
+					<li>
+						<section>
+							<h5><a href="https://www.canada.ca" rel="external">Event 2</a></h5>
+							<p><time datetime="2013-03-11">March 11th, 2013</time></p>
+						</section>
+					</li>
+					<li class="wb-fltr-out">
+						<section>
+							<h5>World Expo Shanghai (Shanghai, China)</h5>
+							<p><time datetime="2013-03-22">March 22nd, 2013</time> to <time datetime="2013-04-26">April 26th, 2013</time></p>
+							<p>The Canada Pavilion celebrates the vibrancy and the vitality of Canadian communities and the people within them.</p>
+							<p>For more information about Canada at Expo 2010 Shanghai, visit: <a href="https://www.expo2010canada.gc.ca/index-eng.cfm" rel="external">www.expo2010canada.gc.ca/index-eng.cfm</a></p>
+						</section>
+					</li>
+					<li class="wb-fltr-out">
+						<section>
+							<h5><a href="https://www.ic.gc.ca" rel="external">Event 4</a></h5>
+							<p><time datetime="2013-03-24">March 24th, 2013</time></p>
+						</section>
+					</li>
+					<li class="wb-fltr-out">
+						<section>
+							<h5><a href="https://www.ec.gc.ca" rel="external">Event 6</a></h5>
+							<p><time datetime="2013-04-11">April 11th, 2013</time></p>
+						</section>
+					</li>
+					<li>
+						<section>
+							<h5><a href="https://www.canada.ca" rel="external">Event 7</a></h5>
+							<p><time datetime="2013-04-23">April 23rd, 2013</time></p>
+						</section>
+					</li>
+					<li>
+						<section>
+							<h5><a href="https://www.canada.ca" rel="external">Event 17</a></h5>
+							<p><time datetime="2013-04-23">April 23rd, 2013</time></p>
+						</section>
+					</li>
+				</ul>
+			</section>
+		</div>
+
+		<section>
+			<h4>Code</h4>
+			<details class="mrgn-bttm-md">
+				<summary>View code</summary>
+				<pre><code>&lt;div id=&quot;cal-exclude&quot;&gt;&lt;/div&gt;
+
+&lt;div class=&quot;wb-calevt evt-anchor&quot; data-calevt-src=&quot;cal-exclude&quot;&gt;
+	&lt;section&gt;
+		&lt;h4&gt;Events List 1&lt;/h4&gt;
+		&lt;ul&gt;
+			&lt;li&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.ec.gc.ca&quot; rel=&quot;external&quot;&gt;Event 1&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-03-11&quot;&gt;March 11th, 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Event 2&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-03-11&quot;&gt;March 11th, 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li class=&quot;wb-fltr-out&quot;&gt;
+				&lt;section&gt;
+					&lt;h5&gt;World Expo Shanghai (Shanghai, China)&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-03-22&quot;&gt;March 22nd, 2013&lt;/time&gt; to &lt;time datetime=&quot;2013-04-26&quot;&gt;April 26th, 2013&lt;/time&gt;&lt;/p&gt;
+					&lt;p&gt;The Canada Pavilion celebrates the vibrancy and the vitality of Canadian communities and the people within them.&lt;/p&gt;
+					&lt;p&gt;For more information about Canada at Expo 2010 Shanghai, visit: &lt;a href=&quot;https://www.expo2010canada.gc.ca/index-eng.cfm&quot; rel=&quot;external&quot;&gt;www.expo2010canada.gc.ca/index-eng.cfm&lt;/a&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li class=&quot;wb-fltr-out&quot;&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.ic.gc.ca&quot; rel=&quot;external&quot;&gt;Event 4&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-03-24&quot;&gt;March 24th, 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li class=&quot;wb-fltr-out&quot;&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.ec.gc.ca&quot; rel=&quot;external&quot;&gt;Event 6&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-04-11&quot;&gt;April 11th, 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Event 7&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-04-23&quot;&gt;April 23rd, 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Event 17&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-04-23&quot;&gt;April 23rd, 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+		&lt;/ul&gt;
 	&lt;/section&gt;
 &lt;/div&gt;</code></pre>
 			</details>
@@ -383,11 +502,11 @@
 	<div class="row">
 	<section class="col-md-4">
 		<h3>Past events</h3>
-		<p>Start at the oldest date.</p>
+		<p>Start at the uldest date.</p>
 		<div id="calevt-out-1"></div>
 
 		<div class="wb-calevt" data-calevt-src="calevt-out-1">
-			<ol>
+			<ul>
 				<li>
 					<section>
 						<h4><a href="https://www.canada.ca" rel="external">Single-Day Event</a></h4>
@@ -402,7 +521,7 @@
 						<p>Event Description</p>
 					</section>
 				</li>
-			</ol>
+			</ul>
 		</div>
 
 		<section>
@@ -412,7 +531,7 @@
 				<pre><code>&lt;div id=&quot;calevt-out-1&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt&quot; data-calevt-src=&quot;calevt-out-1&quot;&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Single-Day Event&lt;/a&gt;&lt;/h4&gt;
@@ -424,7 +543,7 @@
 			...
 		&lt;/li&gt;
 		...
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 			</details>
 		</section>
@@ -436,7 +555,7 @@
 		<div id="calevt-out-3"></div>
 
 		<div class="wb-calevt" data-calevt-src="calevt-out-3">
-			<ol>
+			<ul>
 				<li>
 					<section>
 						<h4><a href="https://www.canada.ca" rel="external">Single-Day Event</a></h4>
@@ -451,7 +570,7 @@
 						<p>Event Description</p>
 					</section>
 				</li>
-			</ol>
+			</ul>
 		</div>
 
 		<section>
@@ -461,7 +580,7 @@
 				<pre><code>&lt;div id=&quot;calevt-out-3&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt&quot; data-calevt-src=&quot;calevt-out-3&quot;&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Single-Day Event&lt;/a&gt;&lt;/h4&gt;
@@ -480,7 +599,7 @@
 			...
 		&lt;/li&gt;
 		...
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 			</details>
 		</section>
@@ -492,7 +611,7 @@
 		<div id="calevt-out-2"></div>
 
 		<div class="wb-calevt" data-calevt-src="calevt-out-2">
-			<ol>
+			<ul>
 				<li>
 					<section>
 						<h4><a href="https://www.canada.ca" rel="external">Single-Day Event</a></h4>
@@ -507,7 +626,7 @@
 						<p>Event Description</p>
 					</section>
 				</li>
-			</ol>
+			</ul>
 		</div>
 
 		<section>
@@ -517,7 +636,7 @@
 				<pre><code>&lt;div id=&quot;calevt-out-2&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt&quot; data-calevt-src=&quot;calevt-out-2&quot;&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Single-Day Event&lt;/a&gt;&lt;/h4&gt;
@@ -529,7 +648,7 @@
 			...
 		&lt;/li&gt;
 		...
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 			</details>
 		</section>

--- a/src/plugins/cal-events/cal-events-fr.hbs
+++ b/src/plugins/cal-events/cal-events-fr.hbs
@@ -21,7 +21,7 @@
 		<div id="calendar1"></div>
 
 		<div class="wb-calevt" data-calevt-src="calendar1">
-			<ol>
+			<ul>
 				<li>
 					<section>
 						<h4><a href="https://www.canada.ca" rel="external">Événement de seul-jour</a></h4>
@@ -36,7 +36,7 @@
 						<p>Description de l'événement</p>
 					</section>
 				</li>
-			</ol>
+			</ul>
 		</div>
 
 		<section>
@@ -46,7 +46,7 @@
 				<pre><code>&lt;div id=&quot;calendar1&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt&quot; data-calevt-src=&quot;calendar1&quot;&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Événement de seul-jour&lt;/a&gt;&lt;/h4&gt;
@@ -58,7 +58,7 @@
 			...
 		&lt;/li&gt;
 		...
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 			</details>
 		</section>
@@ -71,12 +71,12 @@
 		<div id="calendar2"></div>
 
 		<div class="wb-calevt evt-anchor" data-calevt-src="calendar2">
-			<ol>
+			<ul>
 				<li>
 					<section>
 						<h4>Événement de seul-jour</h4>
 						<p><time datetime="2013-03-11">11 mars 2013</time></p>
-						<p>Description de l'événemen</p>
+						<p>Description de l'événement</p>
 						<p>Liens&#160;:</p>
 						<ul>
 							<li><a href="https://www.canada.ca" rel="external">Événement de seul-jour - Lien 1</a></li>
@@ -88,7 +88,7 @@
 					<section>
 						<h4>Événement sur plusieurs jours</h4>
 						<p>Le <time datetime="2013-03-22">22 mars 2013</time> au <time datetime="2013-04-26">26 avril 2013</time></p>
-						<p>Description de l'événemen</p>
+						<p>Description de l'événement</p>
 						<p>Liens&#160;:</p>
 						<ul>
 							<li><a href="https://www.canada.ca" rel="external">Événement sur plusieurs jours - Lien 1</a></li>
@@ -96,7 +96,7 @@
 						</ul>
 					</section>
 				</li>
-			</ol>
+			</ul>
 		</div>
 
 		<section>
@@ -106,7 +106,7 @@
 				<pre><code>&lt;div id=&quot;calendar1&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt&quot; data-calevt-src=&quot;calendar1&quot;&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Événement de seul-jour&lt;/a&gt;&lt;/h4&gt;
@@ -118,7 +118,7 @@
 			...
 		&lt;/li&gt;
 		...
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 			</details>
 		</section>
@@ -131,7 +131,7 @@
 		<div id="cal-ajax"></div>
 
 		<div class="wb-calevt evt-anchor" data-calevt-src="cal-ajax">
-			<ol data-calevt="ajax/cal-include1-fr.html ajax/cal-include2-fr.html ajax/cal-include3-fr.html"></ol>
+			<ul data-calevt="ajax/cal-include1-fr.html ajax/cal-include2-fr.html ajax/cal-include3-fr.html"></ul>
 		</div>
 
 		<section>
@@ -143,7 +143,7 @@
 					<pre><code>&lt;div id=&quot;cal-ajax&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt evt-anchor&quot; data-calevt-src=&quot;cal-ajax&quot;&gt;
-	&lt;ol data-calevt=&quot;ajax/cal-include1-fr.html ajax/cal-include2-fr.html ajax/cal-include3-fr.html&quot;&gt;&lt;/ol&gt;
+	&lt;ul data-calevt=&quot;ajax/cal-include1-fr.html ajax/cal-include2-fr.html ajax/cal-include3-fr.html&quot;&gt;&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 				</section>
 
@@ -212,7 +212,7 @@
 		<div class="wb-calevt evt-anchor" data-calevt-src="calendar3">
 			<section>
 				<h4>Événements - Liste 1</h4>
-				<ol>
+				<ul>
 					<li class="cal-disp-onshow">
 						<section>
 							<h5><a href="https://www.ec.gc.ca" rel="external">Événement 1</a></h5>
@@ -257,7 +257,7 @@
 							<p><time datetime="2013-04-23">23 avril 2013</time></p>
 						</section>
 					</li>
-				</ol>
+				</ul>
 			</section>
 		</div>
 
@@ -270,7 +270,7 @@
 &lt;div class=&quot;wb-calevt evt-anchor&quot; data-calevt-src=&quot;calendar3&quot;&gt;
 	&lt;section&gt;
 		&lt;h4&gt;Événements - Liste 1&lt;/h4&gt;
-		&lt;ol&gt;
+		&lt;ul&gt;
 			&lt;li class=&quot;cal-disp-onshow&quot;&gt;
 				&lt;section&gt;
 					&lt;h5&gt;&lt;a href=&quot;https://www.ec.gc.ca&quot; rel=&quot;external&quot;&gt;Événement 1&lt;/a&gt;&lt;/h5&gt;
@@ -281,7 +281,7 @@
 				...
 			&lt;/li&gt;
 			...
-		&lt;/ol&gt;
+		&lt;/ul&gt;
 	&lt;/section&gt;
 &lt;/div&gt;</code></pre>
 			</details>
@@ -296,7 +296,7 @@
 		<div class="wb-calevt evt-anchor" data-wb-calevt='{"year": 2013, "month": 2}' data-calevt-src="calendar4">
 			<section>
 				<h4>Événements - Liste 1</h4>
-				<ol>
+				<ul>
 					<li class="cal-disp-onshow">
 						<section>
 							<h5><a href="https://www.ec.gc.ca" rel="external">Événement 1</a></h5>
@@ -341,7 +341,7 @@
 							<p><time datetime="2013-04-23">23 avril 2013</time></p>
 						</section>
 					</li>
-				</ol>
+				</ul>
 			</section>
 		</div>
 
@@ -354,7 +354,7 @@
 &lt;div class=&quot;wb-calevt evt-anchor&quot; data-wb-calevt='{"year": 2013, "month": 2}' data-calevt-src=&quot;calendar4&quot;&gt;
 	&lt;section&gt;
 		&lt;h4&gt;Événements - Liste 1&lt;/h4&gt;
-		&lt;ol&gt;
+		&lt;ul&gt;
 			&lt;li class=&quot;cal-disp-onshow&quot;&gt;
 				&lt;section&gt;
 					&lt;h5&gt;&lt;a href=&quot;https://www.ec.gc.ca&quot; rel=&quot;external&quot;&gt;Événement 1&lt;/a&gt;&lt;/h5&gt;
@@ -365,7 +365,126 @@
 				...
 			&lt;/li&gt;
 			...
-		&lt;/ol&gt;
+		&lt;/ul&gt;
+	&lt;/section&gt;
+&lt;/div&gt;</code></pre>
+			</details>
+		</section>
+	</section>
+
+	<section>
+		<h3>Exclure des éléments</h3>
+		<p>Dans cet exemple, certains éléments sont cachés dans la liste ainsi que dans le calendrier en utilisant la classe CSS <code>wb-fltr-out</code>.</p>
+
+		<div id="cal-exclude"></div>
+
+		<div class="wb-calevt evt-anchor" data-calevt-src="cal-exclude">
+			<section>
+				<h4>Événements - Liste 1</h4>
+				<ul>
+					<li>
+						<section>
+							<h5><a href="https://www.ec.gc.ca" rel="external">Événement 1</a></h5>
+							<p><time datetime="2013-03-11">11 mars 2013</time></p>
+						</section>
+					</li>
+					<li>
+						<section>
+							<h5><a href="https://www.canada.ca" rel="external">Événement 2</a></h5>
+							<p><time datetime="2013-03-11">11 mars 2013</time></p>
+						</section>
+					</li>
+					<li class="wb-fltr-out">
+						<section>
+							<h5>Expo 2010 Shanghai</h5>
+							<p>Le <time datetime="2013-03-22">22 mars 2013</time> au <time datetime="2013-04-26">26 avril 2013</time></p>
+							<p>Le Pavillon du Canada souligne le dynamisme et la vitalité des villes canadiennes et de leurs résidents.</p>
+							<p>Pour obtenir de plus amples renseignements, visitez le site Web de Canada à Expo 2010 Shanghai à l’adresse suivante&#160;: <a href="https://www.expo2010canada.gc.ca/index-fra.cfm" rel="external">www.expo2010canada.gc.ca/index-fra.cfm</a></p>
+						</section>
+					</li>
+					<li class="wb-fltr-out">
+						<section>
+							<h5><a href="https://www.ic.gc.ca" rel="external">Événement 4</a></h5>
+							<p><time datetime="2013-03-24">24 mars 2013</time></p>
+						</section>
+					</li>
+					<li class="wb-fltr-out">
+						<section>
+							<h5><a href="https://www.ec.gc.ca" rel="external">Événement 6</a></h5>
+							<p><time datetime="2013-04-11">4 avril 2013</time></p>
+						</section>
+					</li>
+					<li>
+						<section>
+							<h5><a href="https://www.canada.ca" rel="external">Événement 7</a></h5>
+							<p><time datetime="2013-04-23">23 avril 2013</time></p>
+						</section>
+					</li>
+					<li>
+						<section>
+							<h5><a href="https://www.canada.ca" rel="external">Événement 17</a></h5>
+							<p><time datetime="2013-04-23">23 avril 2013</time></p>
+						</section>
+					</li>
+				</ul>
+			</section>
+		</div>
+
+		<section>
+			<h4>Code</h4>
+			<details class="mrgn-bttm-md">
+				<summary>Visualiser le code</summary>
+				<pre><code>&lt;div id=&quot;cal-exclude&quot;&gt;&lt;/div&gt;
+
+&lt;div class=&quot;wb-calevt evt-anchor&quot; data-calevt-src=&quot;cal-exclude&quot;&gt;
+	&lt;section&gt;
+		&lt;h4&gt;&Eacute;v&eacute;nements - Liste 1&lt;/h4&gt;
+		&lt;ul&gt;
+			&lt;li&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.ec.gc.ca&quot; rel=&quot;external&quot;&gt;&Eacute;v&eacute;nement 1&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-03-11&quot;&gt;11 mars 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;&Eacute;v&eacute;nement 2&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-03-11&quot;&gt;11 mars 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li class=&quot;wb-fltr-out&quot;&gt;
+				&lt;section&gt;
+					&lt;h5&gt;Expo 2010 Shanghai&lt;/h5&gt;
+					&lt;p&gt;Le &lt;time datetime=&quot;2013-03-22&quot;&gt;22 mars 2013&lt;/time&gt; au &lt;time datetime=&quot;2013-04-26&quot;&gt;26 avril 2013&lt;/time&gt;&lt;/p&gt;
+					&lt;p&gt;Le Pavillon du Canada souligne le dynamisme et la vitalit&eacute; des villes canadiennes et de leurs r&eacute;sidents.&lt;/p&gt;
+					&lt;p&gt;Pour obtenir de plus amples renseignements, visitez le site Web de Canada &agrave; Expo 2010 Shanghai &agrave; l&rsquo;adresse suivante&amp;#160;: &lt;a href=&quot;https://www.expo2010canada.gc.ca/index-fra.cfm&quot; rel=&quot;external&quot;&gt;www.expo2010canada.gc.ca/index-fra.cfm&lt;/a&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li class=&quot;wb-fltr-out&quot;&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.ic.gc.ca&quot; rel=&quot;external&quot;&gt;&Eacute;v&eacute;nement 4&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-03-24&quot;&gt;24 mars 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li class=&quot;wb-fltr-out&quot;&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.ec.gc.ca&quot; rel=&quot;external&quot;&gt;&Eacute;v&eacute;nement 6&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-04-11&quot;&gt;4 avril 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;&Eacute;v&eacute;nement 7&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-04-23&quot;&gt;23 avril 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+			&lt;li&gt;
+				&lt;section&gt;
+					&lt;h5&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;&Eacute;v&eacute;nement 17&lt;/a&gt;&lt;/h5&gt;
+					&lt;p&gt;&lt;time datetime=&quot;2013-04-23&quot;&gt;23 avril 2013&lt;/time&gt;&lt;/p&gt;
+				&lt;/section&gt;
+			&lt;/li&gt;
+		&lt;/ul&gt;
 	&lt;/section&gt;
 &lt;/div&gt;</code></pre>
 			</details>
@@ -382,7 +501,7 @@
 		<div id="calevt-out-1"></div>
 
 		<div class="wb-calevt" data-calevt-src="calevt-out-1">
-			<ol>
+			<ul>
 				<li>
 					<section>
 						<h4><a href="https://www.canada.ca" rel="external">Événement de seul-jour</a></h4>
@@ -397,7 +516,7 @@
 						<p>Description de l'événement</p>
 					</section>
 				</li>
-			</ol>
+			</ul>
 		</div>
 
 		<section>
@@ -407,7 +526,7 @@
 				<pre><code>&lt;div id=&quot;calevt-out-1&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt&quot; data-calevt-src=&quot;calevt-out-1&quot;&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Événement de seul-jour&lt;/a&gt;&lt;/h4&gt;
@@ -419,7 +538,7 @@
 			...
 		&lt;/li&gt;
 		...
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 			</details>
 		</section>
@@ -431,7 +550,7 @@
 		<div id="calevt-out-3"></div>
 
 		<div class="wb-calevt" data-calevt-src="calevt-out-3">
-			<ol>
+			<ul>
 				<li>
 					<section>
 						<h4><a href="https://www.canada.ca" rel="external">Événement de seul-jour</a></h4>
@@ -446,7 +565,7 @@
 						<p>Description de l'événement</p>
 					</section>
 				</li>
-			</ol>
+			</ul>
 		</div>
 
 		<section>
@@ -456,7 +575,7 @@
 				<pre><code>&lt;div id=&quot;calevt-out-3&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt&quot; data-calevt-src=&quot;calevt-out-3&quot;&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Événement de seul-jour&lt;/a&gt;&lt;/h4&gt;
@@ -475,7 +594,7 @@
 			...
 		&lt;/li&gt;
 		...
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 			</details>
 		</section>
@@ -487,7 +606,7 @@
 		<div id="calevt-out-2"></div>
 
 		<div class="wb-calevt" data-calevt-src="calevt-out-2">
-			<ol>
+			<ul>
 				<li>
 					<section>
 						<h4><a href="https://www.canada.ca" rel="external">Événement de seul-jour</a></h4>
@@ -502,7 +621,7 @@
 						<p>Description de l'événement</p>
 					</section>
 				</li>
-			</ol>
+			</ul>
 		</div>
 
 		<section>
@@ -512,7 +631,7 @@
 				<pre><code>&lt;div id=&quot;calevt-out-2&quot;&gt;&lt;/div&gt;
 
 &lt;div class=&quot;wb-calevt&quot; data-calevt-src=&quot;calevt-out-2&quot;&gt;
-	&lt;ol&gt;
+	&lt;ul&gt;
 		&lt;li&gt;
 			&lt;section&gt;
 				&lt;h4&gt;&lt;a href=&quot;https://www.canada.ca&quot; rel=&quot;external&quot;&gt;Événement de seul-jour&lt;/a&gt;&lt;/h4&gt;
@@ -524,7 +643,7 @@
 			...
 		&lt;/li&gt;
 		...
-	&lt;/ol&gt;
+	&lt;/ul&gt;
 &lt;/div&gt;</code></pre>
 			</details>
 		</section>


### PR DESCRIPTION
Following changes:
- Handling of `wb-redraw` event that deletes the current calendar and generates a new one with updated HTML.
- Changed solution to get list of events.
    - Previous solution would get every `li` directly under an `ol` or `ul` inside the specified element, which could trigger unwanted behaviour (i.e. if an add to calendar was initiated inside a `li`). 
    - New solution finds the first of either `ol` or `ul` and get its immediate `li` children.
- Hiding events in calendar on focus out.
    - Events would remain visible when moving focus to another element or when selecting an event.
- Adding option to exclude items using `data-calevt-exclude`.
- Updated lists of events to use `ul` instead of `ol`. `ul` is now the recommended approach, however `ol` is still supported.