### PR TITLE
Postback: Fix missing submit button variable

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1018,6 +1018,8 @@ module.exports = (grunt) ->
 						# We recommend handling this through the server headers so it never appears in the markup
 						"W002" # `<head>` is missing X-UA-Compatible `<meta>` tag that disables old IE compatibility modes
 						"W005" # Unable to locate jQuery, which is required for Bootstrap's JavaScript plugins to work; however, you might not be using Bootstrap's JavaScript
+						# Opinionated exclusions
+						"W007" # Found one or more `<button>`s missing a `type` attribute.
 						# TODO: The rules below should be resolved
 						"W009" # Using empty spacer columns isn't necessary with Bootstrap's grid. So instead of having an empty grid column with `class=\"col-xs-12"` , just add `class=\"col-xs-offset-12"` to the next grid column.
 						"W010" # Using `.pull-left` or `.pull-right` as part of the media object component is deprecated as of Bootstrap v3.3.0. Use `.media-left` or `.media-right` instead.

--- a/src/plugins/wb-postback/wb-postback-en.hbs
+++ b/src/plugins/wb-postback/wb-postback-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "wb-postback",
 	"parentdir": "wb-postback",
 	"altLangPrefix": "wb-postback",
-	"dateModified": "2023-02-01"
+	"dateModified": "2023-03-06"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -34,7 +34,7 @@
 			<label for="email1"><span class="field-name">Email Address</span> (test@domaine)</label>
 			<input class="form-control" id="email1" name="email" type="email" />
 		</div>
-		<button type="submit" class="btn btn-primary">Submit</button>
+		<button class="btn btn-primary">Submit</button>
 	</div>
 </form>
 <p class="success-message hide">Thank you!</p>
@@ -59,19 +59,48 @@
 			&lt;label for="email1"&gt;&lt;span class="field-name"&gt;Email Address&lt;/span&gt; (test@domaine)&lt;/label&gt;
 			&lt;input class="form-control" id="email1" name="email" type="email" /&gt;
 		&lt;/div&gt;
-		&lt;button type="submit" class="btn btn-primary"&gt;Submit&lt;/button&gt;
+		&lt;button class="btn btn-primary"&gt;Submit&lt;/button&gt;
 	&lt;/div&gt;
 &lt;/form&gt;
 &lt;p class="success-message hide"&gt;Thank you!&lt;/p&gt;
 &lt;p class="failure-message hide"&gt;Something went wrong. Please submit your information via an alternative method.&lt;/p&gt;</code></pre>
 </details>
 
-<p>Submit web form through AJAX call using also the <a href="https://wet-boew.github.io/wet-boew/demos/formvalid/formvalid-en.html">Form Validation</a> plugin.</p>
+<section>
+<h2>Submit button variable</h2>
+
+<p>Submit web form through AJAX call using a submit button variable.</p>
+
+<p>To see this example in action, check the network tab of browser console to see AJAX request sent.</p>
+
+<form action="wb-postback-en.html" class="wb-postback" data-wb-postback='{"success":".success-message-2","failure":".failure-message-2"}'>
+	<div class="form-content">
+		<button class="btn btn-primary" name="submitBtn" value="submitBtnValue">Submit</button>
+	</div>
+</form>
+<p class="success-message-2 hide">Thank you!</p>
+<p class="failure-message-2 hide">Something went wrong. Please submit your information via an alternative method.</p>
+<details class="mrgn-tp-md mrgn-bttm-md">
+	<summary>View code</summary>
+	<pre><code>&lt;form action="wb-postback-en.html" class="wb-postback" data-wb-postback='{"success":".success-message-2","failure":".failure-message-2"}'&gt;
+	&lt;div class="form-content"&gt;
+		&lt;button class="btn btn-primary" name="submitBtn" value="submitBtnValue"&gt;Submit&lt;/button&gt;
+	&lt;/div&gt;
+&lt;/form&gt;
+&lt;p class="success-message-2 hide"&gt;Thank you!&lt;/p&gt;
+&lt;p class="failure-message-2 hide"&gt;Something went wrong. Please submit your information via an alternative method.&lt;/p&gt;</code></pre>
+</details>
+</section>
+
+<section>
+<h2>Form validation plugin</h2>
+
+<p>Submit web form through AJAX call using the <a href="https://wet-boew.github.io/wet-boew/demos/formvalid/formvalid-en.html">form validation</a> plugin.</p>
 
 <p>To see this example in action, check the network tab of browser console to see AJAX request sent.</p>
 
 <div class="wb-frmvld">
