### PR TITLE
Demos: Replace CSS code samples with SCSS includes

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -491,6 +491,10 @@ module.exports = (grunt) ->
 				helpers: "site/helpers/helper{,s}-*.js"
 				partials: [
 					"site/includes/**/*.hbs"
+					"src/other/archived/demo/archived.scss"
+					"src/plugins/eqht-css/demo/eqht-css.scss"
+					"src/plugins/equalheight/demo/equalheight.scss"
+					"src/plugins/share/demo/share.scss"
 					"src/polyfills/datalist/demo/datalist_dynamic.js"
 				]
 				layoutdir: "site/layouts"

--- a/src/other/archived/archived-en.hbs
+++ b/src/other/archived/archived-en.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "archived",
 	"altLangPrefix": "archived",
 	"css": ["demo/archived"],
-	"dateModified": "2014-07-19"
+	"dateModified": "2023-07-17"
 }
 ---
 <span class="wb-prettify all-pre"></span>
@@ -36,27 +36,8 @@
 		</section>
 
 		<section>
-			<h3>CSS</h3>
-			<pre><code>#archived-bnr {
-	background-color: #fd0;
-}
-
-#archived-bnr p {
-	margin: 0;
-	text-align: center;
-}
-
-#archived-bnr a {
-	color: #000;
-	display: block;
-	font-weight: 700;
-	padding: 0.75em 44px;
-	text-decoration: underline;
-}
-
-#archived-bnr .overlay-close {
-	color: #000;
-}</code></pre>
+			<h3>SCSS</h3>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> archived }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</details>
 </section>

--- a/src/other/archived/archived-fr.hbs
+++ b/src/other/archived/archived-fr.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "archived",
 	"altLangPrefix": "archived",
 	"css": ["demo/archived"],
-	"dateModified": "2014-07-19"
+	"dateModified": "2023-07-17"
 }
 ---
 <span class="wb-prettify all-pre"></span>
@@ -36,27 +36,8 @@
 		</section>
 
 		<section>
-			<h3>CSS</h3>
-			<pre><code>#archived-bnr {
-	background-color: #fd0;
-}
-
-#archived-bnr p {
-	margin: 0;
-	text-align: center;
-}
-
-#archived-bnr a {
-	color: #000;
-	display: block;
-	font-weight: 700;
-	padding: 0.75em 44px;
-	text-decoration: underline;
-}
-
-#archived-bnr .overlay-close {
-	color: #000;
-}</code></pre>
+			<h3>SCSS</h3>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> archived }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</details>
 </section>

--- a/src/plugins/eqht-css/eqht-css-en.hbs
+++ b/src/plugins/eqht-css/eqht-css-en.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "eqht-css",
 	"altLangPrefix": "eqht-css",
 	"css": ["demo/eqht-css"],
-	"dateModified": "2023-06-19"
+	"dateModified": "2023-07-17"
 }
 ---
 <section>
@@ -98,14 +98,8 @@
 		</section>
 
 		<section>
-			<h4>CSS</h4>
-			<pre><code>#simple .wb-eqht-grd section {
-	border: 1px solid #ddd;
-	border-radius: 4px;
-	margin-bottom: 15px;
-	padding: 10px;
-}
-</code></pre>
+			<h4>SCSS</h4>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> eqht-css }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</section>
 </section>
@@ -193,14 +187,8 @@
 		</section>
 
 		<section>
-			<h4>CSS</h4>
-			<pre><code>#grow .wb-eqht-grd section {
-	border: 1px solid #ddd;
-	border-radius: 4px;
-	margin-bottom: 15px;
-	padding: 10px;
-}
-</code></pre>
+			<h4>SCSS</h4>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> eqht-css }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</section>
 </section>

--- a/src/plugins/eqht-css/eqht-css-fr.hbs
+++ b/src/plugins/eqht-css/eqht-css-fr.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "eqht-css",
 	"altLangPrefix": "eqht-css",
 	"css": ["demo/eqht-css"],
-	"dateModified": "2023-06-19"
+	"dateModified": "2023-07-17"
 }
 ---
 <section>
@@ -98,14 +98,8 @@
 		</section>
 
 		<section>
-			<h4>CSS</h4>
-			<pre><code>#simple .wb-eqht-grd section {
-	border: 1px solid #ddd;
-	border-radius: 4px;
-	margin-bottom: 15px;
-	padding: 10px;
-}
-</code></pre>
+			<h4>SCSS</h4>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> eqht-css }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</section>
 </section>
@@ -193,14 +187,8 @@
 		</section>
 
 		<section>
