### PR TITLE
Filter: fixing visible items bug

### DIFF
--- a/src/plugins/filter/filter.js
+++ b/src/plugins/filter/filter.js
@@ -132,7 +132,7 @@ var componentName = "wb-filter",
 				uiNbItems.textContent = totalEntries;
 
 				itemsObserver = new MutationObserver( function() {
-					uiNbItems.textContent = $elm.find( secSelector + notFilterClassSel + settings.selector ).length;
+					uiNbItems.textContent = $elm.find( secSelector + settings.selector + notFilterClassSel ).length;
 				} );
 
 				itemsObserver.observe( elm, { attributes: true, subtree: true } );


### PR DESCRIPTION
Fixing bug where the count of visible items would return an incorrect number when the "selector" property was not set to a tag, but rather a CSS selector. For example: "> li" instead of "li".