### PR TITLE
Twitter embedded timeline: Improve loading phase

### DIFF
--- a/src/plugins/twitter/_base.scss
+++ b/src/plugins/twitter/_base.scss
@@ -3,33 +3,78 @@
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
 
-.wb-disable {
-	.wb-twitter {
-		.twitter-timeline {
-			text-indent: 0 !important;
-		}
-	}
-}
-
 .wb-twitter {
-	.twitter-timeline {
-		display: block;
+	/* Align the loading icon relative to the center of the Twitter link in browsers that support :has() */
+	&:has( a.twitter-timeline + .twitter-timeline-loading ) {
+		display: inline-block;
+
+		a {
+			&.twitter-timeline {
+				+ {
+					.twitter-timeline-loading {
+						&::before {
+							left: 0;
+							right: 0;
+						}
+
+						&::after {
+							margin: auto;
+						}
+					}
+				}
+			}
+		}
 	}
 
-	iframe {
-		&[style] {
-			width: 100% !important;
+	/* Display the loading icon as normal content */
+	a {
+		&.twitter-timeline {
+			+ {
+				.twitter-timeline-loading {
+					@extend %global-loading;
+					margin-top: 5px;
+					min: {
+						height: 100px;
+						width: 100px;
+					}
+					position: relative;
+
+					/* Align the loading icon leftwards by default */
+					&::before {
+						right: auto;
+					}
+
+					&::after {
+						margin-left: calc((100px - 1em) / 2);
+					}
+				}
+			}
 		}
 	}
 }
 
-.wb-enable {
+[dir=rtl] {
 	.wb-twitter {
-		.twitter-timeline {
-			@extend %global-loading;
-			min-height: 100px;
-			min-width: 100px;
-			position: relative;
+		a {
+			&.twitter-timeline {
+				+ {
+					.twitter-timeline-loading {
+
+						/* Align the loading icon rightwards by default */
+						&::before {
+							left: auto;
+							right: 0;
+						}
+
+						&::after {
+							margin: {
+								left: auto;
+								right: calc((100px - 1em) / 2);
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
The plugin's loading icon was previously tied to the "twitter-timeline" class... which is used by both the Twitter link and timeline container.

That resulted in the following behaviour:
1. The link's loading icon immediately appeared
2. A second loading icon appeared when Twitter's widget script injected an empty timeline container into the page
3. The link's loading icon got removed when the timeline finished loading... leaving the timeline's loading icon in place forever

The following issues also occurred:
* The empty space to the right of the link was a linked area
* The link's loading icon was a linked area
* The link's loading icon appeared "on top" of the link in mobile viewports
* The loading icon was center-aligned in a full-width overlay... causing it to look like it was in the middle of nowhere in larger viewports
* The link's loading icon appeared forever in IE11

This fixes it by reworking the loading phase as follows:
* The link's linked area now only covers the link text
* The plugin now injects a loading icon ``div`` below the link
* The loading icon now...
  * Appears below the link instead of "on top" of it
  * Is either left/right-aligned or center-aligned relative to the link if a browser supports the ``:has()`` pseudo-class
  * Disappears when Twitter's timeline widget removes the link (CSS immediately hides it, then the plugin removes it behind-the-scenes)
  * Never appears in IE11

Other:
* Only shows one loading icon per plugin container
* Plugin containers with extra Twitter links or non-standard structures won't show loading icons
* Disables the plugin in IE11 (Twitter's widget script no longer supports that browser)

Related:
* Fixes #9503
* Depends on #9539

**Screenshots...**

**Before:**
* **Phase 1 (loading icon on top of the link... centered relative to viewport)**
![twitter-before-1](https://user-images.githubusercontent.com/1907279/219110311-70634bc4-eca7-4644-871d-8825ea4621c5.png)
* **Phase 2 (two loading icons on top of the link)**
![twitter-before-2](https://user-images.githubusercontent.com/1907279/219110464-467b899b-78dd-40e3-b0df-581853c8758a.png)
* **Phase 3 (centered loading icon on top of the timeline... forever)**
![twitter-before-3](https://user-images.githubusercontent.com/1907279/219110486-7bf13754-461c-432b-81bd-56a1b016f727.png)

**After:**
* **Phase 1 (link before plugin init)**
![twitter-after-1](https://user-images.githubusercontent.com/1907279/219110942-5819d82b-2d97-4ae2-b54d-f396d5f8f2b3.png)
* **Phase 2 (loading icon below the link... left-aligned by default, centered relative to link if ``:has()`` is supported)**
![twitter-after-2-without-has](https://user-images.githubusercontent.com/1907279/219111133-75bff421-6e7f-4e7f-8ba1-753da323a78d.png) OR ![twitter-after-2-with-has](https://user-images.githubusercontent.com/1907279/219111013-6353459a-ebf9-412e-a620-5f459d5b3138.png)
* **Phase 3 (timeline)**
![twitter-after-3](https://user-images.githubusercontent.com/1907279/219111141-0c711ac4-5f9d-4f4d-a2e1-ba0da3de5301.png)