### PR TITLE
Equal heights: Fix eqht-trgt row detection

### DIFF
--- a/src/plugins/equalheight/equalheight.js
+++ b/src/plugins/equalheight/equalheight.js
@@ -104,26 +104,26 @@ var componentName = "wb-eqht",
 			}
 			$elm = reattachElement( $anchor );
 
-			// set the top and tallest to the first element
-			rowTop = $children[ 0 ] ? $children[ 0 ].offsetTop : 0;
+			// set the top offset and tallest height to the first element
+			rowTop = $children[ 0 ] ? $children[ 0 ].getBoundingClientRect().top + window.pageYOffset : 0;
 			tallestHeight = $children[ 0 ] ? $children[ 0 ].offsetHeight : 0;
 
 			// first, the loop MUST be from start to end to work.
 			for ( j = 0; j < $children.length; j++ ) {
 				currentChild = $children[ j ];
 
-				currentChildTop = currentChild.offsetTop;
+				currentChildTop = currentChild.getBoundingClientRect().top + window.pageYOffset;
 				currentChildHeight = currentChild.offsetHeight;
 
 				if ( currentChildTop !== rowTop ) {
 
-					// as soon as we find an element not on this row (not the same offsetTop)
+					// as soon as we find an element not on this row (not the same top offset)
 					// we need to equalize each items in that row to align the next row.
 					equalize( row, tallestHeight );
 
 					// since the elements of the previous row was equalized
-					// we need to get the new offsetTop of the current element
-					currentChildTop = currentChild.offsetTop;
+					// we need to get the new top offset of the current element
+					currentChildTop = currentChild.getBoundingClientRect().top + window.pageYOffset;
 
 					// reset the row, rowTop and tallestHeight
 					row.length = 0;


### PR DESCRIPTION
The plugin had trouble detecting new rows when using the ``eqht-trgt`` class. That sometimes caused it to think all of its grids were on the same row and make them as tall as possible. That's undesirable and is inconsistent with "regular" implementations of the plugin.

For instance:
* The heights of linearized grid layouts were needlessly increased in smaller views.
* If a plugin container had enough grids to split across multiple rows, every grid's height was derived from the tallest row's tallest grid... as opposed to the current row's tallest grid.

The cause of this behaviour was the offsetTop property:
* Everything worked fine in "regular" equal heights implementations since all the equalized elements always have the same parent. The ``rowTop`` and ``currentChildTop`` variables that get compared to determine if a new row is starting were based on the ``offsetTop`` property. Since everything being compared are direct children of the plugin container, their ``offsetParent``s (which ``offsetTop`` is derived from) were always the same. So all the offsets in contention used the same baseline.
* ``eqht-trgt`` was flawed by comparison. Why? Because the "targeted" equalized elements can have different parents. As a result, the new row comparison logic wasn't always comparing the same "kinds" of ``offsetTop``s. If a new row was starting and ``rowTop`` + ``currentChildTop`` had the same ``offsetTop`` relative to their respective ``offsetParent``s... the comparison logic would get tricked into thinking everything was still on the same row. So it would treat all equalized elements as belonging to the same row.

This fixes the flaw by replacing ``offsetTop`` with a calculation representing each equalized element's top offset at the ``document``-level. So the new row comparison logic should now function the "correct" way all the time.

**Screenshots...**
* **Extra-small view:**
  | Before | After |
  | --- | --- |
  | ![eqht-trgt-xs-before](https://github.com/wet-boew/wet-boew/assets/1907279/8d394102-7908-442a-bbae-ab0a6453b196) | ![eqht-trgt-xs-after](https://github.com/wet-boew/wet-boew/assets/1907279/5c1259a4-501b-4aa9-aced-ddda94e8a9b8) |
* **Small view:**
  | Before | After |
  | --- | --- |
  | ![eqht-trgt-sm-before](https://github.com/wet-boew/wet-boew/assets/1907279/1d4a617f-ff6b-4718-a6d7-2b21063e53b7) | ![eqht-trgt-sm-after](https://github.com/wet-boew/wet-boew/assets/1907279/c07dacdd-98fb-478d-8772-577563eb2968) |