### PR TITLE
Core - wb: add separate initialization for components when in basic HTML mode

### DIFF
--- a/site/pages/docs/ref/data-ajax/data-ajax-en.hbs
+++ b/site/pages/docs/ref/data-ajax/data-ajax-en.hbs
@@ -270,6 +270,15 @@
 </code></pre>
 </section>
 <section>
+	<h2>Execute the plugin in basic HTML mode</h2>
+	<p>To execute the plugin in basic HTML mode the following attribute should be present <code>data-wb-basic-ajax=true</code></p>
+<pre><code>&lt;section data-wb-basic-ajax=true data-ajax-after="ajax/data-ajax-extra-en.html" class="original"&gt;
+	&lt;h4&gt;Hello World&lt;/h4&gt;
+	&lt;p&gt;Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.&lt;/p&gt;
+&lt;/section&gt;
+</code></pre>
+</section>
+<section>
 	<h2>Events</h2>
 	<table class="table">
 		<thead>

--- a/site/pages/docs/ref/data-ajax/data-ajax-fr.hbs
+++ b/site/pages/docs/ref/data-ajax/data-ajax-fr.hbs
@@ -273,6 +273,15 @@
 </code></pre>
 </section>
 <section>
+<h2>Exécuter le plugiciel en version HTML simplifiée</h2>
+<p>Pour exécuter le plugin en version HTML simplifiée, l'attribut suivant doit être présent <code>data-wb-basic-ajax=true</code></p>
+<pre><code>&lt;section data-wb-basic-ajax=true data-ajax-after="ajax/data-ajax-extra-en.html" class="original"&gt;
+	&lt;h4&gt;Bonjour le monde&lt;/h4&gt;
+	&lt;p&gt;Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.&lt;/p&gt;
+&lt;/section&gt;
+</code></pre>
+</section>
+<section>
 	<h2>Events</h2>
 	<table class="table">
 		<thead>

