### PR TITLE
JSON Manager: Fix JSON pointer not always loaded

### DIFF
--- a/src/plugins/wb-jsonmanager/jsonmanager.js
+++ b/src/plugins/wb-jsonmanager/jsonmanager.js
@@ -243,7 +243,10 @@ var componentName = "wb-jsonmanager",
 			Modernizr.load( {
 
 				// For loading multiple dependencies
-				load: "site!deps/json-patch" + wb.getMode() + ".js",
+				load: [
+					"site!deps/json-patch" + wb.getMode() + ".js",
+					"site!deps/jsonpointer" + wb.getMode() + ".js"
+				],
 				testReady: function() {
 					return window.jsonpatch && window.jsonpointer;
 				},
@@ -435,9 +438,11 @@ var componentName = "wb-jsonmanager",
 					$.extend( jsonSource[ selectedTag.path ], arrMap );
 				}
 
-				targetTag = selectedTag.attr && targetTag [ 0 ].getAttributeNode( selectedTag.attr ) ?
-					targetTag [ 0 ].getAttributeNode( selectedTag.attr ).textContent :
-					targetTag [ 0 ].textContent;
+				if ( targetTag.length ) {
+					targetTag = selectedTag.attr && targetTag [ 0 ].getAttributeNode( selectedTag.attr ) ?
+						targetTag [ 0 ].getAttributeNode( selectedTag.attr ).textContent :
+						targetTag [ 0 ].textContent;
+				}
 
 			} else {
 


### PR DESCRIPTION
JSON pointer was not loaded in some cases which broke JSON manager.