### PR TITLE
Plugin Tables: Do not create sort/order button when column sort is di…

### DIFF
--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -226,7 +226,7 @@ $document.on( "init.dt", function( event ) {
 		$elm.find( "th" ).each( function() {
 			var $th = $( this ),
 				label = ( $th.attr( "aria-sort" ) === "ascending" ) ? i18nText.aria.sortDescending : i18nText.aria.sortAscending;
-			if ( $th.attr( "data-orderable" ) !== "false" ) {
+			if ( ( $th.attr( "data-orderable" ) !== "false" ) && !( $th.hasClass( "sorting_disabled" ) ) ) {
 				$th.html( "<button type='button' aria-controls='" + $th.attr( "aria-controls" ) +  "' title='" + $th.text().replace( /'/g, "&#39;" ) + label + "'>" + $th.html() + "<span class='sorting-cnt'><span class='sorting-icons' aria-hidden='true'></span></span></button>" );
 				$th.removeAttr( "aria-label tabindex aria-controls" );
 			}


### PR DESCRIPTION
…sabled.

There are multiple ways to disable column sorting. This patch does not allow button to be created if th column class sorting_disabled is present.

Related to #9476
Fixes #9588

## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Column sorting can be enabled/disabled different ways:
- using th data-orderable attribute
- using columns in data-wb-table settings
- using columnDefs in data-wb-table settings

When using data-wb-table settings:
```
"columns": [
    { "orderable": false },
    null,
    null,
    null,
    null
  ]  }'
```
or 

```
"columnDefs": [ {
"targets": 0,
"orderable": false
} ]
```

The class name `sorting_disabled` is added to the table header, and WET tables still adds the button code to it.
Adding another check in the if statement, does not add the button code if `sorting_disabled` class exists.

