### PR TITLE
data-json - Allow object be iterated for sub-template + additional attr support

### DIFF
--- a/site/pages/docs/ref/wb-data-json/wb-data-json-en.hbs
+++ b/site/pages/docs/ref/wb-data-json/wb-data-json-en.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Insert content extracted from a JSON file and leverage HTML 5 template element.",
 	"altLangPage": "wb-data-json-fr.html",
-	"dateModified": "2017-01-31"
+	"dateModified": "2022-10-12"
 }
 ---
 <div class="wb-prettify all-pre"></div>
@@ -382,6 +382,7 @@
 </div></div>
 
 <h3>When the array key information will be lost</h3>
+<p>Because the object already contains a field named <code>@id</code></p>
 <div class="row">
 <div class="col-sm-6">
 <p>Source</p>
@@ -505,7 +506,7 @@
 		<td><code>attr</code></td>
 		<td>Specify the element attribute name. Only required when <code>type="attr"</code>.</td>
 		<td><code>data-wb-json='{ "url": "", "type": "attr", "attr": "href" }'</code></td>
-		<td>A valid attribute name supported by the element and be one of the following <code>href, src, data-*, aria-*, role, pattern, min, max, step, low, high</code>.</td>
+		<td>A valid attribute name supported by the element and be one of the following <code>href, src, data-*, aria-*, role, pattern, min, max, step, low, high, lang, hreflang, action</code>.</td>
 	</tr>
 	<tr>
 		<td><code>prop</code></td>

--- a/site/pages/docs/ref/wb-data-json/wb-data-json-fr.hbs
+++ b/site/pages/docs/ref/wb-data-json/wb-data-json-fr.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Insertion de contenu extrait d'un fichier JSON et prends avantage de l'élément template du HTML 5.",
 	"altLangPage": "wb-data-json-en.html",
-	"dateModified": "2017-01-31"
+	"dateModified": "2022-10-12"
 }
 ---
 <div class="wb-prettify all-pre"></div>
@@ -385,6 +385,7 @@
 </div></div>
 
 <h3>When the array key information will be lost</h3>
+<p>Because the object already contains a field named <code>@id</code></p>
 <div class="row">
 <div class="col-sm-6">
 <p>Source</p>
@@ -508,7 +509,7 @@
 		<td><code>attr</code></td>
 		<td>Specify the element attribute name. Only required when <code>type="attr"</code>.</td>
 		<td><code>data-wb-json='{ "url": "", "type": "attr", "attr": "href" }'</code></td>
-		<td>A valid attribute name supported by the element and be one of the following <code>href, src, data-*, aria-*, role, pattern, min, max, step, low, high</code>.</td>
+		<td>A valid attribute name supported by the element and be one of the following <code>href, src, data-*, aria-*, role, pattern, min, max, step, low, high, lang, hreflang, action</code>.</td>
 	</tr>
 	<tr>
 		<td><code>prop</code></td>

--- a/src/plugins/wb-data-json/data-json.js
+++ b/src/plugins/wb-data-json/data-json.js
@@ -27,7 +27,7 @@ var componentName = "wb-data-json",
 		"[data-" + shortName + "]"
 	],
 	allowJsonTypes = [ "after", "append", "before", "prepend", "val" ],
-	allowAttrNames = /(href|src|data-*|pattern|min|max|step|low|high)/,
+	allowAttrNames = /(href|src|data-*|aria-*|role|pattern|min|max|step|low|high|lang|hreflang|action)/,
 	allowPropNames = /(checked|selected|disabled|required|readonly|multiple|hidden)/,
 	selectorsLength = selectors.length,
 	selector = selectors.join( "," ),
@@ -325,10 +325,10 @@ var componentName = "wb-data-json",
 					}
 
 					// Set the value to the node
