### PR TITLE
Dompurify version update to 2.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3155,9 +3155,9 @@
       }
     },
     "dompurify": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.0.tgz",
-      "integrity": "sha512-Be9tbQMZds4a3C6xTmz68NlMfeONA//4dOavl/1rNw50E+/QO0KVpbcU0PcaW0nsQxurXls9ZocqFxk8R2mWEA=="
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.4.4.tgz",
+      "integrity": "sha512-1e2SpqHiRx4DPvmRuXU5J0di3iQACwJM+mFGE2HAkkK7Tbnfk9WcghcAmyWc9CRrjyRRUpmuhPUH6LphQQR3EQ=="
     },
     "domutils": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "bootstrap-sass": "3.4.1",
     "code-prettify": "^0.1.0",
     "datatables.net": "1.11.4",
-    "dompurify": "^2.4.0",
+    "dompurify": "^2.4.4",
     "es5-shim": "2.3.0",
     "fast-json-patch": "github:wet-boew/JSON-Patch#wb1.0+1.1.4",
     "html5shiv": "^3.7.3",


### PR DESCRIPTION
Update Dompurify to version 2.4.4 to be up to date with GCWeb.