### PR TITLE
Patch: fix number range table filter when min and max are equal

### DIFF
--- a/src/plugins/tables/tables-en.hbs
+++ b/src/plugins/tables/tables-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "tables",
 	"parentdir": "tables",
 	"altLangPrefix": "tables",
-	"dateModified": "2020-10-22"
+	"dateModified": "2022-11-29"
 }
 ---
 <section>
@@ -975,5 +975,6 @@
 	<ul>
 		<li><a href="../../demos/tables/tables-fltrs-en.html#dataset-filter1">Date Range, Drop-Down List and Checkbox Filters</a></li>
 		<li><a href="../../demos/tables/tables-fltrs-en.html#dataset-filter2">Number Range Filters (Integers, floats, currency, etc)</a></li>
+		<li><a href="../../demos/tables/tables-fltrs-en.html#dataset-filter3">Other Filters</a></li>
 	</ul>
 </section>

--- a/src/plugins/tables/tables-fltrs-en.hbs
+++ b/src/plugins/tables/tables-fltrs-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "table filters",
 	"parentdir": "tables",
 	"altLangPrefix": "tables-fltrs",
-	"dateModified": "2020-10-22"
+	"dateModified": "2022-11-29"
 }
 ---
 <section>
@@ -382,6 +382,78 @@
 				<li>Column is the number range that the filter well apply too (must match there 'data-column').</li>
 			</ol>
 			<pre><code>&lt;label for="dt_age_aopts1"&gt;&lt;input type="radio" name="dt_age_aopts" id="dt_age_aopts1" data-aopts='{"type": "either", "column": "5"}' checked /&gt;Either&lt;/label&gt;</code></pre>
+		</div>
+	</div>
+	<h3>Other Filters</h3>
+	<p>It is also possible to filter using text or numbers</p>
+	<div class="row">
+		<div class="col-md-3">
+			<h4 class="wb-inv">Filtering Options</h4>
+			<details open>
+				<summary><h4 class="h4">Filter Options</h4></summary>
+				<p class="mrgn-tp-md">Use filters to below options to change the focus of your results in following data table</p>
+				<form class="wb-tables-filter" data-bind-to="dataset-filter3">
+					<div class="form-group">
+						<fieldset>
+							<legend><span class="field-name">Age</span></legend>
+							<div class="row form-group">
+								<div class="col-md-12">
+									<label for="dt_age" class="small">Age</label>
+									<input type="number" class="form-control" id="dt_age" name="dt_age" min="0" data-column="3"/>
+								</div>
+							</div>
+						</fieldset>
+					</div>
+					<div class="form-group">
+						<fieldset>
+							<legend><span class="field-name">Name</span></legend>
+							<div class="row form-group">
+								<div class="col-md-12">
+									<label for="dt_fname" class="small">First Name</label>
+									<input type="text" class="form-control" id="dt_fname" name="dt_fname" data-column="1"/>
+								</div>
+							</div>
+							<div class="row form-group">
+								<div class="col-md-12">
+									<label for="dt_lname" class="small">Last Name</label>
+									<input type="text" class="form-control" id="dt_lname" name="dt_lname" data-column="2"/>
+								</div>
+							</div>
+						</fieldset>
+					</div>
+					<div class="form-group">
+						<button type="submit" class="btn btn-primary" aria-controls="dataset-filter2">Filter</button>
+					</div>
+					<div class="form-group">
+						<button type="reset" class="btn btn-link btn-sm p-0">Reset to defaults</button>
+					</div>
+				</form>
+			</details>
+		</div>
+		<div class="col-md-9">
+			<table class="wb-tables table table-striped table-hover" id="dataset-filter3" data-wb-tables='{
+			"bDeferRender": true,
+			"ajaxSource": "ajax/mockdata.json",
+			"order": [3, "desc"],
+			"columns": [
+				{ "data": "id", "visible": false },
+				{ "data": "first_name" },
+				{ "data": "last_name" },
+				{ "data": "age" },
+				{ "data": "salary", "visible": false },
+				{ "data": "taxes", "visible": false }
+			]}'>
+				<thead>
+				<tr>
+					<th>Id</th>
+					<th>First Name</th>
+					<th>Last Name</th>
+					<th>Age</th>
+					<th>Salary</th>
+					<th>Taxes</th>
+				</tr>
+				</thead>
+			</table>
 		</div>
 	</div>
 </section>

--- a/src/plugins/tables/tables-fltrs-fr.hbs
+++ b/src/plugins/tables/tables-fltrs-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "table filters",
 	"parentdir": "tables",
 	"altLangPrefix": "tables-fltrs",
-	"dateModified": "2020-10-22"
+	"dateModified": "2022-11-29"
 }
 ---
 
