### PR TITLE
json-manager: build json source from dom nodes

### DIFF
--- a/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-en.hbs
+++ b/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-en.hbs
@@ -456,6 +456,28 @@
 			</dl>
 		</td>
 	</tr>
+	<tr>
+		<td><code>extractor</code></td>
+		<td>To be used when the dataset is build from the curent page and no JSON <code>url</code> is provided. Array of objects containing html selectors with their specific paths.</td>
+		<td><code>data-wb-jsonmanager='{ "name": "ex1",	"extractor": ' [ { selector object, (any additional parameter as per the extraction type) } ] }'</code></td>
+		<td>
+			<p>The selector object can have the following properties</p>
+			<dl>
+			<dt><code>selector</code></dt>
+			<dd>Indicate what html element to be selected from the page</dd>
+			<dt><code>path</code></dt>
+			<dd>Required. JSON pointer to the data being evaluated</dd>
+			<dt><code>selectAll</code></dt>
+			<dd>Indicate if should extract all html elements specified in the <code>selector</code>. If not used, it will extract only the first founded.</dd>
+			<dt><code>attr</code></dt>
+			<dd>Indicate if the value should be extracted from the specified tag attribute instead of the specified tag text</dd>
+			<dt><code>interface</code></dt>
+			<dd>Predefined properties that will store the values from: the <code>document.referrer</code> for <code>referer</code>", <code>location.href</code> for <code>locationHref</code></dd>
+			<dt><code>extractor</code></dt>
+			<dd>Used for combined selectors e.g. description lists. Same principle as for <code>extractor</code> configuration option, it is an array of objects containing html selectors with their specific paths.</dd>
+			</dl>
+		</td>
+	</tr>
 </tbody>
 </table>
 <h3 id="evalobj">Filtering (evaluation object)</h3>
@@ -484,6 +506,58 @@
 <td><code>optional</code></td>
 <td><code>{ "filter": [ { "optional": true } ] &hellip;}'</code> or <code>{ "filternot": [ { "optional": true } ] &hellip;}'</code></td>
 <td>True or false. If omited it will be false by default.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="extractobj">Extractor (selector object)</h3>
+<table class="table">
+<thead>
+<tr>
+<th>Option</th>
+<th>How to configure</th>
+<th>Values and clarification</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>selector</code></td>
+<td><code>{ "extractor": [ { "selector": "h2" } ] &hellip;}</code> or <code>{ "extractor": [ { "selector": "dl[data-dl]" } ] &hellip;}</code></td>
+<td>A valid css selector for any html element from the page </td>
+</tr>
+<tr>
+<td><code>path</code></td>
+<td><code>{ "extractor": [ { "path": "firstH2" } ] &hellip;}</code> or <code>{ "extractor": [ { "path": "myGroup" } ] &hellip;}</code></td>
+<td>The value of this property will be the pointer in the JSON object dataset that will be created</td>
+</tr>
+<tr>
+<td><code>selectAll</code></td>
+<td><code>{ "extractor": [ { "selectAll": true } ] &hellip;}</code> </td>
+<td>If true, it will search in the page for  all the html elements indicated in the <code>selector</code> property</td>
+</tr>
+<tr>
+<td><code>attr</code></td>
+<td><code>{ "extractor": [ { "attr":"data-td" } ] &hellip;}</code> </td>
+<td>If present, it will collect the value from the specified attribute for the mentioned selector instead of the text value of the <code>selector</code> property</td>
+</tr>
+<tr>
+<td><code>interface</code></td>
+<td><code>{ "extractor": [ { "interface":"referer" } ] &hellip;}</code> or <code>{ "extractor": [ { "interface":"locationHref" } ] &hellip;}</code> </td>
+<td>If present, it will collect the value from predefined properties as follows <span class="text-muted">(This list is not exhaustive):</span>
+	<ul><li><code>referer</code> is assigned for the <code>document.referrer</code> value</li><li><code>locationHref</code> is assigned for <code>location.href</code> value</li></ul></td>
+</tr>
+<tr>
+<td><code>extractor</code></td>
+<td><code>{ "extractor": [ { "extractor":[ {
+									"selector": "dt",
+									"path": "title",
+									"attr":"data-td"
+								},
+								{
+									"selector": "dd",
+									"path": "desc"
+								}] } ] &hellip;}</code> </td>
+<td>Used for combined selectors e.g. description lists. Same configuration as for outer <code>extractor</code> option, it is an array of objects containing html selectors with their specific paths.
+
 </tr>
 </tbody>
 </table>

