### PR TITLE
data-json - Add conditional template

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -1006,6 +1006,7 @@ module.exports = (grunt) ->
 						"The “contentinfo” role is unnecessary for element “footer”."
 						"The “navigation” role is unnecessary for element “nav”."
 						"The “banner” role is unnecessary for element “header”."
+						"Attribute “href” without an explicit value seen. The attribute may be dropped by IE7."
 					]
 				src: [
 					"dist/unmin/**/*.html"

--- a/site/layouts/assessment_wrote_en-en.hbs
+++ b/site/layouts/assessment_wrote_en-en.hbs
@@ -170,6 +170,111 @@
 					{ "selector": "[data-result-relevancy]", "value": "/acr:relevancy" },
 					{ "selector": "[data-result-notes", "value": "/dct:description" }
 				]
+			},
+			{
+				"@type": "rdf:Alt",
+				"mapping": [
+					{
+						"test": "fn:isLiteral",
+						"assess": "/acr:asset",
+						"mapping": [
+							{
+								"@type": "rdf:Alt",
+								"mapping": [
+									{
+										"template": "[data-asset-literal]",
+										"test": "fn:guessType",
+										"value": "/acr:asset",
+										"expect": "xsd:anyURI",
+										"mapping": [
+											{ "selector": "a", "value": "/acr:asset", "attr": "href" }
+										]
+									},
+									{
+										"template": "[data-asset-code]",
+										"test": "fn:guessType",
+										"value": "/acr:asset",
+										"expect": "xsd:string",
+										"mapping": [
+											{ "selector": "code", "value": "/acr:asset" }
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						"template": "[data-asset-image]",
+						"test": "fn:guessType",
+						"assess": "/acr:asset",
+						"expect": "acr:AttachmentImage",
+						"mapping": [
+							{ "selector": "img", "value": "/acr:asset/acr:content/@value", "attr": "src" },
+							{ "selector": "a", "value": "/acr:asset/acr:content/@value", "attr": "href" },
+							{ "selector": "img", "value": "/acr:asset/dct:title", "attr": "alt" }
+
+						]
+					},
+					{
+						"template": "[data-asset-literal]",
+						"test": "fn:guessType",
+						"value": "/acr:asset",
+						"expect": "xsd:anyURI",
+						"mapping": [
+							{ "selector": "a", "value": "/acr:asset", "attr": "href" }
+						]
+					},
+					{
+						"template": "[data-asset-code]",
+						"test": "fn:guessType",
+						"value": "/acr:asset",
+						"expect": "xsd:string",
+						"mapping": [
+							{ "selector": "code", "value": "/acr:asset" }
+						]
+					},
+					{
+						"about": "When the value is an array of items",
+						"template": "[data-asset-array]",
+						"test": "fn:isArray",
+						"value": "/acr:asset",
+						"mapping": [
+								{
+									"template": "[data-download-link]",
+									"test": "fn:guessType",
+									"value": "/",
+									"expect": "xsd:anyURI",
+									"append": true,
+									"mapping": [
+										{ "selector": "a", "value": "/@value", "attr": "href" }
+									]
+								},
+								{
+									"template": "[data-source-code]",
+									"test": "fn:guessType",
+									"value": "/",
+									"expect": "xsd:string",
+									"append": true,
+									"mapping": [
+										{ "selector": "code", "value": "/@value" }
+									]
+								},
+								{
+									"template": "[data-asset-image]",
+									"test": "fn:guessType",
+									"value": "/",
+									"expect": "acr:AttachmentImage",
+									"append": true,
+									"mapping": [
+										{ "selector": "img", "value": "/acr:content/@value", "attr": "src" },
+										{ "selector": "a", "value": "/acr:content/@value", "attr": "href" },
+										{ "selector": "img", "value": "/dct:title", "attr": "alt" }
+
+									]
+								}
+						]
+					}
+				]
 			}
 		]
 	}'>
@@ -189,6 +294,33 @@
 					<li class="pull-right clr-rght-md clr-rght-lg">Relevance: <span data-relevancy>Not specified</span></li>
 				</ul>
 				<p data-notes></p>
+				<template data-asset-literal>
+					<p><a href download>Download attachment</a></p>
+				</template>
+				<template data-asset-code>
+					<pre><code></code></pre>
+				</template>
+				<template data-asset-image data-proofer-ignore>
+					<p>Image (<a href download>Download</a>):</p>
+					<img class="img-responsive" src="" alt lang="en">
+				</template>
+				<template data-asset-array>
+					<p>Attachments:</p>
+					<ul>
+						<template data-download-link>
+							<li><a href download>Download attachment</a></li>
+						</template>
+						<template data-source-code>
+							<li><pre><code></code></pre></li>
+						</template>
+						<template data-asset-image data-proofer-ignore>
+							<li>
+								<p>Image (<a href download>Download</a>):</p>
+								<img class="img-responsive" src="" alt lang="en">
+							</li>
+						</template>
+					</ul>
+				</template>
 				<dl data-specific-results>
 					<template>
 						<dt data-result-label></dt>

--- a/site/layouts/assessment_wrote_en-fr.hbs
+++ b/site/layouts/assessment_wrote_en-fr.hbs
@@ -169,6 +169,111 @@
 					{ "selector": "[data-result-relevancy]", "value": "/acr:relevancy" },
 					{ "selector": "[data-result-notes", "value": "/dct:description" }
 				]
+			},
+			{
+				"@type": "rdf:Alt",
+				"mapping": [
+					{
+						"test": "fn:isLiteral",
+						"assess": "/acr:asset",
+						"mapping": [
+							{
+								"@type": "rdf:Alt",
+								"mapping": [
+									{
+										"template": "[data-asset-literal]",
+										"test": "fn:guessType",
+										"value": "/acr:asset",
+										"expect": "xsd:anyURI",
+										"mapping": [
+											{ "selector": "a", "value": "/acr:asset", "attr": "href" }
+										]
+									},
+									{
+										"template": "[data-asset-code]",
+										"test": "fn:guessType",
+										"value": "/acr:asset",
+										"expect": "xsd:string",
+										"mapping": [
+											{ "selector": "code", "value": "/acr:asset" }
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						"template": "[data-asset-image]",
+						"test": "fn:guessType",
+						"assess": "/acr:asset",
+						"expect": "acr:AttachmentImage",
+						"mapping": [
+							{ "selector": "img", "value": "/acr:asset/acr:content/@value", "attr": "src" },
+							{ "selector": "a", "value": "/acr:asset/acr:content/@value", "attr": "href" },
+							{ "selector": "img", "value": "/acr:asset/dct:title", "attr": "alt" }
+
+						]
+					},
+					{
+						"template": "[data-asset-literal]",
+						"test": "fn:guessType",
+						"value": "/acr:asset",
+						"expect": "xsd:anyURI",
+						"mapping": [
+							{ "selector": "a", "value": "/acr:asset", "attr": "href" }
+						]
+					},
+					{
+						"template": "[data-asset-code]",
+						"test": "fn:guessType",
+						"value": "/acr:asset",
+						"expect": "xsd:string",
+						"mapping": [
+							{ "selector": "code", "value": "/acr:asset" }
+						]
+					},
+					{
+						"about": "When the value is an array of items",
+						"template": "[data-asset-array]",
+						"test": "fn:isArray",
+						"value": "/acr:asset",
+						"mapping": [
+								{
+									"template": "[data-download-link]",
+									"test": "fn:guessType",
+									"value": "/",
+									"expect": "xsd:anyURI",
+									"append": true,
+									"mapping": [
+										{ "selector": "a", "value": "/@value", "attr": "href" }
+									]
+								},
+								{
+									"template": "[data-source-code]",
+									"test": "fn:guessType",
+									"value": "/",
+									"expect": "xsd:string",
+									"append": true,
+									"mapping": [
+										{ "selector": "code", "value": "/@value" }
+									]
+								},
+								{
+									"template": "[data-asset-image]",
+									"test": "fn:guessType",
+									"value": "/",
+									"expect": "acr:AttachmentImage",
+									"append": true,
+									"mapping": [
+										{ "selector": "img", "value": "/acr:content/@value", "attr": "src" },
+										{ "selector": "a", "value": "/acr:content/@value", "attr": "href" },
+										{ "selector": "img", "value": "/dct:title", "attr": "alt" }
+
+									]
+								}
+						]
+					}
+				]
 			}
 		]
 	}'>
@@ -188,6 +293,33 @@
 					<li class="pull-right clr-rght-md clr-rght-lg">Pertinence: <span data-relevancy>Non précisé</span></li>
 				</ul>
 				<p data-notes lang="en"></p>
+				<template data-asset-literal>
+					<p><a href download>Télécharger la pièce jointe</a></p>
+				</template>
+				<template data-asset-code>
+					<pre><code lang="en"></code></pre>
+				</template>
+				<template data-asset-image data-proofer-ignore>
+					<p>Image (<a href download>Télécharger</a>):</p>
+					<img class="img-responsive" src="" alt lang="en">
+				</template>
+				<template data-asset-array>
+					<p>Pièces jointes:</p>
+					<ul>
+						<template data-download-link>
+							<li><a href download>Télécharger la pièce jointe</a></li>
+						</template>
+						<template data-source-code>
+							<li><pre><code lang="en"></code></pre></li>
+						</template>
+						<template data-asset-image data-proofer-ignore>
+							<li>
+								<p>Image (<a href download>Télécharger</a>):</p>
+								<img class="img-responsive" src="" alt lang="en">
+							</li>
+						</template>
+					</ul>
+				</template>
 				<dl data-specific-results lang="en">
 					<template>
 						<dt data-result-label></dt>

--- a/site/pages/docs/ref/wb-data-json/wb-data-json-en.hbs
+++ b/site/pages/docs/ref/wb-data-json/wb-data-json-en.hbs
@@ -34,11 +34,13 @@
 	<ul>
 		<li><a href="../../../demos/wb-data-json/data-json-en.html">Data JSON</a></li>
 		<li><a href="../../../demos/wb-data-json/template-en.html">HTML 5 template</a></li>
+		<li><a href="../../../demos/wb-data-json/conditional-en.html">Conditional template</a></li>
 	</ul>
 	<p>French:</p>
 	<ul>
 		<li><a href="../../../demos/wb-data-json/data-json-fr.html" hreflang="fr">Data JSON</a></li>
 		<li><a href="../../../demos/wb-data-json/template-fr.html" hreflang="fr" lang="fr">Gabarit HTML 5</a></li>
+		<li><a href="../../../demos/wb-data-json/conditional-fr.html" hreflang="fr" lang="fr">Gabarit conditionel</a></li>
 	</ul>
 </section>
 <section>
@@ -267,7 +269,7 @@
 <section>
 <h2 id="jsonObjToArr">Template - Transforming JSON object into an array</h2>
 
-<p>Since WET 4.0.27 it is now possible to iterate anything that is not an array to render content through a <code>&lt;template&gt;</code>. It simply get transformed into a array. There is a low risk of lost of information, only one specific use case. It's quite similar to the JSON-LD Expanded Form. In this transformation process, it assume the array key is an IRI. Then the will result include some property from JSON-LD such as <code>@id</code> and <code>@value</code>. The <code>@id</code> wont be overwritten, in those such case the array key will be discard after the transformation.</p>
+<p>Since WET 4.0.27 or without the <code>streamline</code> flag since WET 4.0.64 it is possible to iterate anything that is not an array to render content through a <code>&lt;template&gt;</code>. It simply get transformed into a array. There is a low risk of lost of information, only one specific use case. It's quite similar to the JSON-LD Expanded Form. In this transformation process, it assume the array key is an <a href="https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier">IRI</a>. Then the will result include some property from JSON-LD such as <code>@id</code> and <code>@value</code>. The <code>@id</code> wont be overwritten, in those such case the array key will be discard after the transformation.</p>
 
 <h3>When the value is a sub-object</h3>
 <div class="row">
@@ -421,6 +423,60 @@
 <h2>Cache busting</h2>
 <p>Before to use the cache busting mechanism with your data json instance, it's highly recommended to configure your server properly instead.</p>
 <p>Various strategy can be set on the server side and those are communicated to the browser through an http header as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>.</p>
+</section>
+
+<section>
+<h2 id="test-function">Test functions that extract a testable value</h2>
+<p>Those test require a data pointer either provided with the <code>value</code> property which would also iterate or with <code>assess</code> which don't iterate.</p>
+
+<dl class="dl-horizontal">
+	<dt><code>fn:isArray</code></dt>
+	<dd>Boolean returning if the tested value is an array or not.</dd>
+
+	<dt><code>fn:isLiteral</code></dt>
+	<dd>Boolean returning if the tested value is an literal or not. A literal value is considered to be defined and not an object.</dd>
+
+	<dt><code>fn:getType</code></dt>
+	<dd>Return type of the value set via the <code>@type</code> property or its corresponding javascript typeof value.</dd>
+
+	<dt><code>fn:guessType</code></dt>
+	<dd>
+		<p>The template parser will try to guess the data type of the tested value.</p>
+		<p>This test function will return:</p>
+		<ul>
+			<li><code>rdfs:Container</code> when the value is an array.</li>
+			<li><code>rdfs:Literal</code> for any value that is literal. A literal value is considered to be defined and not an object.</li>
+			<li><code>rdfs:Resource</code> when the value is an JSON object without any defined type.</li>
+			<li><code>xsd:anyURI</code> when the value is a string which start with non-spaced letter and digit immediately followed by colon ":" like <code>https://example.com</code></li>
+			<li><code>xsd:string</code> when the value is a string and don't look to be an URI.</li>
+			<li><code>xsd:boolean</code> when the value is a boolean with the value set to <code>true</code> or <code>false</code></li>
+			<li><code>xsd:double</code> when the value is a JSON number</li>
+			<li>The value set via the <code>@type</code> sub property</li>
+			<li><code>undefined</code> when the value is undefined</li>
+		</ul>
+	</dd>
+
+	<dt><code>fn:getValue</code></dt>
+	<dd>Return value as the testable value.</dd>
+</dl>
+</section>
+
+<section>
+<h2 id="operand-function">Operand function</h2>
+<p>Operand functions that check the testable value.</p>
+
+<dl class="dl-horizontal">
+	<dt><code>softEq</code> (default)</dt>
+	<dd>Check if the value is <strong>equivalent equal</strong> to the expectation optionally either in an array value. When no expectation provide, return true if the testable value exist.</dd>
+	<dt><code>eq</code></dt>
+	<dd>Check if the value <strong>equal</strong> the expectation. Including when the value is an object.</dd>
+	<dt><code>neq</code></dt>
+	<dd>Check if the value is <strong>not equal</strong> the expectation. Including when the value is an object.</dd>
+	<dt><code>in</code></dt>
+	<dd>Check if the value (or array of value) <strong>is in</strong> the expectation (or array of expectation)</dd>
+	<dt><code>nin</code></dt>
+	<dd>Check if the value (or array of value) <strong>is not in</strong> the expectation (or array of expectation)</dd>
+</dl>
 </section>
 
 <section>
@@ -605,6 +661,12 @@
 		<td>JQuery selector that represent the template element on the current page.</td>
 	</tr>
 	<tr>
+		<td><code>streamline</code></td>
+		<td>Template only. Indicate not to initiate the process of iterating the data and instead execute the mapping object directly</td>
+		<td><code>data-wb-json='{ "url": "", "streamline": true|false }'</code></td>
+		<td>JQuery selector that represent the template element on the current page.</td>
+	</tr>
+	<tr>
 		<td><code>mapping</code></td>
 		<td>Template only. Array of string represeting a JSON pointer or object where it specify how to bind the data with the template content. If the configuration <code>queryall</code> is used, the number of items in the mapping must match the number of returning result of the queryall. In the other hand, if <code>queryall</code> configuration is not specified, than each mapping object must define a <code>selector</code> configuration.</td>
 		<td><code>data-wb-json='{ "url": "", "mapping": [ "JSON Pointer", "JSON Pointer" ] }'</code> or <code>data-wb-json='{ "url": "", "mapping": [ {mapping object}, {mapping object} ] }'</code></td>
@@ -643,6 +705,47 @@
 		<td>Template only, for mapping object and optional when <code>queryall</code> is not specified. Flag indicating if the content to be mapped is a string HTML.</td>
 		<td><code>data-wb-json='{ "url": "", "mapping": [ { "isHTML": "true" } ] }'</code></td>
 		<td>A valid attribute of the selected element.</td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>test</code></td>
+		<td>Test functions that extract a testable value. It requires a JSON pointer provided by either the mapping property <code>assess</code> or <code>value</code>.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "test": "Test-Technical-Name" } ] }'</code></td>
+		<td>A valid technical test name like <code>fn:guessType</code>. See the <a href="#test-function">predefined list of test function</a></td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>assess</code></td>
+		<td>(JSON Pointer) This the value to take for performing the conditional evaluation. Alternatively, it will take the value from the <code>value</code> property. Another difference is the <code>assess</code> would not be iterated compared to <code>value</code> which would be iterated for the inner mapping.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "assess": "A JSON Pointer", "test": "Test-Technical-Name" } ] }'</code></td>
+		<td>A valid <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a></td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>expect</code></td>
+		<td>The value which is going to be compared by the operand. If not provided it will use the trueness state of the testable value return by the test function.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "expect": "A value", "assess": "A JSON Pointer", "test": "Test-Technical-Name" } ] }'</code></td>
+		<td>A string or an JSON object use for comparison by the operand.</td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>operand</code></td>
+		<td>Operand functions that evaluate the testable value against the expected value.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "operand": "Operand-Technical-Name", "assess": "A JSON Pointer", "test": "Test-Technical-Name" } ] }'</code></td>
+		<td>A valid operand name like <code>fn:eq</code>. See the <a href="#operand-function">predefined list of operand function</a></td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>@type</code></td>
+		<td>Mapping function to use in order to process the data and the configuration.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "@type": "rdf:Alt", "mapping": [ ... ] } ] }'</code></td>
+		<td>
+			<dl>
+				<dt><code>rdf:Alt</code></dt>
+				<dd>Allow to configure a list of mapping where it's going to execute only the first children passing its test condition. The rdf:Alt type require the mapping property <code>mapping</code>.</dd>
+			</dl>
+		</td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>append</code></td>
+		<td>Force the content created via the template to be append from the template parent element instead of being inserted in-place.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "append": "true" } ] }'</code></td>
+		<td>Boolean indicating if the content need to be append.</td>
 	</tr>
 	<tr>
 		<td><code>appendto</code></td>

