### PR TITLE
Plugin Tables: Handle sorting/ordering only on thead.

### DIFF
--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -223,7 +223,7 @@ $document.on( "init.dt", function( event ) {
 	// Handle sorting/ordering
 	var ordering = ( settings && settings.ordering === false ) ? false : true;
 	if ( ordering ) {
-		$elm.find( "th" ).each( function() {
+		$elm.find( "thead th" ).each( function() {
 			var $th = $( this ),
 				label = ( $th.attr( "aria-sort" ) === "ascending" ) ? i18nText.aria.sortDescending : i18nText.aria.sortAscending;
 			if ( $th.attr( "data-orderable" ) !== "false" ) {


### PR DESCRIPTION
If using th elements in tr, sorting/ording is applied, and should only be applied to the thead th. Fixes #9578

This prevents  tr th data cells from being rendered as sorting/ordering buttons.
This allows only table header thead th columns to be rendered as sorting/ordering buttons.

See #9578 for screen shots.
