### PR TITLE
JSON manager, JSON fetch - Allow to set a saving path for fetched URL

### DIFF
--- a/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-en.hbs
+++ b/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-en.hbs
@@ -291,6 +291,11 @@
 						<dd>The url is a reference to a dataset managed by a json-manager defined in the same page.</dd>
 						<dt><code>data-wb-jsonmanager='{ "url": [ "location/of/json/file.json#/", "[datasetName]#/" ] }'</code></dt>
 						<dd>The url is a json file and a reference to a dataset managed by a json-manager defined in the same page. The dataset will be a combination of both references.</dd>
+						<dt><code>data-wb-jsonmanager='{ "url": {Url fetch object} }'</code></dt>
+						<dd>
+							<p>An object defining advanced configuration on how to fetch and merge the file specified by the URL into the JSON manager.</p>
+							<p>There is more details in the <a href="#urlobj">section below</a>.</p>
+						</dd>
 					</dl>
 				</td>
 			</tr>
@@ -493,6 +498,34 @@
 			</tr>
 		</tbody>
 	</table>
+
+	<h3 id="urlobj">URL advanced configuration (Url fetch object)</h3>
+	<p>An object representing the URL to be fetch with some advanced configuration on how to fetch and merge the file specified by the URL into the JSON manager.</p>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Option</th>
+				<th class="col-md-6">How to configure</th>
+				<th>Values and clarification</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>url</code></td>
+				<td><code>{ "url": "location/of/json/file.json#/" &hellip;}</code> or <code>{ "url": "[datasetName]#/" &hellip;}</code></td>
+				<td>
+					<p><strong>Required</strong>. Define the url or the dataset name to use. When used in a template mode, the URL should point to an array object.</p>
+					<p>You can follow the url or the dataset name by a <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a>. The value can be either a string or an array of strings. If all references are arrays, the arrays will be concatenated into one array. If all references are objects, the objects will be extended into a single object. If there are references of multiple types, the plugin will throw an error.</p>
+				</td>
+			</tr>
+			<tr>
+				<td><code>path</code></td>
+				<td><code>{ "url": "location/of/json/file.json#/", "path": "/JSON Pointer" }</code></td>
+				<td>A valid <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a> to where the data would be inserted. It's must start with an "/".</td>
+			</tr>
+		</tbody>
+	</table>
+
 	<h3 id="evalobj">Filtering (evaluation object)</h3>
 	<p>The path selector must point to an valid JSON array object. All the option presented in the table bellow can be combined.</p>
 	<p>The configuration option <code>fpath</code> <strong>must be set</strong> in the JSON manager configuration in order to apply any filtering.</p>

--- a/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-fr.hbs
+++ b/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-fr.hbs
@@ -328,6 +328,11 @@
 				<dd>The url is a reference to a dataset managed by a json-manager defined in the same page.</dd>
 				<dt><code>data-wb-jsonmanager='{ "url": [ "location/of/json/file.json#/", "[datasetName]#/" ] }'</code></dt>
 				<dd>The url is a json file and a reference to a dataset managed by a json-manager defined in the same page. The dataset will be a combination of both references.</dd>
+				<dt><code>data-wb-jsonmanager='{ "url": {Url fetch object} }'</code></dt>
+				<dd>
+					<p>An object defining advanced configuration on how to fetch and merge the file specified by the URL into the JSON manager.</p>
+					<p>There is more details in the <a href="#urlobj">section below</a>.</p>
+				</dd>
 			</dl>
 		</td>
 	</tr>
@@ -529,6 +534,33 @@
 		</td>
 	</tr>
 	</tbody>
+	</table>
+
+	<h3 id="urlobj">URL advanced configuration (Url fetch object)</h3>
+	<p>An object representing the URL to be fetch with some advanced configuration on how to fetch and merge the file specified by the URL into the JSON manager.</p>
+	<table class="table">
+		<thead>
+			<tr>
+				<th>Option</th>
+				<th class="col-md-6">How to configure</th>
+				<th>Values and clarification</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td><code>url</code></td>
+				<td><code>{ "url": "location/of/json/file.json#/" &hellip;}</code> or <code>{ "url": "[datasetName]#/" &hellip;}</code></td>
+				<td>
+					<p><strong>Required</strong>. Define the url or the dataset name to use. When used in a template mode, the URL should point to an array object.</p>
+					<p>You can follow the url or the dataset name by a <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a>. The value can be either a string or an array of strings. If all references are arrays, the arrays will be concatenated into one array. If all references are objects, the objects will be extended into a single object. If there are references of multiple types, the plugin will throw an error.</p>
+				</td>
+			</tr>
+			<tr>
+				<td><code>path</code></td>
+				<td><code>{ "url": "location/of/json/file.json#/", "path": "/JSON Pointer" }</code></td>
+				<td>A valid <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a> to where the data would be inserted. It's must start with an "/".</td>
+			</tr>
+		</tbody>
 	</table>
 
 	<h3 id="evalobj">Filtering (evaluation object)</h3>