-					if ( $.isArray( cached_value ) ) {
-						applyTemplate( cached_node, j_cache, cached_value );
-					} else if ( j_cache.isHTML ) {
+					if ( j_cache.isHTML ) {
 						cached_node.innerHTML = cached_value;
+					} else if ( $.isArray( cached_value ) || cached_value && !( cached_value instanceof String ) && typeof cached_value === "object" ) {
+						applyTemplate( cached_node, j_cache, cached_value );
 					} else {
 						cached_node.textContent = cached_value;
 					}

--- a/src/plugins/wb-data-json/demo/data-en.json
+++ b/src/plugins/wb-data-json/demo/data-en.json
@@ -40,13 +40,33 @@
       "name": "Mr X",
       "city": "Gatineau",
       "somethingHTML": "<strong>Horay</strong> here rich HTML content",
-      "hobby": [ "Car", "Mechanic", "Race" ]
+      "hobby": [ "Car", "Mechanic", "Race" ],
+      "language": {
+        "en": {
+          "description": "description of Mr X",
+          "about": "About Mr X"
+        },
+        "fr": {
+          "description": "description de M. X",
+          "about": "À propos de M. X"
+        }
+      }
     },
     "2017-2": {
       "name": "Mrs Y",
       "city": "St-Pierre",
       "somethingHTML": "<strong>Youpi</strong> word should be with emphasis",
-      "hobby": [ "Spa", "Nature", "Bike", "Reading" ]
+      "hobby": [ "Spa", "Nature", "Bike", "Reading" ],
+      "language": {
+        "en": {
+          "description": "description of Mrs Y",
+          "about": "About Mrs Y"
+        },
+        "fr": {
+          "description": "description de Mme. Y",
+          "about": "À propos de Mme. Y"
+        }
+      }
     }
   }
 }

--- a/src/plugins/wb-data-json/demo/data-fr.json
+++ b/src/plugins/wb-data-json/demo/data-fr.json
@@ -40,13 +40,33 @@
       "nom": "M. X",
       "ville": "Gatineau",
       "quelquesChoseHTML": "<strong>Horay</strong> ici du contenu HTML enrichie",
-      "passetemps": [ "Voiture", "Mécanique", "Course" ]
+      "passetemps": [ "Voiture", "Mécanique", "Course" ],
+      "language": {
+        "fr": {
+          "description": "description de M. X",
+          "about": "À propos de M. X"
+        },
+        "en": {
+          "description": "description of Mr X",
+          "about": "About Mr X"
+        }
+      }
     },
     "2017-2": {
       "nom": "Mme. Y",
       "ville": "St-Pierre",
       "quelquesChoseHTML": "le mot <strong>Youpi</strong> devrais avoir de la mise en évidence",
-      "passetemps": [ "Spa", "Nature", "Bicyclette", "Lecture" ]
+      "passetemps": [ "Spa", "Nature", "Bicyclette", "Lecture" ],
+      "language": {
+        "fr": {
+          "description": "description de Mme. Y",
+          "about": "À propos de Mme. Y"
+        },
+        "en": {
+          "description": "description of Mrs Y",
+          "about": "About Mrs Y"
+        }
+      }
     }
   }
 }

--- a/src/plugins/wb-data-json/template-en.hbs
+++ b/src/plugins/wb-data-json/template-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "data-json",
 	"parentdir": "wb-data-json",
 	"altLangPage": "template-fr.html",
-	"dateModified": "2020-03-02"
+	"dateModified": "2022-10-12"
 }
 ---
 <!--
