### PR TITLE
Data-JSON - Template - Keep default template text + Core - Log element on error

### DIFF
--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -17,6 +17,7 @@ wb.getData = function( element, dataName ) {
 			dataObj = JSON.parse( dataAttr );
 			$.data( elm, dataName, dataObj );
 		} catch ( error ) {
+			console.info( elm );
 			$.error( "Bad JSON array in data-" + dataName + " attribute" );
 		}
 	}

--- a/src/plugins/wb-data-json/data-json.js
+++ b/src/plugins/wb-data-json/data-json.js
@@ -318,6 +318,11 @@ var componentName = "wb-data-json",
 						cached_value = jsonpointer.get( content, basePntr + j_cache.value );
 					}
 
+					// Go to the next mapping if the value of JSON node don't exist to ensure we keep the default text set in the template, but move ahead if empty or null
+					if ( cached_value === undefined ) {
+						continue;
+					}
+
 					// Placeholder text replacement if any
 					if ( j_cache.placeholder ) {
 						cached_textContent = cached_node.textContent || "";
@@ -471,7 +476,7 @@ var componentName = "wb-data-json",
 		loadJSON( elm, wbJsonConfig.url, refId );
 	};
 
-$document.on( "json-failed.wb", selector, function( ) {
+$document.on( "json-failed.wb", selector, function( event ) {
 	throw "Bad JSON Fetched from url in " + componentName;
 } );
 

--- a/src/plugins/wb-data-json/data-json.js
+++ b/src/plugins/wb-data-json/data-json.js
@@ -477,6 +477,7 @@ var componentName = "wb-data-json",
 	};
 
 $document.on( "json-failed.wb", selector, function( event ) {
+	console.info( event.currentTarget );
 	throw "Bad JSON Fetched from url in " + componentName;
 } );
 

--- a/src/plugins/wb-data-json/demo/data-en.json
+++ b/src/plugins/wb-data-json/demo/data-en.json
@@ -44,7 +44,8 @@
       "language": {
         "en": {
           "description": "description of Mr X",
-          "about": "About Mr X"
+          "about": "About Mr X",
+          "test_undefined_override": ","
         },
         "fr": {
           "description": "description de M. X",

--- a/src/plugins/wb-data-json/demo/data-fr.json
+++ b/src/plugins/wb-data-json/demo/data-fr.json
@@ -44,7 +44,8 @@
       "language": {
         "fr": {
           "description": "description de M. X",
-          "about": "À propos de M. X"
+          "about": "À propos de M. X",
+          "test_undefined_override": ","
         },
         "en": {
           "description": "description of Mr X",

--- a/src/plugins/wb-data-json/template-en.hbs
+++ b/src/plugins/wb-data-json/template-en.hbs
@@ -69,7 +69,8 @@
 			"language": {
 				"en": {
 					"description": "description of Mr X",
-					"about": "About Mr X"
+					"about": "About Mr X",
+					"test_undefined_override": ","
 				},
 				"fr": {
 					"description": "description de M. X",
@@ -360,6 +361,7 @@
 				"source": "#externalSubTemplateExample",
 				"mapping": [
 					{ "selector": "[data-language]", "value": "/@id" },
+					{ "selector": "[data-test-undefined-override]", "value": "/test_undefined_override" },
 					{ "selector": "[data-about]", "value": "/about" },
 					{ "selector": "[data-about]", "value": "/@id", "attr": "lang" }
 				]
@@ -387,7 +389,7 @@
 		</div>
 	</template>
 	<template id="externalSubTemplateExample">
-		<li>(<span data-language></span>) <span data-about lang></span></li>
+		<li>(<span data-language></span>) <span data-about lang></span><span data-test-undefined-override>.</span></li>
 	</template>
 </div>
 
@@ -405,6 +407,7 @@
 				"source": "#externalSubTemplateExample",
 				"mapping": [
 					{ "selector": "[data-language]", "value": "/@id" },
+					{ "selector": "[data-test-undefined-override]", "value": "/test_undefined_override" },
 					{ "selector": "[data-about]", "value": "/about" },
 					{ "selector": "[data-about]", "value": "/@id", "attr": "lang" }
 				]
@@ -432,7 +435,7 @@
 		&lt;/div&gt;
 	&lt;/template&gt;
 	&lt;template id="externalSubTemplateExample"&gt;
-		&lt;li&gt;(&lt;span data-language&gt;&lt;/span&gt;) &lt;span data-about lang&gt;&lt;/span&gt;&lt;/li&gt;
+		&lt;li&gt;(&lt;span data-language&gt;&lt;/span&gt;) &lt;span data-about lang&gt;&lt;/span&gt;&lt;span data-test-undefined-override>.&lt;/span>&lt;/li&gt;
 	&lt;/template&gt;
 &lt;/div&gt;</code></pre>
 </details>

--- a/src/plugins/wb-data-json/template-fr.hbs
+++ b/src/plugins/wb-data-json/template-fr.hbs
@@ -70,7 +70,8 @@
 			"language": {
 				"fr": {
 					"description": "description de M. X",
-					"about": "À propos de M. X"
+					"about": "À propos de M. X",
+					"test_undefined_override": ","
 				},
 				"en": {
 					"description": "description of Mr X",
@@ -363,6 +364,7 @@
 				"source": "#gabaritExterneSousModele",
 				"mapping": [
 					{ "selector": "[data-language]", "value": "/@id" },
+					{ "selector": "[data-test-undefined-override]", "value": "/test_undefined_override" },
 					{ "selector": "[data-about]", "value": "/about" },
 					{ "selector": "[data-about]", "value": "/@id", "attr": "lang" }
 				]
@@ -389,7 +391,7 @@
 		</div>
 	</template>
 	<template id="gabaritExterneSousModele">
-		<li>(<span data-language></span>) <span data-about lang></span></li>
+		<li>(<span data-language></span>) <span data-about lang></span><span data-test-undefined-override>.</span></li>
 	</template>
 </div>
 
@@ -407,6 +409,7 @@
 				"source": "#gabaritExterneSousModele",
 				"mapping": [
 					{ "selector": "[data-language]", "value": "/@id" },
+					{ "selector": "[data-test-undefined-override]", "value": "/test_undefined_override" },
 					{ "selector": "[data-about]", "value": "/about" },
 					{ "selector": "[data-about]", "value": "/@id", "attr": "lang" }
 				]
@@ -433,7 +436,7 @@
 		&lt;/div&gt;
 	&lt;/template&gt;
 	&lt;template id="gabaritExterneSousModele"&gt;
-		&lt;li&gt;(&lt;span data-language&gt;&lt;/span&gt;) &lt;span data-about lang&gt;&lt;/span&gt;&lt;/li&gt;
+		&lt;li&gt;(&lt;span data-language&gt;&lt;/span&gt;) &lt;span data-about lang&gt;&lt;/span&gt;&lt;span data-test-undefined-override>.&lt;/span>&lt;/li&gt;
 	&lt;/template&gt;
 &lt;/div&gt;</code></pre>
 </details>


### PR DESCRIPTION
Data-JSON - Template - Keep default template text when JSON node don't exist
Core - Logging the elm to ease debugging of plugin config

This PR is required for the revised accessibility conformance report methodology as discussed in #9271