### PR TITLE
Postback: Prevent form validation double-submits

### DIFF
--- a/src/plugins/wb-postback/wb-postback.js
+++ b/src/plugins/wb-postback/wb-postback.js
@@ -26,18 +26,12 @@ var $document = wb.doc,
 					defaults,
 					wb.getData( $elm, componentName )
 				),
-				attrEngaged = "data-wb-engaged",
-				$buttons = $( "[type=submit], button:not([type])", $elm ),
 				multiple = typeof $elm.data( componentName + "-multiple" ) !== "undefined",
 				classToggle = settings.toggle || "hide",
 				selectorSuccess = settings.success,
 				selectorFailure = settings.failure || selectorSuccess;
-
-			// Set "clicked" attribute on element that initiated the form submit
-			$buttons.on( "click", function() {
-				$buttons.removeAttr( attrEngaged );
-				$( this ).attr( attrEngaged, "" );
-			} );
+			const attrBlocked = "data-wb-blocked",
+				attrSending = "data-wb-sending";
 
 			elm.addEventListener( "submit", function( e ) {
 
@@ -46,24 +40,30 @@ var $document = wb.doc,
 
 				//Check if the form use the validation plugin
 				if ( elm.parentElement.classList.contains( "wb-frmvld" ) ) {
+
+					// Block invalid forms and allow valid ones
 					if ( !$elm.valid() ) {
-						$( this ).attr( attrEngaged, true );
-						$buttons.removeAttr( attrEngaged );
+						$( this ).attr( attrBlocked, "true" );
 					} else {
-						$( this ).attr( attrEngaged, "" );
+						$( this ).removeAttr( attrBlocked );
 					}
 				}
 
-				if ( !$( this ).attr( attrEngaged ) ) {
+				// Submit the form unless it's blocked or currently being sent
+				if ( !$( this ).attr( attrBlocked ) && !$( this ).attr( attrSending ) ) {
 					var data = $elm.serializeArray(),
-						$btn = $( "[name][" + attrEngaged + "]", $elm ),
+						btn = e.submitter,
 						$selectorSuccess = $( selectorSuccess ),
 						$selectorFailure = $( selectorFailure );
 
-					if ( $btn.length ) {
-						data.push( { name: $btn.attr( "name" ), value: $btn.val() } );
+					// Indicate that the form is currently being sent (to prevent multiple submissions in parallel)
+					$( this ).attr( attrSending, true );
+
+					// If the submit button contains a variable, add it to the form's paramaters
+					// Note: Submitting a form via Enter will act as if the FIRST submit button was pressed. Therefore, that button's variable will be added (as opposed to nothing). This is in line with default form submission behaviour.
+					if ( btn && btn.name ) {
+						data.push( { name: btn.name, value: btn.value } );
 					}
-					$( this ).attr( attrEngaged, true );
 
 					// Hide feedback messages
 					$selectorFailure.addClass( classToggle );
@@ -85,12 +85,13 @@ var $document = wb.doc,
 						} )
 						.always( function() {
 
-							// Make the form submittable again if multiple submits are allowed or hide
-							if ( multiple ) {
-								$elm.removeAttr( attrEngaged );
-							} else {
+							// Hide the form unless multiple submits are allowed
+							if ( !multiple ) {
 								$elm.addClass( classToggle );
 							}
+
+							// Remove the sending indicator now that submission is fully complete (i.e. HTTP response code has been received)
+							$elm.removeAttr( attrSending );
 						} );
 				}
 			} );


### PR DESCRIPTION
The form validation plugin's pass/fail logic was interfering with in-progress form submissions.

Repeatedly submitting postback forms on slower internet connections could trick the aforementioned logic into disengaging forms that had already been submitted (but had yet to receive an HTTP response code). That made it possible to initiate multiple parallel submissions.

This fixes it as follows:
* Replaces the form element's ``data-wb-engaged`` attribute with purpose-specific ones:
  * ``data-wb-blocked``: Indicates the form validation plugin failed (to prevent invalid forms from getting submitted).
  * ``data-wb-sending``: Indicates the form is currently being sent (to prevent duplicate submissions... like repeatedly submitting before the first submission finishes)
* Simplifies how pressed submit buttons are detected:
  * Uses the ``submit()`` event's ``submitter`` property to detect pressed submit buttons (instead of juggling with ``data-wb-engaged`` to figure out what was pressed)
  * Note: Changes the plugin to match default browser behaviour:
    * Old behaviour: Submitting a form in JS mode without pressing a button didn't send any submit button variables
    * New behaviour: Same scenario now causes the first submit button's variable to be included in the form submission (since ``submitter`` maps to the first submit button if none were directly pressed)

Successor of sorts to #8924 and #9197.

CC @GormFrank @polmih