@@ -60,18 +60,38 @@
 	{ &quot;name&quot;: &quot;Location name example 10&quot;, &quot;num&quot;: 56, &quot;street&quot;: &quot;Victoria&quot;, &quot;city&quot;: &quot;Gatineau&quot;, &quot;postalCode&quot;: &quot;J8X 0N6&quot;, &quot;css&quot;: &quot;bg-danger&quot;, &quot;homeUrl&quot;: &quot;https://github.com/wet-boew&quot;, &quot;email&quot;: &quot;info10@example.com&quot; },
 	{ &quot;name&quot;: &quot;Location name example 11&quot;, &quot;num&quot;: 200, &quot;street&quot;: &quot;Slater&quot;, &quot;city&quot;: &quot;Ottawa&quot;, &quot;postalCode&quot;: &quot;J8T 0I8&quot;, &quot;css&quot;: &quot;bg-success&quot;, &quot;homeUrl&quot;: &quot;https://github.com/wet-boew&quot;, &quot;email&quot;: &quot;info11@example.com&quot; }
 	],
-	&quot;comments&quot;: {
-		&quot;2017-1&quot;: {
-			&quot;name&quot;: &quot;Mr X&quot;,
-			&quot;city&quot;: &quot;Gatineau&quot;,
-			&quot;somethingHTML&quot;: &quot;&lt;strong&gt;Horay&lt;/strong&gt; here rich HTML content&quot;,
-			&quot;hobby&quot;: [ &quot;Car&quot;, &quot;Mechanic&quot;, &quot;Race&quot; ]
+	"comments": {
+		"2017-1": {
+			"name": "Mr X",
+			"city": "Gatineau",
+			"somethingHTML": "&lt;strong&gt;Horay&lt;/strong&gt; here rich HTML content",
+			"hobby": [ "Car", "Mechanic", "Race" ],
+			"language": {
+				"en": {
+					"description": "description of Mr X",
+					"about": "About Mr X"
+				},
+				"fr": {
+					"description": "description de M. X",
+					"about": "À propos de M. X"
+				}
+			}
 		},
-		&quot;2017-2&quot;: {
-			&quot;name&quot;: &quot;Mrs Y&quot;,
-			&quot;city&quot;: &quot;St-Pierre&quot;,
-			&quot;somethingHTML&quot;: &quot;&lt;strong&gt;Youpi&lt;/strong&gt; word should be with emphasis&quot;,
-			&quot;hobby&quot;: [ &quot;Spa&quot;, &quot;Nature&quot;, &quot;Bike&quot;, &quot;Reading&quot; ]
+		"2017-2": {
+			"name": "Mrs Y",
+			"city": "St-Pierre",
+			"somethingHTML": "&lt;strong&gt;Youpi&lt;/strong&gt; word should be with emphasis",
+			"hobby": [ "Spa", "Nature", "Bike", "Reading" ],
+			"language": {
+				"en": {
+					"description": "description of Mrs Y",
+					"about": "About Mrs Y"
+				},
+				"fr": {
+					"description": "description de Mme. Y",
+					"about": "À propos de Mme. Y"
+				}
+			}
 		}
 	}
 }</code></pre>
@@ -336,7 +356,17 @@
 			{ "selector": ":nth-child(2)", "value": "/city", "placeholder": "[[city]]" },
 			{ "selector": ":nth-child(3)", "value": "/somethingHTML", "isHTML": true },
 
-			{ "selector": "ul", "value": "/hobby", "queryall": "li" }
+			{ "selector": "ul[data-object]", "value": "/language",
+				"source": "#externalSubTemplateExample",
+				"mapping": [
+					{ "selector": "[data-language]", "value": "/@id" },
+					{ "selector": "[data-about]", "value": "/about" },
+					{ "selector": "[data-about]", "value": "/@id", "attr": "lang" }
+				]
+			},
+
+			{ "selector": "ul[data-array]", "value": "/hobby", "queryall": "li" }
+
 		]
 	}'>
 	<template>
@@ -344,41 +374,65 @@
 			<h3></h3> <!-- Name -->
 			<p>From: [[city]]</p>
 			<p></p> <!-- Description -->
+			<!-- Sub-template (iterate object) -->
+			<p>About:</p>
+			<ul data-object>
+			</ul>
 			<h4>Hobby:</h4>
-			<ul class="lst-spcd"> <!-- Sub-template container -->
+			<ul class="lst-spcd" data-array> <!-- Sub-template (iterate array) -->
 				<template>
 					<li></li>
 				</template>
 			</ul>
 		</div>
 	</template>
+	<template id="externalSubTemplateExample">
+		<li>(<span data-language></span>) <span data-about lang></span></li>
+	</template>
 </div>
 
 
 <details>
 	<summary>Source code</summary>
-	<pre><code>&lt;div class=&quot;row&quot; data-wb-json='{
-		&quot;url&quot;: &quot;demo/data-en.json#/comments&quot;,
-		&quot;mapping&quot;: [
-			{ &quot;selector&quot;: &quot;h3&quot;, &quot;value&quot;: &quot;/name&quot; },
-			{ &quot;selector&quot;: &quot;:nth-child(2)&quot;, &quot;value&quot;: &quot;/city&quot;, &quot;placeholder&quot;: &quot;[[city]]&quot; },
-			{ &quot;selector&quot;: &quot;:nth-child(3)&quot;, &quot;value&quot;: &quot;/somethingHTML&quot;, &quot;isHTML&quot;: true },
+	<pre><code>&lt;div class="row" data-wb-json='{
+		"url": "demo/data-en.json#/comments",
+		"mapping": [
+			{ "selector": "h3", "value": "/name" },
+			{ "selector": ":nth-child(2)", "value": "/city", "placeholder": "[[city]]" },
+			{ "selector": ":nth-child(3)", "value": "/somethingHTML", "isHTML": true },
 
-			{ &quot;selector&quot;: &quot;ul&quot;, &quot;value&quot;: &quot;/hobby&quot;, &quot;queryall&quot;: &quot;li&quot; }
+			{ "selector": "ul[data-object]", "value": "/language",
+				"source": "#externalSubTemplateExample",
+				"mapping": [
+					{ "selector": "[data-language]", "value": "/@id" },
+					{ "selector": "[data-about]", "value": "/about" },
+					{ "selector": "[data-about]", "value": "/@id", "attr": "lang" }
+				]
+			},
+
+			{ "selector": "ul[data-array]", "value": "/hobby", "queryall": "li" }
+
 		]
 	}'&gt;
 	&lt;template&gt;
-		&lt;div class=&quot;col-md-6&quot;&gt;
+		&lt;div class="col-md-6"&gt;
 			&lt;h3&gt;&lt;/h3&gt; &lt;!-- Name --&gt;
 			&lt;p&gt;From: [[city]]&lt;/p&gt;
 			&lt;p&gt;&lt;/p&gt; &lt;!-- Description --&gt;
+			&lt;!-- Sub-template (iterate object) --&gt;
+			&lt;p&gt;About:&lt;/p&gt;
+			&lt;ul data-object&gt;
+			&lt;/ul&gt;
 			&lt;h4&gt;Hobby:&lt;/h4&gt;
-			&lt;ul class=&quot;lst-spcd&quot;&gt; &lt;!-- Sub-template container --&gt;
+			&lt;ul class="lst-spcd" data-array&gt; &lt;!-- Sub-template (iterate array) --&gt;
 				&lt;template&gt;
 					&lt;li&gt;&lt;/li&gt;
 				&lt;/template&gt;
 			&lt;/ul&gt;
 		&lt;/div&gt;
+	&lt;/template&gt;
+	&lt;template id="externalSubTemplateExample"&gt;
+		&lt;li&gt;(&lt;span data-language&gt;&lt;/span&gt;) &lt;span data-about lang&gt;&lt;/span&gt;&lt;/li&gt;
 	&lt;/template&gt;
 &lt;/div&gt;</code></pre>
 </details>

--- a/src/plugins/wb-data-json/template-fr.hbs
+++ b/src/plugins/wb-data-json/template-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "data-json",
 	"parentdir": "wb-data-json",
 	"altLangPage": "template-en.html",
-	"dateModified": "2022-03-02"
+	"dateModified": "2022-10-12"
 }
 ---
 <!--
