### PR TITLE
JSON Manager | Core: Add support for Base64 decode and HTML escape

### DIFF
--- a/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-en.hbs
+++ b/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-en.hbs
@@ -178,6 +178,16 @@
 </td>
 </tr>
 <tr>
+<td>Get output from Base64 (UTF-8)</td>
+<td><code>{ "op": "wb-decodeUTF8Base64", "path": &lt;path&gt; }</code><br/> or<br/><code>{ "op": "wb-decodeUTF8Base64", "path": &lt;path&gt;, "set": &lt;path&gt; }</code></td>
+<td>Decodes Base64 content to raw format according to the source at the <code>path</code> location and copy the value at a specified location. If <code>set</code> is not defined, it will be the value located at <code>path</code> that will be replaced.</td>
+</tr>
+<tr>
+<td>Escape HTML</td>
+<td><code>{ "op": "wb-escapeHTML", "path": &lt;path&gt; }</code><br/> or<br/><code>{ "op": "wb-escapeHTML", "path": &lt;path&gt;, "set": &lt;path&gt; }</code></td>
+<td>Escapes HTML characters from content located in the <code>path</code> and copy the value at a specified location. If <code>set</code> is not defined, it will be the value located at <code>path</code> that will be replaced.</td>
+</tr>
+<tr>
 <td>Formating a date to ISO (YYYY-MM-DD)</td>
 <td><code>{ "op": "wb-toDateISO", "path": &lt;path&gt; }</code><br> or<br><code>{ "op": "wb-toDateISO", "path": &lt;path&gt;, "set": &lt;path&gt; }</code></td>
 <td>Format a date value to data ISO and copy the value at a specified location. If <code>set</code> is not defined, it will be the value located at <code>path</code> that will be replaced.</td>

--- a/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-fr.hbs
+++ b/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-fr.hbs
@@ -205,6 +205,18 @@
 	</tr>
 
 	<tr>
+		<td>Get output from Base64 (UTF-8)</td>
+		<td><code>{ "op": "wb-decodeUTF8Base64", "path": &lt;path&gt; }</code><br/> or<br/><code>{ "op": "wb-decodeUTF8Base64", "path": &lt;path&gt;, "set": &lt;path&gt; }</code></td>
+		<td>Decodes Base64 content to raw format according to the source at the <code>path</code> location and copy the value at a specified location. If <code>set</code> is not defined, it will be the value located at <code>path</code> that will be replaced.</td>
+	</tr>
+
+	<tr>
+		<td>Escape HTML</td>
+		<td><code>{ "op": "wb-escapeHTML", "path": &lt;path&gt; }</code><br/> or<br/><code>{ "op": "wb-escapeHTML", "path": &lt;path&gt;, "set": &lt;path&gt; }</code></td>
+		<td>Escapes HTML characters from content located in the <code>path</code> and copy the value at a specified location. If <code>set</code> is not defined, it will be the value located at <code>path</code> that will be replaced.</td>
+	</tr>
+
+	<tr>
 		<td>Formating a date to ISO (YYYY-MM-DD)</td>
 		<td><code>{ "op": "wb-toDateISO", "path": &lt;path&gt; }</code><br/> or<br/><code>{ "op": "wb-toDateISO", "path": &lt;path&gt;, "set": &lt;path&gt; }</code></td>
 		<td>Format a date value to data ISO and copy the value at a specified location. If <code>set</code> is not defined, it will be the value located at <code>path</code> that will be replaced.</td>

