### PR TITLE
Continuous Intergration - Update Ruby to v3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 2.7
+          ruby-version: 3.0
       - name: set up JDK 1.8
         uses: actions/setup-java@v1
         with:


### PR DESCRIPTION
Update line 21 in ci.yml document for ruby version from 2.7 to 3.0 in order to fix the build script.