--- a/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-fr.hbs
+++ b/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-fr.hbs
@@ -494,6 +494,28 @@
 			</dl>
 		</td>
 	</tr>
+	<tr>
+		<td><code>extractor</code></td>
+		<td>To be used when the dataset is build from the curent page and no JSON <code>url</code> is provided. Array of objects containing html selectors with their specific paths.</td>
+		<td><code>data-wb-jsonmanager='{ "name": "ex1",	"extractor": ' [ { selector object, (any additional parameter as per the extraction type) } ] }'</code></td>
+		<td>
+			<p>The selector object can have the following properties</p>
+			<dl>
+			<dt><code>selector</code></dt>
+			<dd>Indicate what html element to be selected from the page</dd>
+			<dt><code>path</code></dt>
+			<dd>Required. JSON pointer to the data being evaluated</dd>
+			<dt><code>selectAll</code></dt>
+			<dd>Indicate if should extract all html elements specified in the <code>selector</code>. If not used, it will extract only the first founded.</dd>
+			<dt><code>attr</code></dt>
+			<dd>Indicate if the value should be extracted from the specified tag attribute instead of the specified tag text</dd>
+			<dt><code>interface</code></dt>
+			<dd>Predefined properties that will store the values from: the <code>document.referrer</code> for <code>referer</code>", <code>location.href</code> for <code>locationHref</code></dd>
+			<dt><code>extractor</code></dt>
+			<dd>Used for combined selectors e.g. description lists. Same principle as for <code>extractor</code> configuration option, it is an array of objects containing html selectors with their specific paths.</dd>
+			</dl>
+		</td>
+	</tr>
 	</tbody>
 	</table>
 
@@ -526,6 +548,59 @@
 	</tr>
 	</tbody>
 	</table>
+	<h3 id="extractobj">Extractor (selector object)</h3>
+<table class="table">
+<thead>
+<tr>
+<th>Option</th>
+<th>How to configure</th>
+<th>Values and clarification</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>selector</code></td>
+<td><code>{ "extractor": [ { "selector": "h2" } ] &hellip;}</code> or <code>{ "extractor": [ { "selector": "dl[data-dl]" } ] &hellip;}</code></td>
+<td>A valid css selector for any html element from the page </td>
+</tr>
+<tr>
+<td><code>path</code></td>
+<td><code>{ "extractor": [ { "path": "firstH2" } ] &hellip;}</code> or <code>{ "extractor": [ { "path": "myGroup" } ] &hellip;}</code></td>
+<td>The value of this property will be the pointer in the JSON object dataset that will be created</td>
+</tr>
+<tr>
+<td><code>selectAll</code></td>
+<td><code>{ "extractor": [ { "selectAll": true } ] &hellip;}</code> </td>
+<td>If true, it will search in the page for  all the html elements indicated in the <code>selector</code> property</td>
+</tr>
+<tr>
+<td><code>attr</code></td>
+<td><code>{ "extractor": [ { "attr":"data-td" } ] &hellip;}</code> </td>
+<td>If present, it will collect the value from the specified attribute for the mentioned selector instead of the text value of the <code>selector</code> property</td>
+</tr>
+<tr>
+<td><code>interface</code></td>
+<td><code>{ "extractor": [ { "interface":"referer" } ] &hellip;}</code> or <code>{ "extractor": [ { "interface":"locationHref" } ] &hellip;}</code> </td>
+<td>If present, it will collect the value from predefined properties as follows <span class="text-muted">(This list is not exhaustive):</span>
+	<ul><li><code>referer</code> is assigned for the <code>document.referrer</code> value</li><li><code>locationHref</code> is assigned for <code>location.href</code> value</li></ul></td>
+</tr>
+<tr>
+<td><code>extractor</code></td>
+<td><code>{ "extractor": [ { "extractor":[ {
+									"selector": "dt",
+									"path": "title",
+									"attr":"data-td"
+								},
+								{
+									"selector": "dd",
+									"path": "desc"
+								}] } ] &hellip;}</code> </td>
+<td>Used for combined selectors e.g. description lists. Same configuration as for outer <code>extractor</code> option, it is an array of objects containing html selectors with their specific paths.
+
+</tr>
+</tbody>
+</table>
+
 
 </section>
 

--- a/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "jsonmanager",
 	"parentdir": "wb-jsonmanager",
 	"altLangPage": "jsonmanager-fr.html",
-	"dateModified": "2017-02-02"
+	"dateModified": "2022-10-31"
 }
 ---
 <!--