@@ -383,6 +383,78 @@
 				<li>Column is the number range that the filter well apply too (must match there 'data-column').</li>
 			</ol>
 			<pre><code>&lt;label for="dt_age_aopts1"&gt;&lt;input type="radio" name="dt_age_aopts" id="dt_age_aopts1" data-aopts='{"type": "either", "column": "5"}' checked /&gt;Either&lt;/label&gt;</code></pre>
+		</div>
+	</div>
+	<h3>Autres filtres</h3>
+	<p>Il est également possible de filtrer à l'aide de texte ou de chiffres.</p>
+	<div class="row">
+		<div class="col-md-3">
+			<h4 class="wb-inv">Options</h4>
+			<details open>
+				<summary><h4 class="h4">Options</h4></summary>
+				<p class="mrgn-tp-md">Utilisez les options ci-dessous pour modifier vos résultats dans le tableau suivant.</p>
+				<form class="wb-tables-filter" data-bind-to="dataset-filter3">
+					<div class="form-group">
+						<fieldset>
+							<legend><span class="field-name">Âge</span></legend>
+							<div class="row form-group">
+								<div class="col-md-12">
+									<label for="dt_age" class="small">Âge</label>
+									<input type="number" class="form-control" id="dt_age" name="dt_age" min="0" data-column="3"/>
+								</div>
+							</div>
+						</fieldset>
+					</div>
+					<div class="form-group">
+						<fieldset>
+							<legend><span class="field-name">Nom</span></legend>
+							<div class="row form-group">
+								<div class="col-md-12">
+									<label for="dt_fname" class="small">Prénom</label>
+									<input type="text" class="form-control" id="dt_fname" name="dt_fname" data-column="1"/>
+								</div>
+							</div>
+							<div class="row form-group">
+								<div class="col-md-12">
+									<label for="dt_lname" class="small">Nom de famille</label>
+									<input type="text" class="form-control" id="dt_lname" name="dt_lname" data-column="2"/>
+								</div>
+							</div>
+						</fieldset>
+					</div>
+					<div class="form-group">
+						<button type="submit" class="btn btn-primary" aria-controls="dataset-filter2">Filter</button>
+					</div>
+					<div class="form-group">
+						<button type="reset" class="btn btn-link btn-sm p-0">Réinitialiser aux valeurs par défaut</button>
+					</div>
+				</form>
+			</details>
+		</div>
+		<div class="col-md-9">
+			<table class="wb-tables table table-striped table-hover" id="dataset-filter3" data-wb-tables='{
+			"bDeferRender": true,
+			"ajaxSource": "ajax/mockdata.json",
+			"order": [3, "desc"],
+			"columns": [
+				{ "data": "id", "visible": false },
+				{ "data": "first_name" },
+				{ "data": "last_name" },
+				{ "data": "age" },
+				{ "data": "salary", "visible": false },
+				{ "data": "taxes", "visible": false }
+			]}'>
+				<thead>
+				<tr>
+					<th>Id</th>
+					<th>Prénom</th>
+					<th>Nom de famille</th>
+					<th>Âge</th>
+					<th>Salaire</th>
+					<th>Impôts</th>
+				</tr>
+				</thead>
+			</table>
 		</div>
 	</div>
 </section>

--- a/src/plugins/tables/tables-fr.hbs
+++ b/src/plugins/tables/tables-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "tables",
 	"parentdir": "tables",
 	"altLangPrefix": "tables",
-	"dateModified": "2020-10-22"
+	"dateModified": "2022-11-29"
 }
 ---
 
@@ -983,5 +983,6 @@
 	<ul>
 		<li><a href="../../demos/tables/tables-fltrs-fr.html#dataset-filter1">Date Range, Drop-Down List and Checkbox Filters</a></li>
 		<li><a href="../../demos/tables/tables-fltrs-fr.html#dataset-filter2">Number Range Filters (Integers, floats, currency, etc)</a></li>
