### PR TITLE
Datalist polyfill: Future-proof dynamic demo's JS code sample

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -479,7 +479,10 @@ module.exports = (grunt) ->
 				production: false
 				data: "site/data/**/*.{yml,json}"
 				helpers: "site/helpers/helper{,s}-*.js"
-				partials: "site/includes/**/*.hbs"
+				partials: [
+					"site/includes/**/*.hbs"
+					"src/polyfills/datalist/demo/datalist_dynamic.js"
+				]
 				layoutdir: "site/layouts"
 				layout: "default.hbs"
 				environment:

--- a/site/helpers/helpers-escape.js
+++ b/site/helpers/helpers-escape.js
@@ -1,0 +1,18 @@
+/**
+ * Handlebars helpers: Escape expression
+ * Encodes special characters (like HTML tags) for code samples
+ * Uses https://handlebarsjs.com/api-reference/utilities.html#handlebars-escapeexpression-string
+ */
+"use strict";
+
+// Export helper
+// eslint-disable-next-line no-undef
+module.exports.register = function( Handlebars, options ) {
+
+	// eslint-disable-next-line no-unused-vars
+	options = options || {};
+
+	Handlebars.registerHelper( "escape", function( options ) {
+		return Handlebars.escapeExpression( options.fn( this ) );
+	} );
+};

--- a/site/helpers/helpers-stripbanner.js
+++ b/site/helpers/helpers-stripbanner.js
@@ -1,0 +1,18 @@
+/**
+ * Handlebars helpers: Strip banner
+ * Removes the banner (i.e. first multi-line comment) from CSS/JavaScript code
+ * Regex derived from Ryan Wheale's answer in https://stackoverflow.com/a/15123777
+ */
+"use strict";
+
+// Export helper
+// eslint-disable-next-line no-undef
+module.exports.register = function( Handlebars, options ) {
+
+	// eslint-disable-next-line no-unused-vars
+	options = options || {};
+
+	Handlebars.registerHelper( "stripbanner", function( options ) {
+		return options.fn( this ).replace( /^\/\*[\s\S]*?\*\/\r?\n?/m, "" );
+	} );
+};

--- a/src/polyfills/datalist/datalist-dynamic-en.hbs
+++ b/src/polyfills/datalist/datalist-dynamic-en.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "datalist",
 	"altLangPrefix": "datalist-dynamic",
 	"js": ["demo/datalist_dynamic"],
-	"dateModified": "2014-07-20"
+	"dateModified": "2023-04-14"
 }
 ---
 <section>
@@ -69,53 +69,7 @@
 
 		<section>
 			<h3>JavaScript</h3>