@@ -66,13 +66,33 @@
 			&quot;nom&quot;: &quot;M. X&quot;,
 			&quot;ville&quot;: &quot;Gatineau&quot;,
 			&quot;quelquesChoseHTML&quot;: &quot;&lt;strong&gt;Horay&lt;/strong&gt; ici du contenu HTML enrichie&quot;,
-			&quot;passetemps&quot;: [ &quot;Voiture&quot;, &quot;Mécanique&quot;, &quot;Course&quot; ]
+			&quot;passetemps&quot;: [ &quot;Voiture&quot;, &quot;Mécanique&quot;, &quot;Course&quot; ],
+			"language": {
+				"fr": {
+					"description": "description de M. X",
+					"about": "À propos de M. X"
+				},
+				"en": {
+					"description": "description of Mr X",
+					"about": "About Mr X"
+				}
+			}
 		},
 		&quot;2017-2&quot;: {
 			&quot;nom&quot;: &quot;Mme. Y&quot;,
 			&quot;ville&quot;: &quot;St-Pierre&quot;,
 			&quot;quelquesChoseHTML&quot;: &quot;le mot &lt;strong&gt;Youpi&lt;/strong&gt; devrais avoir de la mise en évidence&quot;,
-			&quot;passetemps&quot;: [ &quot;Spa&quot;, &quot;Nature&quot;, &quot;Bicyclette&quot;, &quot;Lecture&quot; ]
+			&quot;passetemps&quot;: [ &quot;Spa&quot;, &quot;Nature&quot;, &quot;Bicyclette&quot;, &quot;Lecture&quot; ],
+			"language": {
+				"fr": {
+					"description": "description de Mme. Y",
+					"about": "À propos de Mme. Y"
+				},
+				"en": {
+					"description": "description of Mrs Y",
+					"about": "About Mrs Y"
+				}
+			}
 		}
 	}
 }</code></pre>
@@ -339,6 +359,15 @@
 			{ "selector": ":nth-child(2)", "value": "/ville", "placeholder": "[[ville]]" },
 			{ "selector": ":nth-child(3)", "value": "/quelquesChoseHTML", "isHTML": true },
 
+			{ "selector": "ul[data-object]", "value": "/language",
+				"source": "#gabaritExterneSousModele",
+				"mapping": [
+					{ "selector": "[data-language]", "value": "/@id" },
+					{ "selector": "[data-about]", "value": "/about" },
+					{ "selector": "[data-about]", "value": "/@id", "attr": "lang" }
+				]
+			},
+
 			{ "selector": "ul", "value": "/passetemps", "queryall": "li" }
 		]
 	}'>