+		<li><a href="../../demos/tables/tables-fltrs-fr.html#dataset-filter3">Autres filtres</a></li>
 	</ul>
 </section>

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -282,17 +282,17 @@ $document.on( "submit", ".wb-tables-filter", function( event ) {
 		if ( $elm.is( "select" ) ) {
 			$value = $elm.find( "option:selected" ).val();
 		} else if ( $elm.is( "input[type='number']" ) ) {
-			var $minNum, $maxNum;
+			var $minNum, $maxNum = "-0";
 
 			// Retain minimum number (always the first number input)
 			if ( $cachedVal === "" ) {
 				$cachedVal = parseFloat( $val );
 				$cachedVal = ( $cachedVal ) ? $cachedVal : "-0";
+			} else {
+				$maxNum = parseFloat( $val );
+				$maxNum = ( $maxNum ) ? $maxNum : "-0";
 			}
 			$minNum = $cachedVal;
-
-			// Maximum number is always the current selected number
-			$maxNum = parseFloat( $val );
 
 			//Number filtering logic needs to be reviewed in order to remove the "-0" value (issue #9235)
 			// Generates a list of numbers (within the min and max number)
@@ -302,15 +302,19 @@ $document.on( "submit", ".wb-tables-filter", function( event ) {
 
 					if ( !isNaN( $num ) ) {
 						if ( $aoType === "and" ) {
-							if ( $cachedVal !== $maxNum && $cachedVal !== "-0" && $num >= $minNum && $num <= $maxNum ) {
+							if ( $cachedVal !== $maxNum && $cachedVal !== "-0" && $maxNum !== "0" && $num >= $minNum && $num <= $maxNum ) {
 								return true;
 							}
 						} else {
-							if ( $cachedVal === $maxNum && $num >= $minNum ) {
+							if ( $maxNum === $cachedVal && $cachedVal === "-0" ) { // both are empty
 								return true;
-							} else if ( $cachedVal === "-0" && $num <= $maxNum ) {
+							} else if ( $maxNum !== "-0" && $minNum === $maxNum && $num === $maxNum ) { // min and max are the same
 								return true;
-							} else if ( $cachedVal !== "-0" && $num >= $minNum && $num <= $maxNum ) {
+							} else if ( $maxNum === "-0" && $num >= $minNum ) { // max number is missing
+								return true;
+							} else if ( $cachedVal === "-0" && $num <= $maxNum ) { // min number is missing
+								return true;
+							} else if ( $cachedVal !== "-0" && $num >= $minNum && $num <= $maxNum ) { // min and max are present
 								return true;
 							}
 						}

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -282,7 +282,7 @@ $document.on( "submit", ".wb-tables-filter", function( event ) {
 		if ( $elm.is( "select" ) ) {
 			$value = $elm.find( "option:selected" ).val();
 		} else if ( $elm.is( "input[type='number']" ) ) {
-			var $minNum, $maxNum = "-0";
+			var $minNum, $maxNum = null;
 
 			// Retain minimum number (always the first number input)
 			if ( $cachedVal === "" ) {
@@ -306,7 +306,9 @@ $document.on( "submit", ".wb-tables-filter", function( event ) {
 								return true;
 							}
 						} else {
-							if ( $maxNum === $cachedVal && $cachedVal === "-0" ) { // both are empty
+							if ( $maxNum === null ) { // only one input number
+								return $minNum === "-0" || $minNum === $num;
+							} else if ( $maxNum === $cachedVal && $cachedVal === "-0" ) { // both are empty
 								return true;
 							} else if ( $maxNum !== "-0" && $minNum === $maxNum && $num === $maxNum ) { // min and max are the same
 								return true;


### PR DESCRIPTION
## What does this pull request (PR) do?
It fixes the logic of the number range to properly handle when min and max are equal +  when there is only one number input

## Additional information (optional)
I added the tests I performed at the bottom 

**General checklist**
Make your own list for the purpose of your Pull request.

- [x] Build and test PR's code /// Rouler le script de compilation et tester le code de la PR

**Related issues**
If min and max value were the same then it would ignore the max value.
closes #9235

**Screenshots**
## Tests
### Test 1
1) Don't change any values
2) All values are shown
![image](https://user-images.githubusercontent.com/55817894/203646640-5cf48514-d7fd-4c77-8d94-b0a8d050bfa6.png)

### Test 2 *(this is what changed)
1) Change min and max age value to 71
2) Only see people aged 71
![image](https://user-images.githubusercontent.com/55817894/203646787-e5ef383a-6824-4f62-9180-280860442baf.png)

### Test 3
1) Set Min age to 71 
2) See ages for 71 and up
![image](https://user-images.githubusercontent.com/55817894/203646342-5eae2bdc-df79-4295-b047-8392cbbbc2f7.png)

### Test 4
1) Set Max age to 50
2) Only see ages below 50
![image](https://user-images.githubusercontent.com/55817894/203647020-e4346df3-f346-460e-887d-bf57e61ceec6.png)

### Test 5
1) Set Max age to 70 and Min age to 65
2) Only see values between 65 and 70
![image](https://user-images.githubusercontent.com/55817894/203647203-30128df7-9fdc-4e7c-a884-6a232abbec83.png)

### Test 6
1) Copy the table code from #9235 and replace the number filter table with the one provided in the issue description
2) Set age to 70
3) only see row of 70 year old
![image](https://user-images.githubusercontent.com/55817894/204393358-bc6a22b1-e436-45ca-8928-2f863cb821e4.png)