--- a/site/pages/docs/ref/wb-data-json/wb-data-json-fr.hbs
+++ b/site/pages/docs/ref/wb-data-json/wb-data-json-fr.hbs
@@ -37,11 +37,13 @@
 	<ul>
 		<li><a href="../../../demos/wb-data-json/data-json-en.html">Data JSON</a></li>
 		<li><a href="../../../demos/wb-data-json/template-en.html">HTML 5 template</a></li>
+		<li><a href="../../../demos/wb-data-json/conditional-en.html">Conditional template</a></li>
 	</ul>
 	<p>French:</p>
 	<ul>
 		<li><a href="../../../demos/wb-data-json/data-json-fr.html" hreflang="fr">Data JSON</a></li>
 		<li><a href="../../../demos/wb-data-json/template-fr.html" hreflang="fr" lang="fr">Gabarit HTML 5</a></li>
+		<li><a href="../../../demos/wb-data-json/conditional-fr.html" hreflang="fr" lang="fr">Gabarit conditionel</a></li>
 	</ul>
 </section>
 <section>
@@ -270,7 +272,7 @@
 <section>
 <h2 id="jsonObjToArr">Template - Transforming JSON object into an array</h2>
 
-<p>Since WET 4.0.27 it is now possible to iterate anything that is not an array to render content through a <code>&lt;template&gt;</code>. It simply get transformed into a array. There is a low risk of lost of information, only one specific use case. It's quite similar to the JSON-LD Expanded Form. In this transformation process, it assume the array key is an IRI. Then the will result include some property from JSON-LD such as <code>@id</code> and <code>@value</code>. The <code>@id</code> wont be overwritten, in those such case the array key will be discard after the transformation.</p>
+<p>Since WET 4.0.27 or without the <code>streamline</code> flag since WET 4.0.64 it is possible to iterate anything that is not an array to render content through a <code>&lt;template&gt;</code>. It simply get transformed into a array. There is a low risk of lost of information, only one specific use case. It's quite similar to the JSON-LD Expanded Form. In this transformation process, it assume the array key is an <a href="https://en.wikipedia.org/wiki/Internationalized_Resource_Identifier">IRI</a>. Then the will result include some property from JSON-LD such as <code>@id</code> and <code>@value</code>. The <code>@id</code> wont be overwritten, in those such case the array key will be discard after the transformation.</p>
 
 <h3>When the value is a sub-object</h3>
 <div class="row">
@@ -424,6 +426,60 @@
 <h2>Cache busting</h2>
 <p>Before to use the cache busting mechanism with your data json instance, it's highly recommended to configure your server properly instead.</p>
 <p>Various strategy can be set on the server side and those are communicated to the browser through an http header as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>.</p>
+</section>
+
+<section>
+<h2 id="test-function">Test functions that extract a testable value</h2>
+<p>Those test require a data pointer either provided with the <code>value</code> property which would also iterate or with <code>assess</code> which don't iterate.</p>
+
+<dl class="dl-horizontal">
+	<dt><code>fn:isArray</code></dt>
+	<dd>Boolean returning if the tested value is an array or not.</dd>
+
+	<dt><code>fn:isLiteral</code></dt>
+	<dd>Boolean returning if the tested value is an literal or not. A literal value is considered to be defined and not an object.</dd>
+
+	<dt><code>fn:getType</code></dt>
+	<dd>Return type of the value set via the <code>@type</code> property or its corresponding javascript typeof value.</dd>
+
+	<dt><code>fn:guessType</code></dt>
+	<dd>
+		<p>The template parser will try to guess the data type of the tested value.</p>
+		<p>This test function will return:</p>
+		<ul>
+			<li><code>rdfs:Container</code> when the value is an array.</li>
+			<li><code>rdfs:Literal</code> for any value that is literal. A literal value is considered to be defined and not an object.</li>
+			<li><code>rdfs:Resource</code> when the value is an JSON object without any defined type.</li>
+			<li><code>xsd:anyURI</code> when the value is a string which start with non-spaced letter and digit immediately followed by colon ":" like <code>https://example.com</code></li>
+			<li><code>xsd:string</code> when the value is a string and don't look to be an URI.</li>
+			<li><code>xsd:boolean</code> when the value is a boolean with the value set to <code>true</code> or <code>false</code></li>
+			<li><code>xsd:double</code> when the value is a JSON number</li>
+			<li>The value set via the <code>@type</code> sub property</li>
+			<li><code>undefined</code> when the value is undefined</li>
+		</ul>
+	</dd>
+
+	<dt><code>fn:getValue</code></dt>
+	<dd>Return value as the testable value.</dd>
+</dl>
+</section>
+
+<section>
+<h2 id="operand-function">Operand function</h2>
+<p>Operand functions that check the testable value.</p>
+
+<dl class="dl-horizontal">
+	<dt><code>softEq</code> (default)</dt>
+	<dd>Check if the value is <strong>equivalent equal</strong> to the expectation optionally either in an array value. When no expectation provide, return true if the testable value exist.</dd>
+	<dt><code>eq</code></dt>
+	<dd>Check if the value <strong>equal</strong> the expectation. Including when the value is an object.</dd>
+	<dt><code>neq</code></dt>
+	<dd>Check if the value is <strong>not equal</strong> the expectation. Including when the value is an object.</dd>
+	<dt><code>in</code></dt>
+	<dd>Check if the value (or array of value) <strong>is in</strong> the expectation (or array of expectation)</dd>
+	<dt><code>nin</code></dt>
+	<dd>Check if the value (or array of value) <strong>is not in</strong> the expectation (or array of expectation)</dd>
+</dl>
 </section>
 
 <section>
@@ -608,6 +664,12 @@
 		<td>JQuery selector that represent the template element on the current page.</td>
 	</tr>
 	<tr>
+		<td><code>streamline</code></td>
+		<td>Template only. Indicate not to initiate the process of iterating the data and instead execute the mapping object directly</td>
+		<td><code>data-wb-json='{ "url": "", "streamline": true|false }'</code></td>
+		<td>JQuery selector that represent the template element on the current page.</td>
+	</tr>
+	<tr>
 		<td><code>mapping</code></td>
 		<td>Template only. Array of string represeting a JSON pointer or object where it specify how to bind the data with the template content. If the configuration <code>queryall</code> is used, the number of items in the mapping must match the number of returning result of the queryall. In the other hand, if <code>queryall</code> configuration is not specified, than each mapping object must define a <code>selector</code> configuration.</td>
 		<td><code>data-wb-json='{ "url": "", "mapping": [ "JSON Pointer", "JSON Pointer" ] }'</code> or <code>data-wb-json='{ "url": "", "mapping": [ {mapping object}, {mapping object} ] }'</code></td>
@@ -646,6 +708,48 @@
 		<td>Template only, for mapping object and optional when <code>queryall</code> is not specified. Flag indicating if the content to be mapped is a string HTML.</td>
 		<td><code>data-wb-json='{ "url": "", "mapping": [ { "isHTML": "true" } ] }'</code></td>
 		<td>A valid attribute of the selected element.</td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>test</code></td>
+		<td>Test functions that extract a testable value. It requires a JSON pointer provided by either the mapping property <code>assess</code> or <code>value</code>.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "test": "Test-Technical-Name" } ] }'</code></td>
+		<td>A valid technical test name like <code>fn:guessType</code>. See the <a href="#test-function">predefined list of test function</a></td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>assess</code></td>
+		<td>(JSON Pointer) This the value to take for performing the conditional evaluation. Alternatively, it will take the value from the <code>value</code> property. Another difference is the <code>assess</code> would not be iterated compared to <code>value</code> which would be iterated for the inner mapping.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "assess": "A JSON Pointer", "test": "Test-Technical-Name" } ] }'</code></td>
+		<td>A valid <a href="https://tools.ietf.org/html/rfc6901">JSON Pointer (RFC6901)</a></td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>expect</code></td>
+		<td>The value which is going to be compared by the operand. If not provided it will use the trueness state of the testable value return by the test function.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "expect": "A value", "assess": "A JSON Pointer", "test": "Test-Technical-Name" } ] }'</code></td>
+		<td>A string or an JSON object use for comparison by the operand.</td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>operand</code></td>
+		<td>Operand functions that evaluate the testable value against the expected value.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "operand": "Operand-Technical-Name", "assess": "A JSON Pointer", "test": "Test-Technical-Name" } ] }'</code></td>
+		<td>A valid operand name like <code>fn:eq</code>. See the <a href="#operand-function">predefined list of operand function</a></td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>@type</code></td>
+		<td>Mapping function to use in order to process the data and the configuration.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "@type": "rdf:Alt", "mapping": [ ... ] } ] }'</code></td>
+		<td>
+			<dl>
+				<dt><code>rdf:Alt</code></dt>
+				<dd>Allow to configure a list of mapping where it's going to execute only the first children passing its test condition. The rdf:Alt type require the mapping property <code>mapping</code>.</dd>
+			</dl>
+
+		</td>
+	</tr>
+	<tr>
+		<td>Mapping object <code>append</code></td>
+		<td>Force the content created via the template to be append from the template parent element instead of being inserted in-place.</td>
+		<td><code>data-wb-json='{ "url": "", "mapping": [ { "append": "true" } ] }'</code></td>
+		<td>Boolean indicating if the content need to be append.</td>
 	</tr>
 	<tr>
 		<td><code>appendto</code></td>

