### PR TITLE
Tables wrap on mobile (extra-small viewport and under)

### DIFF
--- a/src/base/bootstrap-overrides/_core-tables.scss
+++ b/src/base/bootstrap-overrides/_core-tables.scss
@@ -12,3 +12,9 @@ caption {
 	}
 	text-align: center;
 }
+
+
+// Not ported from, but inline with Bootstrap 4: Makes the table to scroll horizontally and makes the content wrap in any viewport including small devices (under 768px)
+.table-responsive > .table, th, td {
+	white-space: normal;
+}

--- a/src/other/utility/utility-en.hbs
+++ b/src/other/utility/utility-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "utility",
 	"parentdir": "utility",
 	"altLangPrefix": "utility",
-	"dateModified": "2022-11-21"
+	"dateModified": "2022-12-13"
 }
 ---
 
@@ -24,6 +24,7 @@
 	<li><a href="#sizing">Sizing</a></li>
 	<li><a href="#flexbox">Flexbox</a></li>
 	<li><a href="#positioning">Positioning</a></li>
+	<li><a href="#tables">Tables</a></li>
 	<li><a href="#miscellaneous">Miscellaneous</a></li>
 </ul>
 
@@ -416,6 +417,54 @@
 <p class="position-relative">This is a paragraph relatively positioned.</p>
 <h4>Code sample</h4>
 <pre><code>&lt;p class="<strong>position-relative</strong>"&gt;This is a paragraph relatively positioned.&lt;/p&gt;</code></pre>
+
+<h2 id="tables">Tables</h2>
+<h3><code>table-responsive</code></h3>
+<p>Not ported from, but inline with Bootstrap 4: Makes the content wrap in any viewport including small devices (under 768px).</p>
+<h4>Working example</h4>
+<div class="table-responsive">
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Rendering engine</th>
+				<th>Browser</th>
+				<th>Platform(s)</th>
+				<th>Engine version</th>
+				<th>CSS grade</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="gradeX">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 4.0</td>
+				<td>Win 95+</td>
+				<td class="center">4</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 5.0</td>
+				<td>Win 95+</td>
+				<td class="center">5</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 5.5</td>
+				<td>Win 95+</td>
+				<td class="center">5.5</td>
+				<td class="center">A</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+<h4>Code sample</h4>
+<pre><code>&lt;div class="<strong>table-responsive</strong>"&gt;
+	&lt;!-- Table here --&gt;
+&lt;/div&gt;</code></pre>
 
 <h2 id="miscellaneous">Miscellaneous</h2>
 

--- a/src/other/utility/utility-fr.hbs
+++ b/src/other/utility/utility-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "utility",
 	"parentdir": "utility",
 	"altLangPrefix": "utility",
-	"dateModified": "2022-11-21"
+	"dateModified": "2022-12-13"
 }
 ---
 
@@ -23,6 +23,7 @@
 	<li><a href="#dimension">Dimensionnement</a></li>
 	<li><a href="#flexbox" lang="en">Flexbox</a></li>
 	<li><a href="#positionnement">Positionnement</a></li>
+	<li><a href="#tables">Tables</a></li>
 	<li><a href="#divers">Divers</a></li>
 </ul>
 
@@ -406,13 +407,60 @@
 &lt;/div&gt;</code></pre>
 
 <h2 id="positionnement">Positionnement</h2>
-
 <h3><code>position-relative</code></h3>
 <p>Défini une position relative pour un élément. Ceci a été créée afin de supporter l'utilitaire <code>stretched-link</code>. Afin d'obtenir un meilleur effet visuel, référez vous à la <a href="#sl">section de l'utilitaire 'streched-link'</a> ci-desous.  </p>
 <h4>Exemple pratique</h4>
 <p class="position-relative">Ceci est un paragraphe relativement positionné.</p>
 <h4>Exemple de code</h4>
 <pre><code>&lt;p class="<strong>position-relative</strong>"&gt;Ceci est un paragraphe relativement positionné.&lt;/p&gt;</code></pre>
+
+<h2 id="tables">Tables</h2>
+<h3><code>table-responsive</code></h3>
+<p>Non porté de, mais en ligne avec Bootstrap 4: renvoie le texte automatiquement à la ligne suivante dans n'importe quelle fenêtre d'affichage incluant les petits appareils (sous 768px)</p>
+<h4>Exemple pratique</h4>
+<div class="table-responsive">
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Moteur de rendu</th>
+				<th>Navigateur</th>
+				<th>Platformes</th>
+				<th>Version de moteur</th>
+				<th>Niveau de CSS</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="gradeX">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 4.0</td>
+				<td>Win 95+</td>
+				<td class="center">4</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 5.0</td>
+				<td>Win 95+</td>
+				<td class="center">5</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 5.5</td>
+				<td>Win 95+</td>
+				<td class="center">5.5</td>
+				<td class="center">A</td>
+			</tr>
+		</tbody>
+	</table>
+</div>
+<h4>Exemple de code</h4>
+<pre><code>&lt;div class="<strong>table-responsive</strong>"&gt;
+	&lt;!-- Tableau ici --&gt;
+&lt;/div&gt;</code></pre>
 
 <h2 id="divers">Divers</h2>
 <h3><code>max-content</code></h3>


### PR DESCRIPTION
Addition of a CSS class in order for tables to wrap on mobile (<768px) when using `table-responsive`.