### PR TITLE
Utility: adding flexbox utilities

### DIFF
--- a/src/base/_bootstrap-4.scss
+++ b/src/base/_bootstrap-4.scss
@@ -66,8 +66,16 @@
 	flex-direction: column !important;
 }
 
+.align-items-center {
+	align-items: center !important;
+}
+
 .align-self-center {
 	align-self: center !important;
+}
+
+.align-self-end {
+	align-self: flex-end !important;
 }
 
 /* Vertical alignment */

--- a/src/other/utility/utility-en.hbs
+++ b/src/other/utility/utility-en.hbs
@@ -254,7 +254,7 @@
 &lt;/div&gt;</code></pre>
 
 <h3><code>d-sm-flex</code></h3>
-<p>Set an element as a flexbox container and change its direct children into flex items in small view and over.</p>
+<p>Set an element as a flexbox container and change its direct children into flex items. To use when you only want the style applied for <code>sm</code> breakpoint and up.</p>
 <h4>Working example</h4>
 <div class="d-sm-flex">
 	<p class="well">Flex item</p>
@@ -313,8 +313,48 @@
 	&lt;p class="d-flex <strong>align-self-center</strong> mrgn-lft-md"&gt;Paragraph is vertically aligned with sibling image.&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 
+<h3><code>align-self-end</code></h3>
+<p>Vertically moves an element to the bottom. This is to be used jointly with the <a href="#d-flex"><code>d-flex</code> utility</a>.</p>
+<h4>Working example</h4>
+<div class="d-flex">
+	<img src="https://via.placeholder.com/100" alt="" class="d-flex mrgn-rght-md" />
+	<p class="d-flex align-self-end mrgn-lft-md">Paragraph is vertically moved to the bottom.</p>
+</div>
+<h4>Code sample</h4>
+<pre><code>&lt;div class="d-flex"&gt;
+	&lt;img src="https://via.placeholder.com/80" alt="" class="d-flex mrgn-rght-md" /&gt;
+	&lt;p class="d-flex <strong>align-self-end</strong> mrgn-lft-md"&gt;Paragraph is vertically moved to the bottom.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+
+<h3><code>align-items-center</code></h3>
+<p>Center-align a flexbox container's flex items. Useful for middle-aligning.</p>
+<h4>Working example</h4>
+<div class="row d-flex align-items-center">
+	<div class="col-xs-4">
+		<p class="well">Line 1<br />Line 2<br />Line 3<br />Line 4<br />Line 5</p>
+	</div>
+	<div class="col-xs-4">
+		<p class="well">Line 1<br />Line 2<br />Line 3</p>
+	</div>
+	<div class="col-xs-4">
+		<p class="well">Line 1</p>
+	</div>
+</div>
+<h4>Code sample</h4>
+<pre><code>&lt;div class="row d-flex <strong>align-items-center</strong>"&gt;
+	&lt;div class="col-xs-4"&gt;
+		&lt;p class="well"&gt;Line 1&lt;br /&gt;Line 2&lt;br /&gt;Line 3&lt;br /&gt;Line 4&lt;br /&gt;Line 5&lt;/p&gt;
+	&lt;/div&gt;
+	&lt;div class="col-xs-4"&gt;
+		&lt;p class="well"&gt;Line 1&lt;br /&gt;Line 2&lt;br /&gt;Line 3&lt;/p&gt;
+	&lt;/div&gt;
+	&lt;div class="col-xs-4"&gt;
+		&lt;p class="well"&gt;Line 1&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
 <h3><code>align-items-sm-center</code></h3>
-<p>Center-align a flexbox container's flex items in small view and over. Useful for middle-aligning.</p>
+<p>Center-align a flexbox container's flex items. Useful for middle-aligning. To use when you only want the style applied for <code>sm</code> breakpoint and up.</p>
 <h4>Working example</h4>
 <div class="row d-sm-flex align-items-sm-center">
 	<div class="col-xs-4">

--- a/src/other/utility/utility-fr.hbs
+++ b/src/other/utility/utility-fr.hbs
@@ -238,7 +238,7 @@
 <h2 id="flexbox" lang="en">Flexbox</h2>
 
 <h3 id="d-flex"><code>d-flex</code></h3>
-<p>Défini un élément en tant que conteneur "flex" et changer ses enfants directs en tant qu'éléments "flex".</p>
+<p>Défini un élément en tant que conteneur "flex" et change ses enfants directs en tant qu'éléments "flex".</p>
 <h4>Exemple pratique</h4>
 <div class="d-flex">
 	<p class="well">Élément flex</p>