--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -1251,6 +1251,24 @@ wb.escapeAttribute = function( str ) {
 };
 
 /*
+ * Returns an escaped HTML string
+ */
+wb.escapeHTML = function( str ) {
+	return wb.escapeAttribute( str
+		.replace( /&/g, "&#38;" )
+		.replace( /</g, "&#60;" )
+		.replace( />/g, "&#62;" ) );
+};
+
+/*
+ * Returns a UTF-8 output from Base64
+ * Reference: https://developer.mozilla.org/fr/docs/Glossary/Base64 (To be reviewed later because escape function is deprecated)
+ */
+wb.decodeUTF8Base64 = function( str ) {
+	return decodeURIComponent( escape( atob( str ) ) );
+};
+
+/*
 * Find most common Personal Identifiable Information (PII) in a string and return either the cleaned string either true/false
 * @param {string} str (required) - the content that needs to be verified
 *

--- a/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
@@ -286,9 +286,44 @@
 	</template>
 </ul>
 
+<h3>Content of a GitHub file</h3>
+<p>Calling a file through GitHub API has to be crafted as such:</p>
+<pre><code>http://api.github.com/repos/[Organisation-Name]/[Repository-Name]/contents/[Path-to-file]</code></pre>
+<p><strong>Note:</strong> Take into consideration that GitHub has a rate limit for API usage, which is currently set to 60 per hour (without authentication).</p>
+<div data-wb-jsonmanager='{
+		"url": "http://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-en.html",
+		"name": "githubCode",
+		"patches": [
+			{ "op": "wb-decodeUTF8Base64", "path": "/content", "set": "/raw" },
+			{ "op": "copy", "from": "/raw", "path": "/escape" },
+			{ "op": "wb-escapeHTML", "path": "/escape" }
+		]
+	}'>
+	<div data-json-replace="#[githubCode]/raw">Content here...</div>
+	<h4>Escaped HTML content</h4>
+	<pre><code data-json-append="#[githubCode]/escape"></code></pre>
+</div>
+
+<details>
+<summary>View source code</summary>
+<pre><code>&lt;div data-wb-jsonmanager=&apos;{
+	&quot;url&quot;: &quot;http://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-en.html&quot;,
+	&quot;name&quot;: &quot;githubCode&quot;,
+	&quot;patches&quot;: [
+		{ &quot;op&quot;: &quot;wb-decodeUTF8Base64&quot;, &quot;path&quot;: &quot;/content&quot;, &quot;set&quot;: &quot;/raw&quot; },
+		{ &quot;op&quot;: &quot;copy&quot;, &quot;from&quot;: &quot;/raw&quot;, &quot;path&quot;: &quot;/escape&quot; },
+		{ &quot;op&quot;: &quot;wb-escapeHTML&quot;, &quot;path&quot;: &quot;/escape&quot; }
+	]
+}&apos;&gt;
+&lt;div data-json-replace=&quot;#[githubCode]/raw&quot;&gt;Content here...&lt;/div&gt;
+&lt;h4&gt;Escaped HTML version&lt;/h4&gt;
+&lt;pre&gt;&lt;code data-json-append=&quot;#[githubCode]/escape&quot;&gt;&lt;/code&gt;&lt;/pre&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
 <h2>JSON patches operation</h2>
 
-<p>JSON operation is defined as per <a href="https://tools.ietf.org/html/rfc6902">RFC6002 - JavaScript Object Notation (JSON) Patch</a> with additional operation to fullfill the needs of the JSON manager. Described in the documentation, the following operation are supported by default: <code>add</code>, <code>remove</code>, <code>replace</code>, <code>move</code>, <code>copy</code>, <code>test</code>, <code>wb-count</code>, <code>wb-first</code>, <code>wb-last</code>, <code>wb-toDateISO</code> and <code>wb-toDateTimeISO</code>.</p>
+<p>JSON operation is defined as per <a href="https://tools.ietf.org/html/rfc6902">RFC6002 - JavaScript Object Notation (JSON) Patch</a> with additional operation to fullfill the needs of the JSON manager. Described in the documentation, the following operation are supported by default: <code>add</code>, <code>remove</code>, <code>replace</code>, <code>move</code>, <code>copy</code>, <code>test</code>, <code>wb-count</code>, <code>wb-first</code>, <code>wb-last</code>, <code>wb-decodeUTF8Base64</code>, <code>wb-escapeHTML</code>, <code>wb-toDateISO</code> and <code>wb-toDateTimeISO</code>.</p>
 
 <h2>Debugging</h2>
 

--- a/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
@@ -285,9 +285,44 @@
 	</template>
 </ul>
 
+<h3>Contenu d'un fichier provenant de GitHub</h3>
+<p>L'appel à l'API GitHub pour obtenir le contenu d'un fichier doit être effectué de la sorte&nbsp;:</p>
+<pre><code>http://api.github.com/repos/[Nom-Organisation]/[Nom-Répertoire]/contents/[Chemin-Vers-Fichier]</code></pre>
+<p><strong>Remarque&nbsp;:</strong> Veuillez prendre en considération que GitHub a une limite d'utilisation de son API, qui est présentement réglée à 60 par heure (sans identifiant).</p>
+<div data-wb-jsonmanager='{
+		"url": "http://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-fr.html",
+		"name": "githubCode",
+		"patches": [
+			{ "op": "wb-decodeUTF8Base64", "path": "/content", "set": "/raw" },
+			{ "op": "copy", "from": "/raw", "path": "/escape" },
+			{ "op": "wb-escapeHTML", "path": "/escape" }
+		]
+	}'>
+	<div data-json-replace="#[githubCode]/raw">Contenu ici...</div>
+	<h4>Contenu HTML échappé</h4>
+	<pre><code data-json-append="#[githubCode]/escape"></code></pre>
+</div>
+
+<details>
+<summary>Code source</summary>
+<pre><code>&lt;div data-wb-jsonmanager=&apos;{
+	&quot;url&quot;: &quot;http://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-fr.html&quot;,
+	&quot;name&quot;: &quot;githubCode&quot;,
+	&quot;patches&quot;: [
+		{ &quot;op&quot;: &quot;wb-decodeUTF8Base64&quot;, &quot;path&quot;: &quot;/content&quot;, &quot;set&quot;: &quot;/raw&quot; },
+		{ &quot;op&quot;: &quot;copy&quot;, &quot;from&quot;: &quot;/raw&quot;, &quot;path&quot;: &quot;/escape&quot; },
+		{ &quot;op&quot;: &quot;wb-escapeHTML&quot;, &quot;path&quot;: &quot;/escape&quot; }
+	]
+}&apos;&gt;
+&lt;div data-json-replace=&quot;#[githubCode]/raw&quot;&gt;Contenu ici...&lt;/div&gt;
+&lt;h4&gt;Contenu HTML échappé&lt;/h4&gt;
+&lt;pre&gt;&lt;code data-json-append=&quot;#[githubCode]/escape&quot;&gt;&lt;/code&gt;&lt;/pre&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
 <h2>Opération de correctifs JSON</h2>
 
-<p>Les opération de correctifs JSON sont définie par <a href="https://tools.ietf.org/html/rfc6902" lang="en" hreflang="en">RFC6002 - JavaScript Object Notation (JSON) Patch</a> avec quelques ajout d'opération afin de combler les besoins du gestionnaire JSON. Détaillé dans la documentations, les opérations suivant sont supporté par défaut: <code>add</code>, <code>remove</code>, <code>replace</code>, <code>move</code>, <code>copy</code>, <code>test</code>, <code>wb-count</code>, <code>wb-first</code>, <code>wb-last</code>, <code>wb-toDateISO</code> and <code>wb-toDateTimeISO</code>.</p>
+<p>Les opération de correctifs JSON sont définie par <a href="https://tools.ietf.org/html/rfc6902" lang="en" hreflang="en">RFC6002 - JavaScript Object Notation (JSON) Patch</a> avec quelques ajout d'opération afin de combler les besoins du gestionnaire JSON. Détaillé dans la documentations, les opérations suivant sont supporté par défaut: <code>add</code>, <code>remove</code>, <code>replace</code>, <code>move</code>, <code>copy</code>, <code>test</code>, <code>wb-count</code>, <code>wb-first</code>, <code>wb-last</code>, <code>wb-decodeUTF8Base64</code>, <code>wb-escapeHTML</code>, <code>wb-toDateISO</code> and <code>wb-toDateTimeISO</code>.</p>
 
 <h2>Débogage</h2>
 

--- a/src/plugins/wb-jsonmanager/jsonmanager.js
+++ b/src/plugins/wb-jsonmanager/jsonmanager.js
@@ -109,6 +109,38 @@ var componentName = "wb-jsonmanager",
 				}
 			},
 			{
+				name: "wb-decodeUTF8Base64",
+				fn: function( obj, key, tree ) {
+					var val = obj[ key ];
+
+					if ( !this.set ) {
+						jsonpatch.apply( tree, [
+							{ op: "replace", path: this.path, value: wb.decodeUTF8Base64( val ) }
+						] );
+					} else {
+						jsonpatch.apply( tree, [
+							{ op: "add", path: this.set, value: wb.decodeUTF8Base64( val ) }
+						] );
+					}
+				}
+			},
+			{
+				name: "wb-escapeHTML",
+				fn: function( obj, key, tree ) {
+					var val = obj[ key ];
+
+					if ( !this.set ) {
+						jsonpatch.apply( tree, [
+							{ op: "replace", path: this.path, value: wb.escapeHTML( val ) }
+						] );
+					} else {
+						jsonpatch.apply( tree, [
+							{ op: "add", path: this.set, value: wb.escapeHTML( val ) }
+						] );
+					}
+				}
+			},
+			{
 				name: "wb-toDateISO",
 				fn: function( obj, key, tree ) {
 					if ( !this.set ) {


### PR DESCRIPTION
## What does this pull request (PR) do?

Adds helpers in the core as well as operations in JSON Manager to:

- Decode Base64 content; and
- Escape HTML characters from an HTML string.

This comes in handy when generating code samples for documentation purposes, by allowing to grab content directly from GitHub (see working example in PR). Note that the GitHub API has a rate limit however (see note in PR).

Related to WET-294