### PR TITLE
Equal heights: Vary example 1's row heights

### DIFF
--- a/src/plugins/eqht-css/demo/eqht-css.scss
+++ b/src/plugins/eqht-css/demo/eqht-css.scss
@@ -4,7 +4,7 @@
 			border: 1px solid #ddd;
 			border-radius: 4px;
 			margin-bottom: 23px;
-			padding: 15px;
+			padding: 10px;
 		}
 	}
 }

--- a/src/plugins/eqht-css/eqht-css-en.hbs
+++ b/src/plugins/eqht-css/eqht-css-en.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "eqht-css",
 	"altLangPrefix": "eqht-css",
 	"css": ["demo/eqht-css"],
-	"dateModified": "2021-01-18"
+	"dateModified": "2023-06-19"
 }
 ---
 <section>
@@ -21,36 +21,36 @@
 	<div class="row wb-eqht-grd">
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Short container</h3>
-				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<h3>Short container 1</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Medium container</h3>
-				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<h3>Medium container 1</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
 				<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Long container</h3>
-				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<h3>Long container 1</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
 				<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
-				<p>Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text.</p>
+				<p>Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Short container</h3>
-				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<h3>Short container 2</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Medium container</h3>
-				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
-				<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
+				<h3>Medium container 2</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<p>Different example text. Different example text. Different example text. Different example text.</p>
 			</section>
 		</div>
 	</div>
@@ -65,31 +65,31 @@
 	&lt;div class=&quot;row wb-eqht-grd&quot;&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Short container&lt;/h3&gt;
+				&lt;h3&gt;Short container 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Medium container&lt;/h3&gt;
+				&lt;h3&gt;Medium container 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Long container&lt;/h3&gt;
+				&lt;h3&gt;Long container 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Short container&lt;/h3&gt;
+				&lt;h3&gt;Short container 2&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Medium container&lt;/h3&gt;
+				&lt;h3&gt;Medium container 2&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
@@ -103,7 +103,7 @@
 	border: 1px solid #ddd;
 	border-radius: 4px;
 	margin-bottom: 15px;
-	padding: 15px;
+	padding: 10px;
 }
 </code></pre>
 		</section>
@@ -116,36 +116,36 @@
 	<div class="row wb-eqht-grd grow">
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Short container</h3>
-				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<h3>Short container 1</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Medium container</h3>
-				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<h3>Medium container 1</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
 				<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Long container</h3>
-				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<h3>Long container 1</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
 				<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
-				<p>Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text.</p>
+				<p>Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Short container</h3>
-				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<h3>Short container 2</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Medium container</h3>
-				<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
-				<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
+				<h3>Medium container 2</h3>
+				<p>Example text. Example text. Example text. Example text. Example text. Example text.</p>
+				<p>Different example text. Different example text. Different example text. Different example text.</p>
 			</section>
 		</div>
 	</div>
@@ -160,31 +160,31 @@
 	&lt;div class=&quot;row wb-eqht-grd grow&quot;&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Short container&lt;/h3&gt;
+				&lt;h3&gt;Short container 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Medium container&lt;/h3&gt;
+				&lt;h3&gt;Medium container 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Long container&lt;/h3&gt;
+				&lt;h3&gt;Long container 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Short container&lt;/h3&gt;
+				&lt;h3&gt;Short container 2&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Medium container&lt;/h3&gt;
+				&lt;h3&gt;Medium container 2&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
@@ -198,7 +198,7 @@
 	border: 1px solid #ddd;
 	border-radius: 4px;
 	margin-bottom: 15px;
-	padding: 15px;
+	padding: 10px;
 }
 </code></pre>
 		</section>

--- a/src/plugins/eqht-css/eqht-css-fr.hbs
+++ b/src/plugins/eqht-css/eqht-css-fr.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "eqht-css",
 	"altLangPrefix": "eqht-css",
 	"css": ["demo/eqht-css"],
-	"dateModified": "2021-01-18"
+	"dateModified": "2023-06-19"
 }
 ---
 <section>
