### PR TITLE
Added alerts to Facebook plugin page

### DIFF
--- a/src/plugins/facebook/facebook-en.hbs
+++ b/src/plugins/facebook/facebook-en.hbs
@@ -7,10 +7,14 @@
 	"tag": "facebook",
 	"parentdir": "facebook",
 	"altLangPrefix": "facebook",
-	"dateModified": "2015-08-03"
+	"dateModified": "2022-10-28"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
+<section class="alert alert-info">
+	<h2>Facebook feeds may not display</h2>
+	<p>Please be advised that Facebook feeds may not display on certain browsers and/or by using certain extensions or proxy, due to additional privacy measures taken by those.</p>
+</section>
 
 <section>
 	<h2>Purpose</h2>

--- a/src/plugins/facebook/facebook-fr.hbs
+++ b/src/plugins/facebook/facebook-fr.hbs
@@ -7,10 +7,14 @@
 	"tag": "facebook",
 	"parentdir": "facebook",
 	"altLangPrefix": "facebook",
-	"dateModified": "2015-08-03"
+	"dateModified": "2022-10-28"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
+<section class="alert alert-info">
+	<h2>Flux de Facebook pourraient ne pas s'afficher</h2>
+	<p>Flux de Facebook pourraient ne pas s'afficher sur certains navigateurs et/ou en utilisant certaines extensions ou proxy, dues à des mesures additionelles de confidentialités prises par ces derniers.</p>
+</section>
 
 <section>
 	<h2>Purpose</h2>


### PR DESCRIPTION
## What does this pull request (PR) do? 
This pull request adds an alert to the Facebook embedded pages plugin on wet-boew for both the English and French pages informing users that the plugin might  not display on certain browsers or if they are using certain extensions or proxies, due to additional privacy measures taken by those. 

**General checklist**
- [x] Updated documentation to include the alert
- [x] PR's code has been built and tested
- [x] Ensured documentation is bilingual

**Related issues**
This pull request was done for the WET-253 ticket in JIRA

**Screenshots**
English Page:
![image](https://user-images.githubusercontent.com/75642614/198709682-4ee07476-7832-47f0-b352-03abeeafff41.png)


French Page:
![image](https://user-images.githubusercontent.com/75642614/198709983-e91e3699-2850-4041-8a75-e8aee51cbf5f.png)