@@ -347,41 +376,64 @@
 			<h3></h3> <!-- Nom -->
 			<p>De: [[ville]]</p>
 			<p></p> <!-- Description -->
+			<!-- Sous-modèle (Itération d'object) -->
+			<p>About:</p>
+			<ul data-object>
+			</ul>
 			<h4>Hobby:</h4>
-			<ul class="lst-spcd"> <!-- Conteneur du sous-modèle -->
+			<ul class="lst-spcd"> <!-- Sous-modèle (Itération de liste) -->
 				<template>
 					<li></li>
 				</template>
 			</ul>
 		</div>
 	</template>
+	<template id="gabaritExterneSousModele">
+		<li>(<span data-language></span>) <span data-about lang></span></li>
+	</template>
 </div>
 
 
 <details>
 	<summary>Source code</summary>
-	<pre><code>&lt;div class=&quot;row&quot; data-wb-json='{
-		&quot;url&quot;: &quot;demo/data-fr.json#/commentaire&quot;,
-		&quot;mapping&quot;: [
-			{ &quot;selector&quot;: &quot;h3&quot;, &quot;value&quot;: &quot;/nom&quot; },
-			{ &quot;selector&quot;: &quot;:nth-child(2)&quot;, &quot;value&quot;: &quot;/ville&quot;, &quot;placeholder&quot;: &quot;[[ville]]&quot; },
-			{ &quot;selector&quot;: &quot;:nth-child(3)&quot;, &quot;value&quot;: &quot;/quelquesChoseHTML&quot;, &quot;isHTML&quot;: true },
+	<pre><code>&lt;div class="row" data-wb-json='{
+		"url": "demo/data-fr.json#/commentaire",
+		"mapping": [
+			{ "selector": "h3", "value": "/nom" },
+			{ "selector": ":nth-child(2)", "value": "/ville", "placeholder": "[[ville]]" },
+			{ "selector": ":nth-child(3)", "value": "/quelquesChoseHTML", "isHTML": true },
 
-			{ &quot;selector&quot;: &quot;ul&quot;, &quot;value&quot;: &quot;/passetemps&quot;, &quot;queryall&quot;: &quot;li&quot; }
+			{ "selector": "ul[data-object]", "value": "/language",
+				"source": "#gabaritExterneSousModele",
+				"mapping": [
+					{ "selector": "[data-language]", "value": "/@id" },
+					{ "selector": "[data-about]", "value": "/about" },
+					{ "selector": "[data-about]", "value": "/@id", "attr": "lang" }
+				]
+			},
+
+			{ "selector": "ul", "value": "/passetemps", "queryall": "li" }
 		]
 	}'&gt;
 	&lt;template&gt;
-		&lt;div class=&quot;col-md-6&quot;&gt;
+		&lt;div class="col-md-6"&gt;
 			&lt;h3&gt;&lt;/h3&gt; &lt;!-- Nom --&gt;
 			&lt;p&gt;De: [[ville]]&lt;/p&gt;
 			&lt;p&gt;&lt;/p&gt; &lt;!-- Description --&gt;
+			&lt;!-- Sous-modèle (Itération d'object) --&gt;
+			&lt;p&gt;About:&lt;/p&gt;
+			&lt;ul data-object&gt;
+			&lt;/ul&gt;
 			&lt;h4&gt;Hobby:&lt;/h4&gt;
-			&lt;ul class=&quot;lst-spcd&quot;&gt; &lt;!-- Conteneur du sous-modèle --&gt;
+			&lt;ul class="lst-spcd"&gt; &lt;!-- Sous-modèle (Itération de liste) --&gt;
 				&lt;template&gt;
 					&lt;li&gt;&lt;/li&gt;
 				&lt;/template&gt;
 			&lt;/ul&gt;
 		&lt;/div&gt;
+	&lt;/template&gt;
+	&lt;template id="gabaritExterneSousModele"&gt;
+		&lt;li&gt;(&lt;span data-language&gt;&lt;/span&gt;) &lt;span data-about lang&gt;&lt;/span&gt;&lt;/li&gt;
 	&lt;/template&gt;
 &lt;/div&gt;</code></pre>
 </details>


### PR DESCRIPTION
This is minor change. 
* It allow object to be iterated for sub-template. This was already possible for template without sub-template.
* data can now be mapped into the following attribute: 
  * `lang` ease the JSON content mapping in pages in different languages
  * `hreflang` ease the JSON content mapping in pages in different languages
  * `aria-*` was documented but not allowed in the code
  * `role` was documented but not allowed in the code
  * `action` To be usable as form submission fallback solution.

Use case: To automate the insertion of component versioning information into each GCWeb component documentation page.