@@ -344,4 +344,291 @@
 	&quot;patches&quot;: { &quot;op&quot;: &quot;wb-count&quot;, &quot;path&quot;: &quot;/products&quot;, &quot;set&quot;: &quot;/nbproduct&quot; },
 	&quot;debug&quot;: true
 }'&gt;Number of products: &lt;span data-json-replace=&quot;#[example3]/nbproduct&quot;&gt;Not available&lt;/span&gt;&lt;/p&gt;</code></pre>
+</details>
+
+<h2>Extract the data from the DOM nodes to build the data source JSON object</h2>
+<p>Use <code>replace</code> and <code>mapping</code> on the same JSON data source</p>
+<div data-wb-jsonmanager='{
+		"name": "ex1",
+		"extractor": [
+						{ "selector": "title", "path": "pageTitle" },
+						{ "selector": "h2", "path": "firstH2" },
+						{ "selector": "h4", "path": "allH4", "selectAll": true }
+					],
+		"wraproot": "rootArray"
+}'>
+	<p> The page title is: <span data-json-replace="#[ex1]/rootArray/pageTitle">Not available</span></p>
+	<p> The first H2 is: <span data-json-replace="#[ex1]/rootArray/firstH2">Not available</span></p>
+	<p>All h4 from the page:</p>
+	<ul data-wb-json='{
+						"url": "#[ex1]/rootArray/allH4",
+						"mapping": [
+							{ "selector": "li" }
+						]
+					}'>
+		<template>
+			<li></li>
+		</template>
+	</ul>
+</div>
+
+<details>
+	<summary>View source code</summary>
+<pre><code>
+&lt;div data-wb-jsonmanager='{
+		&quot;name&quot;: &quot;ex1&quot;,
+		&quot;extractor&quot;: [
+			{ &quot;selector&quot;: &quot;title&quot;, &quot;path&quot;: &quot;pageTitle&quot; },
+			{ &quot;selector&quot;: &quot;h2&quot;, &quot;path&quot;: &quot;firstH2&quot; },
+			{ &quot;selector&quot;: &quot;h4&quot;, &quot;path&quot;: &quot;allH4&quot;, &quot;selectAll&quot;: true }
+		],
+		&quot;wraproot&quot;: &quot;rootArray&quot;
+	}'&gt;
+	&lt;p&gt;The page title is: &lt;span data-json-replace=&quot;#[ex1]/rootArray/pageTitle&quot;&gt;Not available&lt;/span&gt;&lt;/p&gt;
+	&lt;p&gt;The first H2 is: &lt;span data-json-replace=&quot;#[ex1]/rootArray/firstH2&quot;&gt;Not available&lt;/span&gt;&lt;/p&gt;
+	&lt;p&gt;All H4 from the page:&lt;/p&gt;
+	&lt;ul data-wb-json='{
+			&quot;url&quot;: &quot;#[ex1]/rootArray/allH4&quot;,
+			&quot;mapping&quot;: [
+				{ &quot;selector&quot;: &quot;li&quot; }
+			]
+		}'&gt;
+		&lt;template&gt;
+			&lt;li&gt;&lt;/li&gt;
+		&lt;/template&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+<h3>Grouping selectors on the same JSON data source</h3>
+<p>The description list below is the source of the combined selectors:</p>
+<dl data-dl="test">
+	<dt data-td="data-title-1">Title 1</dt>
+	<dd>Description 1</dd>
+
+	<dt data-td="data-title-2">Title 2</dt>
+	<dd>Description 2</dd>
+
+	<dt>Title 3</dt>
+	<dd>Description 3</dd>
+</dl>
+
+<div data-wb-jsonmanager='{
+		"name": "ex2",
+		"url": "demo/data-en.json",
+		"extractor": [
+						{ "selector": "title", "path": "pageTitle" },
+						{ "selector": "h2", "path": "firstH2" },
+						{
+							"selector": "dl[data-dl]",
+							"path": "myGroup",
+							"extractor": [
+								{
+									"selector": "dt",
+									"path": "title",
+									"attr":"data-td"
+								},
+								{
+									"selector": "dd",
+									"path": "desc"
+								}
+							]
+						}
+					]
+		}'>
+	<p>Output in a table the combined selectors values :</p>
+	<table class="table table-striped">
+		<thead>
+			<tr data-wb-json='{
+				"url": "#[ex2]/myGroup",
+				"mapping": [
+					{ "selector": "th", "value": "/title" }
+				]
+				}'>
+				<template>
+					<th></th>
+				</template>
+			</tr>
+		</thead>
+		<tbody>
+			<tr data-wb-json='{
+				"url": "#[ex2]/myGroup",
+				"mapping": [
+					{ "selector": "td", "value": "/desc" }
+				]
+				}'>
+				<template>
+					<td></td>
+				</template>
+			</tr>
+		</tbody>
+	</table>
+	<p> The page title is: <span data-json-replace="#[ex2]/pageTitle">Not available</span></p>
+	<p> The first H2 is: <span data-json-replace="#[ex2]/firstH2">Not available</span></p>
+</div>
+<details>
+	<summary>View source code</summary>
+
+	<h3>HTML</h3>
+	<pre><code>
+&lt;div data-wb-jsonmanager='{
+		&quot;name&quot;: &quot;ex2&quot;,
+		&quot;url&quot;: &quot;demo/data-en.json&quot;,
+		&quot;extractor&quot;: &#91;
+			{ &quot;selector&quot;: &quot;title&quot;, &quot;path&quot;: &quot;pageTitle&quot; },
+			{ &quot;selector&quot;: &quot;h2&quot;, &quot;path&quot;: &quot;firstH2&quot; },
+			{
+				&quot;selector&quot;: &quot;dl&#91;data-dl&#93;&quot;,
+				&quot;path&quot;: &quot;myGroup&quot;,
+				&quot;extractor&quot;: &#91;
+					{
+						&quot;selector&quot;: &quot;dt&quot;,
+						&quot;path&quot;: &quot;title&quot;,
+						&quot;attr&quot;:&quot;data-td&quot;
+					},
+					{
+						&quot;selector&quot;: &quot;dd&quot;,
+						&quot;path&quot;: &quot;desc&quot;
+					}
+				&#93;
+			}
+		&#93;
+	}'&gt;
+
+	&lt;p&gt;Output in a table the combined selectors values :&lt;/p&gt;
+	&lt;table class=&quot;table table-striped&quot;&gt;
+		&lt;thead&gt;
+			&lt;tr data-wb-json='{
+				&quot;url&quot;: &quot;#[ex2]/myGroup&quot;,
+				&quot;mapping&quot;: [
+					{ &quot;selector&quot;: &quot;th&quot;, &quot;value&quot;: &quot;/title&quot; }
+				]
+				}'&gt;
+				&lt;template&gt;
+					&lt;th&gt;&lt;/th&gt;
+				&lt;/template&gt;
+			&lt;/tr&gt;
+		&lt;/thead&gt;
+		&lt;tbody&gt;
+			&lt;tr data-wb-json='{
+				&quot;url&quot;: &quot;#[ex2]/myGroup&quot;,
+				&quot;mapping&quot;: [
+					{ &quot;selector&quot;: &quot;td&quot;, &quot;value&quot;: &quot;/desc&quot; }
+				]
+				}'&gt;
+				&lt;template&gt;
+					&lt;td&gt;&lt;/td&gt;
+				&lt;/template&gt;
+			&lt;/tr&gt;
+		&lt;/tbody&gt;
+	&lt;/table&gt;
+	&lt;p&gt; The page title is: &lt;span data-json-replace=&quot;#[ex2]/pageTitle&quot;&gt;Not available&lt;/span&gt;&lt;/p&gt;
+	&lt;p&gt; The first H2 is: &lt;span data-json-replace=&quot;#[ex2]/firstH2&quot;&gt;Not available&lt;/span&gt;&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+
+<h3>Extract values from tag attributes or extract all specific tags values:</h3>
+<div data-wb-jsonmanager='{
+		"name": "ex3",
+		"extractor": [
+
+						{ "path": "/formfields/pageTitle", "selector": "title" },
+						{ "path": "/formfields/lang", "attr":"lang", "selector": "html" },
+						{ "path": "/formfields/externalReferer", "interface": "referer" },
+						{ "path": "/formfields/submissionPage", "interface": "locationHref" },
+						{ "selector": "h2", "path": "allH2", "selectAll":true },
+						{ "selector": "h3", "path": "allH3", "selectAll":true }
+					],
+		"patches": { "op": "wb-count", "path": "/allH3", "set": "/nbH3Total" }
+		}'>
+	<div data-wb-json='{
+						"url": "#[ex3]/formfields",
+						"mapping": [
+							{ "selector": "input", "attr": "name", "value": "/@id" },
+							{ "selector": "input", "attr": "value", "value": "/@value" }
+						]
+					}'>
+		<template>
+			<input type="text" name="" value="">
+		</template>
+	</div>
+
+	<p>All H2 from the page:</p>
+	<ul data-wb-json='{
+		"url": "#[ex3]/allH2",
+		"mapping": [
+			{ "selector": "li" }
+		]
+	}'>
+		<template>
+			<li></li>
+		</template>
+	</ul>
+
+	<p>All H3 from the page (<span data-json-replace="#[ex3]/nbH3Total">unknown</span> instances):</p>
+	<ul data-wb-json='{
+						"url": "#[ex3]/allH3",
+						"mapping": [
+							{ "selector": "li" }
+						]
+					}'>
+		<template>
+			<li></li>
+		</template>
+	</ul>
+</div>
+
+<details>
+	<summary>View source code</summary>
+
+	<h3>HTML</h3>
+	<pre><code>
+&lt;div data-wb-jsonmanager='{
+		&quot;name&quot;: &quot;ex3&quot;,
+		&quot;extractor&quot;: [
+			{ &quot;path&quot;: &quot;/formfields/pageTitle&quot;, &quot;selector&quot;: &quot;title&quot; },
+			{ &quot;path&quot;: &quot;/formfields/lang&quot;, &quot;attr&quot;:&quot;lang&quot;, &quot;selector&quot;: &quot;html&quot; },
+			{ &quot;path&quot;: &quot;/formfields/externalReferer&quot;, &quot;interface&quot;: &quot;referer&quot; },
+			{ &quot;path&quot;: &quot;/formfields/submissionPage&quot;, &quot;interface&quot;: &quot;locationHref&quot; },
+			{ &quot;selector&quot;: &quot;h2&quot;, &quot;path&quot;: &quot;allH2&quot;, &quot;selectAll&quot;:true },
+			{ &quot;selector&quot;: &quot;h3&quot;, &quot;path&quot;: &quot;allH3&quot;, &quot;selectAll&quot;:true }
+		],
+		&quot;patches&quot;: { &quot;op&quot;: &quot;wb-count&quot;, &quot;path&quot;: &quot;/allH3&quot;, &quot;set&quot;: &quot;/nbH3Total&quot; }
+	}'&gt;
+
+	&lt;div data-wb-json='{
+			&quot;url&quot;: &quot;#[ex3]/formfields&quot;,
+			&quot;mapping&quot;: [
+				{ &quot;selector&quot;: &quot;input&quot;, &quot;attr&quot;: &quot;name&quot;, &quot;value&quot;: &quot;/@id&quot; },
+				{ &quot;selector&quot;: &quot;input&quot;, &quot;attr&quot;: &quot;name&quot;, &quot;value&quot;: &quot;/@value&quot; }
+			]
+		}'&gt;
+		&lt;template&gt;
+			&lt;input type=&quot;text&quot; name=&quot;&quot; value=&quot;&quot; &gt;
+		&lt;/template&gt;
+	&lt;/div&gt;
+	&lt;p&gt;All H2 from the page:&lt;/p&gt;
+	&lt;ul data-wb-json='{
+						&quot;url&quot;: &quot;#[ex3]/allH2&quot;,
+						&quot;mapping&quot;: [
+							{ &quot;selector&quot;: &quot;li&quot; }
+						]
+					}'&gt;
+		&lt;template&gt;
+			&lt;li&gt;&lt;/li&gt;
+		&lt;/template&gt;
+	&lt;/ul&gt;
+	&lt;p&gt;All H3 from the page (&lt;span data-json-replace=&quot;#[ex3]/nbH3Total&quot;&gt;unknown&lt;/span&gt; instances):&lt;/p&gt;
+	&lt;ul data-wb-json='{
+						&quot;url&quot;: &quot;#[ex3]/allH3&quot;,
+						&quot;mapping&quot;: [
+							{ &quot;selector&quot;: &quot;li&quot; }
+						]
+					}'&gt;
+		&lt;template&gt;
+			&lt;li&gt;&lt;/li&gt;
+		&lt;/template&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
 </details>