-	<form action="wb-postback-en.html" class="wb-postback" data-wb-postback='{"success":".success-message-2","failure":".failure-message-2"}'>
+	<form action="wb-postback-en.html" class="wb-postback" data-wb-postback='{"success":".success-message-3","failure":".failure-message-3"}'>
 		<div class="form-content">
 			<div class="form-group">
 				<label for="firstname2" class="required"><span class="field-name">First Name</span> <strong class="required">(required)</strong></label>
@@ -89,17 +118,17 @@
 				<label for="email2"><span class="field-name">Email Address</span> (test@domaine)</label>
 				<input class="form-control" id="email2" name="email" type="email" />
 			</div>
-			<button type="submit" class="btn btn-primary">Submit</button>
+			<button class="btn btn-primary">Submit</button>
 		</div>
 	</form>
-	<p class="success-message-2 hide">Thank you!</p>
-	<p class="failure-message-2 hide">Something went wrong. Please submit your information via an alternative method.</p>
+	<p class="success-message-3 hide">Thank you!</p>
+	<p class="failure-message-3 hide">Something went wrong. Please submit your information via an alternative method.</p>
 </div>
 <details class="mrgn-tp-md mrgn-bttm-md">
 	<summary>View code</summary>
 	{{>alertariahidden}}
 	<pre><code>&lt;div class="wb-frmvld"&gt;
-	&lt;form action="wb-postback-en.html" class="wb-postback" data-wb-postback='{"success":".success-message-2","failure":".failure-message-2"}'&gt;
+	&lt;form action="wb-postback-en.html" class="wb-postback" data-wb-postback='{"success":".success-message-3","failure":".failure-message-3"}'&gt;
 		&lt;div class="form-content"&gt;
 			&lt;div class="form-group"&gt;
 				&lt;label for="firstname2" class="required"&gt;&lt;span class="field-name"&gt;First Name&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
@@ -117,10 +146,50 @@
 				&lt;label for="email2"&gt;&lt;span class="field-name"&gt;Email Address&lt;/span&gt; (test@domaine)&lt;/label&gt;
 				&lt;input class="form-control" id="email2" name="email" type="email" /&gt;
 			&lt;/div&gt;
-			&lt;button type="submit" class="btn btn-primary"&gt;Submit&lt;/button&gt;
+			&lt;button class="btn btn-primary"&gt;Submit&lt;/button&gt;
 		&lt;/div&gt;
 	&lt;/form&gt;
-	&lt;p class="success-message-2 hide"&gt;Thank you!&lt;/p&gt;
-	&lt;p class="failure-message-2 hide"&gt;Something went wrong. Please submit your information via an alternative method.&lt;/p&gt;
+	&lt;p class="success-message-3 hide"&gt;Thank you!&lt;/p&gt;
+	&lt;p class="failure-message-3 hide"&gt;Something went wrong. Please submit your information via an alternative method.&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 </details>
+</section>
+
+<section>
+<h2>Form validation plugin with submit button variable</h2>
+
+<p>Submit web form through AJAX call using the <a href="https://wet-boew.github.io/wet-boew/demos/formvalid/formvalid-en.html">form validation</a> plugin with a submit button variable.</p>
+
+<p>To see this example in action, check the network tab of browser console to see AJAX request sent.</p>
+
+<div class="wb-frmvld">
+	<form action="wb-postback-en.html" class="wb-postback" data-wb-postback='{"success":".success-message-4","failure":".failure-message-4"}'>
+		<div class="form-content">
+			<div class="form-group">
+				<label for="firstname3" class="required"><span class="field-name">First Name</span> <strong class="required">(required)</strong></label>
+				<input class="form-control" id="firstname3" name="firstname" type="text" data-rule-minlength="2" required="required" />
+			</div>
+			<button class="btn btn-primary" name="submitBtn" value="submitBtnValue">Submit</button>
+		</div>
+	</form>
+	<p class="success-message-4 hide">Thank you!</p>
+	<p class="failure-message-4 hide">Something went wrong. Please submit your information via an alternative method.</p>
+</div>
+<details class="mrgn-tp-md mrgn-bttm-md">
+	<summary>View code</summary>
+	{{>alertariahidden}}
+	<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="wb-postback-en.html" class="wb-postback" data-wb-postback='{"success":".success-message-4","failure":".failure-message-4"}'&gt;
+		&lt;div class="form-content"&gt;
+			&lt;div class="form-group"&gt;
+				&lt;label for="firstname3" class="required"&gt;&lt;span class="field-name"&gt;First Name&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
+				&lt;input class="form-control" id="firstname3" name="firstname" type="text" data-rule-minlength="2" required="required" /&gt;
+			&lt;/div&gt;
+			&lt;button class="btn btn-primary" name="submitBtn" value="submitBtnValue"&gt;Submit&lt;/button&gt;
+		&lt;/div&gt;
+	&lt;/form&gt;
+	&lt;p class="success-message-4 hide"&gt;Thank you!&lt;/p&gt;
+	&lt;p class="failure-message-4 hide"&gt;Something went wrong. Please submit your information via an alternative method.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+</details>
+</section>