--- a/src/plugins/wb-data-json/conditional-en.hbs
+++ b/src/plugins/wb-data-json/conditional-en.hbs
@@ -1,0 +1,1534 @@
+---
+{
+	"title": "Conditional template",
+	"language": "en",
+	"category": "Plugins",
+	"description": "Map JSON content by following a conditional template.",
+	"tag": "data-json",
+	"parentdir": "wb-data-json",
+	"altLangPage": "conditional-fr.html",
+	"dateModified": "2023-06-07"
+}
+---
+
+<nav>
+	<ul>
+		<li><a href="data-json-en.html">Data JSON</a></li>
+		<li><a href="template-en.html">HTML 5 template</a></li>
+		<li>(This page) Conditional template</li>
+	</ul>
+</nav>
+
+<p>Map JSON content by following a conditional template.</p>
+
+
+<p>The following list is an example of a conditional mapping by guessing the data type.</p>
+
+<ul data-wb-json='{
+	"url": "demo/conditional-1.json#/subject",
+	"mapping": [
+		{
+			"template": "[data-text]",
+			"test": "fn:guessType",
+			"expect": "xsd:string",
+			"assess": "/foo",
+			"mapping": [
+				{ "selector": "[data-foo]", "value": "/foo" },
+				{ "selector": "[data-bar]", "value": "/bar" }
+			]
+		},
+		{
+			"template": "[data-link]",
+			"test": "fn:guessType",
+			"expect": "xsd:anyURI",
+			"assess": "/foo",
+			"mapping": [
+				{ "selector": "a", "value": "/foo", "attr": "href" },
+				{ "selector": "a", "value": "/bar" }
+			]
+		}
+	]
+}'>
+	<template data-text>
+		<li><span data-foo></span> - <span data-bar></span></li>
+	</template>
+	<template data-link>
+		<li><a href></a></li>
+	</template>
+</ul>
+
+<details>
+	<summary>Source code of the preceding working example</summary>
+	<p>Json:</p>
+	<pre><code>{
+	"subject": [
+		{
+			"foo": "bar",
+			"bar": "hello world"
+		},
+		{
+			"foo": "https://example.com",
+			"bar": "hello world"
+		}
+	]
+}</code></pre>
+
+<p>Html:</p>
+<pre><code>&lt;ul data-wb-json='{
+	"url": "demo/conditional-1.json#/subject",
+	"mapping": [
+		{
+			"template": "[data-text]",
+			"test": "fn:guessType",
+			"expect": "xsd:string",
+			"assess": "/foo",
+			"mapping": [
+				{ "selector": "[data-foo]", "value": "/foo" },
+				{ "selector": "[data-bar]", "value": "/bar" }
+			]
+		},
+		{
+			"template": "[data-link]",
+			"test": "fn:guessType",
+			"expect": "xsd:anyURI",
+			"assess": "/foo",
+			"mapping": [
+				{ "selector": "a", "value": "/foo", "attr": "href" },
+				{ "selector": "a", "value": "/bar" }
+			]
+		}
+	]
+}'>
+	&lt;template data-text>
+		&lt;li>&lt;span data-foo>&lt;/span> - &lt;span data-bar>&lt;/span>&lt;/li>
+	&lt;/template>
+	&lt;template data-link>
+		&lt;li>&lt;a href>&lt;/a>&lt;/li>
+	&lt;/template>
+&lt;/ul></code></pre>
+</details>
+
+
+<p>Through the following example, it also show the use of these, not limited to, configurations. A complete list of all configuration is available through the data-json plugin documentation.</p>
+<dl class="dl-horizontal">
+	<dt>Configuration <code>streamline</code></dt>
+	<dd>(Boolean: true or false) This flag indicate the data-json plugin will apply the template via the mapping object directly without trying to iterate the data source.</dd>
+
+	<dt>Mapping object <code>assess</code></dt>
+	<dd>(JSON Pointer) This the value to take for performing the conditional evaluation. Alternatively, it will take the value from the <code>value</code> property. Another difference is the <code>assess</code> would not be iterated compared to <code>value</code> which would be iterated for the inner mapping.</dd>
+</dl>
+
+<p>Note: The conditional template will consider the data associated to the property <code>@value</code> to be seen as the value of it's corresponding parent. Some of the example below to leverage that auto-mapping feature which do help for an interoperability with typed object as per defined in the JSON-LD standard.</p>
+
+<details>
+	<summary>Source code of the JSON file used by the working exmaple on this page</summary>
+	<div class="row">
+		<div class="col-md-6">
+			<p>File: conditional-1.json</p>
+			<pre><code>{
+	"subject": [
+		{
+			"foo": "bar",
+			"bar": "hello world"
+		},
+		{
+			"foo": "https://example.com",
+			"bar": "hello world"
+		}
+	],
+	"list": [
+		{
+			"@type": "xsd:string",
+			"@value": "string"
+		},
+		{
+			"@type": "xsd:double",
+			"@value": 123.45
+		},
+		{
+			"@type": "xsd:boolean",
+			"@value": true
+		},
+		{
+			"@type": "xsd:anyURI",
+			"@value": "https://example.com"
+		},
+		{
+			"@type": "xsd:string",
+			"@value": "second string"
+		}
+	],
+	"text": {
+		"alpha": "alpha",
+		"beta": "beta",
+		"gamma": "gamma",
+		"delta": "delta"
+	}
+}</code></pre>
+		</div>
+		<div class="col-md-6">
+			<p>File: conditional-2.json</p>
+			<pre><code>{
+	"alpha": [ "alpha" ],
+	"beta": "beta",
+	"gamma": { "@value": "gamma" },
+	"delta": { "@type": "rdfs:Resource", "@value": "delta" },
+	"epsilon": "epsilon",
+	"zeta": true,
+	"eta": "http://example.com",
+	"theta": 123.45,
+	"iota": {
+		"@type": [ "rdfs:Resource", "xsd:string" ],
+		"@value": "iota"
+	},
+	"kappa": {
+		"lamdba": "mu"
+	},
+	"nu": {
+		"@type": "@json",
+		"@value": {
+			"xi": "xi",
+			"omicron": "omicron",
+			"pi": "pi"
+		}
+	},
+	"rho": {
+		"@type": "@json",
+		"@value": {
+			"sigma": "sigma",
+			"tau": "tau",
+			"upsilon": "upsilon"
+		}
+	},
+	"sigma": {
+		"alpha": "sigma",
+		"gamma": "sigma"
+	},
+	"undefined": "tau",
+
+	"text": {
+		"zeta": "zeta",
+		"eta": "eta",
+		"theta": "theta",
+		"kappa": "kappa"
+	}
+}</code></pre>
+		</div>
+	</div>
+</details>
+
+<h2>Test functions that extract a testable value</h2>
+<p>Those test require a data pointer either provided with the <code>value</code> property which would also iterate or with <code>assess</code> which don't iterate.</p>
+
+<dl class="dl-horizontal">
+	<dt><code>fn:isArray</code></dt>
+	<dd>Boolean returning if the tested value is an array or not.</dd>
+
+	<dt><code>fn:isLiteral</code></dt>
+	<dd>Boolean returning if the tested value is an literal or not. A literal value is considered to be defined and not an object.</dd>
+
+	<dt><code>fn:getType</code></dt>
+	<dd>Return type of the value set via the <code>@type</code> property or its corresponding javascript typeof value.</dd>
+
+	<dt><code>fn:guessType</code></dt>
+	<dd>
+		<p>The template parser will try to guess the data type of the tested value.</p>
+		<p>This test function will return:</p>
+		<ul>
+			<li><code>rdfs:Container</code> when the value is an array.</li>
+			<li><code>rdfs:Literal</code> for any value that is literal. A literal value is considered to be defined and not an object.</li>
+			<li><code>rdfs:Resource</code> when the value is an JSON object without any defined type.</li>
+			<li><code>xsd:anyURI</code> when the value is a string which start with non-spaced letter and digit immediately followed by colon ":" like <code>https://example.com</code></li>
+			<li><code>xsd:string</code> when the value is a string and don't look to be an URI.</li>
+			<li><code>xsd:boolean</code> when the value is a boolean with the value set to <code>true</code> or <code>false</code></li>
+			<li><code>xsd:double</code> when the value is a JSON number</li>
+			<li>The value set via the <code>@type</code> sub property</li>
+			<li><code>undefined</code> when the value is undefined</li>
+		</ul>
+	</dd>
+
+	<dt><code>fn:getValue</code></dt>
+	<dd>Return value as the testable value.</dd>
+</dl>
+
+<h3>Example of each test function</h3>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Demo of each test function.</p>
+		<ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-isarray]",
+					"test": "fn:isArray",
+					"assess": "/alpha",
+					"mapping": [
+						{ "selector": "span", "value": "/alpha/0" }
+					]
+				},
+				{
+					"template": "[data-isliteral]",
+					"test": "fn:isLiteral",
+					"assess": "/beta",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-isliteral]",
+					"test": "fn:isLiteral",
+					"assess": "/gamma",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/delta",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/epsilon",
+					"expect": "string",
+					"mapping": [
+						{ "selector": "span", "value": "/epsilon" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/zeta",
+					"expect": "boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/text/zeta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/alpha",
+					"expect": "rdfs:Container",
+					"mapping": [
+						{ "selector": "span", "value": "/alpha/0" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/eta",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/text/eta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/eta",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/text/eta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/zeta",
+					"expect": "xsd:boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/text/zeta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/theta",
+					"expect": "xsd:double",
+					"mapping": [
+						{ "selector": "span", "value": "/text/theta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/sigma",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/sigma/alpha" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/tau",
+					"expect": "undefined",
+					"mapping": [
+						{ "selector": "span", "value": "/undefined" }
+					]
+				},
+				{
+					"template": "[data-getvalue]",
+					"test": "fn:getValue",
+					"assess": "/kappa",
+					"operand": "eq",
+					"expect": { "lamdba": "mu" },
+					"mapping": [
+						{ "selector": "span", "value": "/text/kappa" }
+					]
+				}
+			]
+		}'>
+			<template data-isarray>
+				<li><code>fn:isArray</code>: <span></span></li>
+			</template>
+			<template data-isliteral>
+				<li><code>fn:isLiteral</code>: <span></span></li>
+			</template>
+			<template data-gettype>
+				<li><code>fn:getType</code>: <span></span></li>
+			</template>
+			<template data-guesstype>
+				<li><code>fn:guessType</code>: <span></span></li>
+			</template>
+			<template data-getvalue>
+				<li><code>fn:getValue</code>: <span></span></li>
+			</template>
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo.</p>
+		<ul>
+			<li><code>fn:isArray</code>: alpha</li>
+			<li><code>fn:isLiteral</code>: beta</li>
+			<li><code>fn:isLiteral</code>: gamma</li>
+			<li><code>fn:getType</code>: delta</li>
+			<li><code>fn:getType</code>: epsilon</li>
+			<li><code>fn:getType</code>: zeta</li>
+			<li><code>fn:guessType</code>: alpha</li>
+			<li><code>fn:guessType</code>: beta</li>
+			<li><code>fn:guessType</code>: gamma</li>
+			<li><code>fn:guessType</code>: eta</li>
+			<li><code>fn:guessType</code>: beta</li>
+			<li><code>fn:guessType</code>: gamma</li>
+			<li><code>fn:guessType</code>: zeta</li>
+			<li><code>fn:guessType</code>: theta</li>
+			<li><code>fn:guessType</code>: delta</li>
+			<li><code>fn:guessType</code>: sigma</li>
+			<li><code>fn:guessType</code>: tau</li>
+			<li><code>fn:getValue</code>: kappa</li>
+		</ul>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Demo of each test function.&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-isarray]",
+					"test": "fn:isArray",
+					"assess": "/alpha",
+					"mapping": [
+						{ "selector": "span", "value": "/alpha/0" }
+					]
+				},
+				{
+					"template": "[data-isliteral]",
+					"test": "fn:isLiteral",
+					"assess": "/beta",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-isliteral]",
+					"test": "fn:isLiteral",
+					"assess": "/gamma",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/delta",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/epsilon",
+					"expect": "string",
+					"mapping": [
+						{ "selector": "span", "value": "/epsilon" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/zeta",
+					"expect": "boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/text/zeta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/alpha",
+					"expect": "rdfs:Container",
+					"mapping": [
+						{ "selector": "span", "value": "/alpha/0" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/eta",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/text/eta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/eta",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/text/eta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/zeta",
+					"expect": "xsd:boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/text/zeta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/theta",
+					"expect": "xsd:double",
+					"mapping": [
+						{ "selector": "span", "value": "/text/theta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/sigma",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/sigma/alpha" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/tau",
+					"expect": "undefined",
+					"mapping": [
+						{ "selector": "span", "value": "/undefined" }
+					]
+				},
+				{
+					"template": "[data-getvalue]",
+					"test": "fn:getValue",
+					"assess": "/kappa",
+					"operand": "eq",
+					"expect": { "lamdba": "mu" },
+					"mapping": [
+						{ "selector": "span", "value": "/text/kappa" }
+					]
+				}
+			]
+		}'>
+			&lt;template data-isarray>
+				&lt;li>&lt;code>fn:isArray&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-isliteral>
+				&lt;li>&lt;code>fn:isLiteral&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-gettype>
+				&lt;li>&lt;code>fn:getType&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-guesstype>
+				&lt;li>&lt;code>fn:guessType&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-getvalue>
+				&lt;li>&lt;code>fn:getValue&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Expectation of the preceding demo.&lt;/p>
+		&lt;ul>
+			&lt;li>&lt;code>fn:isArray&lt;/code>: alpha&lt;/li>
+			&lt;li>&lt;code>fn:isLiteral&lt;/code>: beta&lt;/li>
+			&lt;li>&lt;code>fn:isLiteral&lt;/code>: gamma&lt;/li>
+			&lt;li>&lt;code>fn:getType&lt;/code>: delta&lt;/li>
+			&lt;li>&lt;code>fn:getType&lt;/code>: epsilon&lt;/li>
+			&lt;li>&lt;code>fn:getType&lt;/code>: zeta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: alpha&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: beta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: gamma&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: eta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: beta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: gamma&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: zeta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: theta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: delta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: sigma&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: tau&lt;/li>
+			&lt;li>&lt;code>fn:getValue&lt;/code>: kappa&lt;/li>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
+<h2>Operand function</h2>
+<p>Operand functions that check the testable value.</p>
+
+<dl class="dl-horizontal">
+	<dt><code>softEq</code> (default)</dt>
+	<dd>Check if the value is <strong>equivalent equal</strong> to the expectation optionally either in an array value. When no expectation provide, return true if the testable value exist.</dd>
+	<dt><code>eq</code></dt>
+	<dd>Check if the value <strong>equal</strong> the expectation. Including when the value is an object.</dd>
+	<dt><code>neq</code></dt>
+	<dd>Check if the value is <strong>not equal</strong> the expectation. Including when the value is an object.</dd>
+	<dt><code>in</code></dt>
+	<dd>Check if the value (or array of value) <strong>is in</strong> the expectation (or array of expectation)</dd>
+	<dt><code>nin</code></dt>
+	<dd>Check if the value (or array of value) <strong>is not in</strong> the expectation (or array of expectation)</dd>
+</dl>
+
+
+<h3>Example of operand</h3>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Demo of each test function.</p>
+		<ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-eq]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"operand": "eq",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-eq]",
+					"test": "fn:getValue",
+					"assess": "/kappa",
+					"operand": "eq",
+					"expect":  { "lamdba": "mu" },
+					"mapping": [
+						{ "selector": "span", "value": "/text/kappa" }
+					]
+				},
+				{
+					"template": "[data-eq]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "eq",
+					"expect": [ "rdfs:Resource", "xsd:string" ],
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				},
+				{
+					"template": "[data-neq]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"operand": "neq",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-in]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "in",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				},
+				{
+					"template": "[data-nin]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "nin",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				}
+
+			]
+		}'>
+			<template data-eq>
+				<li><code>eq</code>: <span></span></li>
+			</template>
+			<template data-neq>
+				<li><code>neq</code>: <span></span></li>
+			</template>
+			<template data-in>
+				<li><code>in</code>: <span></span></li>
+			</template>
+			<template data-nin>
+				<li><code>nin</code>: <span></span></li>
+			</template>
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo.</p>
+		<ul>
+			<li><code>eq</code>: delta</li>
+			<li><code>eq</code>: kappa</li>
+			<li><code>eq</code>: iota</li>
+			<li><code>neq</code>: delta</li>
+			<li><code>in</code>: iota</li>
+			<li><code>nin</code>: iota</li>
+		</ul>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Demo of each test function.&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-eq]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"operand": "eq",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-eq]",
+					"test": "fn:getValue",
+					"assess": "/kappa",
+					"operand": "eq",
+					"expect":  { "lamdba": "mu" },
+					"mapping": [
+						{ "selector": "span", "value": "/text/kappa" }
+					]
+				},
+				{
+					"template": "[data-eq]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "eq",
+					"expect": [ "rdfs:Resource", "xsd:string" ],
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				},
+				{
+					"template": "[data-neq]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"operand": "neq",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-in]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "in",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				},
+				{
+					"template": "[data-nin]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "nin",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				}
+
+			]
+		}'>
+			&lt;template data-eq>
+				&lt;li>&lt;code>eq&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-neq>
+				&lt;li>&lt;code>neq&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-in>
+				&lt;li>&lt;code>in&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-nin>
+				&lt;li>&lt;code>nin&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Expectation of the preceding demo.&lt;/p>
+		&lt;ul>
+			&lt;li>&lt;code>eq&lt;/code>: delta&lt;/li>
+			&lt;li>&lt;code>eq&lt;/code>: kappa&lt;/li>
+			&lt;li>&lt;code>eq&lt;/code>: iota&lt;/li>
+			&lt;li>&lt;code>neq&lt;/code>: delta&lt;/li>
+			&lt;li>&lt;code>in&lt;/code>: iota&lt;/li>
+			&lt;li>&lt;code>nin&lt;/code>: iota&lt;/li>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
+<h2>The mapping function: Alternative</h2>
+
+<p>This special mapping function allow to configure a list of mapping where it's going to execute only the first children passing its test condition.</p>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Demo of the alternative function.</p>
+		<ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"@type": "rdf:Alt",
+					"mapping": [
+						{
+							"template": "[data-first]",
+							"test": "fn:guessType",
+							"assess": "/gamma",
+							"expect": "rdfs:Literal",
+							"mapping": [
+								{ "selector": "span", "value": "/gamma" }
+							]
+						},
+						{
+							"template": "[data-second]",
+							"test": "fn:guessType",
+							"assess": "/eta",
+							"expect": "xsd:anyURI",
+							"mapping": [
+								{ "selector": "span", "value": "/eta" }
+							]
+						}
+					]
+				}
+			]
+		}'>
+			<template data-first>
+				<li>First template: <span></span></li>
+			</template>
+			<template data-second>
+				<li>Second template: <span></span></li>
+			</template>
+
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo.</p>
+		<ul>
+			<li>First template: gamma</li>
+		</ul>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Demo of the alternative function.&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"@type": "rdf:Alt",
+					"mapping": [
+						{
+							"template": "[data-first]",
+							"test": "fn:guessType",
+							"assess": "/gamma",
+							"expect": "rdfs:Literal",
+							"mapping": [
+								{ "selector": "span", "value": "/gamma" }
+							]
+						},
+						{
+							"template": "[data-second]",
+							"test": "fn:guessType",
+							"assess": "/eta",
+							"expect": "xsd:anyURI",
+							"mapping": [
+								{ "selector": "span", "value": "/eta" }
+							]
+						}
+					]
+				}
+			]
+		}'>
+			&lt;template data-first>
+				&lt;li>First template: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-second>
+				&lt;li>Second template: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Expectation of the preceding demo.&lt;/p>
+		&lt;ul>
+			&lt;li>First template: gamma&lt;/li>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
+<h2>Location of the merged template</h2>
+
+<p>By default, when the configuration is not streamlined, the content created with the initial template are appended to the element.</p>
+<p>For inner template, through mapping configuration, and when the plugin configuration streamline flag is on, the content created with the template are added just before that template. However, you can use the flag "append" to append from the parent element of the template.</p>
+
+<p>Rendering example of a template specified via mapping by default.</p>
+<div class="row">
+	<div class="col-md-6">
+		<p>Demo (Default, inserted in-place):</p>
+		<ul data-wb-json='{
+			"url": "demo/conditional-1.json#/list",
+			"mapping": [
+				{
+					"template": "[data-string]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-double]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:double",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-boolean]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-anyuri]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				}
+			]
+		}'>
+			<template data-string>
+				<li><code>xsd:string</code>: <span></span></li>
+			</template>
+			<template data-double>
+				<li><code>xsd:double</code>: <span></span></li>
+			</template>
+			<template data-boolean>
+				<li><code>xsd:boolean</code>: <span></span></li>
+			</template>
+			<template data-anyuri>
+				<li><code>xsd:anyURI</code>: <span></span></li>
+			</template>
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo.</p>
+		<ul>
+			<li><code>xsd:string</code>: string</li>
+			<li><code>xsd:string</code>: second string</li>
+			<li><code>xsd:double</code>: 123.45</li>
+			<li><code>xsd:boolean</code>: true</li>
+			<li><code>xsd:anyURI</code>: https://example.com</li>
+		</ul>
+	</div>
+</div>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Demo (With <code>append</code> flag):</p>
+		<ul data-wb-json='{
+			"url": "demo/conditional-1.json#/list",
+			"mapping": [
+				{
+					"template": "[data-string]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:string",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-double]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:double",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-boolean]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:boolean",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-anyuri]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:anyURI",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				}
+			]
+		}'>
+			<template data-string>
+				<li><code>xsd:string</code>: <span></span></li>
+			</template>
+			<template data-double>
+				<li><code>xsd:double</code>: <span></span></li>
+			</template>
+			<template data-boolean>
+				<li><code>xsd:boolean</code>: <span></span></li>
+			</template>
+			<template data-anyuri>
+				<li><code>xsd:anyURI</code>: <span></span></li>
+			</template>
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo.</p>
+		<ul>
+			<li><code>xsd:string</code>: string</li>
+			<li><code>xsd:double</code>: 123.45</li>
+			<li><code>xsd:boolean</code>: true</li>
+			<li><code>xsd:anyURI</code>: https://example.com</li>
+			<li><code>xsd:string</code>: second string</li>
+		</ul>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Demo (Default, inserted in-place):&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "demo/conditional-1.json#/list",
+			"mapping": [
+				{
+					"template": "[data-string]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-double]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:double",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-boolean]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-anyuri]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				}
+			]
+		}'>
+			&lt;template data-string>
+				&lt;li>&lt;code>xsd:string&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-double>
+				&lt;li>&lt;code>xsd:double&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-boolean>
+				&lt;li>&lt;code>xsd:boolean&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-anyuri>
+				&lt;li>&lt;code>xsd:anyURI&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Expectation of the preceding demo.&lt;/p>
+		&lt;ul>
+			&lt;li>&lt;code>xsd:string&lt;/code>: string&lt;/li>
+			&lt;li>&lt;code>xsd:string&lt;/code>: second string&lt;/li>
+			&lt;li>&lt;code>xsd:double&lt;/code>: 123.45&lt;/li>
+			&lt;li>&lt;code>xsd:boolean&lt;/code>: true&lt;/li>
+			&lt;li>&lt;code>xsd:anyURI&lt;/code>: https://example.com&lt;/li>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div>
+
+&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Demo (With &lt;code>append&lt;/code> flag):&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "demo/conditional-1.json#/list",
+			"mapping": [
+				{
+					"template": "[data-string]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:string",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-double]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:double",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-boolean]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:boolean",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-anyuri]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:anyURI",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				}
+			]
+		}'>
+			&lt;template data-string>
+				&lt;li>&lt;code>xsd:string&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-double>
+				&lt;li>&lt;code>xsd:double&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-boolean>
+				&lt;li>&lt;code>xsd:boolean&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-anyuri>
+				&lt;li>&lt;code>xsd:anyURI&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Expectation of the preceding demo.&lt;/p>
+		&lt;ul>
+			&lt;li>&lt;code>xsd:string&lt;/code>: string&lt;/li>
+			&lt;li>&lt;code>xsd:double&lt;/code>: 123.45&lt;/li>
+			&lt;li>&lt;code>xsd:boolean&lt;/code>: true&lt;/li>
+			&lt;li>&lt;code>xsd:anyURI&lt;/code>: https://example.com&lt;/li>
+			&lt;li>&lt;code>xsd:string&lt;/code>: second string&lt;/li>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
+<h2>Mapping of a <code>@json</code> (or <code>rdf:JSON</code>) value</h2>
+
+<p>Allow to display in a textual form <code>@json</code> typed value or <code>rdf:JSON</code> value which are the exact same. The test function for data type will always return the RDF form of the type <code>@json</code> which is <code>rdf:JSON</code></p>
+
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Demo of mapping <code>@json</code> and <code>rdf:JSON</code> data</p>
+		<div data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-json-content]",
+					"test": "fn:guessType",
+					"assess": "/nu",
+					"expect": "rdf:JSON",
+					"mapping": [
+						{ "selector": "data", "value": "/nu" },
+						{ "selector": "data", "value": "/nu", "attr": "value" }
+					]
+				},
+				{
+					"template": "[data-json-content]",
+					"test": "fn:guessType",
+					"assess": "/rho",
+					"expect": "rdf:JSON",
+					"mapping": [
+						{ "selector": "data", "value": "/rho" },
+						{ "selector": "data", "value": "/rho", "attr": "value" }
+					]
+				}
+			]
+		}'>
+			<template data-json-content>
+				<pre><code><data value></data></code></pre>
+			</template>
+		</div>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo.</p>
+		<pre><code><data value='{"xi":"xi","omicron":"omicron","pi":"pi"}'>{"xi":"xi","omicron":"omicron","pi":"pi"}</data></code></pre>
+		<pre><code><data value='{"sigma":"sigma","tau":"tau","upsilon":"upsilon"}'>{"sigma":"sigma","tau":"tau","upsilon":"upsilon"}</data></code></pre>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Demo of mapping &lt;code>@json&lt;/code> and &lt;code>rdf:JSON&lt;/code> data&lt;/p>
+		&lt;div data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-json-content]",
+					"test": "fn:guessType",
+					"assess": "/nu",
+					"expect": "rdf:JSON",
+					"mapping": [
+						{ "selector": "data", "value": "/nu" },
+						{ "selector": "data", "value": "/nu", "attr": "value" }
+					]
+				},
+				{
+					"template": "[data-json-content]",
+					"test": "fn:guessType",
+					"assess": "/rho",
+					"expect": "rdf:JSON",
+					"mapping": [
+						{ "selector": "data", "value": "/rho" },
+						{ "selector": "data", "value": "/rho", "attr": "value" }
+					]
+				}
+			]
+		}'>
+			&lt;template data-json-content>
+				&lt;pre>&lt;code>&lt;data value>&lt;/data>&lt;/code>&lt;/pre>
+			&lt;/template>
+		&lt;/div>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Expectation of the preceding demo.&lt;/p>
+		&lt;pre>&lt;code>&lt;data value='{"xi":"xi","omicron":"omicron","pi":"pi"}'>{"xi":"xi","omicron":"omicron","pi":"pi"}&lt;/data>&lt;/code>&lt;/pre>
+		&lt;pre>&lt;code>&lt;data value='{"sigma":"sigma","tau":"tau","upsilon":"upsilon"}'>{"sigma":"sigma","tau":"tau","upsilon":"upsilon"}&lt;/data>&lt;/code>&lt;/pre>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
+<h2>Extension of test function and operand</h2>
+
+<p>The data-json plugin has been adapted to allow extension of it's test function and list of operand. And it is not possible to override any existing one.</p>
+
+<script>
+window[ "wb-data-json" ] = {
+	functionForTest: {
+		"myCustomTest": function( value, rawValue ) {
+			if ( value === "beta" ) {
+				return "foo";
+			}
+			return value;
+		}
+	},
+	functionForOperand: {
+		"myCustomOperand": function( value, expect ) {
+			if ( value === "foo" && expect === "bar" ) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+	}
+};
+</script>
+
+<p data-wb-json='{
+	"url": "demo/conditional-2.json",
+	"streamline": true,
+	"mapping": [
+		{
+			"template": "[data-custom]",
+			"test": "myCustomTest",
+			"value": "/beta",
+			"operand": "myCustomOperand",
+			"expect": "bar",
+			"mapping": [
+				{ "selector": "strong", "value": "/" }
+			]
+		}
+	]
+}'>If the custom test function and operand defined uniquely on this page are positive, the following will be emphasised text with the content set to "beta":
+	<template data-custom>
+		<strong></strong>
+	</template>
+</p>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;script>
+window[ "wb-data-json" ] = {
+	functionForTest: {
+		"myCustomTest": function( value, rawValue ) {
+			if ( value === "beta" ) {
+				return "foo";
+			}
+			return value;
+		}
+	},
+	functionForOperand: {
+		"myCustomOperand": function( value, expect ) {
+			if ( value === "foo" && expect === "bar" ) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+	}
+};
+&lt;/script>
+
+&lt;p data-wb-json='{
+	"url": "demo/conditional-2.json",
+	"streamline": true,
+	"mapping": [
+		{
+			"template": "[data-custom]",
+			"test": "myCustomTest",
+			"value": "/beta",
+			"operand": "myCustomOperand",
+			"expect": "bar",
+			"mapping": [
+				{ "selector": "strong", "value": "/" }
+			]
+		}
+	]
+}'>If the custom test function and operand defined uniquely on this page are positive, the following will be emphasised text with the content set to "beta":
+	&lt;template data-custom>
+		&lt;strong>&lt;/strong>
+	&lt;/template>
+&lt;/p></code></pre>
+</details>

