### PR TITLE
Theme: Show deprecated comment in wet-boew.min.css

### DIFF
--- a/theme/wet-boew.scss
+++ b/theme/wet-boew.scss
@@ -2,4 +2,4 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
-/* Deprecated */
+/*! Deprecated */


### PR DESCRIPTION
WET's themes come with a ``theme/wet-boew.scss`` file.

It originally contained a "themed" version of WET core (i.e. WET core using the current theme's variable overrides).

Later on, #6813 moved WET core into ``theme/theme.scss``. When that happened, ``theme/wet-boew.scss``'s contents were replaced with a deprecation comment. Probably to prevent HTTP 404 errors in pre-existing WET implementations that upgraded.

When compiling WET's CSS, the deprecation comment showed-up fine in unminified CSS, but disappeared when minified. Why? Because the ``cssmin`` task strips-out CSS comments.

This change turns the deprecation comment into a "special" comment that'll be kept by ``cssmin``. That'll clarify the "hollow" minified file's purpose. Plus it's in line with what ``theme/ie8-wet-boew.scss`` already does.