@@ -21,36 +21,36 @@
 	<div class="row wb-eqht-grd">
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Contenant à basse hauteur</h3>
-				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<h3>Contenant à basse hauteur 1</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Contenant à hauteur moyenne</h3>
-				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<h3>Contenant à hauteur moyenne 1</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Contenant à grande hauteur</h3>
-				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<h3>Contenant à grande hauteur 1</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
-				<p>Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte.</p>
+				<p>Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Contenant à basse hauteur</h3>
-				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<h3>Contenant à basse hauteur 2</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Contenant à hauteur moyenne</h3>
-				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
-				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
+				<h3>Contenant à hauteur moyenne 2</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
 			</section>
 		</div>
 	</div>
@@ -65,31 +65,31 @@
 	&lt;div class=&quot;row wb-eqht-grd&quot;&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Contenant à basse hauteur&lt;/h3&gt;
+				&lt;h3&gt;Contenant à basse hauteur 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Contenant à hauteur moyenne&lt;/h3&gt;
+				&lt;h3&gt;Contenant à hauteur moyenne 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Contenant à grande hauteur&lt;/h3&gt;
+				&lt;h3&gt;Contenant à grande hauteur 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Contenant à basse hauteur&lt;/h3&gt;
+				&lt;h3&gt;Contenant à basse hauteur 2&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Contenant à hauteur moyenne&lt;/h3&gt;
+				&lt;h3&gt;Contenant à hauteur moyenne 2&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
@@ -103,7 +103,7 @@
 	border: 1px solid #ddd;
 	border-radius: 4px;
 	margin-bottom: 15px;
-	padding: 15px;
+	padding: 10px;
 }
 </code></pre>
 		</section>
@@ -116,36 +116,36 @@
 	<div class="row wb-eqht-grd grow">
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Contenant à basse hauteur</h3>
-				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<h3>Contenant à basse hauteur 1</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Contenant à hauteur moyenne</h3>
-				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<h3>Contenant à hauteur moyenne 1</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Contenant à grande hauteur</h3>
-				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<h3>Contenant à grande hauteur 1</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
-				<p>Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte.</p>
+				<p>Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Contenant à basse hauteur</h3>
-				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<h3>Contenant à basse hauteur 2</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 			</section>
 		</div>
 		<div class="col-sm-6 col-md-4">
 			<section>
-				<h3>Contenant à hauteur moyenne</h3>
-				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
-				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
+				<h3>Contenant à hauteur moyenne 2</h3>
+				<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+				<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
 			</section>
 		</div>
 	</div>
@@ -160,31 +160,31 @@
 	&lt;div class=&quot;row wb-eqht-grd grow&quot;&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Contenant à basse hauteur&lt;/h3&gt;
+				&lt;h3&gt;Contenant à basse hauteur 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Contenant à hauteur moyenne&lt;/h3&gt;
+				&lt;h3&gt;Contenant à hauteur moyenne 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Contenant à grande hauteur&lt;/h3&gt;
+				&lt;h3&gt;Contenant à grande hauteur 1&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Contenant à basse hauteur&lt;/h3&gt;
+				&lt;h3&gt;Contenant à basse hauteur 2&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
 		&lt;div class=&quot;col-sm-6 col-md-4&quot;&gt;
 			&lt;section&gt;
-				&lt;h3&gt;Contenant à hauteur moyenne&lt;/h3&gt;
+				&lt;h3&gt;Contenant à hauteur moyenne 2&lt;/h3&gt;
 				...
 			&lt;/section&gt;
 		&lt;/div&gt;
@@ -198,7 +198,7 @@
 	border: 1px solid #ddd;
 	border-radius: 4px;
 	margin-bottom: 15px;
-	padding: 15px;
+	padding: 10px;
 }
 </code></pre>
 		</section>

--- a/src/plugins/equalheight/equalheight-en.hbs
+++ b/src/plugins/equalheight/equalheight-en.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "equalheight",
 	"altLangPrefix": "equalheight",
 	"css": ["demo/equalheight"],