--- a/src/plugins/wb-data-json/conditional-fr.hbs
+++ b/src/plugins/wb-data-json/conditional-fr.hbs
@@ -1,0 +1,1536 @@
+---
+{
+	"title": "Gabarit conditionel",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Association et insertion de contenu JSON tout en suivant un gabarit conditionel.",
+	"tag": "data-json",
+	"parentdir": "wb-data-json",
+	"altLangPage": "conditional-en.html",
+	"dateModified": "2023-06-07"
+}
+---
+<nav>
+	<ul>
+		<li><a href="data-json-fr.html">Data JSON</a></li>
+		<li><a href="template-fr.html">Gabarit HTML 5</a></li>
+		<li>(Cette page) Gabarit conditionel</li>
+	</ul>
+</nav>
+
+<p>Association et insertion de contenu JSON tout en suivant un gabarit conditionel.</p>
+
+<p>La liste suivante est un exemple d'association conditionnel en devinant le type de données.</p>
+
+<ul data-wb-json='{
+	"url": "demo/conditional-1.json#/subject",
+	"mapping": [
+		{
+			"template": "[data-text]",
+			"test": "fn:guessType",
+			"expect": "xsd:string",
+			"assess": "/foo",
+			"mapping": [
+				{ "selector": "[data-foo]", "value": "/foo" },
+				{ "selector": "[data-bar]", "value": "/bar" }
+			]
+		},
+		{
+			"template": "[data-link]",
+			"test": "fn:guessType",
+			"expect": "xsd:anyURI",
+			"assess": "/foo",
+			"mapping": [
+				{ "selector": "a", "value": "/foo", "attr": "href" },
+				{ "selector": "a", "value": "/bar" }
+			]
+		}
+	]
+}'>
+	<template data-text>
+		<li><span data-foo></span> - <span data-bar></span></li>
+	</template>
+	<template data-link>
+		<li><a href></a></li>
+	</template>
+</ul>
+
+<details>
+	<summary>Code source de l'example précédent</summary>
+	<p>Json:</p>
+	<pre><code>{
+	"subject": [
+		{
+			"foo": "bar",
+			"bar": "hello world"
+		},
+		{
+			"foo": "https://example.com",
+			"bar": "hello world"
+		}
+	]
+}</code></pre>
+
+<p>Html:</p>
+<pre><code>&lt;ul data-wb-json='{
+	"url": "demo/conditional-1.json#/subject",
+	"mapping": [
+		{
+			"template": "[data-text]",
+			"test": "fn:guessType",
+			"expect": "xsd:string",
+			"assess": "/foo",
+			"mapping": [
+				{ "selector": "[data-foo]", "value": "/foo" },
+				{ "selector": "[data-bar]", "value": "/bar" }
+			]
+		},
+		{
+			"template": "[data-link]",
+			"test": "fn:guessType",
+			"expect": "xsd:anyURI",
+			"assess": "/foo",
+			"mapping": [
+				{ "selector": "a", "value": "/foo", "attr": "href" },
+				{ "selector": "a", "value": "/bar" }
+			]
+		}
+	]
+}'>
+	&lt;template data-text>
+		&lt;li>&lt;span data-foo>&lt;/span> - &lt;span data-bar>&lt;/span>&lt;/li>
+	&lt;/template>
+	&lt;template data-link>
+		&lt;li>&lt;a href>&lt;/a>&lt;/li>
+	&lt;/template>
+&lt;/ul></code></pre>
+</details>
+
+
+<p>À travers des exemples suivants, il montre également l'utilisation de ces configurations, sans s'y limiter. Une liste complète de toutes les configurations est disponible dans la documentation du plugin data-json.</p>
+<dl class="dl-horizontal">
+	<dt>Configuration <code>streamline</code></dt>
+	<dd>(Booléen: vrai ou faux) Cet indicateur indique que le plugin data-json appliquera le gabarit via l'objet d'association directement, sans essayer d'itérer la source de données.</dd>
+
+	<dt>Object d'association <code>assess</code></dt>
+	<dd>(Pointeur JSON) C'est la valeur qui sera prise pour effectuer l'évaluation conditionnelle. Alternativement, elle prendra la valeur de la propriété <code>value</code>. Une autre différence est que <code>assess</code> ne sera pas itéré par rapport à <code>value</code> qui lui sera itéré pour la correspondance interne.</dd>
+</dl>
+
+<p>Note : Le gabarit conditionnel considérera les données associées à la propriété <code>@value</code> comme la valeur de son parent correspondant. Quelques exemples utilise cette fonctionnalité d'association automatique, ce qui facilite l'interopérabilité avec des objets typés tels que définis dans la norme JSON-LD.</p>
+
+<details>
+	<summary>Code source des fichiers JSON utilisé par les examples dans cette page-ci</summary>
+	<div class="row">
+		<div class="col-md-6">
+			<p>Fichier: conditional-1.json</p>
+			<pre><code>{
+	"subject": [
+		{
+			"foo": "bar",
+			"bar": "hello world"
+		},
+		{
+			"foo": "https://example.com",
+			"bar": "hello world"
+		}
+	],
+	"list": [
+		{
+			"@type": "xsd:string",
+			"@value": "string"
+		},
+		{
+			"@type": "xsd:double",
+			"@value": 123.45
+		},
+		{
+			"@type": "xsd:boolean",
+			"@value": true
+		},
+		{
+			"@type": "xsd:anyURI",
+			"@value": "https://example.com"
+		},
+		{
+			"@type": "xsd:string",
+			"@value": "second string"
+		}
+	],
+	"text": {
+		"alpha": "alpha",
+		"beta": "beta",
+		"gamma": "gamma",
+		"delta": "delta"
+	}
+}</code></pre>
+		</div>
+		<div class="col-md-6">
+			<p>Fichier: conditional-2.json</p>
+			<pre><code>{
+	"alpha": [ "alpha" ],
+	"beta": "beta",
+	"gamma": { "@value": "gamma" },
+	"delta": { "@type": "rdfs:Resource", "@value": "delta" },
+	"epsilon": "epsilon",
+	"zeta": true,
+	"eta": "http://example.com",
+	"theta": 123.45,
+	"iota": {
+		"@type": [ "rdfs:Resource", "xsd:string" ],
+		"@value": "iota"
+	},
+	"kappa": {
+		"lamdba": "mu"
+	},
+	"nu": {
+		"@type": "@json",
+		"@value": {
+			"xi": "xi",
+			"omicron": "omicron",
+			"pi": "pi"
+		}
+	},
+	"rho": {
+		"@type": "@json",
+		"@value": {
+			"sigma": "sigma",
+			"tau": "tau",
+			"upsilon": "upsilon"
+		}
+	},
+	"sigma": {
+		"alpha": "sigma",
+		"gamma": "sigma"
+	},
+	"undefined": "tau",
+
+	"text": {
+		"zeta": "zeta",
+		"eta": "eta",
+		"theta": "theta",
+		"kappa": "kappa"
+	}
+}</code></pre>
+		</div>
+	</div>
+</details>
+
+<h2>Fonctions de test qui extraient une valeur testable.</h2>
+<p>Ces tests nécessitent un pointeur de données fourni soit avec la propriété <code>value</code>, qui itérera également, soit avec <code>assess</code> qui n'itérera pas.</p>
+
+<dl class="dl-horizontal">
+	<dt><code>fn:isArray</code></dt>
+	<dd>Retourne un booléen indiquant si la valeur testée est un tableau ou non.</dd>
+
+	<dt><code>fn:isLiteral</code></dt>
+	<dd>Retourne un booléen indiquant si la valeur testée est littérale ou non. Une valeur littérale est considérée comme définie et non comme un objet.</dd>
+
+	<dt><code>fn:getType</code></dt>
+	<dd>Renvoie le type de la valeur définie via la propriété <code>@type</code> ou son type JavaScript correspondant à l'aide de la fonction typeof.</dd>
+
+	<dt><code>fn:guessType</code></dt>
+	<dd>
+		<p>Le parseur de gabarits essaiera de deviner le type de données de la valeur testée.</p>
+		<p>Cette fonction de test renverra :</p>
+		<ul>
+			<li><code>rdfs:Container</code> lorsque la valeur est un tableau.</li>
+			<li><code>rdfs:Literal</code> pour toute valeur qui est littérale. Une valeur littérale est considérée comme définie et non comme un objet.</li>
+			<li><code>rdfs:Resource</code> lorsque la valeur est un objet JSON sans type de définie.</li>
+			<li><code>xsd:anyURI</code> lorsque la valeur est une chaîne de caractères qui commence par une lettre et un chiffre immédiatement suivis de deux points ":" sans espaces, comme <code>https://example.com.</code></li>
+			<li><code>xsd:string</code> lorsque la valeur est une chaîne de caractères qui ne semble pas être une URI.</li>
+			<li><code>xsd:boolean</code>  lorsque la valeur est un booléen avec la valeur <code>true</code> ou <code>false</code>.</li>
+			<li><code>xsd:double</code> lorsque la valeur est un nombre JSON.</li>
+			<li>La valeur définie via la sous-propriété <code>@type</code>.</li>
+			<li><code>undefined</code> lorsque la valeur est indéfinie.</li>
+		</ul>
+	</dd>
+
+	<dt><code>fn:getValue</code></dt>
+	<dd>Renvoie la valeur en tant que valeur testable.</dd>
+</dl>
+
+<h3>Exemple de chaque fonction de test :</h3>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Démo de chaque fonction de test.</p>
+		<ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-isarray]",
+					"test": "fn:isArray",
+					"assess": "/alpha",
+					"mapping": [
+						{ "selector": "span", "value": "/alpha/0" }
+					]
+				},
+				{
+					"template": "[data-isliteral]",
+					"test": "fn:isLiteral",
+					"assess": "/beta",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-isliteral]",
+					"test": "fn:isLiteral",
+					"assess": "/gamma",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/delta",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/epsilon",
+					"expect": "string",
+					"mapping": [
+						{ "selector": "span", "value": "/epsilon" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/zeta",
+					"expect": "boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/text/zeta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/alpha",
+					"expect": "rdfs:Container",
+					"mapping": [
+						{ "selector": "span", "value": "/alpha/0" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/eta",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/text/eta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/eta",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/text/eta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/zeta",
+					"expect": "xsd:boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/text/zeta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/theta",
+					"expect": "xsd:double",
+					"mapping": [
+						{ "selector": "span", "value": "/text/theta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/sigma",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/sigma/alpha" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/tau",
+					"expect": "undefined",
+					"mapping": [
+						{ "selector": "span", "value": "/undefined" }
+					]
+				},
+				{
+					"template": "[data-getvalue]",
+					"test": "fn:getValue",
+					"assess": "/kappa",
+					"operand": "eq",
+					"expect": { "lamdba": "mu" },
+					"mapping": [
+						{ "selector": "span", "value": "/text/kappa" }
+					]
+				}
+			]
+		}'>
+			<template data-isarray>
+				<li><code>fn:isArray</code>: <span></span></li>
+			</template>
+			<template data-isliteral>
+				<li><code>fn:isLiteral</code>: <span></span></li>
+			</template>
+			<template data-gettype>
+				<li><code>fn:getType</code>: <span></span></li>
+			</template>
+			<template data-guesstype>
+				<li><code>fn:guessType</code>: <span></span></li>
+			</template>
+			<template data-getvalue>
+				<li><code>fn:getValue</code>: <span></span></li>
+			</template>
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Résultat attendu de la démonstration précédente.</p>
+		<ul>
+			<li><code>fn:isArray</code>: alpha</li>
+			<li><code>fn:isLiteral</code>: beta</li>
+			<li><code>fn:isLiteral</code>: gamma</li>
+			<li><code>fn:getType</code>: delta</li>
+			<li><code>fn:getType</code>: epsilon</li>
+			<li><code>fn:getType</code>: zeta</li>
+			<li><code>fn:guessType</code>: alpha</li>
+			<li><code>fn:guessType</code>: beta</li>
+			<li><code>fn:guessType</code>: gamma</li>
+			<li><code>fn:guessType</code>: eta</li>
+			<li><code>fn:guessType</code>: beta</li>
+			<li><code>fn:guessType</code>: gamma</li>
+			<li><code>fn:guessType</code>: zeta</li>
+			<li><code>fn:guessType</code>: theta</li>
+			<li><code>fn:guessType</code>: delta</li>
+			<li><code>fn:guessType</code>: sigma</li>
+			<li><code>fn:guessType</code>: tau</li>
+			<li><code>fn:getValue</code>: kappa</li>
+		</ul>
+	</div>
+</div>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Démo de chaque fonction de test.&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-isarray]",
+					"test": "fn:isArray",
+					"assess": "/alpha",
+					"mapping": [
+						{ "selector": "span", "value": "/alpha/0" }
+					]
+				},
+				{
+					"template": "[data-isliteral]",
+					"test": "fn:isLiteral",
+					"assess": "/beta",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-isliteral]",
+					"test": "fn:isLiteral",
+					"assess": "/gamma",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/delta",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/epsilon",
+					"expect": "string",
+					"mapping": [
+						{ "selector": "span", "value": "/epsilon" }
+					]
+				},
+				{
+					"template": "[data-gettype]",
+					"test": "fn:getType",
+					"assess": "/zeta",
+					"expect": "boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/text/zeta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/alpha",
+					"expect": "rdfs:Container",
+					"mapping": [
+						{ "selector": "span", "value": "/alpha/0" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/eta",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/text/eta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/beta",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/beta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/gamma",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/gamma" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/eta",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/text/eta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/zeta",
+					"expect": "xsd:boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/text/zeta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/theta",
+					"expect": "xsd:double",
+					"mapping": [
+						{ "selector": "span", "value": "/text/theta" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/sigma",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/sigma/alpha" }
+					]
+				},
+				{
+					"template": "[data-guesstype]",
+					"test": "fn:guessType",
+					"assess": "/tau",
+					"expect": "undefined",
+					"mapping": [
+						{ "selector": "span", "value": "/undefined" }
+					]
+				},
+				{
+					"template": "[data-getvalue]",
+					"test": "fn:getValue",
+					"assess": "/kappa",
+					"operand": "eq",
+					"expect": { "lamdba": "mu" },
+					"mapping": [
+						{ "selector": "span", "value": "/text/kappa" }
+					]
+				}
+			]
+		}'>
+			&lt;template data-isarray>
+				&lt;li>&lt;code>fn:isArray&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-isliteral>
+				&lt;li>&lt;code>fn:isLiteral&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-gettype>
+				&lt;li>&lt;code>fn:getType&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-guesstype>
+				&lt;li>&lt;code>fn:guessType&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-getvalue>
+				&lt;li>&lt;code>fn:getValue&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Résultat attendu de la démonstration précédente.&lt;/p>
+		&lt;ul>
+			&lt;li>&lt;code>fn:isArray&lt;/code>: alpha&lt;/li>
+			&lt;li>&lt;code>fn:isLiteral&lt;/code>: beta&lt;/li>
+			&lt;li>&lt;code>fn:isLiteral&lt;/code>: gamma&lt;/li>
+			&lt;li>&lt;code>fn:getType&lt;/code>: delta&lt;/li>
+			&lt;li>&lt;code>fn:getType&lt;/code>: epsilon&lt;/li>
+			&lt;li>&lt;code>fn:getType&lt;/code>: zeta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: alpha&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: beta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: gamma&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: eta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: beta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: gamma&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: zeta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: theta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: delta&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: sigma&lt;/li>
+			&lt;li>&lt;code>fn:guessType&lt;/code>: tau&lt;/li>
+			&lt;li>&lt;code>fn:getValue&lt;/code>: kappa&lt;/li>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
+
+<h2>Fonction d'opérande</h2>
+<p>Fonctions d'opérande qui vérifient la valeur testable.</p>
+
+<dl class="dl-horizontal">
+	<dt><code>softEq</code> (défaut)</dt>
+	<dd>Vérifie si la valeur <strong>est équivalente</strong> à l'attente, optionellement un tableau. Lorsqu'aucune attente n'est spécifiée, il retournera <code>true</code> si la valeur testable existe.</dd>
+	<dt><code>eq</code></dt>
+	<dd>Vérifie si la valeur <strong>est égale</strong> à l'attente, y compris lorsque la valeur est un objet.</dd>
+	<dt><code>neq</code></dt>
+	<dd>Vérifie si la valeur <strong>n'est pas égale</strong> à l'attente, y compris lorsque la valeur est un objet.</dd>
+	<dt><code>in</code></dt>
+	<dd>Check if the value (or array of value) is <strong>in</strong> the expectation (or array of expectation)</dd>
+	<dd>Vérifie si la valeur (ou un tableau de valeurs) <strong>se trouve dans</strong> l'attente (ou un tableau d'attentes).</dd>
+	<dt><code>nin</code></dt>
+	<dd>Vérifie si la valeur (ou un tableau de valeurs) <strong>se ne trouve pas dans</strong> l'attente (ou un tableau d'attentes).</dd>
+</dl>
+
+
+<h3>Exemple d'opérande</h3>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Démonstration de chaque opérande.</p>
+		<ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-eq]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"operand": "eq",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-eq]",
+					"test": "fn:getValue",
+					"assess": "/kappa",
+					"operand": "eq",
+					"expect":  { "lamdba": "mu" },
+					"mapping": [
+						{ "selector": "span", "value": "/text/kappa" }
+					]
+				},
+				{
+					"template": "[data-eq]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "eq",
+					"expect": [ "rdfs:Resource", "xsd:string" ],
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				},
+				{
+					"template": "[data-neq]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"operand": "neq",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-in]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "in",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				},
+				{
+					"template": "[data-nin]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "nin",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				}
+
+			]
+		}'>
+			<template data-eq>
+				<li><code>eq</code>: <span></span></li>
+			</template>
+			<template data-neq>
+				<li><code>neq</code>: <span></span></li>
+			</template>
+			<template data-in>
+				<li><code>in</code>: <span></span></li>
+			</template>
+			<template data-nin>
+				<li><code>nin</code>: <span></span></li>
+			</template>
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Résultat attendu de la démonstration précédente.</p>
+		<ul>
+			<li><code>eq</code>: delta</li>
+			<li><code>eq</code>: kappa</li>
+			<li><code>eq</code>: iota</li>
+			<li><code>neq</code>: delta</li>
+			<li><code>in</code>: iota</li>
+			<li><code>nin</code>: iota</li>
+		</ul>
+	</div>
+</div>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Démonstration de chaque opérande.&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-eq]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"operand": "eq",
+					"expect": "rdfs:Resource",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-eq]",
+					"test": "fn:getValue",
+					"assess": "/kappa",
+					"operand": "eq",
+					"expect":  { "lamdba": "mu" },
+					"mapping": [
+						{ "selector": "span", "value": "/text/kappa" }
+					]
+				},
+				{
+					"template": "[data-eq]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "eq",
+					"expect": [ "rdfs:Resource", "xsd:string" ],
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				},
+				{
+					"template": "[data-neq]",
+					"test": "fn:guessType",
+					"assess": "/delta",
+					"operand": "neq",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/delta/@value" }
+					]
+				},
+				{
+					"template": "[data-in]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "in",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				},
+				{
+					"template": "[data-nin]",
+					"test": "fn:guessType",
+					"assess": "/iota",
+					"operand": "nin",
+					"expect": "rdfs:Literal",
+					"mapping": [
+						{ "selector": "span", "value": "/iota/@value" }
+					]
+				}
+
+			]
+		}'>
+			&lt;template data-eq>
+				&lt;li>&lt;code>eq&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-neq>
+				&lt;li>&lt;code>neq&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-in>
+				&lt;li>&lt;code>in&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-nin>
+				&lt;li>&lt;code>nin&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Résultat attendu de la démonstration précédente.&lt;/p>
+		&lt;ul>
+			&lt;li>&lt;code>eq&lt;/code>: delta&lt;/li>
+			&lt;li>&lt;code>eq&lt;/code>: kappa&lt;/li>
+			&lt;li>&lt;code>eq&lt;/code>: iota&lt;/li>
+			&lt;li>&lt;code>neq&lt;/code>: delta&lt;/li>
+			&lt;li>&lt;code>in&lt;/code>: iota&lt;/li>
+			&lt;li>&lt;code>nin&lt;/code>: iota&lt;/li>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
+<h2>La fonction d'association : Alternative</h2>
+
+<p>Cette fonction d'association spéciale permet de configurer une liste d'associations où seul le premier enfant satisfaisant à la condition de test sera exécuté.</p>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Démonstration de la fonction alternative.</p>
+		<ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"@type": "rdf:Alt",
+					"mapping": [
+						{
+							"template": "[data-first]",
+							"test": "fn:guessType",
+							"assess": "/gamma",
+							"expect": "rdfs:Literal",
+							"mapping": [
+								{ "selector": "span", "value": "/gamma" }
+							]
+						},
+						{
+							"template": "[data-second]",
+							"test": "fn:guessType",
+							"assess": "/eta",
+							"expect": "xsd:anyURI",
+							"mapping": [
+								{ "selector": "span", "value": "/eta" }
+							]
+						}
+					]
+				}
+			]
+		}'>
+			<template data-first>
+				<li>Premier gabarit: <span></span></li>
+			</template>
+			<template data-second>
+				<li>Second gabarit: <span></span></li>
+			</template>
+
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Résultat attendu de la démonstration précédente.</p>
+		<ul>
+			<li>Premier gabarit: gamma</li>
+		</ul>
+	</div>
+</div>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Démonstration de la fonction alternative.&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"@type": "rdf:Alt",
+					"mapping": [
+						{
+							"template": "[data-first]",
+							"test": "fn:guessType",
+							"assess": "/gamma",
+							"expect": "rdfs:Literal",
+							"mapping": [
+								{ "selector": "span", "value": "/gamma" }
+							]
+						},
+						{
+							"template": "[data-second]",
+							"test": "fn:guessType",
+							"assess": "/eta",
+							"expect": "xsd:anyURI",
+							"mapping": [
+								{ "selector": "span", "value": "/eta" }
+							]
+						}
+					]
+				}
+			]
+		}'>
+			&lt;template data-first>
+				&lt;li>Premier gabarit: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-second>
+				&lt;li>Second gabarit: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Résultat attendu de la démonstration précédente.&lt;/p>
+		&lt;ul>
+			&lt;li>Premier gabarit: gamma&lt;/li>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
+<h2>Emplacement du gabarit fusionné</h2>
+
+<p>Par défaut, lorsque la configuration n'est pas rationalisée, le contenu créé avec le gabarit initial est ajouté à l'élément.</p>
+<p>For inner template, through mapping configuration, and when the plugin configuration streamline flag is on, the content created with the template are added just before that template. However, you can use the flag "append" to append from the parent element of the template.</p>
+<p>Pour le gabarit interne, via la configuration d'association et lorsque l'indicateur de rationalisation de la configuration du plugin est activé, le contenu créé avec le gabarit sera ajouté juste avant ce gabarit. Cependant, vous pouvez utiliser l'indicateur "append" pour ajouter à la fin à partir de l'élément parent du gabarit.</p>
+
+<p>Voici un exemple de rendu d'un modèle spécifié via une association par défaut.</p>
+<div class="row">
+	<div class="col-md-6">
+		<p>Démonstration (par défault, insertions sur place):</p>
+		<ul data-wb-json='{
+			"url": "demo/conditional-1.json#/list",
+			"mapping": [
+				{
+					"template": "[data-string]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-double]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:double",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-boolean]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-anyuri]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				}
+			]
+		}'>
+			<template data-string>
+				<li><code>xsd:string</code>: <span></span></li>
+			</template>
+			<template data-double>
+				<li><code>xsd:double</code>: <span></span></li>
+			</template>
+			<template data-boolean>
+				<li><code>xsd:boolean</code>: <span></span></li>
+			</template>
+			<template data-anyuri>
+				<li><code>xsd:anyURI</code>: <span></span></li>
+			</template>
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Résultat attendu de la démonstration précédente.</p>
+		<ul>
+			<li><code>xsd:string</code>: string</li>
+			<li><code>xsd:string</code>: second string</li>
+			<li><code>xsd:double</code>: 123.45</li>
+			<li><code>xsd:boolean</code>: true</li>
+			<li><code>xsd:anyURI</code>: https://example.com</li>
+		</ul>
+	</div>
+</div>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Démonstration (Avec l'indicateur <code>append</code>):</p>
+		<ul data-wb-json='{
+			"url": "demo/conditional-1.json#/list",
+			"mapping": [
+				{
+					"template": "[data-string]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:string",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-double]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:double",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-boolean]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:boolean",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-anyuri]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:anyURI",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				}
+			]
+		}'>
+			<template data-string>
+				<li><code>xsd:string</code>: <span></span></li>
+			</template>
+			<template data-double>
+				<li><code>xsd:double</code>: <span></span></li>
+			</template>
+			<template data-boolean>
+				<li><code>xsd:boolean</code>: <span></span></li>
+			</template>
+			<template data-anyuri>
+				<li><code>xsd:anyURI</code>: <span></span></li>
+			</template>
+		</ul>
+	</div>
+	<div class="col-md-6">
+		<p>Résultat attendu de la démonstration précédente.</p>
+		<ul>
+			<li><code>xsd:string</code>: string</li>
+			<li><code>xsd:double</code>: 123.45</li>
+			<li><code>xsd:boolean</code>: true</li>
+			<li><code>xsd:anyURI</code>: https://example.com</li>
+			<li><code>xsd:string</code>: second string</li>
+		</ul>
+	</div>
+</div>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Démonstration (par défault, insertions sur place):&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "demo/conditional-1.json#/list",
+			"mapping": [
+				{
+					"template": "[data-string]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:string",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-double]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:double",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-boolean]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:boolean",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-anyuri]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:anyURI",
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				}
+			]
+		}'>
+			&lt;template data-string>
+				&lt;li>&lt;code>xsd:string&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-double>
+				&lt;li>&lt;code>xsd:double&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-boolean>
+				&lt;li>&lt;code>xsd:boolean&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-anyuri>
+				&lt;li>&lt;code>xsd:anyURI&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Résultat attendu de la démonstration précédente.&lt;/p>
+		&lt;ul>
+			&lt;li>&lt;code>xsd:string&lt;/code>: string&lt;/li>
+			&lt;li>&lt;code>xsd:string&lt;/code>: second string&lt;/li>
+			&lt;li>&lt;code>xsd:double&lt;/code>: 123.45&lt;/li>
+			&lt;li>&lt;code>xsd:boolean&lt;/code>: true&lt;/li>
+			&lt;li>&lt;code>xsd:anyURI&lt;/code>: https://example.com&lt;/li>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div>
+
+&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Démonstration (Avec l'indicateur &lt;code>append&lt;/code>):&lt;/p>
+		&lt;ul data-wb-json='{
+			"url": "demo/conditional-1.json#/list",
+			"mapping": [
+				{
+					"template": "[data-string]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:string",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-double]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:double",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-boolean]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:boolean",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				},
+				{
+					"template": "[data-anyuri]",
+					"test": "fn:guessType",
+					"assess": "/",
+					"expect": "xsd:anyURI",
+					"append": true,
+					"mapping": [
+						{ "selector": "span", "value": "/" }
+					]
+				}
+			]
+		}'>
+			&lt;template data-string>
+				&lt;li>&lt;code>xsd:string&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-double>
+				&lt;li>&lt;code>xsd:double&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-boolean>
+				&lt;li>&lt;code>xsd:boolean&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+			&lt;template data-anyuri>
+				&lt;li>&lt;code>xsd:anyURI&lt;/code>: &lt;span>&lt;/span>&lt;/li>
+			&lt;/template>
+		&lt;/ul>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Résultat attendu de la démonstration précédente.&lt;/p>
+		&lt;ul>
+			&lt;li>&lt;code>xsd:string&lt;/code>: string&lt;/li>
+			&lt;li>&lt;code>xsd:double&lt;/code>: 123.45&lt;/li>
+			&lt;li>&lt;code>xsd:boolean&lt;/code>: true&lt;/li>
+			&lt;li>&lt;code>xsd:anyURI&lt;/code>: https://example.com&lt;/li>
+			&lt;li>&lt;code>xsd:string&lt;/code>: second string&lt;/li>
+		&lt;/ul>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
+<h2>Association de la valeur du type <code>@json</code> (ou <code>rdf:JSON</code>)</h2>
+
+<p>Allow to display in a textual form <code>@json</code> typed value or <code>rdf:JSON</code> value which are the exact same. The test function for data type will always return the RDF form of the type <code>@json</code> which is <code>rdf:JSON</code></p>
+<p>Permet d'afficher sous une forme textuel les valeur du type <code>@json</code> ou de <code>rdf:JSON</code> lequel ont exactement la même signification. La fonction d'essaie du type de donné va toujours retourné ce type sous se forme RDF. Par example, le type <code>@json</code> sera retourné comme valeur <code>rdf:JSON</code></p>
+
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Démonstration d'association d'une donnée <code>@json</code> et de <code>rdf:JSON</code></p>
+		<div data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-json-content]",
+					"test": "fn:guessType",
+					"assess": "/nu",
+					"expect": "rdf:JSON",
+					"mapping": [
+						{ "selector": "data", "value": "/nu" },
+						{ "selector": "data", "value": "/nu", "attr": "value" }
+					]
+				},
+				{
+					"template": "[data-json-content]",
+					"test": "fn:guessType",
+					"assess": "/rho",
+					"expect": "rdf:JSON",
+					"mapping": [
+						{ "selector": "data", "value": "/rho" },
+						{ "selector": "data", "value": "/rho", "attr": "value" }
+					]
+				}
+			]
+		}'>
+			<template data-json-content>
+				<pre><code><data value></data></code></pre>
+			</template>
+		</div>
+	</div>
+	<div class="col-md-6">
+		<p>Résultat attendu de la démonstration précédente.</p>
+		<pre><code><data value='{"xi":"xi","omicron":"omicron","pi":"pi"}'>{"xi":"xi","omicron":"omicron","pi":"pi"}</data></code></pre>
+		<pre><code><data value='{"sigma":"sigma","tau":"tau","upsilon":"upsilon"}'>{"sigma":"sigma","tau":"tau","upsilon":"upsilon"}</data></code></pre>
+	</div>
+</div>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;div class="row">
+	&lt;div class="col-md-6">
+		&lt;p>Démonstration d'association d'une donnée &lt;code>@json&lt;/code> et de &lt;code>rdf:JSON&lt;/code>&lt;/p>
+		&lt;div data-wb-json='{
+			"url": "demo/conditional-2.json",
+			"streamline": true,
+			"mapping": [
+				{
+					"template": "[data-json-content]",
+					"test": "fn:guessType",
+					"assess": "/nu",
+					"expect": "rdf:JSON",
+					"mapping": [
+						{ "selector": "data", "value": "/nu" },
+						{ "selector": "data", "value": "/nu", "attr": "value" }
+					]
+				},
+				{
+					"template": "[data-json-content]",
+					"test": "fn:guessType",
+					"assess": "/rho",
+					"expect": "rdf:JSON",
+					"mapping": [
+						{ "selector": "data", "value": "/rho" },
+						{ "selector": "data", "value": "/rho", "attr": "value" }
+					]
+				}
+			]
+		}'>
+			&lt;template data-json-content>
+				&lt;pre>&lt;code>&lt;data value>&lt;/data>&lt;/code>&lt;/pre>
+			&lt;/template>
+		&lt;/div>
+	&lt;/div>
+	&lt;div class="col-md-6">
+		&lt;p>Résultat attendu de la démonstration précédente.&lt;/p>
+		&lt;pre>&lt;code>&lt;data value='{"xi":"xi","omicron":"omicron","pi":"pi"}'>{"xi":"xi","omicron":"omicron","pi":"pi"}&lt;/data>&lt;/code>&lt;/pre>
+		&lt;pre>&lt;code>&lt;data value='{"sigma":"sigma","tau":"tau","upsilon":"upsilon"}'>{"sigma":"sigma","tau":"tau","upsilon":"upsilon"}&lt;/data>&lt;/code>&lt;/pre>
+	&lt;/div>
+&lt;/div></code></pre>
+</details>
+
+<h2>Extension de la fonction de test et de l'opérande</h2>
+
+<p>Le plugin data-json a été adapté pour permettre l'extension de sa fonction de test et de sa liste d'opérandes, sans possibilité de les remplacer.</p>
+
+<script>
+window[ "wb-data-json" ] = {
+	functionForTest: {
+		"myCustomTest": function( value, rawValue ) {
+			if ( value === "beta" ) {
+				return "foo";
+			}
+			return value;
+		}
+	},
+	functionForOperand: {
+		"myCustomOperand": function( value, expect ) {
+			if ( value === "foo" && expect === "bar" ) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+	}
+};
+</script>
+
+<p data-wb-json='{
+	"url": "demo/conditional-2.json",
+	"streamline": true,
+	"mapping": [
+		{
+			"template": "[data-custom]",
+			"test": "myCustomTest",
+			"value": "/beta",
+			"operand": "myCustomOperand",
+			"expect": "bar",
+			"mapping": [
+				{ "selector": "strong", "value": "/" }
+			]
+		}
+	]
+}'>Si la fonction de test personnalisée et l'opérande définis uniquement sur cette page sont positifs, le texte suivant sera mis en évidence avec le contenu défini sur "beta":
+	<template data-custom>
+		<strong></strong>
+	</template>
+</p>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;script>
+window[ "wb-data-json" ] = {
+	functionForTest: {
+		"myCustomTest": function( value, rawValue ) {
+			if ( value === "beta" ) {
+				return "foo";
+			}
+			return value;
+		}
+	},
+	functionForOperand: {
+		"myCustomOperand": function( value, expect ) {
+			if ( value === "foo" && expect === "bar" ) {
+				return true;
+			} else {
+				return false;
+			}
+		}
+	}
+};
+&lt;/script>
+
+&lt;p data-wb-json='{
+	"url": "demo/conditional-2.json",
+	"streamline": true,
+	"mapping": [
+		{
+			"template": "[data-custom]",
+			"test": "myCustomTest",
+			"value": "/beta",
+			"operand": "myCustomOperand",
+			"expect": "bar",
+			"mapping": [
+				{ "selector": "strong", "value": "/" }
+			]
+		}
+	]
+}'>Si la fonction de test personnalisée et l'opérande définis uniquement sur cette page sont positifs, le texte suivant sera mis en évidence avec le contenu défini sur "beta":
+	&lt;template data-custom>
+		&lt;strong>&lt;/strong>
+	&lt;/template>
+&lt;/p></code></pre>
+</details>