--- a/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "jsonmanager",
 	"parentdir": "wb-jsonmanager",
 	"altLangPage": "jsonmanager-en.html",
-	"dateModified": "2017-02-02"
+	"dateModified": "2022-10-31"
 }
 ---
 <!--
@@ -343,4 +343,286 @@
 	&quot;patches&quot;: { &quot;op&quot;: &quot;wb-count&quot;, &quot;path&quot;: &quot;/produits&quot;, &quot;set&quot;: &quot;/nbproduit&quot; },
 	&quot;debug&quot;: true
 }'&gt;Nombre de produits: &lt;span data-json-replace=&quot;#[exemple3]/nbproduit&quot;&gt;Non disponible&lt;/span&gt;&lt;/p&gt;</code></pre>
+</details>
+
+<h2>Extraire les données des nœuds DOM pour créer l'objet JSON de la source de données</h2>
+	<p>Utilisez <code>replace</code> et <code>mappage</code> sur la même source de données JSON</p>
+<div data-wb-jsonmanager='{
+	"name": "ex1",
+	"extractor": [
+					{ "selector": "title", "path": "pageTitle" },
+					{ "selector": "h2", "path": "firstH2" },
+					{ "selector": "h4", "path": "allH4", "selectAll": true }
+				],
+	"wraproot": "rootArray"
+}'>
+	<p> Le titre de la page est : <span data-json-replace="#[ex1]/rootArray/pageTitle">Non disponible</span></p>
+	<p> Le premier H2 est : <span data-json-replace="#[ex1]/rootArray/firstH2">Non disponible</span></p>
+	<p>Tous les H4 de la page :</p>
+	<ul data-wb-json='{
+						"url": "#[ex1]/rootArray/allH4",
+						"mapping": [
+							{ "selector": "li" }
+						]
+					}'>
+		<template>
+			<li></li>
+		</template>
+	</ul>
+</div>
+
+<details>
+<summary>Afficher le code source</summary>
+<pre><code>
+&lt;p&gt;Utilisez &lt;code&gt;replace&lt;/code&gt; et &lt;code&gt;mapping&lt;/code&gt; sur la même source de données JSON&lt;/p&gt;
+
+&lt;div data-wb-jsonmanager='{
+		&quot;name&quot; : &quot;ex1&quot;,
+		&quot;extractor&quot; : [
+			{ &quot;selector&quot; : &quot;title&quot;, &quot;path&quot; : &quot;pageTitle&quot; },
+			{ &quot;selector&quot; : &quot;h2&quot;, &quot;path&quot; : &quot;firstH2&quot;},
+			{ &quot;selector&quot; : &quot;h4&quot;, &quot;path&quot; : &quot;allH4&quot;, &quot;selectAll&quot; : true}
+		],
+		&quot;wraproot&quot;: &quot;rootArray&quot;
+	}'>
+	&lt;p&gt;Le titre de la page est : &lt;span data-json-replace=&quot;#[ex1]/rootArray/pageTitle&quot;&gt;Non disponible&lt;/span&gt;&lt;/p&gt;
+	&lt;p&gt;Le premier H2 est : &lt;span data-json-replace="#[ex1]/rootArray/firstH2&quot;&gt;Non disponible&lt;/span&gt;&lt;/p&gt;
+	&lt;p&gt;Tous les H4 de la page :&lt;/p&gt;
+	&lt;ul data-wb-json='{
+			&quot;url&quot; : &quot;#[ex1]/rootArray/allH4&quot;,
+				&quot;mapping&quot; : [
+					{ &quot;selector&quot; : &quot;li&quot; }
+				]
+		}'>
+		&lt;template&gt;
+			&lt;li&gt;&lt;/li&gt;
+		&lt;/template&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
+<h3>Regrouper les sélecteurs sur la même source de données JSON</h3>
+<p>La liste de description ci-dessous est la source des sélecteurs combinés :</p>
+<dl data-dl="test">
+	<dt data-td="data-title-1">Titre 1</dt>
+	<dd>Description 1</dd>
+
+	<dt data-td="data-title-2">Titre 2</dt>
+	<dd>Description 2</dd>
+
+	<dt>Titre 3</dt>
+	<dd>Description 3</dd>
+</dl>
+
+<div data-wb-jsonmanager='{
+		"name": "ex2",
+		"url": "demo/data-en.json",
+		"extractor": [
+			{ "selector": "title", "path": "pageTitle" },
+			{ "selector": "h2", "path": "firstH2" },
+			{
+				"selector": "dl[data-dl]",
+				"path": "monGroup",
+				"extractor": [
+					{
+						"selector": "dt",
+						"path": "title",
+						"attr":"data-td"
+					},
+					{
+						"selector": "dd",
+						"path": "desc"
+					}
+
+				]
+			}
+		]
+}'>
+	<p>Afficher dans un tableau les valeurs combinées des sélecteurs :</p>
+	<table class="table table-striped">
+		<thead>
+			<tr data-wb-json='{
+				"url": "#[ex2]/monGroup",
+				"mapping": [
+					{ "selector": "th", "value": "/title" }
+				]
+				}'>
+				<template>
+					<th></th>
+				</template>
+			</tr>
+		</thead>
+		<tbody>
+			<tr data-wb-json='{
+				"url": "#[ex2]/monGroup",
+				"mapping": [
+					{ "selector": "td", "value": "/desc" }
+				]
+				}'>
+				<template>
+					<td></td>
+				</template>
+			</tr>
+		</tbody>
+	</table>
+	<p> Le titre de la page est: <span data-json-replace="#[ex2]/pageTitle">Indisponible</span></p>
+	<p> Le premier H2 est: <span data-json-replace="#[ex2]/firstH2">Indisponible</span></p>
+</div>
+<details>
+	<summary>Afficher le code source</summary>
+
+	<h3>HTML</h3>
+	<pre><code>
+&lt;div data-wb-jsonmanager='{
+		&quot;name&quot;: &quot;ex2&quot;,
+		&quot;extractor&quot;: [
+			{ &quot;selector&quot;: &quot;title&quot;, &quot;path&quot;: &quot;pageTitle&quot; },
+			{ &quot;selector&quot;: &quot;h2&quot;, &quot;path&quot;: &quot;firstH2&quot; },
+			{ &quot;selector&quot;: &quot;dl&#91;data-dl&#93;&quot;, &quot;path&quot;: &quot;monGroup&quot;, &quot;extractor&quot;: &#91;
+				{
+					&quot;selector&quot;: &quot;dt&quot;,
+					&quot;path&quot;: &quot;title&quot;,
+					&quot;attr&quot;:&quot;data-td&quot;
+				},
+				{
+					&quot;selector&quot;: &quot;dd&quot;,
+					&quot;path&quot;: &quot;desc&quot;
+				} &#93;&quot;}
+		]
+	}'&gt;
+
+	&lt;table class=&quot;table table-striped&quot;&gt;
+		&lt;thead&gt;
+			&lt;tr data-wb-json='{
+				&quot;url&quot;: &quot;#[ex2]/monGroup&quot;,
+				&quot;mapping&quot;: [
+					{ &quot;selector&quot;: &quot;th&quot;, &quot;value&quot;: &quot;/title&quot; }
+				]
+				}'&gt;
+				&lt;template&gt;
+					&lt;th&gt;&lt;/th&gt;
+				&lt;/template&gt;
+			&lt;/tr&gt;
+		&lt;/thead&gt;
+		&lt;tbody&gt;
+			&lt;tr data-wb-json='{
+				&quot;url&quot;: &quot;#[ex2]/monGroup&quot;,
+				&quot;mapping&quot;: [
+					{ &quot;selector&quot;: &quot;td&quot;, &quot;value&quot;: &quot;/desc&quot; }
+				]
+				}'&gt;
+				&lt;template&gt;
+					&lt;td&gt;&lt;/td&gt;
+				&lt;/template&gt;
+			&lt;/tr&gt;
+		&lt;/tbody&gt;
+	&lt;/table&gt;
+	&lt;p&gt; Le titre de la page est: &lt;span data-json-replace=&quot;#[ex2]/pageTitle&quot;&gt;Indisponible&lt;/span&gt;&lt;/p&gt;
+	&lt;p&gt; Le premier H2 est: &lt;span data-json-replace=&quot;#[ex2]/firstH2&quot;&gt;Indisponible&lt;/span&gt;&lt;/p&gt;
+
+
+&lt;/div&gt;</code></pre>
+</details>
+
+
+<h3>Extraire les valeurs des attributs de balises ou extraire toutes les valeurs de balises spécifiques :</h3>
+<div data-wb-jsonmanager='{
+		"name": "ex3",
+		"extractor": [
+						{ "path": "/formfields/pageTitle", "selector": "title" },
+						{ "path": "/formfields/lang", "attr":"lang", "selector": "html" },
+						{ "path": "/formfields/externalReferer", "interface": "referer" },
+						{ "path": "/formfields/submissionPage", "interface": "locationHref" },
+						{ "selector": "h2", "path": "allH2", "selectAll":true },
+						{ "selector": "h3", "path": "allH3", "selectAll":true }
+					],
+		"patches": { "op": "wb-count", "path": "/allH3", "set": "/nbH3Total" }
+	}'>
+	<div data-wb-json='{
+						"url": "#[ex3]/formfields",
+						"mapping": [
+								{ "selector": "input", "attr": "name", "value": "/@id" },
+								{ "selector": "input", "attr": "value", "value": "/@value" }
+						]
+					}'>
+		<template>
+			<input type="text" name="" value="">
+		</template>
+	</div>
+	<p>Tous les H2 de la page :</p>
+	<ul data-wb-json='{
+		"url": "#[ex3]/allH2",
+		"mapping": [
+			{ "selector": "li" }
+		]
+	}'>
+		<template>
+			<li></li>
+		</template>
+	</ul>
+	<p>Tous les H3 de la page (<span data-json-replace="#[ex3]/nbH3Total">inconnu</span> instances) :</p>
+	<ul data-wb-json='{
+		"url": "#[ex3]/allH3",
+		"mapping": [
+					{ "selector": "li" }
+				]
+		}'>
+		<template>
+			<li></li>
+		</template>
+	</ul>
+</div>
+
+<details>
+<summary>Afficher le code source</summary>
+
+<h3>HTML</h3>
+<pre><code>
+&lt;div data-wb-jsonmanager='{
+		&quot;name&quot;: &quot;ex3&quot;,
+		&quot;extractor&quot;: [
+			{ &quot;path&quot;: &quot;/formfields/pageTitle&quot;, &quot;selector&quot;: &quot;title&quot; },
+			{ &quot;path&quot;: &quot;/formfields/lang&quot;, &quot;attr&quot;:&quot;lang&quot;, &quot;selector&quot;: &quot;html&quot; },
+			{ &quot;path&quot;: &quot;/formfields/externalReferer&quot;, &quot;interface&quot;: &quot;referer&quot; },
+			{ &quot;path&quot;: &quot;/formfields/submissionPage&quot;, &quot;interface&quot;: &quot;locationHref&quot; },
+			{ &quot;selector&quot;: &quot;h2&quot;, &quot;path&quot;: &quot;allH2&quot;, &quot;selectAll&quot;:true },
+			{ &quot;selector&quot;: &quot;h3&quot;, &quot;path&quot;: &quot;allH3&quot;, &quot;selectAll&quot;:true }
+		],
+		&quot;patches&quot;: { &quot;op&quot;: &quot;wb-count&quot;, &quot;path&quot;: &quot;/allH3&quot;, &quot;set&quot;: &quot;/nbH3Total&quot; }
+	}'&gt;
+
+	&lt;div data-wb-json='{
+		&quot;url&quot; : &quot;#[ex3]/formfields&quot;,
+		&quot;mapping&quot; : [
+			{ &quot;selector&quot; : &quot;input&quot;, &quot;attr&quot; : &quot;name&quot;, &quot;value&quot; : &quot;/@id&quot; },
+			{ &quot;selector&quot; : &quot;input&quot;, &quot;attr&quot; : &quot;name&quot;, &quot;value&quot; : &quot;/@value&quot; }
+		]
+	}'>
+		&lt;template&gt;
+			&lt;input type=&quot;text&quot; name="" value=&quot;&quot; &gt;
+		&lt;/template&gt;
+	&lt;/div&gt;
+	&lt;p&gt;Tous les H2 de la page :&lt;/p&gt;
+	&lt;ul data-wb-json='{
+			&quot;url&quot; : &quot;#[ex3]/allH2&quot;,
+			&quot;mapping&quot; : [
+			{ &quot;selector&quot; : &quot;li&quot; }
+			]
+		}'>
+		&lt;template&gt;
+			&lt;li&gt;&lt;/li&gt;
+		&lt;/template&gt;
+	&lt;/ul&gt;
+	&lt;p&gt;Tous les H3 de la page (&lt;span data-json-replace=&quot;#[ex3]/nbH3Total&quot;&gt;inconnu&lt;/span&gt; instances):&lt;/p&gt;
+	&lt;ul data-wb-json='{
+		&quot;url&quot; : &quot;#[ex3]/allH3&quot;,
+		&quot;mapping&quot; : [
+			{ &quot;selector&quot;: &quot;li&quot; }
+		]
+		}'>
+		&lt;template&gt;
+			&lt;li&gt;&lt;/li&gt;
+		&lt;/template&gt;
+	&lt;/ul&gt;
+&lt;/div&gt;</code></pre>
 </details>


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?


JSON source object is built from values extracted from dom nodes.
Values can be either the text content of the tag, either the attribute value of the selected tag or the values of combined selectors (e.g. dt, dd).
 

New setting added to json-manager:

"**`extractor`**" - a JSON object containing:

-    `selector`(string): the selectors tag name;
-    `path` (string) : the pointer name that will be used as the key for the needed value;
-    `attr` (string) : this property wait for an attribute name and if will output the attribute value instead of the selected tag text content; 
-    `selectAll` (boolean):  if true, it will select from the page all tags for that specific selector, if false, it will select only the first found;
-    `extractor` (array of objects): here can be passed the combined selectors e.g dt, dd, and the values will be merged in one object;
-    `interface` (string): the value assigned to the "`path`" will be taken from the predefined web interface commands : `"referer": document.referrer, "locationHref": location.href `