--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -178,6 +178,7 @@ var getUrlParts = function( url ) {
 		isReady: false,
 		ignoreHashChange: false,
 		initQueue: 0,
+		initType: disabled ? "wb-basic-init" : "wb-init",
 
 		getPath: function( property ) {
 			return Object.prototype.hasOwnProperty.call( this, property ) ? this[ property ] : undef;
@@ -195,7 +196,7 @@ var getUrlParts = function( url ) {
 			var	eventTarget = event.target,
 				isEvent = !!eventTarget,
 				node = isEvent ? eventTarget : event,
-				initedClass = componentName + "-inited",
+				initedClass = this.isDisabled ? componentName + "-basic-inited" : componentName + "-inited",
 				isDocumentNode = node === document;
 
 			// Filter out any events triggered by descendants and only initializes
@@ -225,8 +226,8 @@ var getUrlParts = function( url ) {
 				// Trigger any nested elements (excluding nested within nested)
 				$elm
 					.find( wb.allSelectors )
-					.addClass( "wb-init" )
-					.filter( ":not(#" + $elm.attr( "id" ) + " .wb-init .wb-init)" )
+					.addClass( this.initType )
+					.filter( ":not(#" + $elm.attr( "id" ) + " ." + this.initType + " ." + this.initType + ")" )
 					.trigger( "timerpoke.wb" );
 
 				// Identify that the component is ready
@@ -294,11 +295,6 @@ var getUrlParts = function( url ) {
 				len = wb.selectors.length,
 				i;
 
-			// Lets ensure we are not running if things are disabled
-			if ( wb.isDisabled && selector !== "#wb-tphp" ) {
-				return 0;
-			}
-
 			// Check to see if the selector is already targeted
 			for ( i = 0; i !== len; i += 1 ) {
 				if ( wb.selectors[ i ] === selector ) {
@@ -347,7 +343,7 @@ var getUrlParts = function( url ) {
 				}
 
 				// Keep only the non-nested plugin/polyfill elements
-				$elms = $foundElms.filter( ":not(.wb-init .wb-init)" ).addClass( "wb-init" );
+				$elms = $foundElms.filter( ":not(." + this.initType + " ." + this.initType + ")" ).addClass( this.initType );
 			} else {
 				$elms = $( selectorsLocal.join( ", " ) );
 			}
@@ -586,7 +582,7 @@ Modernizr.load( [
 				let isTrident = new Boolean( window.navigator.msSaveOrOpenBlob );
 
 				// Bind the init event of the plugin
-				$document.one( "timerpoke.wb wb-init." + componentName, selector, function() {
+				$document.one( "timerpoke.wb " + this.initType + "." + componentName, selector, function() {
 
 					// Start initialization
 					wb.init( document, componentName, selector );

--- a/src/plugins/data-ajax/data-ajax-en.hbs
+++ b/src/plugins/data-ajax/data-ajax-en.hbs
@@ -42,8 +42,8 @@
 			<section>
 				<h4>data-ajax-extra-en.html</h4>
 				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
-	&lt;h4&gt;J'ai été affiché via Ajax&lt;/h4&gt;
-	&lt;p&gt;J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax.&lt;/p&gt;
+	&lt;h4&gt;I was ajaxed in&lt;/h4&gt;
+	&lt;p&gt;I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in.&lt;/p&gt;
 &lt;/section&gt;</code></pre>
 			</section>
 
@@ -365,4 +365,33 @@
 	&lt;p&gt;This content will be replaced if you browse to this page from the &lt;a href="../data-ajax-en.html"&gt;French version of this page&lt;/a&gt; page&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 		</details>
+</section>
+
+<section>
+	<h2>Activate the plugin in basic html mode (<code>data-wb-basic-ajax=true</code>)</h2>
+	<section>
+		<h3>Example</h3>
+		<section data-wb-basic-ajax=true data-ajax-after="ajax/data-ajax-extra-en.html" class="original">
+			<h4>Hello World</h4>
+			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+		</section>
+		<details>
+			<summary>View code</summary>
+			<section>
+				<h4>In-page HTML</h4>
+				<pre><code>&lt;section data-wb-basic-ajax=true data-ajax-after="ajax/data-ajax-extra-en.html" class="original"&gt;
+	&lt;h4&gt;Hello World&lt;/h4&gt;
+	&lt;p&gt;Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.&lt;/p&gt;
+&lt;/section&gt;
+</code></pre>
+			</section>
+			<section>
+				<h4>data-ajax-extra-en.html</h4>
+				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
+	&lt;h4&gt;I was ajaxed in&lt;/h4&gt;
+	&lt;p&gt;I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in.&lt;/p&gt;
+&lt;/section&gt;</code></pre>
+			</section>
+		</details>
+	</section>
 </section>

--- a/src/plugins/data-ajax/data-ajax-fr.hbs
+++ b/src/plugins/data-ajax/data-ajax-fr.hbs
@@ -364,3 +364,31 @@
 &lt;/div&gt;</code></pre>
 		</details>
 </section>
+
+<section>
+	<h2>Activer le plugiciel en version HTML simplifiée (<code>data-ajax-after</code>)</h2>
+	<section>
+		<h3>Exemple</h3>
+		<section data-wb-basic-ajax=true data-ajax-after="ajax/data-ajax-extra-fr.html" class="original">
+			<h4>Bonjour tout le monde</h4>
+			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+		</section>
+		<details>
+			<summary>Visualiser le code</summary>
+			<section>
+				<h4>HTML dans la page</h4>
+				<pre><code>&lt;section data-wb-basic-ajax=true data-ajax-after="ajax/data-ajax-extra-fr.html" class="original"&gt;
+	&lt;h4&gt;Bonjour tout le monde&lt;/h4&gt;
+	&lt;p&gt;Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.&lt;/p&gt;
+&lt;/section&gt;</code></pre>
+<section>
+		<h4>data-ajax-extra-fr.html</h4>
+		<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
+&lt;h4&gt;J'ai été affiché via Ajax&lt;/h4&gt;
+&lt;p&gt;J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax.&lt;/p&gt;
+&lt;/section&gt;</code></pre>
+	</section>
+			</section>
+		</details>
+	</section>
+</section>

--- a/src/plugins/data-ajax/data-ajax.js
+++ b/src/plugins/data-ajax/data-ajax.js
@@ -34,11 +34,34 @@ var componentName = "wb-data-ajax",
 	],
 	selectorsLength = selectors.length,
 	selector = selectors.join( "," ),
-	initEvent = "wb-init." + componentName,
+	initEvent = wb.isDisabled ? "wb-basic-init" + selector : "wb-init" + selector,
 	updateEvent = "wb-update." + componentName,
 	contentUpdatedEvent = "wb-contentupdated",
 	$document = wb.doc,
 	s,
+	basicInit = function( event ) {
+
+		// Start initialization
+		// returns DOM object = proceed with init
+		// returns undefined = do not proceed with init (e.g., already initialized)
+		var ajxInfo = getAjxInfo( event.target ),
+			ajaxType = ajxInfo.type,
+			elm = wb.init( event, componentName + "-" + ajaxType, selector );
+
+		// Run the plugin only if data-wb-basic-ajax attribute is present
+		if ( $( elm ).data( "wbBasicAjax" ) ) {
+			if ( elm && ajxInfo.url ) {
+
+				ajax.call( this, event, ajxInfo );
+
+				// Identify that initialization has completed
+				wb.ready( $( elm ), componentName, [ ajaxType ] );
+			}
+		} else {
+			wb.ready( $( elm ), componentName );
+		}
+	},
+
 
 	/**
 	 * @method init
@@ -209,7 +232,7 @@ $document.on( "timerpoke.wb " + initEvent + " " + updateEvent + " ajax-fetched.w
 
 	case "timerpoke":
 	case "wb-init":
-		init( event );
+		( wb.isDisabled ) ? basicInit( event ) : init( event );
 		break;
 	case "wb-update":
 		ajax( event );


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

- add separate initialization for components when in basic HTML mode;
- create basicInit function for data-ajax component to allow to be executed in basic HTML mode. For that a new data attribute is added: `data-wb-basic-ajax=true`