--- a/src/plugins/wb-data-json/data-json-en.hbs
+++ b/src/plugins/wb-data-json/data-json-en.hbs
@@ -10,12 +10,13 @@
 	"dateModified": "2017-01-31"
 }
 ---
-<!--
-<ul class="list-inline">
-	<li><a class="btn btn-primary" href="data-json-doc-en.html">Documentation</a></li>
-	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=DataJSON">Questions or comments?</a></li>
-</ul>
--->
+<nav>
+	<ul>
+		<li>(This page) Data JSON</li>
+		<li><a href="template-en.html">HTML 5 template</a></li>
+		<li><a href="conditional-en.html">Conditional template</a></li>
+	</ul>
+</nav>
 <p>Insert content extracted from a JSON file.</p>
 
 <div class="wb-prettify all-pre"></div>

--- a/src/plugins/wb-data-json/data-json-fr.hbs
+++ b/src/plugins/wb-data-json/data-json-fr.hbs
@@ -10,12 +10,13 @@
 	"dateModified": "2017-01-31"
 }
 ---
-<!--
-<ul class="list-inline">
-	<li><a class="btn btn-primary" href="data-json-doc-fr.html">Documentation</a></li>
-	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=DataJSON">Questions ou commentaires?</a></li>
-</ul>
--->
+<nav>
+	<ul>
+		<li>(Cette page) Data JSON</li>
+		<li><a href="template-fr.html">Gabarit HTML 5</a></li>
+		<li><a href="conditional-fr.html">Gabarit conditionel</a></li>
+	</ul>
+</nav>
 <p>Insertion de contenu extrait d'un fichier JSON</p>
 
 <div class="wb-prettify all-pre"></div>