-			<pre><code>(function( $, wb ) {
-&quot;use strict&quot;;
-
-var $document = wb.doc,
-	pluginSelector = &quot;#plugin&quot;,
-	issueInput = $( &quot;#issue&quot; );
-
-$document.on( &quot;change&quot;, pluginSelector, function( event ) {
-	var pluginName = event.target.value;
-
-	$( this ).trigger({
-		type: &quot;ajax-fetch.wb&quot;,
-		fetch: {
-			url: encodeURI( &quot;https://api.github.com/repos/wet-boew/wet-boew/issues?labels=Feature: &quot; + pluginName ),
-			dataType: wb.ielt10 ? &quot;jsonp&quot; : &quot;json&quot;,
-			jsonp: wb.ielt10 ? &quot;callback&quot; : null
-		}
-	});
-
-	issueInput.get( 0 ).value = &quot;&quot;;
-});
-
-$document.on( &quot;ajax-fetched.wb&quot;, pluginSelector, function( event ) {
-	var dataList = $( &quot;#&quot; + issueInput.attr( &quot;list&quot; ) ),
-		issues = wb.ielt10 ? event.fetch.response.data : event.fetch.response,
-		lenIssues = issues.length,
-		options = &quot;&quot;,
-		indIssue, issue;
-
-	dataList.empty();
-
-	for ( indIssue = 0; indIssue !== lenIssues; indIssue += 1 ) {
-		issue = issues[ indIssue ];
-
-		options += &quot;&lt;option label=\&quot;&quot; + issue.title + &quot;\&quot; value=\&quot;&quot; + issue.title + &quot;\&quot;&gt;&lt;/option&gt;&quot;;
-	}
-
-	if ( wb.ielt10 ) {
-		options = &quot;&lt;select&gt;&quot; + options + &quot;&lt;/select&gt;&quot;;
-	}
-
-	dataList.append( options );
-
-	issueInput.trigger( &quot;wb-update.wb-datalist&quot; );
-});
-
-})( jQuery, wb );</code></pre>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> datalist_dynamic }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</details>
 </section>

--- a/src/polyfills/datalist/datalist-dynamic-fr.hbs
+++ b/src/polyfills/datalist/datalist-dynamic-fr.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "datalist",
 	"altLangPrefix": "datalist-dynamic",
 	"js": ["demo/datalist_dynamic"],
-	"dateModified": "2014-07-20"
+	"dateModified": "2023-04-14"
 }
 ---
 <section>
@@ -69,54 +69,7 @@
 
 		<section>
 			<h3>JavaScript</h3>
-			<pre><code>(function( $, wb ) {
-&quot;use strict&quot;;
-
-var $document = wb.doc,
-	pluginSelector = &quot;#plugin&quot;,
-	issueInput = $( &quot;#issue&quot; );
-
-$document.on( &quot;change&quot;, pluginSelector, function( event ) {
-	var pluginName = event.target.value;
-
-	$document.trigger({
-		type: &quot;ajax-fetch.wb&quot;,
-		element: this,
-		fetch: {
-			url: encodeURI( &quot;https://api.github.com/repos/wet-boew/wet-boew/issues?labels=Feature: &quot; + pluginName ),
-			dataType: wb.ielt10 ? &quot;jsonp&quot; : &quot;json&quot;,
-			jsonp: wb.ielt10 ? &quot;callback&quot; : null
-		}
-	});
-
-	issueInput.get( 0 ).value = &quot;&quot;;
-});
-
-$document.on( &quot;ajax-fetched.wb&quot;, pluginSelector, function( event ) {
-	var dataList = $( &quot;#&quot; + issueInput.attr( &quot;list&quot; ) ),
-		issues = wb.ielt10 ? event.fetch.response.data : event.fetch.response,
-		lenIssues = issues.length,
-		options = &quot;&quot;,
-		indIssue, issue;
-
-	dataList.empty();
-
-	for ( indIssue = 0; indIssue !== lenIssues; indIssue += 1 ) {
-		issue = issues[ indIssue ];
-
-		options += &quot;&lt;option label=\&quot;&quot; + issue.title + &quot;\&quot; value=\&quot;&quot; + issue.title + &quot;\&quot;&gt;&lt;/option&gt;&quot;;
-	}
-
-	if ( wb.ielt10 ) {
-		options = &quot;&lt;select&gt;&quot; + options + &quot;&lt;/select&gt;&quot;;
-	}
-
-	dataList.append( options );
-
-	issueInput.trigger( &quot;wb-update.wb-datalist&quot; );
-});
-
-})( jQuery, wb );</code></pre>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> datalist_dynamic }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</details>
 </section>


### PR DESCRIPTION
The dynamic demo pages use a custom JavaScript plugin. A code sample of the plugin also exists in them. But it was hardcoded and hadn't been kept in sync with updates to the plugin itself.

This updates the code sample and future-proofs it by:
* Setting up the custom JS plugin as an include (i.e. handlebars partial)
* Adding two custom handlebars helpers:
  * ``escape``: Encodes special characters (like HTML tags) for code samples
  * ``stripbanner``: Removes the banner (i.e. first multi-line comment) from CSS/JavaScript code
* Demo page: Automating the JS code sample via the include and new helpers

Spinoff of #9388.