### PR TITLE
Table: Don't create column sort button when sort is disabled

### DIFF
--- a/src/plugins/tables/tables-en.hbs
+++ b/src/plugins/tables/tables-en.hbs
@@ -22,7 +22,7 @@
 				<th>Browser</th>
 				<th>Platform(s)</th>
 				<th>Engine version</th>
-				<th>CSS grade</th>
+				<th data-orderable="false">CSS grade</th>
 			</tr>
 		</thead>
 		<tbody>
@@ -431,7 +431,6 @@
 			</tr>
 		</tbody>
 	</table>
-	<div class="clearfix"></div>
 	<h3>Options Example</h3>
 	<p>The <a href="https://www.datatables.net/ref">DataTables API</a> is fully accessible through the <code>data-wb-tables</code> attribute using a JSON array.</p>
 	<pre>&lt;table class="wb-tables table table-striped table-hover" data-wb-tables='{ "ordering" : false }'&gt;</pre>

--- a/src/plugins/tables/tables-fr.hbs
+++ b/src/plugins/tables/tables-fr.hbs
@@ -24,7 +24,7 @@
 				<th>Navigateur</th>
 				<th>Platformes</th>
 				<th>Version de moteur</th>
-				<th>Niveau de CSS</th>
+				<th data-orderable="false">Niveau de CSS</th>
 			</tr>
 		</thead>
 		<tbody>

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -221,9 +221,10 @@ $document.on( "init.dt", function( event ) {
 		$elm.find( "th" ).each( function() {
 			var $th = $( this ),
 				label = ( $th.attr( "aria-sort" ) === "ascending" ) ? i18nText.aria.sortDescending : i18nText.aria.sortAscending;
-
-			$th.html( "<button type='button' aria-controls='" + $th.attr( "aria-controls" ) +  "' title='" + $th.text().replace( /'/g, "&#39;" ) + label + "'>" + $th.html() + "<span class='sorting-cnt'><span class='sorting-icons' aria-hidden='true'></span></span></button>" );
-			$th.removeAttr( "aria-label tabindex aria-controls" );
+			if ( $th.attr( "data-orderable" ) !== "false" ) {
+				$th.html( "<button type='button' aria-controls='" + $th.attr( "aria-controls" ) +  "' title='" + $th.text().replace( /'/g, "&#39;" ) + label + "'>" + $th.html() + "<span class='sorting-cnt'><span class='sorting-icons' aria-hidden='true'></span></span></button>" );
+				$th.removeAttr( "aria-label tabindex aria-controls" );
+			}
 		} );
 		$elm.attr( "aria-label", i18nText.tblFilterInstruction );
 	}


### PR DESCRIPTION
## What does this pull request (PR) do?
DataTables has support for adding `data-orderable="false"` to `th` elements in order to disable sorting on a specific column. When using `data-orderable` with wet, it creates the sort button but sorting is disabled. This PR stops that button from being created.

## Additional information (optional)
This is my first PR for this project, let me know if I should create documentation for this

**General checklist**
Make your own list for the purpose of your Pull request.

- [x] Build and test PR's code
- [x] Validate changes against WCAG for accessibility 

**Related issues / Requêtes associées**
None.

**Screenshots / Captures d'écrans**
Tested with `data-orderable='false'` on the `Engine Version` column.

![DataTable where all columns excluding the Engine Version column are sortable](https://user-images.githubusercontent.com/55817894/202232746-312d956d-64ad-4efe-afdc-9763079378ca.png)
