### PR TITLE
dl horizontal - Fix characters hidding when a word overflow

### DIFF
--- a/src/base/bootstrap-overrides/_core.scss
+++ b/src/base/bootstrap-overrides/_core.scss
@@ -48,9 +48,11 @@ a {
 
 		dt {
 			border-top: 1px solid $clrMedium;
+			hyphens: auto;
 			padding: 10px 10px 10px 0;
 			text-align: left;
 			white-space: normal;
+			word-break: break-word;
 		}
 
 		dd {

--- a/src/other/utility/utility-en.hbs
+++ b/src/other/utility/utility-en.hbs
@@ -26,6 +26,7 @@
 	<li><a href="#positioning">Positioning</a></li>
 	<li><a href="#tables">Tables</a></li>
 	<li><a href="#miscellaneous">Miscellaneous</a></li>
+	<li><a href="#dl-horizontal">Horizontal description list</a></li>
 </ul>
 
 <h2 id="alignment">Alignment</h2>
@@ -525,3 +526,16 @@
 <pre><code>&lt;body class="<strong>test-textSpacing</strong>" vocab="http://schema.org/" typeof="WebPage" resource="#wb-webpage" class="home page-type-nav "&gt;
 ...
 &lt;/body&gt;</code></pre>
+
+<h2 id="dl-horizontal">Horizontal description list</h2>
+
+<p>This test a special egde case where the word in the description title (<code>&lt;dt></code>) are larger than the available space.</p>
+
+<dl class="dl-horizontal">
+	<dt>Description title</dt>
+	<dd>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</dd>
+	<dt>Long word: incomprehensibilities</dt>
+	<dd>Etiam at erat et sapien tempus vulputate.</dd>
+	<dt>A fews filling words that take space</dt>
+	<dd>Quisque tristique dui in ante mattis, nec commodo tortor eleifend.</dd>
+</dl>

--- a/src/other/utility/utility-fr.hbs
+++ b/src/other/utility/utility-fr.hbs
@@ -25,6 +25,7 @@
 	<li><a href="#positionnement">Positionnement</a></li>
 	<li><a href="#tables">Tables</a></li>
 	<li><a href="#divers">Divers</a></li>
+	<li><a href="#dl-horizontal">Liste descriptive horizontale</a></li>
 </ul>
 
 <h2 id="alignment">Alignement</h2>
@@ -520,3 +521,16 @@
 <pre><code>&lt;body class="<strong>test-textSpacing</strong>" vocab="http://schema.org/" typeof="WebPage" resource="#wb-webpage" class="home page-type-nav "&gt;
 ...
 &lt;/body&gt;</code></pre>
+
+<h2 id="dl-horizontal">Liste descriptive horizontale</h2>
+
+<p>Ceci est la mise à l'essaie d'un cas d'utilisation spécifique où le mot est tronqué dans le titre de la description lorsque ce dernier est long et prend toute l'espace disponible.</p>
+
+<dl class="dl-horizontal">
+	<dt>Titre de la description</dt>
+	<dd>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</dd>
+	<dt>Un long mot : anticonstitutionnellement</dt>
+	<dd>Etiam at erat et sapien tempus vulputate.</dd>
+	<dt>Quelques mots afin de remplir de l'espace</dt>
+	<dd>Quisque tristique dui in ante mattis, nec commodo tortor eleifend.</dd>
+</dl>


### PR DESCRIPTION
Fix an accessibility issue which use non text content to hide the overflow without providing a text alternative. It's only happen when the word in the description title `<dt>` are larger than the available width.

cc @nfrenette