### PR TITLE
Plugin Charts: If reverseTblParsing, use column header not row header.

### DIFF
--- a/src/plugins/charts/charts.js
+++ b/src/plugins/charts/charts.js
@@ -894,7 +894,7 @@ var componentName = "wb-charts",
 
 				} else {
 
-					header = currentRowGroup.row[ rIndex ].header;
+					header = !reverseTblParsing ? dataCell.row.header : dataCell.col.header;
 
 					figurehtml = "<figure><figcaption>" +
 						header[ header.length - 1 ].elem.innerHTML +


### PR DESCRIPTION
Incorrect row header shows in figure caption, if using reverse table parsing, use the column header for the figure caption. Fixes #9583.

There is an error with the pie chart figure caption text when reverseTblParsing is true.
The figure caption text should be taken from the column, not the row.
This fixes this issue as demonstrated with the Charts and graphs - Specific test cases example page.

Screenshots of problem and fix located in #9583 .