-	"dateModified": "2014-09-30"
+	"dateModified": "2023-06-19"
 }
 ---
 <section>
@@ -21,52 +21,49 @@
 
 	<div class="wb-eqht">
 		<section>
-			<h3>Short container</h3>
-			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+			<h3>Short container 1</h3>
+			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
 		</section>
 		<section>
-			<h3>Medium container</h3>
-			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+			<h3>Medium container 1</h3>
+			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
 			<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
 		</section>
 		<section>
-			<h3>Long container</h3>
-			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+			<h3>Long container 1</h3>
+			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
 			<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
-			<p>Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text.</p>
-		</section>
-	</div>
-
-	<div class="wb-eqht">
-		<section>
-			<h3>Short container</h3>
-			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+			<p>Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text.</p>
 		</section>
 		<section>
-			<h3>Medium container</h3>
-			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
-			<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
+			<h3>Short container 2</h3>
+			<p>Example text. Example text. Example text. Example text. Example text. Example text.</p>
 		</section>
 		<section>
-			<h3>Long container</h3>
-			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
-			<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
-			<p>Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text.</p>
+			<h3>Medium container 2</h3>
+			<p>Example text. Example text. Example text. Example text. Example text. Example text.</p>
+			<p>Different example text. Different example text. Different example text. Different example text.</p>
 		</section>
 		<section>
-			<h3>Short container</h3>
-			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
+			<h3>Long container 2</h3>
+			<p>Example text. Example text. Example text. Example text. Example text. Example text.</p>
+			<p>Different example text. Different example text. Different example text. Different example text.</p>
+			<p>Other example text. Other example text. Other example text. Other example text.</p>
 		</section>
 		<section>
-			<h3>Medium container</h3>
-			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
-			<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
+			<h3>Short container 3</h3>
+			<p>Example text. Example text. Example text.</p>
 		</section>
 		<section>
-			<h3>Long container</h3>
-			<p>Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text. Example text.</p>
-			<p>Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text. Different example text.</p>
-			<p>Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text. Other example text.</p>
+			<h3>Medium container 3</h3>
+			<p>Example text. Example text. Example text.</p>
+			<p>Different example text. Different example text.</p>
+		</section>
+		<section>
+			<h3>Long container 3</h3>
+			<p>Example text. Example text. Example text.</p>
+			<p>Different example text. Different example text.</p>
+			<p>Other example text. Other example text.</p>
 		</section>
 	</div>
 
@@ -79,42 +76,39 @@
 
 	&lt;div class=&quot;wb-eqht&quot;&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Short container&lt;/h3&gt;
+			&lt;h3&gt;Short container 1&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Medium container&lt;/h3&gt;
+			&lt;h3&gt;Medium container 1&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Long container&lt;/h3&gt;
-			...
-		&lt;/section&gt;
-	&lt;/div&gt;
-
-	&lt;div class=&quot;wb-eqht&quot;&gt;
-		&lt;section&gt;
-			&lt;h3&gt;Short container&lt;/h3&gt;
+			&lt;h3&gt;Long container 1&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Medium container&lt;/h3&gt;
+			&lt;h3&gt;Short container 2&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Long container&lt;/h3&gt;
+			&lt;h3&gt;Medium container 2&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Short container&lt;/h3&gt;
+			&lt;h3&gt;Long container 2&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Medium container&lt;/h3&gt;
+			&lt;h3&gt;Short container 3&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Long container&lt;/h3&gt;
+			&lt;h3&gt;Medium container 3&lt;/h3&gt;
+			...
+		&lt;/section&gt;
+		&lt;section&gt;
+			&lt;h3&gt;Long container 3&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 	&lt;/div&gt;

--- a/src/plugins/equalheight/equalheight-fr.hbs
+++ b/src/plugins/equalheight/equalheight-fr.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "equalheight",
 	"altLangPrefix": "equalheight",
 	"css": ["demo/equalheight"],