@@ -251,9 +251,8 @@
 &lt;/div&gt;</code></pre>
 
 <h3><code>d-sm-flex</code></h3>
-<p>Set an element as a flexbox container and change its direct children into flex items in small view and over.</p>
-<p>Définissez un élément comme un conteneur «&nbsp;<span lang="en">flexbox</span>&nbsp;» et change ces enfants directs en éléments flex dans la petite vue et plus.</p>
-<h4>Example pratique</h4>
+<p>Défini un élément en tant que conteneur "flex" et change ses enfants directs en tant qu'éléments "flex". À utiliser lorsque vous souhaitez que le style soit appliqué uniquement pour les points d'arrêt <code>sm</code> et plus.</p>
+<h4>Exemple pratique</h4>
 <div class="d-sm-flex">
 	<p class="well">Élément flex</p>
 	<p class="well">Élément flex</p>
@@ -311,8 +310,48 @@
 	&lt;p class="d-flex <strong>align-self-center</strong> mrgn-lft-md"&gt;Paragraphe centré verticalement avec l'image à côté.&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 
+<h3><code>align-self-end</code></h3>
+<p>Aligne un élément au bas. Cet utilitaire doit être utilisé conjointement avec <a href="#d-flex">l'utilitaire <code>d-flex</code></a>.</p>
+<h4>Exemple pratique</h4>
+<div class="d-flex">
+	<img src="https://via.placeholder.com/100" alt="" class="d-flex mrgn-rght-md" />
+	<p class="d-flex align-self-end mrgn-lft-md">Paragraphe placé au bas verticalement avec l'image à côté.</p>
+</div>
+<h4>Exemple de code</h4>
+<pre><code>&lt;div class="d-flex"&gt;
+	&lt;img src="https://via.placeholder.com/80" alt="" class="d-flex mrgn-rght-md" /&gt;
+	&lt;p class="d-flex <strong>align-self-end</strong> mrgn-lft-md"&gt;Paragraphe placé au bas verticalement avec l'image à côté.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+
+<h3><code>align-items-center</code></h3>
+<p>Aligner au centre les éléments flex d'un conteneur flexbox. Utile pour l'alignement au centre.</p>
+<h4>Example pratique</h4>
+<div class="row d-flex align-items-center">
+	<div class="col-xs-4">
+		<p class="well">Ligne 1<br />Ligne 2<br />Ligne 3<br />Ligne 4<br />Ligne 5</p>
+	</div>
+	<div class="col-xs-4">
+		<p class="well">Ligne 1<br />Ligne 2<br />Ligne 3</p>
+	</div>
+	<div class="col-xs-4">
+		<p class="well">Ligne 1</p>
+	</div>
+</div>
+<h4>Exemple de code</h4>
+<pre><code>&lt;div class="row d-flex <strong>align-items-center</strong>"&gt;
+	&lt;div class="col-xs-4"&gt;
+		&lt;p class="well"&gt;Ligne 1&lt;br /&gt;Ligne 2&lt;br /&gt;Ligne 3&lt;br /&gt;Ligne 4&lt;br /&gt;Ligne 5&lt;/p&gt;
+	&lt;/div&gt;
+	&lt;div class="col-xs-4"&gt;
+		&lt;p class="well"&gt;Ligne 1&lt;br /&gt;Ligne 2&lt;br /&gt;Ligne 3&lt;/p&gt;
+	&lt;/div&gt;
+	&lt;div class="col-xs-4"&gt;
+		&lt;p class="well"&gt;Ligne 1&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
 <h3><code>align-items-sm-center</code></h3>
-<p>Aligner les éléments flex d'un conteneur «&nbsp;<span lang="en">flexbox</span>&nbsp;» dans la petite vue et plus. Utile pour aligner vers le milieu.</p>
+<p>Aligner au centre les éléments flex d'un conteneur flexbox. Utile pour l'alignement au centre. À utiliser lorsque vous souhaitez que le style soit appliqué uniquement pour les points d'arrêt <code>sm</code> et plus.</p>
 <h4>Example pratique</h4>
 <div class="row d-sm-flex align-items-sm-center">
 	<div class="col-xs-4">


### PR DESCRIPTION
This PR introduces the following flexbox utility classes:

- `.align-items-center`
- `.align-self-end`

I have also merged the documentation for `d-flex` and `d-sm-flex` as well as `align-items-center` and `align-items-sm-center` for better readability.

Changes related to WET-289.