### PR TITLE
Bootstrap 4: Backport pr-sm-3 class

### DIFF
--- a/src/base/views/_bootstrap-4-screen-sm-min.scss
+++ b/src/base/views/_bootstrap-4-screen-sm-min.scss
@@ -38,3 +38,7 @@
 	padding-left: 15px;
 	padding-right: 15px;
 }
+
+.pr-sm-3 {
+	padding-right: 15px !important;
+}

--- a/src/other/utility/utility-en.hbs
+++ b/src/other/utility/utility-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "utility",
 	"parentdir": "utility",
 	"altLangPrefix": "utility",
-	"dateModified": "2022-09-14"
+	"dateModified": "2022-11-03"
 }
 ---
 
@@ -170,6 +170,13 @@
 <p class="pr-2 bg-primary max-content">Suspendisse faucibus nisl at consectetur.</p>
 <h4>Code sample</h4>
 <pre><code>&lt;p class="<strong>pr-2</strong> bg-primary max-content"&gt;Suspendisse faucibus nisl at consectetur.&lt;/p&gt;</code></pre>
+
+<h3><code>pr-sm-3</code></h3>
+<p>Set a right padding of 15px in small view and over.</p>
+<h4>Working example</h4>
+<p class="pr-sm-3 bg-primary max-content">Suspendisse faucibus nisl at consectetur.</p>
+<h4>Code sample</h4>
+<pre><code>&lt;p class="<strong>pr-sm-3</strong> bg-primary max-content"&gt;Suspendisse faucibus nisl at consectetur.&lt;/p&gt;</code></pre>
 
 <h3><code>pt-4</code></h3>
 <p>Set a top padding of 30px.</p>

--- a/src/other/utility/utility-fr.hbs
+++ b/src/other/utility/utility-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "utility",
 	"parentdir": "utility",
 	"altLangPrefix": "utility",
-	"dateModified": "2022-09-14"
+	"dateModified": "2022-11-03"
 }
 ---
 
@@ -167,6 +167,13 @@
 <p class="pr-2 bg-primary max-content">Suspendisse faucibus nisl at consectetur.</p>
 <h4>Exemple de code</h4>
 <pre><code>&lt;p class="<strong>pr-2</strong> bg-primary max-content"&gt;Suspendisse faucibus nisl at consectetur.&lt;/p&gt;</code></pre>
+
+<h3><code>pr-sm-3</code></h3>
+<p>Défini un remplissage à droite de 15px dans la petite vue et plus.</p>
+<h4>Exemple pratique</h4>
+<p class="pr-sm-3 bg-primary max-content">Suspendisse faucibus nisl at consectetur.</p>
+<h4>Exemple de code</h4>
+<pre><code>&lt;p class="<strong>pr-sm-3</strong> bg-primary max-content"&gt;Suspendisse faucibus nisl at consectetur.&lt;/p&gt;</code></pre>
 
 <h3><code>pt-4</code></h3>
 <p>Défini un remplissage au-dessus de 30px.</p>


### PR DESCRIPTION
**Notes:**
* Unit measurement differences:
  * Bootstrap 4-5 use ``.5rem`` for this class... which is technically ``16px``
  * Went with ``15px`` to stay consistent with pre-existing backported classes
* Using ``!important`` for the following reasons:
  * It's needed for my use case
  * Bootstrap 4-5 themselves use it for their versions of this class
* This class name no longer exists in Bootstrap 5:
  * It was renamed to ``pe-sm-3`` (``r`` for "right" changed to ``e`` for "end")
  * Went with the outdated name since pre-existing backported classes are already using ``r`` for "right"

Spinoff of wet-boew/GCWeb#1916.