-			<h4>CSS</h4>
-			<pre><code>#grow .wb-eqht-grd section {
-	border: 1px solid #ddd;
-	border-radius: 4px;
-	margin-bottom: 15px;
-	padding: 10px;
-}
-</code></pre>
+			<h4>SCSS</h4>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> eqht-css }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</section>
 </section>

--- a/src/plugins/equalheight/equalheight-en.hbs
+++ b/src/plugins/equalheight/equalheight-en.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "equalheight",
 	"altLangPrefix": "equalheight",
 	"css": ["demo/equalheight"],
-	"dateModified": "2023-06-19"
+	"dateModified": "2023-07-17"
 }
 ---
 <section>
@@ -116,25 +116,8 @@
 		</section>
 
 		<section>
-			<h4>CSS</h4>
-			<pre><code>#simple .wb-eqht section {
-	display: inline-block;
-	margin-bottom: 15px;
-	padding: 15px;
-	width: 100%;
-}
-
-@media (min-width: 768px) {
-	#simple .wb-eqht section {
-		width: 49%;
-	}
-}
-
-@media (min-width: 1200px) {
-	#simple .wb-eqht section {
-		width: 33%;
-	}
-}</code></pre>
+			<h4>SCSS</h4>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> equalheight }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</section>
 </section>

--- a/src/plugins/equalheight/equalheight-fr.hbs
+++ b/src/plugins/equalheight/equalheight-fr.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "equalheight",
 	"altLangPrefix": "equalheight",
 	"css": ["demo/equalheight"],
-	"dateModified": "2023-06-19"
+	"dateModified": "2023-07-17"
 }
 ---
 <section>
@@ -116,25 +116,8 @@
 		</section>
 
 		<section>
-			<h4>CSS</h4>
-			<pre><code>#simple .wb-eqht section {
-	display: inline-block;
-	margin-bottom: 15px;
-	padding: 15px;
-	width: 100%;
-}
-
-@media (min-width: 768px) {
-	#simple .wb-eqht section {
-		width: 49%;
-	}
-}
-
-@media (min-width: 1200px) {
-	#simple .wb-eqht section {
-		width: 33%;
-	}
-}</code></pre>
+			<h4>SCSS</h4>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> equalheight }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</section>
 </section>

--- a/src/plugins/share/share-en.hbs
+++ b/src/plugins/share/share-en.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "share",
 	"altLangPrefix": "share",
 	"css": ["demo/share"],
-	"dateModified": "2015-05-27"
+	"dateModified": "2023-07-17"
 }
 ---
 <section>
@@ -122,10 +122,8 @@
 			<pre class="wb-prettify"><code>&lt;div class="wb-share" data-wb-share='{"pnlId": "pnl7", "sites": "demosite": {"name": "Demo site", "url": "https://www.example.org/?to=&amp;subject={t}&amp;body={u}%0A{d}"}}'&gt;&lt;/div&gt;</code></pre>
 		</section>
 		<section>
-			<h3>CSS</h3>
-			<pre class="wb-prettify"><code>.wb-share .demosite:before {
-	background: url("demosite.png") no-repeat;
-}</code></pre>
+			<h3>SCSS</h3>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> share }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</details>
 </section>

--- a/src/plugins/share/share-fr.hbs
+++ b/src/plugins/share/share-fr.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "share",
 	"altLangPrefix": "share",
 	"css": ["demo/share"],
-	"dateModified": "2015-05-27"
+	"dateModified": "2023-07-17"
 }
 ---
 <section>
@@ -121,10 +121,8 @@
 			<pre class="wb-prettify"><code>&lt;div class="wb-share" data-wb-share='{"pnlId": "pnl7", "sites": {"Site démo": {"name": "Site démo", "url": "https://www.example.org/?to=&amp;subject={t}&amp;body={u}%0A{d}"}}}'&gt;&lt;/div&gt;</code></pre>
 		</section>
 		<section>
-			<h3>CSS</h3>
-			<pre class="wb-prettify"><code>.wb-share .demosite:before {
-	background: url("demosite.png") no-repeat;
-}</code></pre>
+			<h3>SCSS</h3>
+			<pre><code>{{#escape}}{{#stripbanner}}{{> share }}{{/stripbanner}}{{/escape}}</code></pre>
 		</section>
 	</details>
 </section>


### PR DESCRIPTION
The equal heights demo's hardcoded CSS sample was outdated compared to its "real" SCSS source file.

Rather than updating the affected CSS sample, this replaces all demo CSS samples with future-proof SCSS ones. The SCSS samples are setup as includes (handlebars partials) that are sourced from the demos' "real" SCSS files. #9566's custom handlebars helpers are also used to make the SCSS samples more presentable.