--- a/src/plugins/wb-postback/wb-postback-fr.hbs
+++ b/src/plugins/wb-postback/wb-postback-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "wb-postback",
 	"parentdir": "wb-postback",
 	"altLangPrefix": "wb-postback",
-	"dateModified": "2023-02-01"
+	"dateModified": "2023-03-06"
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -34,7 +34,7 @@
 			<label for="email1"><span class="field-name">Addresse courriel</span> (test@domaine)</label>
 			<input class="form-control" id="email1" name="email" type="email" />
 		</div>
-		<button type="submit" class="btn btn-primary">Soumettre</button>
+		<button class="btn btn-primary">Soumettre</button>
 	</div>
 </form>
 <p class="success-message hide">Merci!</p>
@@ -59,19 +59,48 @@
 			&lt;label for="email1"&gt;&lt;span class="field-name"&gt;Addresse courriel&lt;/span&gt; (test@domaine)&lt;/label&gt;
 			&lt;input class="form-control" id="email1" name="email" type="email" /&gt;
 		&lt;/div&gt;
-		&lt;button type="submit" class="btn btn-primary"&gt;Soumettre&lt;/button&gt;
+		&lt;button class="btn btn-primary"&gt;Soumettre&lt;/button&gt;
 	&lt;/div&gt;
 &lt;/form&gt;
 &lt;p class="success-message hide"&gt;Merci!&lt;/p&gt;
 &lt;p class="failure-message hide"&gt;Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.&lt;/p&gt;</code></pre>
 </details>
 
-<p>Soumission de formulaire via une requête Ajax en utilisant aussi le plugiciel <a href="https://wet-boew.github.io/wet-boew/demos/formvalid/formvalid-fr.html">Validation de formulaires</a> .</p>
+<section>
+<h2>Variable de bouton de soumission</h2>
+
+<p>Soumission de formulaire via une requête Ajax utilisant une variable de bouton de soumission.</p>
+
+<p>Pour voir cet example en action, vérifier l'onglet réseaux de la console du fureteur afin de voir la requête Ajax envoyé.</p>
+
+<form action="wb-postback-fr.html" class="wb-postback" data-wb-postback='{"success":".success-message-2","failure":".failure-message-2"}'>
+	<div class="form-content">
+		<button class="btn btn-primary" name="submitBtn" value="submitBtnValue">Soumettre</button>
+	</div>
+</form>
+<p class="success-message-2 hide">Merci!</p>
+<p class="failure-message-2 hide">Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.</p>
+<details class="mrgn-tp-md mrgn-bttm-md">
+	<summary>View code</summary>
+	<pre><code>&lt;form action="wb-postback-fr.html" class="wb-postback" data-wb-postback='{"success":".success-message-2","failure":".failure-message-2"}'&gt;
+	&lt;div class="form-content"&gt;
+		&lt;button class="btn btn-primary" name="submitBtn" value="submitBtnValue"&gt;Soumettre&lt;/button&gt;
+	&lt;/div&gt;
+&lt;/form&gt;
+&lt;p class="success-message-2 hide"&gt;Merci!&lt;/p&gt;
+&lt;p class="failure-message-2 hide"&gt;Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.&lt;/p&gt;</code></pre>
+</details>
+</section>
+
+<section>
+<h2>Plugiciel validation de formulaires</h2>
+
+<p>Soumission de formulaire via une requête Ajax en utilisant le plugiciel <a href="https://wet-boew.github.io/wet-boew/demos/formvalid/formvalid-fr.html">validation de formulaires</a> .</p>
 
 <p>Pour voir cet example en action, vérifier l'onglet réseaux de la console du fureteur afin de voir la requête Ajax envoyé.</p>
 
 <div class="wb-frmvld">