--- a/src/plugins/wb-data-json/data-json.js
+++ b/src/plugins/wb-data-json/data-json.js
@@ -36,6 +36,7 @@ var componentName = "wb-data-json",
 	contentUpdatedEvent = "wb-contentupdated",
 	dataQueue = componentName + "-queue",
 	$document = wb.doc,
+	isExtensionRegistered,
 	s,
 
 	/**
@@ -49,6 +50,8 @@ var componentName = "wb-data-json",
 		// returns DOM object = proceed with init
 		// returns undefined = do not proceed with init (e.g., already initialized)
 		var elm = wb.init( event, componentName, selector ),
+			jsSettings = window[ componentName ] || { },
+			prop,
 			$elm;
 
 		if ( elm ) {
@@ -77,6 +80,25 @@ var componentName = "wb-data-json",
 						url: url
 					} );
 				}
+			}
+
+			// Extend but not overwrite the functionTest and the functionForOperand if some was added
+			if ( !isExtensionRegistered ) {
+				if ( jsSettings.functionForTest ) {
+					for ( prop in jsSettings.functionForTest ) {
+						if ( !functionForTest[ prop ] ) {
+							functionForTest[ prop ] = jsSettings.functionForTest[ prop ];
+						}
+					}
+				}
+				if ( jsSettings.functionForOperand ) {
+					for ( prop in jsSettings.functionForOperand ) {
+						if ( !functionForOperand[ prop ] ) {
+							functionForOperand[ prop ] = jsSettings.functionForOperand[ prop ];
+						}
+					}
+				}
+				isExtensionRegistered = true;
 			}
 
 			// Identify that initialization has completed
@@ -190,21 +212,7 @@ var componentName = "wb-data-json",
 	// Apply the template as per the configuration
 	applyTemplate = function( elm, settings, content ) {
 
-		var mapping = settings.mapping || [ {} ],
-			mapping_len,
-			filterTrueness = settings.filter || [],
-			filterFaslseness = settings.filternot || [],
-			queryAll = settings.queryall,
-			i, i_len, i_cache,
-			j, j_cache, j_cache_attr,
-			basePntr,
-			clone, selElements,
-			cached_node,
-			cached_textContent,
-			cached_value,
-			selectorToClone = settings.tobeclone,
-			elmClass = elm.className,
-			elmAppendTo = elm,
+		var elmClass = elm.className,
 			dataTable,
 			dataTableAddRow,
 			template = settings.source ? document.querySelector( settings.source ) : elm.querySelector( "template" );
@@ -231,9 +239,51 @@ var componentName = "wb-data-json",
 
 			dataTable = $( elm ).dataTable( { "retrieve": true } ).api();
 			dataTableAddRow = dataTable.row.add;
-			selectorToClone = "tr"; // Only table row can be added
+			settings.tobeclone = "tr"; // Only table row can be added
 		}
 
+		if ( !template ) {
+			return;
+		}
+
+		// Needed when executing sub-template that wasn't polyfill, like in IE11
+		if ( !template.content ) {
+			wb.tmplPolyfill( template );
+		}
+
+		if ( !settings.streamline ) {
+			dataIterator( elm, content, settings );
+		} else {
+			processMapping( elm, elm, content, settings );
+		}
+
+		// Refresh the dataTable display
+		if ( dataTableAddRow ) {
+			dataTable.draw();
+		}
+	},
+
+	// Iterate over the dataset
+	dataIterator = function( elm, content, mappingConfig, useClone ) {
+
+		var i, i_len, i_cache,
+			elmAppendTo = elm,
+			clone, template,
+			dataTable, dataTableAddRow;
+
+		if ( mappingConfig.appendto ) {
+			elmAppendTo = $( mappingConfig.appendto ).get( 0 );
+		}
+
+		// Connection with data table plugin
+		if ( elm.tagName === "TABLE" && elm.className.indexOf( "wb-tables" ) !== -1 ) {
+			dataTable = $( elm ).dataTable( { "retrieve": true } ).api();
+			dataTableAddRow = dataTable.row.add;
+			mappingConfig.tobeclone = "tr";
+		}
+
+
+		// if content is object, transform into array @id and @value
 		if ( !$.isArray( content ) ) {
 			if ( typeof content !== "object" ) {
 				content = [ content ];
@@ -255,105 +305,574 @@ var componentName = "wb-data-json",
 		}
 		i_len = content.length;
 
+		// Get the template to be iterated.
+		if ( !useClone && mappingConfig.source ) {
+			template = document.querySelector( mappingConfig.source );
+		} else if ( !useClone && mappingConfig.template ) {
+			template = elm.querySelector( mappingConfig.template );
+		} else if ( !useClone ) {
+			template = elm.querySelectorAll( ":scope > template" );
+			if ( template.length === 1 || template[ 0 ].attributes.length === 0 ) {
+
+				// Only when there is one choice or take the first one only if only there is no attribute set on the element
+				template = template[ 0 ];
+			} else {
+
+				// let the mapping instructions to define which template to use
+				template = false;
+			}
+		}
+
+		// Iterate the data array
+		for ( i = 0; i < i_len; i += 1 ) {
+			i_cache = content[ i ];
+
+
+			// If the data are filtered. This is deprecated and are only for backward compatible purpose
+			if ( !filterPassJSON( i_cache, mappingConfig.filter, mappingConfig.filternot ) ) {
+				continue;
+			}
+
+			// Get the template (if applicable)
+			if ( !clone && useClone ) {
+				clone = useClone;
+			}
+
+			// Create a clone if one unique template is found
+			if ( !useClone && template && !mappingConfig.tobeclone ) {
+				clone = template.content.cloneNode( true );
+			} else if ( !useClone && template ) {
+				clone = template.content.querySelector( mappingConfig.tobeclone ).cloneNode( true );
+			}
+
+			// process the mapping, return value is the new clone object if applicable
+			var tmpClone;
+			tmpClone = processMapping( elm, clone, i_cache, mappingConfig );
+
+			// Remove the template flag, to ensure we do reuse it for the subsequent iteration
+			if ( tmpClone ) {
+				delete mappingConfig.template;
+				clone = tmpClone;
+			}
+
+			// Add the clone object
+			if ( dataTableAddRow ) {
+				dataTableAddRow( $( clone ) ); // If wb-tables, use its API to add rows
+			} else if ( !useClone && template ) {
+				elmAppendTo.appendChild( clone );
+			}
+		}
+
+		// Refresh the dataTable display (if applicable)
+		if ( dataTableAddRow ) {
+			dataTable.draw();
+		}
+
+	},
+
+	// Check if the mapping are met or not
+	canProcessMapping = function( content, mappingConfig ) {
+
+		var rawValue, value,
+			testableData,
+			operand = mappingConfig.operand || "softEq",
+			operandOutcome;
+
+		if ( !mappingConfig.test ) {
+			return;
+		}
+
+		// Get the value to be tested
+		try {
+			rawValue = getRawValue( content, mappingConfig.assess || mappingConfig.value );
+			value = getValue( rawValue );
+		} catch ( ex ) {
+
+			// If this is an error, the path probably don't exist
+			rawValue = undefined;
+			value = undefined;
+		}
+
+		// Get the function to use
+		if ( !functionForTest[ mappingConfig.test ] ) {
+			console.error( "The test function '" + mappingConfig.test + "' don't exist. Default to false test result" );
+			console.error( mappingConfig );
+			return false;
+		}
+		testableData = functionForTest[ mappingConfig.test ].call( mappingConfig, value, rawValue );
+
+		// Run the operand
+		if ( !functionForOperand[ operand ] ) {
+			console.error( "The operand '" + operand + "' don't exist" );
+			console.error( mappingConfig );
+			operand = "softEq";
+		}
+		operandOutcome = functionForOperand[ operand ].call( mappingConfig, testableData, mappingConfig.expect );
+
+		// If not true, go next
+		if ( !operandOutcome ) {
+			return false;
+		}
+
+		// Run mapping if satisfied
+		return true;
+	},
+
+	// Special mapping typed function
+	functionForTypedMapping = {
+
+		"rdf:Alt": function( elm, clone, content, mappingConfig ) {
+
+			var mapping = mappingConfig.mapping,
+				i, i_cache,
+				i_len = mapping.length,
+				value = content;
+
+			for ( i = 0; i < i_len || i === 0; i += 1 ) {
+				i_cache = mapping[ i ];
+
+				if ( canProcessMapping( content, i_cache ) ) {
+
+					// Clone the object to avoid conflict when it is reused for other data
+					i_cache = $.extend( true, {}, i_cache );
+
+					// Remove the test, because it was checked
+					delete i_cache.test;
+
+					// Navigate the content if specified
+					if ( i_cache.value ) {
+						value = getValue( content, i_cache.value );
+					}
+
+					// Process the mapping
+					processMapping( elm, clone, value, i_cache );
+
+					// End
+					return;
+				}
+			}
+		}
+	},
+
+	// Function called for testing the mapping condition, which can be extend via the js configuration
+	functionForTest = {
+
+		"fn:isArray": function( value ) {
+			return $.isArray( value );
+		},
+
+		"fn:isLiteral": function( value ) {
+
+			// Check if the value are set under the JSON-LD parameter @value
+			if ( value && value[ "@value" ] ) {
+				value = value[ "@value" ];
+			}
+
+			if ( value && typeof value !== "object" ) {
+				return true;
+			}
+
+			return false;
+		},
+
+		"fn:getType": function( value, rawValue ) {
+
+			var tp = value[ "@type" ] || rawValue[ "@type" ];
+
+			if ( tp === "@json" ) {
+				return "rdf:JSON";
+			} else if ( $.isArray( tp ) && tp.indexOf( "@json" ) !== -1 ) {
+				tp[ tp.indexOf( "@json" ) ] = "rdf:JSON";
+			}
+
+			if ( tp ) {
+				return tp;
+			} else {
+				return typeof value;
+			}
+		},
+
+		"fn:getValue": function( value ) {
+
+			return value;
+
+		},
+
+		"fn:guessType": function( value, rawValue ) {
+
+			var guessType;
+
+			if ( !value ) {
+				guessType = "undefined";
+			} else if ( value[ "@type" ] ) {
+				guessType = value[ "@type" ];
+			} else if ( rawValue[ "@type" ] ) {
+				guessType = rawValue[ "@type" ];
+			} else if ( value[ "@value" ] ) {
+
+				// Only if we are in JSON ld mode
+				// Check if the value are set under the JSON-LD parameter @value
+				value = value[ "@value" ];
+			}
+
+			// Edge case to convert the @json data type into its RDF form
+			if ( guessType && guessType !== "undefined" ) {
+				if ( guessType === "@json" ) {
+					guessType = "rdf:JSON";
+				} else if ( $.isArray( guessType ) && guessType.indexOf( "@json" ) !== -1 ) {
+					guessType[ guessType.indexOf( "@json" ) ] = "rdf:JSON";
+				}
+			}
+
+			if ( !guessType ) {
+				if ( typeof value === "string" && value.match( /^([a-z][a-z0-9+\-.]*):/i ) ) {
+					guessType = [ "xsd:anyURI", "rdfs:Literal" ];
+				} else if ( typeof value === "string" ) {
+					guessType = [ "xsd:string", "rdfs:Literal" ];
+				} else if ( typeof value === "boolean" ) {
+					guessType = [ "xsd:boolean", "rdfs:Literal" ];
+				} else if ( typeof value === "number" ) {
+					guessType = [ "xsd:double", "rdfs:Literal" ];
+				} else if ( typeof value === "undefined" ) {
+					guessType = "undefined";
+				} else if ( $.isArray( value ) ) {
+					guessType = "rdfs:Container";
+				} else {
+
+					// The type is a generic Object
+					guessType = "rdfs:Resource";
+				}
+			}
+
+			return guessType;
+		}
+
+	},
+
+	// Operand used to evaluate the testable output from functionForTest to determine if the mapping condition is met or not, which can be extend via the js configuration
+	functionForOperand = {
+
+		"softEq": function( value, expect ) {
+			var i, i_len;
+
+			if ( $.isArray( value ) && !$.isArray( expect ) && value.indexOf( expect ) !== -1 ) {
+				return true;
+			} else if ( $.isArray( value ) &&  $.isArray( expect ) ) {
+				i_len = expect.length;
+				for ( i = 0; i !== i_len; i++ ) {
+					if ( value.indexOf( expect[ i ] ) ) {
+						return true;
+					}
+				}
+			} else if ( expect && value === expect ) {
+				return true;
+			} else if ( !expect && value ) {
+				return true;
+			}
+
+			return false;
+
+		},
+
+		"eq": function( value, expect ) {
+
+			if ( _equalsJSON( value, expect ) ) {
+				return true;
+			}
+
+			return false;
+		},
+
+		"neq": function( value, expect ) {
+			if ( !_equalsJSON( value, expect ) ) {
+				return true;
+			}
+
+			return false;
+		},
+
+		"in": function( value, expect ) {
+
+			var i;
+
+			if ( !expect ) {
+				console.error( "Expected value is missing. Defaulting to false." );
+				console.error( this );
+				return false;
+			}
+
+			if ( $.isArray( value ) && !$.isArray( expect ) && value.indexOf( expect ) !== -1 ) {
+				return true;
+			} else if ( $.isArray( value ) &&  $.isArray( expect ) ) {
+				for ( i = 0; i !== expect.length; i++ ) {
+					if ( value.indexOf( expect[ i ] ) ) {
+						return true;
+					}
+				}
+			} else if ( !$.isArray( value ) &&  $.isArray( expect ) && expect.indexOf( value ) !== -1  ) {
+				return true;
+			} else if ( value === expect ) {
+				return true;
+			}
+
+			return false;
+		},
+
+		"nin": function( value, expect ) {
+			return !functionForOperand.in.call( this, value, expect );
+		}
+	},
+
+	// Mapping the data into a template or into a node
+	processMapping = function( elm, clone, content, mappingConfig ) {
+
+		var j, j_cache,
+			cached_node, cached_value,
+			queryAll = mappingConfig.queryall,
+			selElements,
+			mapping = mappingConfig.mapping,
+			mapping_len,
+			upstreamClone, template;
+
+
+		// Is this mapping a special mapping type?
+		if ( mappingConfig[ "@type" ] ) {
+			functionForTypedMapping[ mappingConfig[ "@type" ] ].call( content, elm, clone, content, mappingConfig );
+			return;
+		}
+
+		// Can we proceed?
+		if ( mappingConfig.test && !canProcessMapping( content, mappingConfig ) ) {
+			return;
+		}
+
+		// Check if there is some mapping configuration
+		if ( !mapping && !queryAll && !mappingConfig.template ) {
+			return;
+		}
+
+		// Clone mappingConfig to ensure it don't interfere with subsequent data iteration
+		mappingConfig = $.extend( true, {}, mappingConfig );
+
+		// If there is no clone, let use the element (parent)
+		clone = clone || elm;
+
+		// If there is a "template" property, get the inner template
+		if ( mappingConfig.template ) {
+			template = clone.querySelector( mappingConfig.template );
+
+			upstreamClone = clone; // Keep reference of the top clone
+
+			clone = template.content.cloneNode( true );
+
+			// Ensure we don't recreated it if during a subsequent iteration
+			delete mappingConfig.template;
+		}
+
+
+		// Is content an array? then iterate the content
+		if ( $.isArray( content ) ) {
+
+
+			dataIterator( clone, content, mappingConfig, clone );
+
+			// Case of where a template is associated with this mapping action
+			if ( template ) {
+				if ( template.parentNode ) {
+
+					if ( !mappingConfig.append ) {
+						template.parentNode.insertBefore( clone, template );
+					} else {
+						template.parentNode.appendChild( clone );
+					}
+				} else {
+					upstreamClone.appendChild( clone );
+				}
+
+				return elm;
+
+			}
+			return;
+		}
+
+		// Prepare the mapping object to be iterated
+		if ( !mapping ) {
+			mapping = [ {} ];
+		}
 		if ( !$.isArray( mapping ) ) {
 			mapping = [ mapping ];
 		}
 		mapping_len = mapping.length;
 
-		if ( !template ) {
-			return;
+		// Ensure the mapping is an array of Mapping Object
+		for ( j = 0; j < mapping_len || j === 0; j += 1 ) {
+			if ( typeof mapping[ j ] === "string" ) {
+				mapping[ j ] = {
+					value: mapping[ j ]
+				};
+			}
 		}
 
-		// Needed when executing sub-template that wasn't polyfill, like in IE11
-		if ( !template.content ) {
-			wb.tmplPolyfill( template );
-		}
+		if ( queryAll ) {
+			selElements = clone.querySelectorAll( queryAll );
 
-		if ( settings.appendto ) {
-			elmAppendTo = $( settings.appendto ).get( 0 );
-		}
-
-		for ( i = 0; i < i_len; i += 1 ) {
-			i_cache = content[ i ];
-
-			if ( filterPassJSON( i_cache, filterTrueness, filterFaslseness ) ) {
-
-				basePntr = "/" + i;
-
-				if ( !selectorToClone ) {
-					clone = template.content.cloneNode( true );
-				} else {
-					clone = template.content.querySelector( selectorToClone ).cloneNode( true );
-				}
-
-				if ( queryAll ) {
-					selElements = clone.querySelectorAll( queryAll );
-				}
-
-				for ( j = 0; j < mapping_len || j === 0; j += 1 ) {
-					j_cache = mapping[ j ];
-
-					// Get the node used to insert content
-					if ( selElements ) {
-						cached_node = selElements[ j ];
-					} else if ( j_cache.selector ) {
-						cached_node = clone.querySelector( j_cache.selector );
-					} else {
-						cached_node = clone;
-					}
-					j_cache_attr = j_cache.attr;
-					if ( j_cache_attr ) {
-						if ( !cached_node.hasAttribute( j_cache_attr ) ) {
-							cached_node.setAttribute( j_cache_attr, "" );
-						}
-						cached_node = cached_node.getAttributeNode( j_cache_attr );
-					}
-
-					// Get the value
-					if ( typeof i_cache === "string" ) {
-						cached_value = i_cache;
-					} else if ( typeof j_cache === "string" ) {
-						cached_value = jsonpointer.get( content, basePntr + j_cache );
-					} else {
-						cached_value = jsonpointer.get( content, basePntr + j_cache.value );
-					}
-
-					// Go to the next mapping if the value of JSON node don't exist to ensure we keep the default text set in the template, but move ahead if empty or null
-					if ( cached_value === undefined ) {
-						continue;
-					}
-
-					// Placeholder text replacement if any
-					if ( j_cache.placeholder ) {
-						cached_textContent = cached_node.textContent || "";
-						cached_value = cached_textContent.replace( j_cache.placeholder, cached_value );
-					}
-
-					// Set the value to the node
-					if ( j_cache.isHTML ) {
-						cached_node.innerHTML = cached_value;
-					} else if ( $.isArray( cached_value ) || cached_value && !( cached_value instanceof String ) && typeof cached_value === "object" ) {
-						applyTemplate( cached_node, j_cache, cached_value );
-					} else {
-						cached_node.textContent = cached_value;
-					}
-				}
-
-				if ( dataTableAddRow ) {
-
-					// If wb-tables, use its API to add rows
-					dataTableAddRow( $( clone ) );
-				} else {
-					elmAppendTo.appendChild( clone );
+			// Replicate this setting the in the mapping
+			for ( j = 0; j < selElements.length || j === 0; j += 1 ) {
+				if ( !mapping[ j ].selector && queryAll.indexOf( "nth-child" ) === -1 ) {
+					mapping[ j ].selector = queryAll + ":nth-child(" + ( j + 1 ) + ")";
+				} else if ( !mapping[ j ].selector ) {
+					mapping[ j ].selector = queryAll;
 				}
 			}
 		}
 
-		// Refresh the dataTable display
-		if ( dataTableAddRow ) {
-			dataTable.draw();
+
+		//
+		// Process the mapping
+		//
+		for ( j = 0; j < mapping_len || j === 0; j += 1 ) {
+			j_cache = mapping[ j ];
+
+			// Get the element to be updated
+			if ( j_cache.selector ) {
+				cached_node = clone.querySelector( j_cache.selector );
+			} else {
+				cached_node = clone;
+			}
+
+			// Get the value to be set
+			try {
+				cached_value = getRawValue( content, j_cache );
+			} catch ( ex ) {
+
+				// The path don't exist, let continue to the next mapping item
+				console.info( "JSON selector path for mapping don't exist in content" );
+				console.info( j_cache );
+				console.info( content );
+				continue;
+			}
+
+			// Go to the next mapping if the value of JSON node don't exist to ensure we keep the default text set in the template, but move ahead if empty or null
+			if ( typeof cached_value === "undefined" ) {
+				continue;
+			}
+
+			// Action the value
+			if ( $.isArray( cached_value ) && ( j_cache.mapping || j_cache.queryall ) ) {
+
+				// Deep dive into the content if a mapping exist
+				dataIterator( cached_node, cached_value, j_cache );
+
+			} else if ( j_cache.mapping || j_cache.queryall ) {
+				try {
+
+					// Map the inner mapping
+					processMapping( template || elm, cached_node, cached_value, j_cache );
+				} catch ( ex ) {
+
+					if ( ex === "cached_node: null" && typeof cached_value === "object" ) {
+
+						// If it fail, let iterate the cached_value object
+						dataIterator( cached_node, cached_value, j_cache );
+					} else {
+						throw ex;
+					}
+				}
+			} else if ( !cached_node && typeof cached_value === "object" ) {
+				throw "cached_node: null";
+			} else {
+
+				cached_value = getValue( cached_value );
+
+				// Serialize the value if it is an JS object
+				if ( typeof cached_value === "object" ) {
+					cached_value = JSON.stringify( cached_value );
+				}
+
+				// Map the value in the element
+				mapValue( cached_node, cached_value, j_cache );
+			}
+
+		}
+
+		// Add the template, if applicable
+		if ( template ) {
+			if ( template.parentNode ) {
+
+				if ( !mappingConfig.append ) {
+					template.parentNode.insertBefore( clone, template );
+				} else {
+					template.parentNode.appendChild( clone );
+				}
+			} else {
+				upstreamClone.appendChild( clone );
+			}
+
+			return elm;
+		}
+
+	},
+
+	// Extract the value of an JS object
+	getValue = function( source, pointer ) {
+
+		var value = getRawValue( source, pointer );
+
+		// for JSON-LD @value support
+		if ( typeof value === "object" && value[ "@value" ] ) {
+			value = value[ "@value" ];
+		}
+
+		return value;
+	},
+
+	// Extract the value without considering it possible JSON-LD value
+	getRawValue = function( source, pointer ) {
+
+		var value;
+		pointer = pointer || false; // Ensure pointer is defined
+
+		// Get the value if source is string or pointer is pointing to root
+		if ( typeof source === "string" || pointer === "/" || pointer === "/@value" || pointer.value === "/" || pointer.value === "/@value" ) {
+			value = source;
+		} else if ( typeof pointer === "string" ) {
+			value = jsonpointer.get( source, pointer );
+		} else if ( pointer.value ) {
+			value = jsonpointer.get( source, pointer.value );
+		} else {
+			value = source;
+		}
+
+		return value;
+	},
+
+	// Map a value into an HTML element or attribute
+	mapValue = function( element, value, mappingConfig ) {
+
+		var attributeName, placeholderText;
+
+		attributeName = mappingConfig.attr;
+		if ( attributeName ) {
+			if ( !element.hasAttribute( attributeName ) ) {
+				element.setAttribute( attributeName, "" );
+			}
+			element = element.getAttributeNode( attributeName );
+		}
+
+		// Placeholder text replacement if any
+		if ( mappingConfig.placeholder ) {
+			placeholderText = element.textContent || "";
+			value = placeholderText.replace( mappingConfig.placeholder, value );
+		}
+
+		// Set the value to the node
+		if ( mappingConfig.isHTML ) {
+			element.innerHTML = value;
+		} else {
+			element.textContent = value;
 		}
 	},
+
 
 	// Filtering a JSON
 	// Return true if trueness && falseness
@@ -361,8 +880,8 @@ var componentName = "wb-data-json",
 	// trueness and falseness is an array of { "path": "", "value": "" } object
 	filterPassJSON = function( obj, trueness, falseness ) {
 		var i, i_cache,
-			trueness_len = trueness.length,
-			falseness_len = falseness.length,
+			trueness_len = trueness ? trueness.length : 0,
+			falseness_len = falseness ? falseness.length : 0,
 			compareResult = false,
 			isEqual;
 
@@ -412,7 +931,7 @@ var componentName = "wb-data-json",
 			}
 			var i, l;
 			if ( $.isArray( a ) ) {
-				if (  $.isArray( b ) || a.length !== b.length ) {
+				if (  !$.isArray( b ) || a.length !== b.length ) {
 					return false;
 				}
 				for ( i = 0, l = a.length; i < l; i++ ) {
@@ -427,7 +946,7 @@ var componentName = "wb-data-json",
 			if ( _objectKeys( a ).length !== bLength ) {
 				return false;
 			}
-			for ( i = 0; i < bLength; i++ ) {
+			for ( i in a ) {
 				if ( !_equalsJSON( a[ i ], b[ i ] ) ) {
 					return false;
 				}

--- a/src/plugins/wb-data-json/demo/conditional-1.json
+++ b/src/plugins/wb-data-json/demo/conditional-1.json
@@ -1,0 +1,40 @@
+{
+  "subject": [
+    {
+      "foo": "bar",
+      "bar": "hello world"
+    },
+    {
+      "foo": "https://example.com",
+      "bar": "hello world"
+    }
+  ],
+  "list": [
+    {
+    "@type": "xsd:string",
+      "@value": "string"
+    },
+    {
+      "@type": "xsd:double",
+      "@value": 123.45
+    },
+    {
+      "@type": "xsd:boolean",
+      "@value": true
+    },
+    {
+      "@type": "xsd:anyURI",
+      "@value": "https://example.com"
+    },
+    {
+      "@type": "xsd:string",
+      "@value": "second string"
+    }
+  ],
+  "text": {
+    "alpha": "alpha",
+    "beta": "beta",
+    "gamma": "gamma",
+    "delta": "delta"
+  }
+}

--- a/src/plugins/wb-data-json/demo/conditional-2.json
+++ b/src/plugins/wb-data-json/demo/conditional-2.json
@@ -1,0 +1,45 @@
+{
+  "alpha": [ "alpha" ],
+  "beta": "beta",
+  "gamma": { "@value": "gamma" },
+  "delta": { "@type": "rdfs:Resource", "@value": "delta" },
+  "epsilon": "epsilon",
+  "zeta": true,
+  "eta": "http://example.com",
+  "theta": 123.45,
+  "iota": {
+    "@type": [ "rdfs:Resource", "xsd:string" ],
+    "@value": "iota"
+  },
+  "kappa": {
+    "lamdba": "mu"
+  },
+  "nu": {
+    "@type": "@json",
+    "@value": {
+      "xi": "xi",
+      "omicron": "omicron",
+      "pi": "pi"
+    }
+  },
+  "rho": {
+    "@type": "@json",
+    "@value": {
+      "sigma": "sigma",
+      "tau": "tau",
+      "upsilon": "upsilon"
+    }
+  },
+  "sigma": {
+    "alpha": "sigma",
+    "gamma": "sigma"
+  },
+  "undefined": "tau",
+
+  "text": {
+      "zeta": "zeta",
+      "eta": "eta",
+      "theta": "theta",
+      "kappa": "kappa"
+  }
+}

--- a/src/plugins/wb-data-json/template-en.hbs
+++ b/src/plugins/wb-data-json/template-en.hbs
@@ -10,12 +10,13 @@
 	"dateModified": "2022-10-12"
 }
 ---
-<!--
-<ul class="list-inline">
-	<li><a class="btn btn-primary" href="data-json-doc-en.html">Documentation</a></li>
-	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=DataJSON">Questions or comments?</a></li>
-</ul>
--->
+<nav>
+	<ul>
+		<li><a href="data-json-en.html">Data JSON</a></li>
+		<li>(This page) HTML 5 template</li>
+		<li><a href="conditional-en.html">Conditional template</a></li>
+	</ul>
+</nav>
 <p>Leverage HTML 5 <code>&lt;template&gt;</code> element by using the data json plugin.</p>
 
 <div class="wb-prettify all-pre"></div>

--- a/src/plugins/wb-data-json/template-fr.hbs
+++ b/src/plugins/wb-data-json/template-fr.hbs
@@ -10,12 +10,13 @@
 	"dateModified": "2022-10-12"
 }
 ---
-<!--
-<ul class="list-inline">
-	<li><a class="btn btn-primary" href="data-json-doc-fr.html">Documentation</a></li>
-	<li><a class="btn btn-primary" href="https://github.com/wet-boew/GCWeb/issues/new?title=DataJSON">Questions ou commentaires?</a></li>
-</ul>
--->
+<nav>
+	<ul>
+		<li><a href="data-json-fr.html">Data JSON</a></li>
+		<li>(Cette page) Gabarit HTML 5</li>
+		<li><a href="conditional-fr.html">Gabarit conditionel</a></li>
+	</ul>
+</nav>
 <p>Prendre avantage de l'élément <code>&lt;template&gt;</code> du HTML 5 avec le plugiciel data json</p>
 
 <div class="wb-prettify all-pre"></div>


### PR DESCRIPTION
Add the possibility to do conditional template with the data-json plugin.

Test to do at least:
* [x] Ensure the data-json working example work the same as before
* [x] Ensure the data-json HTML5 template working example work the same as before
* [x] Ensure the JSON manager working example work the same as before
* [x] Test the functional aspect of the conditional template via its working example
* [x] Review the code.

Working example: https://universallabs.org/wet/labs/conditional-tmpl/unmin/demos/wb-data-json/conditional-en.html