### PR TITLE
Data table - Add provisional style - Apply emphasis on filtering UI

### DIFF
--- a/src/plugins/tables/_base.scss
+++ b/src/plugins/tables/_base.scss
@@ -926,6 +926,22 @@ table {
 		}
 	}
 
+	&.filterEmphasis.provisional {
+		.dataTables_filter {
+			background-color: #D9EDF7;
+			float: none;
+			margin-bottom:7px;
+			padding: 10px;
+		}
+
+		.dataTables_info {
+			padding-left: 7px;
+			&:after {
+				content: "";
+			}
+		}
+	}
+
 	.dataTables_length {
 		@extend %tables-color-333;
 		@extend %tables-font-weight-400;

--- a/src/plugins/tables/tables-en.hbs
+++ b/src/plugins/tables/tables-en.hbs
@@ -977,4 +977,125 @@
 		<li><a href="../../demos/tables/tables-fltrs-en.html#dataset-filter2">Number Range Filters (Integers, floats, currency, etc)</a></li>
 		<li><a href="../../demos/tables/tables-fltrs-en.html#dataset-filter3">Other Filters</a></li>
 	</ul>
+
+</section>
+<section>
+	<h2 id="filter-emphasis">Provisional - Filtering interface emphasis</h2>
+
+	<p>The following style is an experiment led by the <a href="https://www.canada.ca/en/government/about/design-system.html">Digital Transformation Office</a> with the objective of enhancing the visibility of the table filtering interface when the user scrolls the page.</p>
+
+	<table class="wb-tables table filterEmphasis provisional">
+		<thead>
+			<tr>
+				<th>Rendering engine</th>
+				<th>Browser</th>
+				<th>Platform(s)</th>
+				<th>Engine version</th>
+				<th data-orderable="false">CSS grade</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="gradeX">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 4.0</td>
+				<td>Win 95+</td>
+				<td class="center">4</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 5.0</td>
+				<td>Win 95+</td>
+				<td class="center">5</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 5.5</td>
+				<td>Win 95+</td>
+				<td class="center">5.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 6</td>
+				<td>Win 98+</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet Explorer 7</td>
+				<td>Win XP SP2+</td>
+				<td class="center">7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.5</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 2.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 3.0</td>
+				<td>Win 2k+ / OSX.3+</td>
+				<td class="center">1.9</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.0</td>
+				<td>OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.3</td>
+				<td>OSX.3</td>
+				<td class="center">312.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 2.0</td>
+				<td>OSX.4+</td>
+				<td class="center">419.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 3.0</td>
+				<td>OSX.4+</td>
+				<td class="center">522.1</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>OmniWeb 5.5</td>
+				<td>OSX.4+</td>
+				<td class="center">420</td>
+				<td class="center">A</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Source code</p>
+	<pre><code>&lt;table class="wb-tables table filterEmphasis provisional">
+	...
+&lt;/table></code></pre>
+
 </section>

--- a/src/plugins/tables/tables-fr.hbs
+++ b/src/plugins/tables/tables-fr.hbs
@@ -986,3 +986,122 @@
 		<li><a href="../../demos/tables/tables-fltrs-fr.html#dataset-filter3">Autres filtres</a></li>
 	</ul>
 </section>
+<section>
+	<h2 id="filter-emphasis">Provisionel - Emphase sur l'interface de filtrage</h2>
+
+	<p>Le style suivant est une expérimentation coordonné par le <a href="https://www.canada.ca/fr/gouvernement/a-propos/systeme-conception.html">Bureau de la transformation numérique</a> ayant pour objectif d'améliorer la visibilité de l'interface de filtrage du tableau lorsque l'utilisateur fait défiler le contenu de la page.</p>
+
+	<table class="wb-tables table filterEmphasis provisional">
+		<thead>
+			<tr>
+				<th>Moteur de rendu</th>
+				<th>Navigateur</th>
+				<th>Platformes</th>
+				<th>Version de moteur</th>
+				<th data-orderable="false">Niveau de CSS</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="gradeX">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 4.0</td>
+				<td>Win 95+</td>
+				<td class="center">4</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 5.0</td>
+				<td>Win 95+</td>
+				<td class="center">5</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 5.5</td>
+				<td>Win 95+</td>
+				<td class="center">5.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 6</td>
+				<td>Win 98+</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet Explorer 7</td>
+				<td>Win XP SP2+</td>
+				<td class="center">7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.5</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 2.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 3.0</td>
+				<td>Win 2k+ / OSX.3+</td>
+				<td class="center">1.9</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.2</td>
+				<td>OSX.3</td>
+				<td class="center">125.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 1.3</td>
+				<td>OSX.3</td>
+				<td class="center">312.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 2.0</td>
+				<td>OSX.4+</td>
+				<td class="center">419.3</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Webkit</td>
+				<td>Safari 3.0</td>
+				<td>OSX.4+</td>
+				<td class="center">522.1</td>
+				<td class="center">A</td>
+			</tr>
+		</tbody>
+	</table>
+
+	<p>Code source</p>
+	<pre><code>&lt;table class="wb-tables table filterEmphasis provisional">
+	...
+&lt;/table></code></pre>
+</section>

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -86,7 +86,12 @@ var componentName = "wb-tables",
 				complete: function() {
 					var $elm = $( "#" + elmId ),
 						dataTableExt = $.fn.dataTableExt,
-						settings = wb.getData( $elm, componentName );
+						settings = wb.getData( $elm, componentName ) || {};
+
+					// Explicitly deactivate the paging for the filterEmphasis provisional feature/styling when not configured
+					if ( $elm.hasClass( "provisional" ) && $elm.hasClass( "filterEmphasis" ) ) {
+						settings.paging = settings.paging ? settings.paging : false;
+					}
 
 					/*
 					 * Extend sorting support
@@ -228,6 +233,12 @@ $document.on( "init.dt", function( event ) {
 		} );
 		$elm.attr( "aria-label", i18nText.tblFilterInstruction );
 	}
+
+	// Apply the filter emphasis style
+	if ( $elm.hasClass( "provisional" ) && $elm.hasClass( "filterEmphasis" ) ) {
+		$elm.parent().addClass( "provisional filterEmphasis" );
+	}
+
 	wb.ready( $( event.target ), componentName );
 } );
 


### PR DESCRIPTION
Add a new provisional style to the data table plugin.

As discussed during the office hours, that new style will improve the findability of the filtering interface when the user are scrolling the page.

For you information, here the prototype provided by DTO - https://test.canada.ca/experimental/lana/contacts.html

@lanastewa