### PR TITLE
Plugin Tables: Apply WET DataTables options to wb-tables only.

### DIFF
--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -216,7 +216,7 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 } );
 
 // Identify that initialization has completed
-$document.on( "init.dt ", ".wb-tables", function( event ) {
+$document.on( "init.dt ", selector, function( event ) {
 	var $elm = $( event.target ),
 		settings = $.extend( true, {}, defaults, window[ componentName ], wb.getData( $elm, componentName ) );
 

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -216,7 +216,7 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 } );
 
 // Identify that initialization has completed
-$document.on( "init.dt", function( event ) {
+$document.on( "init.dt ", ".wb-tables", function( event ) {
 	var $elm = $( event.target ),
 		settings = $.extend( true, {}, defaults, window[ componentName ], wb.getData( $elm, componentName ) );
 

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -216,7 +216,7 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 } );
 
 // Identify that initialization has completed
-$document.on( "init.dt ", selector, function( event ) {
+$document.on( "init.dt", selector, function( event ) {
 	var $elm = $( event.target ),
 		settings = $.extend( true, {}, defaults, window[ componentName ], wb.getData( $elm, componentName ) );
 


### PR DESCRIPTION
WET tables applies options to all DataTables tables after initialization. Should only apply options to tables that are WET wb-tables. This fix will apply WET table plugin options to only those tables with class wb-tables. Fixes: #9470,  Fixes: #9548

If using DataTables outside of WET wb-tables, WET will attempt to apply options to those tables that are not wb-tables.
This usually will trigger the following error:
`wet-boew Uncaught TypeError: i18nText is undefined`

If a table is not a WET wb-table, WET table.js $document.on('init.dt'.... should not execute.

