### PR TITLE
Steps form: Add type to next previous buttons

### DIFF
--- a/src/plugins/stepsform/stepsform.js
+++ b/src/plugins/stepsform/stepsform.js
@@ -143,6 +143,7 @@ var componentName = "wb-steps",
 
 		// set default attributes
 		control.className = ( type === "prev" ? "btn btn-md btn-default" : "btn btn-md btn-primary" ) + " " + style;
+		control.setAttribute("type", "button");
 		control.innerHTML = text;
 
 		return control;

--- a/src/plugins/stepsform/stepsform.js
+++ b/src/plugins/stepsform/stepsform.js
@@ -143,7 +143,7 @@ var componentName = "wb-steps",
 
 		// set default attributes
 		control.className = ( type === "prev" ? "btn btn-md btn-default" : "btn btn-md btn-primary" ) + " " + style;
-		control.setAttribute("type", "button");
+		control.setAttribute( "type", "button" );
 		control.innerHTML = text;
 
 		return control;


### PR DESCRIPTION
Fix: The default WET action on pressing Enter in an input field is to trigger a click event on the first submit type button located on the form. Since the first button on a step form is often the generated "next" button on the first step and no type is specified for this button the form will open to the second step. Specifying the button type should fix this issue.