-	"dateModified": "2014-09-30"
+	"dateModified": "2023-06-19"
 }
 ---
 <section>
@@ -21,52 +21,49 @@
 
 	<div class="wb-eqht">
 		<section>
-			<h3>Contenant à basse hauteur</h3>
-			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+			<h3>Contenant à basse hauteur 1</h3>
+			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 		</section>
 		<section>
-			<h3>Contenant à hauteur moyenne</h3>
-			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+			<h3>Contenant à hauteur moyenne 1</h3>
+			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 			<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
 		</section>
 		<section>
-			<h3>Contenant à grande hauteur</h3>
-			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+			<h3>Contenant à grande hauteur 1</h3>
+			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 			<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
-			<p>Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte.</p>
-		</section>
-	</div>
-
-	<div class="wb-eqht">
-		<section>
-			<h3>Contenant à basse hauteur</h3>
-			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+			<p>Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte.</p>
 		</section>
 		<section>
-			<h3>Contenant à hauteur moyenne</h3>
-			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
-			<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
+			<h3>Contenant à basse hauteur 2</h3>
+			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
 		</section>
 		<section>
-			<h3>Contenant à grande hauteur</h3>
-			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
-			<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
-			<p>Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte.</p>
+			<h3>Contenant à hauteur moyenne 2</h3>
+			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+			<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
 		</section>
 		<section>
-			<h3>Contenant à basse hauteur</h3>
-			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+			<h3>Contenant à grande hauteur 2</h3>
+			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
+			<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
+			<p>Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte.</p>
 		</section>
 		<section>
-			<h3>Contenant à hauteur moyenne</h3>
-			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
-			<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
+			<h3>Contenant à basse hauteur 3</h3>
+			<p>Exemple de texte. Exemple de texte.</p>
 		</section>
 		<section>
-			<h3>Contenant à grande hauteur</h3>
-			<p>Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte. Exemple de texte.</p>
-			<p>Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent. Exemple de texte différent.</p>
-			<p>Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte. Autre exemple de texte.</p>
+			<h3>Contenant à hauteur moyenne 3</h3>
+			<p>Exemple de texte. Exemple de texte.</p>
+			<p>Exemple de texte différent.</p>
+		</section>
+		<section>
+			<h3>Contenant à grande hauteur 3</h3>
+			<p>Exemple de texte. Exemple de texte.</p>
+			<p>Exemple de texte différent.</p>
+			<p>Autre exemple de texte. Autre exemple de texte.</p>
 		</section>
 	</div>
 
@@ -79,42 +76,39 @@
 
 	&lt;div class=&quot;wb-eqht&quot;&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Contenant à basse hauteur&lt;/h3&gt;
+			&lt;h3&gt;Contenant à basse hauteur 1&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Contenant à hauteur moyenne&lt;/h3&gt;
+			&lt;h3&gt;Contenant à hauteur moyenne 1&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Contenant à grande hauteur&lt;/h3&gt;
-			...
-		&lt;/section&gt;
-	&lt;/div&gt;
-
-	&lt;div class=&quot;wb-eqht&quot;&gt;
-		&lt;section&gt;
-			&lt;h3&gt;Contenant à basse hauteur&lt;/h3&gt;
+			&lt;h3&gt;Contenant à grande hauteur 1&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Contenant à hauteur moyenne&lt;/h3&gt;
+			&lt;h3&gt;Contenant à basse hauteur 2&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Contenant à grande hauteur&lt;/h3&gt;
+			&lt;h3&gt;Contenant à hauteur moyenne 2&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Contenant à basse hauteur&lt;/h3&gt;
+			&lt;h3&gt;Contenant à grande hauteur 2&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Contenant à hauteur moyenne&lt;/h3&gt;
+			&lt;h3&gt;Contenant à basse hauteur 3&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 		&lt;section&gt;
-			&lt;h3&gt;Contenant à grande hauteur&lt;/h3&gt;
+			&lt;h3&gt;Contenant à hauteur moyenne 3&lt;/h3&gt;
+			...
+		&lt;/section&gt;
+		&lt;section&gt;
+			&lt;h3&gt;Contenant à grande hauteur 3&lt;/h3&gt;
 			...
 		&lt;/section&gt;
 	&lt;/div&gt;


