### PR TITLE
JSON Manager: Fix documentation to point GitHub to HTTPS

### DIFF
--- a/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
@@ -288,10 +288,10 @@
 
 <h3>Content of a GitHub file</h3>
 <p>Calling a file through GitHub API has to be crafted as such:</p>
-<pre><code>http://api.github.com/repos/[Organisation-Name]/[Repository-Name]/contents/[Path-to-file]</code></pre>
+<pre><code>https://api.github.com/repos/[Organisation-Name]/[Repository-Name]/contents/[Path-to-file]</code></pre>
 <p><strong>Note:</strong> Take into consideration that GitHub has a rate limit for API usage, which is currently set to 60 per hour (without authentication).</p>
 <div data-wb-jsonmanager='{
-		"url": "http://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-en.html",
+		"url": "https://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-en.html",
 		"name": "githubCode",
 		"patches": [
 			{ "op": "wb-decodeUTF8Base64", "path": "/content", "set": "/raw" },
@@ -307,7 +307,7 @@
 <details>
 <summary>View source code</summary>
 <pre><code>&lt;div data-wb-jsonmanager=&apos;{
-	&quot;url&quot;: &quot;http://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-en.html&quot;,
+	&quot;url&quot;: &quot;https://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-en.html&quot;,
 	&quot;name&quot;: &quot;githubCode&quot;,
 	&quot;patches&quot;: [
 		{ &quot;op&quot;: &quot;wb-decodeUTF8Base64&quot;, &quot;path&quot;: &quot;/content&quot;, &quot;set&quot;: &quot;/raw&quot; },

--- a/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
@@ -287,10 +287,10 @@
 
 <h3>Contenu d'un fichier provenant de GitHub</h3>
 <p>L'appel à l'API GitHub pour obtenir le contenu d'un fichier doit être effectué de la sorte&nbsp;:</p>
-<pre><code>http://api.github.com/repos/[Nom-Organisation]/[Nom-Répertoire]/contents/[Chemin-Vers-Fichier]</code></pre>
+<pre><code>https://api.github.com/repos/[Nom-Organisation]/[Nom-Répertoire]/contents/[Chemin-Vers-Fichier]</code></pre>
 <p><strong>Remarque&nbsp;:</strong> Veuillez prendre en considération que GitHub a une limite d'utilisation de son API, qui est présentement réglée à 60 par heure (sans identifiant).</p>
 <div data-wb-jsonmanager='{
-		"url": "http://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-fr.html",
+		"url": "https://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-fr.html",
 		"name": "githubCode",
 		"patches": [
 			{ "op": "wb-decodeUTF8Base64", "path": "/content", "set": "/raw" },
@@ -306,7 +306,7 @@
 <details>
 <summary>Code source</summary>
 <pre><code>&lt;div data-wb-jsonmanager=&apos;{
-	&quot;url&quot;: &quot;http://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-fr.html&quot;,
+	&quot;url&quot;: &quot;https://api.github.com/repos/wet-boew/wet-boew/contents/src/plugins/data-ajax/ajax/data-ajax-extra-fr.html&quot;,
 	&quot;name&quot;: &quot;githubCode&quot;,
 	&quot;patches&quot;: [
 		{ &quot;op&quot;: &quot;wb-decodeUTF8Base64&quot;, &quot;path&quot;: &quot;/content&quot;, &quot;set&quot;: &quot;/raw&quot; },


### PR DESCRIPTION
## What does this pull request (PR) do? 

Fixes a typo in the demo where HTTP was used for the API endpoint to GitHub instead of HTTPS.