--- a/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
@@ -518,6 +518,92 @@
 }</code></pre>
 </details>
 
+<h3>Example 3</h3>
+<p>This example shows an advanced configuration of loading multiple data sources and inserting them into specific locations within the JSON manager dataset.</p>
+
+<div data-wb-jsonmanager='{
+	"name": "mappingDataSource",
+	"url": [
+		"demo/data-en.json",
+		{
+			"url": "demo/data-fr.json#/produits",
+			"path": "/français/liste"
+		}
+	]
+}'></div>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>List of English products</p>
+		<ul data-wb-json='{
+			"url": "#[mappingDataSource]/products",
+			"mapping": [
+				{ "selector": "li" }
+			]
+		}'>
+			<template>
+				<li></li>
+			</template>
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>List of French products</p>
+		<ul lang="fr" data-wb-json='{
+			"url": "#[mappingDataSource]/français/liste",
+			"mapping": [
+				{ "selector": "li" }
+			]
+		}'>
+			<template>
+				<li></li>
+			</template>
+		</ul>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div data-wb-jsonmanager='{
+	"name": "mappingDataSource",
+	"url": [
+		"demo/data-en.json",
+		{
+			"url": "demo/data-fr.json#/produits",
+			"path": "/français/liste"
+		}
+	]
+}'>&lt;/div>
+
+&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>List of English products&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "#[mappingDataSource]/products",
+			"mapping": [
+				{ "selector": "li" }
+			]
+		}'>
+			&lt;template>
+				&lt;li>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>List of French products&lt;/p>
+		&lt;ul lang="fr" data-wb-json='{
+			"url": "#[mappingDataSource]/français/liste",
+			"mapping": [
+				{ "selector": "li" }
+			]
+		}'>
+			&lt;template>
+				&lt;li>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
 <h2>Displaying result from a JSON RESTful API</h2>
 
 <details>

--- a/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
@@ -517,6 +517,92 @@
 }</code></pre>
 </details>
 
+<h3>Exemple 3</h3>
+<p>Cet exemple démontre une configuration avancée pour le chargement de fichiers sources multiples, avec la possibilité de spécifier l'emplacement de l'insertion du contenu dans l'ensemble de données du gestionnaire JSON.</p>
+
+<div data-wb-jsonmanager='{
+	"name": "mappingDataSource",
+	"url": [
+		"demo/data-fr.json",
+		{
+			"url": "demo/data-en.json#/products",
+			"path": "/english/list"
+		}
+	]
+}'></div>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Liste des produits français</p>
+		<ul data-wb-json='{
+			"url": "#[mappingDataSource]/produits",
+			"mapping": [
+				{ "selector": "li" }
+			]
+		}'>
+			<template>
+				<li></li>
+			</template>
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Liste des produits anglais</p>
+		<ul lang="en" data-wb-json='{
+			"url": "#[mappingDataSource]/english/list",
+			"mapping": [
+				{ "selector": "li" }
+			]
+		}'>
+			<template>
+				<li></li>
+			</template>
+		</ul>
+	</div>
+</div>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;div data-wb-jsonmanager='{
+	"name": "mappingDataSource",
+	"url": [
+		"demo/data-fr.json",
+		{
+			"url": "demo/data-en.json#/products",
+			"path": "/english/list"
+		}
+	]
+}'>&lt;/div>
+
+&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Liste des produits français&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "#[mappingDataSource]/produits",
+			"mapping": [
+				{ "selector": "li" }
+			]
+		}'>
+			&lt;template>
+				&lt;li>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Liste des produits anglais&lt;/p>
+		&lt;ul lang="en" data-wb-json='{
+			"url": "#[mappingDataSource]/english/list",
+			"mapping": [
+				{ "selector": "li" }
+			]
+		}'>
+			&lt;template>
+				&lt;li>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
 <h2>Afficher des résultats à partir d'un JSON RESTful API</h2>
 
 <details>


### PR DESCRIPTION
Minor change to: JSON manager and JSON fetch 
Patch change to JSON manager: fix a bug when loading URL to JSON manager via the GCWeb action manager

Allow to set a saving path for fetched URL.

This feature is needed for the ACR methodology in order to load a centralized implementation independent version of the labels and then do the wb-swap to show meaningful content to the translated JSON documents.