### PR DESCRIPTION
The demo page's first example demonstrates the plugin's basic concept, but re-uses the exact same content in all three rows. In large view, that gives off the impression that the plugin is unable to distinguish "virtual" rows.

In practice, the plugin is sophisticated-enough to automatically detect new rows and keep track of varying row heights. So why not show it off?

This changes the first example as follows to better demonstrate that capability:
* Place all rows in the same ``wb-eqht`` container
* Make the first row's paragraphs 4 lines apiece
* Halve the amount of content lines in each subsequent row in large view
* Use unique headings for each row
* Note: Shortened French content to get the same number of content lines as the English version in large view

The first two examples in the "pure CSS" equal heights demo have also been updated to match:
* Same changes as the normal equal heights demo
* Reduce demo's custom CSS ``padding`` from ``15px`` to ``10px`` (to prevent the French examples' H3 headings from spanning across multiple lines in large view)

**Screenshots...**
* **English:**
  * **Equal height - example 1**
    | Before | After |
    | --- | --- |
    | ![equalheight-example1-en-before](https://github.com/wet-boew/wet-boew/assets/1907279/afdb1364-3bb1-4c7a-9020-cd3e4f767cb7) | ![equalheight-example1-en-after](https://github.com/wet-boew/wet-boew/assets/1907279/1d27ca44-6baf-4a88-ad32-0a322d4c34dc) |
  * **Equal height (pure CSS) - example 1**
    | Before | After |
    | --- | --- |
    | ![eqht-css-example1-en-before](https://github.com/wet-boew/wet-boew/assets/1907279/d6e61c96-ea52-4396-9cfb-57a09ec9a2c4) | ![eqht-css-example1-en-after](https://github.com/wet-boew/wet-boew/assets/1907279/ca881c31-427b-464e-ae0d-81ea985ae832) |
  * **Equal height (pure CSS) - example 2**
    | Before | After |
    | --- | --- |
    | ![eqht-css-example2-en-before](https://github.com/wet-boew/wet-boew/assets/1907279/8288ed3e-5a97-424d-a0b3-530b0ba50db1) | ![eqht-css-example2-en-after](https://github.com/wet-boew/wet-boew/assets/1907279/e987fffc-9644-4278-a37c-a3fd269e33c2) |
* **Français:**
  * **Égalisation des hauteurs - exemple 1**
    | Avant | Après |
    | --- | --- |
    | ![equalheight-example1-fr-before](https://github.com/wet-boew/wet-boew/assets/1907279/ee95f9fe-fee6-451a-9831-064b27af4d8b) | ![equalheight-example1-fr-after](https://github.com/wet-boew/wet-boew/assets/1907279/f3abbab9-de5d-4b10-a23c-f90ea49331a0) |
  * **Égalisation des hauteurs (pure CSS) - exemple 1**
    | Avant | Après |
    | --- | --- |
    | ![eqht-css-example1-fr-before](https://github.com/wet-boew/wet-boew/assets/1907279/4844e649-e17d-4c7f-a6f2-9f7f7c78e1ba) | ![eqht-css-example1-fr-after](https://github.com/wet-boew/wet-boew/assets/1907279/f8c7f1b6-745d-4449-90b3-8b0d1fef40ec) |
  * **Égalisation des hauteurs (pure CSS) - exemple 2**
    | Avant | Après |
    | --- | --- |
    | ![eqht-css-example2-fr-before](https://github.com/wet-boew/wet-boew/assets/1907279/e6b89dc9-2acd-412b-97b3-1d802281edc8) | ![eqht-css-example2-fr-after](https://github.com/wet-boew/wet-boew/assets/1907279/0c3ecfd9-df1e-47a6-b30f-a1ed4e0be4b4) |