-	<form action="wb-postback-fr.html" class="wb-postback" data-wb-postback='{"success":".success-message-2","failure":".failure-message-2"}'>
+	<form action="wb-postback-fr.html" class="wb-postback" data-wb-postback='{"success":".success-message-3","failure":".failure-message-3"}'>
 		<div class="form-content">
 			<div class="form-group">
 				<label for="firstname2" class="required"><span class="field-name">Prénom</span> <strong class="required">(obligatoire)</strong></label>
@@ -89,17 +118,17 @@
 				<label for="email2"><span class="field-name">Addresse courriel</span> (test@domaine)</label>
 				<input class="form-control" id="email2" name="email" type="email" />
 			</div>
-			<button type="submit" class="btn btn-primary">Soumettre</button>
+			<button class="btn btn-primary">Soumettre</button>
 		</div>
 	</form>
-	<p class="success-message-2 hide">Merci!</p>
-	<p class="failure-message-2 hide">Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.</p>
+	<p class="success-message-3 hide">Merci!</p>
+	<p class="failure-message-3 hide">Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.</p>
 </div>
 <details class="mrgn-tp-md mrgn-bttm-md">
 	<summary>View code</summary>
 	{{>alertariahidden}}
 	<pre><code>&lt;div class="wb-frmvld"&gt;
-	&lt;form action="wb-postback-fr.html" class="wb-postback" data-wb-postback='{"success":".success-message-2","failure":".failure-message-2"}'&gt;
+	&lt;form action="wb-postback-fr.html" class="wb-postback" data-wb-postback='{"success":".success-message-3","failure":".failure-message-3"}'&gt;
 		&lt;div class="form-content"&gt;
 			&lt;div class="form-group"&gt;
 				&lt;label for="firstname2" class="required"&gt;&lt;span class="field-name"&gt;Prénom&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
@@ -117,10 +146,50 @@
 				&lt;label for="email2"&gt;&lt;span class="field-name"&gt;Addresse courriel&lt;/span&gt; (test@domaine)&lt;/label&gt;
 				&lt;input class="form-control" id="email2" name="email" type="email" /&gt;
 			&lt;/div&gt;
-			&lt;button type="submit" class="btn btn-primary"&gt;Soumettre&lt;/button&gt;
+			&lt;button class="btn btn-primary"&gt;Soumettre&lt;/button&gt;
 		&lt;/div&gt;
 	&lt;/form&gt;
-	&lt;p class="success-message-2 hide"&gt;Merci!&lt;/p&gt;
-	&lt;p class="failure-message-2 hide"&gt;Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.&lt;/p&gt;
+	&lt;p class="success-message-3 hide"&gt;Merci!&lt;/p&gt;
+	&lt;p class="failure-message-3 hide"&gt;Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 </details>
+</section>
+
+<section>
+<h2>Plugiciel validation de formulaires</h2>
+
+<p>Soumission de formulaire via une requête Ajax en utilisant le plugiciel <a href="https://wet-boew.github.io/wet-boew/demos/formvalid/formvalid-fr.html">validation de formulaires</a>  avec une variable de bouton de soumission.</p>
+
+<p>Pour voir cet example en action, vérifier l'onglet réseaux de la console du fureteur afin de voir la requête Ajax envoyé.</p>
+
+<div class="wb-frmvld">
+	<form action="wb-postback-fr.html" class="wb-postback" data-wb-postback='{"success":".success-message-4","failure":".failure-message-4"}'>
+		<div class="form-content">
+			<div class="form-group">
+				<label for="firstname3" class="required"><span class="field-name">Prénom</span> <strong class="required">(obligatoire)</strong></label>
+				<input class="form-control" id="firstname3" name="firstname" type="text" data-rule-minlength="2" required="required" />
+			</div>
+			<button class="btn btn-primary" name="submitBtn" value="submitBtnValue">Soumettre</button>
+		</div>
+	</form>
+	<p class="success-message-4 hide">Merci!</p>
+	<p class="failure-message-4 hide">Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.</p>
+</div>
+<details class="mrgn-tp-md mrgn-bttm-md">
+	<summary>View code</summary>
+	{{>alertariahidden}}
+	<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="wb-postback-fr.html" class="wb-postback" data-wb-postback='{"success":".success-message-4","failure":".failure-message-4"}'&gt;
+		&lt;div class="form-content"&gt;
+			&lt;div class="form-group"&gt;
+				&lt;label for="firstname3" class="required"&gt;&lt;span class="field-name"&gt;Prénom&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
+				&lt;input class="form-control" id="firstname3" name="firstname" type="text" data-rule-minlength="2" required="required" /&gt;
+			&lt;/div&gt;
+			&lt;button class="btn btn-primary" name="submitBtn" value="submitBtnValue"&gt;Soumettre&lt;/button&gt;
+		&lt;/div&gt;
+	&lt;/form&gt;
+	&lt;p class="success-message-4 hide"&gt;Merci!&lt;/p&gt;
+	&lt;p class="failure-message-4 hide"&gt;Nous somme désolé, un problème est survenu lors de la soumission de votre formulaire. Veuillez nous envoyer l'information via une méthode alternative.&lt;/p&gt;
+&lt;/div&gt;</code></pre>
+</details>
+</section>

--- a/src/plugins/wb-postback/wb-postback.js
+++ b/src/plugins/wb-postback/wb-postback.js
@@ -27,7 +27,7 @@ var $document = wb.doc,
 					wb.getData( $elm, componentName )
 				),
 				attrEngaged = "data-wb-engaged",
-				$buttons = $( "[type=submit]", $elm ),
+				$buttons = $( "[type=submit], button:not([type])", $elm ),
 				multiple = typeof $elm.data( componentName + "-multiple" ) !== "undefined",
 				classToggle = settings.toggle || "hide",
 				selectorSuccess = settings.success,
@@ -48,15 +48,15 @@ var $document = wb.doc,
 				if ( elm.parentElement.classList.contains( "wb-frmvld" ) ) {
 					if ( !$elm.valid() ) {
 						$( this ).attr( attrEngaged, true );
-					} else {
 						$buttons.removeAttr( attrEngaged );
+					} else {
 						$( this ).attr( attrEngaged, "" );
 					}
 				}
 
 				if ( !$( this ).attr( attrEngaged ) ) {
 					var data = $elm.serializeArray(),
-						$btn = $( "[type=submit][name][" + attrEngaged + "]", $elm ),
+						$btn = $( "[name][" + attrEngaged + "]", $elm ),
 						$selectorSuccess = $( selectorSuccess ),
 						$selectorFailure = $( selectorFailure );
 


### PR DESCRIPTION
The postback plugin was previously excluding submit button variables in the following scenarios:
1. When the submit button was a type-less ``button`` element (the ``button`` element's default type is ``submit`` according to the HTML spec)
2. When the form validation plugin was used

This fixes it by:
1. Adjusting button selectors as follows:
   * Expand the ``$buttons`` selector to cover type-less button elements
   * Remove ``[type=submit]`` from the ``$btn`` selector (what remains should be able to pick up any engaged submit button associated to a variable)
2. Removing the ``data-wb-engaged`` attribute from a clicked submit button if form validation fails (opposite of what was previously being done)

Also updates the demo page's examples to better represent the fixed scenarios:
* Add submit button variable examples (``name``/``value`` attributes):
  * Standard form with just a submit button
  * Form validation plugin with one required field and a submit button
* Remove all submit buttons' ``type="submit"`` attributes
* Gruntfile: Add exclusion for bootlint's ``W007`` rule to suppress errors on type-less ``button`` elements
* Place all examples into their own sections