### PR TITLE
Tagilfter: adding reinitialization on content updated

### DIFF
--- a/src/plugins/tagfilter/data_en.json
+++ b/src/plugins/tagfilter/data_en.json
@@ -1,0 +1,116 @@
+{
+    "events": [
+        {
+            "tags": "language__english language__french location__online dayOTW_friday",
+            "title": "Ask PAC Anything!",
+            "date": "Friday August 5th, 2022",
+            "time": "12:00 PM to 1:00 PM",
+            "location": "Online",
+            "language": "English, French"
+        },
+        {
+            "tags": "language__english location__vancouver dayOTW_wednesday",
+            "title": "Bidding on Opportunities",
+            "date": "Wednesday August 10th, 2022",
+            "time": "2:00 PM to 3:30 PM",
+            "location": "Vancouver",
+            "language": "English"
+        },
+        {
+            "tags": "language__english location__ottawa dayOTW_thursday",
+            "title": "Doing business with the Government of Canada (Webinar)",
+            "date": "Thursday August 11th, 2022",
+            "time": "12:00 PM to 2:00 PM",
+            "location": "Ottawa",
+            "language": "English"
+        },
+        {
+            "tags": "language__english location__online dayOTW_friday",
+            "title": "Ask PAC Anything!",
+            "date": "Friday August 12th, 2022",
+            "time": "12:00 PM to 1:00 PM",
+            "location": "Online",
+            "language": "English"
+        },
+        {
+            "tags": "language__english location__ottawa dayOTW_thursday",
+            "title": "Bidding on opportunities (Webinar)",
+            "date": "Thursday August 18th, 2022",
+            "time": "12:00 PM to 2:00 PM",
+            "location": "Ottawa",
+            "language": "English"
+        },
+        {
+            "tags": "language__english location__online dayOTW_friday",
+            "title": "Ask PAC Anything!",
+            "date": "Friday August 19th, 2022",
+            "time": "12:00 PM to 1:00 PM",
+            "location": "Online",
+            "language": "English"
+        },
+        {
+            "tags": "language__french location__ottawa dayOTW_thursday",
+            "title": "Workshop to register in the Supplier Registration Information (SRI) system and in the Indigenous ness Directory (IBD) for Indigenous-led businesses",
+            "date": "Thursday August 25th, 2022",
+            "time": "9:30 AM to 11:00 AM",
+            "location": "Ottawa",
+            "language": "French"
+        },
+        {
+            "tags": "language__english location__ottawa location__montreal dayOTW_thursday",
+            "title": "Workshop to register in the Supplier Registration Information (SRI) system and in the Indigenous ness Directory (IBD) for Indigenous-led businesses",
+            "date": "Thursday August 25th, 2022",
+            "time": "1:00 PM to 2:30 PM",
+            "location": "Ottawa and Montreal",
+            "language": "English"
+        },
+        {
+            "tags": "language__french location__montreal dayOTW_thursday",
+            "title": "Doing Business with the Government of Canada",
+            "date": "Thursday August 25th, 2022",
+            "time": "1:30 PM to 3:00 PM",
+            "location": "Montreal",
+            "language": "French"
+        },
+        {
+            "tags": "language__english location__vancouver dayOTW_thursday",
+            "title": "Doing Business with the Government of Canada",
+            "date": "Thursday August 25th, 2022",
+            "time": "2:00 PM to 3:30 PM",
+            "location": "Vancouver",
+            "language": "English"
+        },
+        {
+            "tags": "language__english location__online dayOTW_friday",
+            "title": "Ask PAC Anything!",
+            "date": "Friday August 26th, 2022",
+            "time": "12:00 PM to 1:30 PM",
+            "location": "Online",
+            "language": "English"
+        },
+        {
+            "tags": "language__english location__toronto dayOTW_tuesday",
+            "title": "Mythbusting Federal Government Procurement and Overview of Innovation for Defence, Excellence and rity (IDEaS) ",
+            "date": "Tuesday August 30th, 2022",
+            "time": "10:00 AM to 11:00 AM",
+            "location": "Toronto",
+            "language": "English"
+        },
+        {
+            "tags": "language__french location__montreal dayOTW_tuesday",
+            "title": "Register as supplier and find opportunities on BuyAndSell.gc.ca",
+            "date": "Tuesday August 30th, 2022",
+            "time": "1:30 PM to 3:00 PM",
+            "location": "Montreal",
+            "language": "French"
+        },
+        {
+            "tags": "language__english location__toronto dayOTW_wednesday",
+            "title": "Federal Procurement Virtual Drop-in Café",
+            "date": "Wednesday August 31th, 2022",
+            "time": "3:00 PM to 4:00 PM",
+            "location": "Toronto",
+            "language": "English"
+        }
+    ]
+}

--- a/src/plugins/tagfilter/data_fr.json
+++ b/src/plugins/tagfilter/data_fr.json
@@ -1,0 +1,116 @@
+{
+    "events": [
+        {
+            "tags": "language__english language__french location__online dayOTW_friday",
+            "title": "Demandez tout à PAC",
+            "date": "Vendredi 5 août, 2022",
+            "time": "12h à 13h",
+            "location": "En ligne",
+            "language": "Français et anglais"
+        },
+        {
+            "tags": "language__english location__vancouver dayOTW_wednesday",
+            "title": "Misez sur des opportunités",
+            "date": "Mercredi 10 août, 2022",
+            "time": "14h à 15h30",
+            "location": "Vancouver",
+            "language": "Anglais"
+        },
+        {
+            "tags": "language__english location__ottawa dayOTW_thursday",
+            "title": "Faire affaire avec le gouvernement du Canada (Webinaire)",
+            "date": "Jeudi 11 août, 2022",
+            "time": "12h à 14h",
+            "location": "Ottawa",
+            "language": "Anglais"
+        },
+        {
+            "tags": "language__english location__online dayOTW_friday",
+            "title": "Demandez tout à PAC",
+            "date": "Vendredi 12 août, 2022",
+            "time": "12h à 13h",
+            "location": "Online",
+            "language": "Anglais"
+        },
+        {
+            "tags": "language__english location__ottawa dayOTW_thursday",
+            "title": "Misez sur des opportunités (Webinaire)",
+            "date": "Jeudi 18 août, 2022",
+            "time": "12h à 14h",
+            "location": "Ottawa",
+            "language": "Anglais"
+        },
+        {
+            "tags": "language__english location__online dayOTW_friday",
+            "title": "Demandez tout à PAC",
+            "date": "Vendredi 19 août, 2022",
+            "time": "12h à 13h",
+            "location": "En ligne",
+            "language": "Anglais"
+        },
+        {
+            "tags": "language__french location__ottawa dayOTW_thursday",
+            "title": "Atelier pour s'inscrire au système d'information sur l'inscription des fournisseurs (SRI) et au Répertoire des Autochtones (IBD) pour les entreprises dirigées par des Autochtones",
+            "date": "Jeudi 25 août, 2022",
+            "time": "9h30 à 11h",
+            "location": "Ottawa",
+            "language": "Français"
+        },
+        {
+            "tags": "language__english location__ottawa location__montreal dayOTW_thursday",
+            "title": "Atelier pour s'inscrire au système d'information sur l'inscription des fournisseurs (SRI) et au Répertoire des Autochtones (IBD) pour les entreprises dirigées par des Autochtones",
+            "date": "Jeudi 25 août, 2022",
+            "time": "13h à 14h30",
+            "location": "Ottawa et Montréal",
+            "language": "Anglais"
+        },
+        {
+            "tags": "language__french location__montreal dayOTW_thursday",
+            "title": "Faire affaire avec le gouvernement du Canada",
+            "date": "Jeudi 25 août, 2022",
+            "time": "13h30 à 15h",
+            "location": "Montréal",
+            "language": "Français"
+        },
+        {
+            "tags": "language__english location__vancouver dayOTW_thursday",
+            "title": "Faire affaire avec le gouvernement du Canada",
+            "date": "Jeudi 25 août, 2022",
+            "time": "14h à 15h30",
+            "location": "Vancouver",
+            "language": "Anglais"
+        },
+        {
+            "tags": "language__english location__online dayOTW_friday",
+            "title": "Demandez tout à PAC",
+            "date": "Vendredi 26 août, 2022",
+            "time": "12h à 13h30",
+            "location": "En ligne",
+            "language": "Anglais"
+        },
+        {
+            "tags": "language__english location__toronto dayOTW_tuesday",
+            "title": "Démystifier les marchés publics fédéraux et aperçu de l'innovation pour la défense, l'excellence et la rité (IDEaS)",
+            "date": "Mardi 30 août, 2022",
+            "time": "10h à 11h",
+            "location": "Toronto",
+            "language": "Anglais"
+        },
+        {
+            "tags": "language__french location__montreal dayOTW_tuesday",
+            "title": "Inscrivez-vous en tant que fournisseur et trouvez des opportunités sur Achatsetventes.gc.ca",
+            "date": "Mardi 30 août, 2022",
+            "time": "13h30 à 15h",
+            "location": "Montréal",
+            "language": "Français"
+        },
+        {
+            "tags": "language__english location__toronto dayOTW_wednesday",
+            "title": "Café virtuel sans rendez-vous sur l'approvisionnement fédéral",
+            "date": "Mercredi 31 août, 2022",
+            "time": "15h à 16h",
+            "location": "Toronto",
+            "language": "Anglais"
+        }
+    ]
+}

--- a/src/plugins/tagfilter/tagfilter-en.hbs
+++ b/src/plugins/tagfilter/tagfilter-en.hbs
@@ -109,77 +109,24 @@
 			</details>
 		</div>
 		<div class="col-xs-12 col-sm-8 col-lg-9">
-			<ul class="list-unstyled events-list wb-tagfilter-items">
-				<li data-wb-tags="language__english language__french location__online dayOTW_friday">
-					<h3>Ask PAC Anything!</h3>
-					<p>Friday August 5th, 2022 | 12:00 PM to 1:00 PM</p>
-					<p><span><strong>Location:</strong> Online</span> <strong>Language</strong>: English, French</p>
-				</li>
-				<li data-wb-tags="language__english location__vancouver dayOTW_wednesday">
-					<h3>Bidding on Opportunities</h3>
-					<p>Wednesday August 10th, 2022 | 2:00 PM to 3:30 PM</p>
-					<p><span><strong>Location:</strong> Vancouver</span> <strong>Language</strong>: English</p>
-				</li>
-				<li data-wb-tags="language__english location__ottawa dayOTW_thursday">
-					<h3>Doing business with the Government of Canada (Webinar)</h3>
-					<p>Thursday August 11th, 2022 | 12:00 PM to 2:00 PM</p>
-					<p><span><strong>Location:</strong> Ottawa</span> <strong>Language</strong>: English</p>
-				</li>
-				<li data-wb-tags="language__english location__online dayOTW_friday">
-					<h3>Ask PAC Anything!</h3>
-					<p>Friday August 12th, 2022 | 12:00 PM to 1:00 PM</p>
-					<p><span><strong>Location:</strong> Online</span> <strong>Language</strong>: English</p>
-				</li>
-				<li data-wb-tags="language__english location__ottawa dayOTW_thursday">
-					<h3>Bidding on opportunities (Webinar)</h3>
-					<p>Thursday August 18th, 2022 | 12:00 PM to 2:00 PM</p>
-					<p><span><strong>Location:</strong> Ottawa</span> <strong>Language</strong>: English</p>
-				</li>
-				<li data-wb-tags="language__english location__online dayOTW_friday">
-					<h3>Ask PAC Anything!</h3>
-					<p>Friday August 19th, 2022 | 12:00 PM to 1:00 PM</p>
-					<p><span><strong>Location:</strong> Online</span> <strong>Language</strong>: English</p>
-				</li>
-				<li data-wb-tags="language__french location__ottawa dayOTW_thursday">
-					<h3>Workshop to register in the Supplier Registration Information (SRI) system and in the Indigenous ness Directory (IBD) for Indigenous-led businesses</h3>
-					<p>Thursday August 25th, 2022 | 9:30 AM to 11:00 AM</p>
-					<p><span><strong>Location:</strong> Ottawa</span> <strong>Language</strong>: French</p>
-				</li>
-				<li data-wb-tags="language__english location__ottawa location__montreal dayOTW_thursday">
-					<h3>Workshop to register in the Supplier Registration Information (SRI) system and in the Indigenous ness Directory (IBD) for Indigenous-led businesses</h3>
-					<p>Thursday August 25th, 2022 | 1:00 PM to 2:30 PM</p>
-					<p><span><strong>Location:</strong> Ottawa and Montreal</span> <strong>Language</strong>: English</p>
-				</li>
-				<li data-wb-tags="language__french location__montreal dayOTW_thursday">
-					<h3>Doing Business with the Government of Canada</h3>
-					<p>Thursday August 25th, 2022 | 1:30 PM to 3:00 PM</p>
-					<p><span><strong>Location:</strong> Montreal</span> <strong>Language</strong>: French</p>
-				</li>
-				<li data-wb-tags="language__english location__vancouver dayOTW_thursday">
-					<h3>Doing Business with the Government of Canada</h3>
-					<p>Thursday August 25th, 2022 | 2:00 PM to 3:30 PM</p>
-					<p><span><strong>Location:</strong> Vancouver</span> <strong>Language</strong>: English</p>
-				</li>
-				<li data-wb-tags="language__english location__online dayOTW_friday">
-					<h3>Ask PAC Anything!</h3>
-					<p>Friday August 26th, 2022 | 12:00 PM to 1:30 PM</p>
-					<p><span><strong>Location:</strong> Online</span> <strong>Language</strong>: English</p>
-				</li>
-				<li data-wb-tags="language__english location__toronto dayOTW_tuesday">
-					<h3>Mythbusting Federal Government Procurement and Overview of Innovation for Defence, Excellence and rity (IDEaS) </h3>
-					<p>Tuesday August 30th, 2022 | 10:00 AM to 11:00 AM</p>
-					<p><span><strong>Location:</strong> Toronto</span> <strong>Language</strong>: English</p>
-				</li>
-				<li data-wb-tags="language__french location__montreal dayOTW_tuesday">
-					<h3>Register as supplier and find opportunities on BuyAndSell.gc.ca</h3>
-					<p>Tuesday August 30th, 2022 | 1:30 PM to 3:00 PM</p>
-					<p><span><strong>Location:</strong> Montreal</span> <strong>Language</strong>: French</p>
-				</li>
-				<li data-wb-tags="language__english location__toronto dayOTW_wednesday">
-					<h3>Federal Procurement Virtual Drop-in Café</h3>
-					<p>Wednesday August 31th, 2022 | 3:00 PM to 4:00 PM</p>
-					<p><span><strong>Location:</strong> Toronto</span> <strong>Language</strong>: English</p>
-				</li>
+			<ul class="list-unstyled events-list wb-tagfilter-items" data-wb-json='{
+				"url": "data_en.json#/events",
+				"mapping": [
+					{ "selector": "li", "attr": "data-wb-tags", "value": "/tags" },
+					{ "selector": "h3", "value": "/title" },
+					{ "selector": ".event-date", "value": "/date" },
+					{ "selector": ".event-time", "value": "/time" },
+					{ "selector": ".event-location", "value": "/location" },
+					{ "selector": ".event-language", "value": "/language" }
+				]
+			}'>
+				<template>
+					<li data-wb-tags="">
+						<h3></h3>
+						<p><span class="event-date"></span> | <span class="event-time"></span></p>
+						<p><strong>Location:</strong> <span class="event-location"></span>, <strong>Language</strong>: <span class="event-language"></span></p>
+					</li>
+				</template>
 			</ul>
 		</div>
 	</div>
@@ -265,77 +212,24 @@
 			&lt;/details>
 		&lt;/div>
 		&lt;div class="col-xs-12 col-sm-8 col-lg-9">
-			&lt;ul class="list-unstyled events-list wb-tagfilter-items">
-				&lt;li data-wb-tags="language__english language__french location__online dayOTW_friday">
-					&lt;h3>Ask PAC Anything!&lt;/h3>
-					&lt;p>Friday August 5th, 2022 | 12:00 PM to 1:00 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Online&lt;/span> &lt;strong>Language&lt;/strong>: English, French&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__english location__vancouver dayOTW_wednesday">
-					&lt;h3>Bidding on Opportunities&lt;/h3>
-					&lt;p>Wednesday August 10th, 2022 | 2:00 PM to 3:30 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Vancouver&lt;/span> &lt;strong>Language&lt;/strong>: English&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__english location__ottawa dayOTW_thursday">
-					&lt;h3>Doing business with the Government of Canada (Webinar)&lt;/h3>
-					&lt;p>Thursday August 11th, 2022 | 12:00 PM to 2:00 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Ottawa&lt;/span> &lt;strong>Language&lt;/strong>: English&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__english location__online dayOTW_friday">
-					&lt;h3>Ask PAC Anything!&lt;/h3>
-					&lt;p>Friday August 12th, 2022 | 12:00 PM to 1:00 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Online&lt;/span> &lt;strong>Language&lt;/strong>: English&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__english location__ottawa dayOTW_thursday">
-					&lt;h3>Bidding on opportunities (Webinar)&lt;/h3>
-					&lt;p>Thursday August 18th, 2022 | 12:00 PM to 2:00 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Ottawa&lt;/span> &lt;strong>Language&lt;/strong>: English&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__english location__online dayOTW_friday">
-					&lt;h3>Ask PAC Anything!&lt;/h3>
-					&lt;p>Friday August 19th, 2022 | 12:00 PM to 1:00 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Online&lt;/span> &lt;strong>Language&lt;/strong>: English&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__french location__ottawa dayOTW_thursday">
-					&lt;h3>Workshop to register in the Supplier Registration Information (SRI) system and in the Indigusiness Directory (IBD) for Indigenous-led businesses&lt;/a>&lt;/h3>
-					&lt;p>Thursday August 25th, 2022 | 9:30 AM to 11:00 AM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Ottawa&lt;/span> &lt;strong>Language&lt;/strong>: French&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__english location__ottawa location__montreal dayOTW_thursday">
-					&lt;h3>Workshop to register in the Supplier Registration Information (SRI) system and in the Indigusiness Directory (IBD) for Indigenous-led businesses&lt;/a>&lt;/h3>
-					&lt;p>Thursday August 25th, 2022 | 1:00 PM to 2:30 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Ottawa and Montreal&lt;/span> &lt;strong>Language&lt;/strong>: English&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__french location__montreal dayOTW_thursday">
-					&lt;h3>Doing Business with the Government of Canada&lt;/h3>
-					&lt;p>Thursday August 25th, 2022 | 1:30 PM to 3:00 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Montreal&lt;/span> &lt;strong>Language&lt;/strong>: French&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__english location__vancouver dayOTW_thursday">
-					&lt;h3>Doing Business with the Government of Canada&lt;/h3>
-					&lt;p>Thursday August 25th, 2022 | 2:00 PM to 3:30 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Vancouver&lt;/span> &lt;strong>Language&lt;/strong>: English&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__english location__online dayOTW_friday">
-					&lt;h3>Ask PAC Anything!&lt;/h3>
-					&lt;p>Friday August 26th, 2022 | 12:00 PM to 1:30 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Online&lt;/span> &lt;strong>Language&lt;/strong>: English&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__english location__toronto dayOTW_tuesday">
-					&lt;h3>Mythbusting Federal Government Procurement and Overview of Innovation for Defence, Excellencecurity (IDEaS)&lt;/a> &lt;/h3>
-					&lt;p>Tuesday August 30th, 2022 | 10:00 AM to 11:00 AM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Toronto&lt;/span> &lt;strong>Language&lt;/strong>: English&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__french location__montreal dayOTW_tuesday">
-					&lt;h3>Register as supplier and find opportunities on BuyAndSell.gc.ca&lt;/h3>
-					&lt;p>Tuesday August 30th, 2022 | 1:30 PM to 3:00 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Montreal&lt;/span> &lt;strong>Language&lt;/strong>: French&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="language__english location__toronto dayOTW_wednesday">
-					&lt;h3>Federal Procurement Virtual Drop-in Café&lt;/h3>
-					&lt;p>Wednesday August 31th, 2022 | 3:00 PM to 4:00 PM&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Location:&lt;/strong> Toronto&lt;/span> &lt;strong>Language&lt;/strong>: English&lt;/p>
-				&lt;/li>
+			&lt;ul class="list-unstyled events-list wb-tagfilter-items" data-wb-json='{
+				"url": "data_en.json#/events",
+				"mapping": [
+					{ "selector": "li", "attr": "data-wb-tags", "value": "/tags" },
+					{ "selector": "h3", "value": "/title" },
+					{ "selector": ".event-date", "value": "/date" },
+					{ "selector": ".event-time", "value": "/time" },
+					{ "selector": ".event-location", "value": "/location" },
+					{ "selector": ".event-language", "value": "/language" }
+				]
+			}'>
+				&lt;template>
+					&lt;li data-wb-tags="">
+						&lt;h3>&lt;/h3>
+						&lt;p>&lt;span class="event-date">&lt;/span> | &lt;span class="event-time">&lt;/span>&lt;/p>
+						&lt;p>&lt;strong>Location:&lt;/strong> &lt;span class="event-location">&lt;/span>, &lt;strong>Language&lt;/strong>: &lt;span class="event-language">&lt;/span>&lt;/p>
+					&lt;/li>
+				&lt;/template>
 			&lt;/ul>
 		&lt;/div>
 	&lt;/div>

--- a/src/plugins/tagfilter/tagfilter-fr.hbs
+++ b/src/plugins/tagfilter/tagfilter-fr.hbs
@@ -47,12 +47,12 @@
 							</li>
 							<li class="radio">
 								<label>
-									<input type="radio" name="langue" class="wb-tagfilter-ctrl" value="langue__francais"> Français
+									<input type="radio" name="langue" class="wb-tagfilter-ctrl" value="language__french"> Français
 								</label>
 							</li>
 							<li class="radio">
 								<label>
-									<input type="radio" name="langue" class="wb-tagfilter-ctrl" value="langue__anglais"> Anglais
+									<input type="radio" name="langue" class="wb-tagfilter-ctrl" value="language__english"> Anglais
 								</label>
 							</li>
 						</ul>
@@ -68,8 +68,8 @@
 								</label>
 							</li>
 							<li class="checkbox">
-								<label for="location__enline">
-									<input type="checkbox" name="location" id="location__enline" class="wb-tagfilter-ctrl" value="location__enline"> En ligne
+								<label for="location__online">
+									<input type="checkbox" name="location" id="location__online" class="wb-tagfilter-ctrl" value="location__online"> En ligne
 								</label>
 							</li>
 							<li class="checkbox">
@@ -94,89 +94,36 @@
 					<label for="jourListe">Jour de la semaine</label>
 					<select id="jourListe" name="jour" class="form-control full-width wb-tagfilter-ctrl">
 						<option value="">Tous</option>
-						<option value="jour_lundi">Lundi</option>
-						<option value="jour_mardi">Mardi</option>
-						<option value="jour_mercredi">Mercredi</option>
-						<option value="jour_jeudi">Jeudi</option>
-						<option value="jour_vendredi">Vendredi</option>
-						<option value="jour_samedi">Samedi</option>
-						<option value="jour_dimanche">Dimanche</option>
+						<option value="dayOTW_monday">Lundi</option>
+						<option value="dayOTW_tuesday">Mardi</option>
+						<option value="dayOTW_wednesday">Mercredi</option>
+						<option value="dayOTW_thursday">Jeudi</option>
+						<option value="dayOTW_friday">Vendredi</option>
+						<option value="dayOTW_saturday">Samedi</option>
+						<option value="dayOTW_sunday">Dimanche</option>
 					</select>
 				</div>
 			</details>
 		</div>
 		<div class="col-xs-12 col-sm-8 col-lg-9">
-			<ul class="list-unstyled events-list wb-tagfilter-items">
-				<li data-wb-tags="langue__anglais langue__francais location__enline jour_vendredi">
-					<h3>Ask PAC Anything!</h3>
-					<p>Vendredi le 5 août 2022 | 12h à 13h</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> En ligne</span> <strong>Langue</strong>: Anglais, Français</p>
-				</li>
-				<li data-wb-tags="langue__anglais location__vancouver jour_mercredi">
-					<h3>Bidding on Opportunities</h3>
-					<p>Mercredi le 10 août 2022 | 14h à 15h30</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> Vancouver</span> <strong>Langue</strong>: Anglais</p>
-				</li>
-				<li data-wb-tags="langue__anglais location__ottawa jour_jeudi">
-					<h3>Doing business with the Government of Canada (Webinar)</h3>
-					<p>Jeudi le 11 août 2022 | 12h à 14h</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> Ottawa</span> <strong>Langue</strong>: Anglais</p>
-				</li>
-				<li data-wb-tags="langue__anglais location__enline jour_vendredi">
-					<h3>Ask PAC Anything!</h3>
-					<p>Vendredi le 12 août 2022 | 12h à 13h</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> En ligne</span> <strong>Langue</strong>: Anglais</p>
-				</li>
-				<li data-wb-tags="langue__anglais location__ottawa jour_jeudi">
-					<h3>Bidding on opportunities (Webinar)</h3>
-					<p>Jeudi le 18 août 2022 | 12h à 14h</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> Ottawa</span> <strong>Langue</strong>: Anglais</p>
-				</li>
-				<li data-wb-tags="langue__anglais location__enline jour_vendredi">
-					<h3>Ask PAC Anything!</h3>
-					<p>Vendredi le 19 août 2022 | 12h à 13h</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> En ligne</span> <strong>Langue</strong>: Anglais</p>
-				</li>
-				<li data-wb-tags="langue__francais location__ottawa jour_jeudi">
-					<h3>Workshop to register in the Supplier Registration Information (SRI) system and in the Indigenous ness Directory (IBD) for Indigenous-led businesses</h3>
-					<p>Jeudi le 25 août 2022 | 9h30 à 11h</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> Ottawa</span> <strong>Langue</strong>: Français</p>
-				</li>
-				<li data-wb-tags="langue__anglais location__ottawa location__montreal jour_jeudi">
-					<h3>Workshop to register in the Supplier Registration Information (SRI) system and in the Indigenous ness Directory (IBD) for Indigenous-led businesses</h3>
-					<p>Jeudi le 25 août 2022 | 13h à 14h30</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> Ottawa et Montréal</span> <strong>Langue</strong>: Anglais</p>
-				</li>
-				<li data-wb-tags="langue__francais location__montreal jour_jeudi">
-					<h3>Doing Business with the Government of Canada</h3>
-					<p>Jeudi le 25 août 2022 | 13h30 à 15h</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> Montréal</span> <strong>Langue</strong>: Français</p>
-				</li>
-				<li data-wb-tags="langue__anglais location__vancouver jour_jeudi">
-					<h3>Doing Business with the Government of Canada</h3>
-					<p>Jeudi le 25 août 2022 | 14h à 15h30</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> Vancouver</span> <strong>Langue</strong>: Anglais</p>
-				</li>
-				<li data-wb-tags="langue__anglais location__enline jour_vendredi">
-					<h3>Ask PAC Anything!</h3>
-					<p>Vendredi le 26 août 2022 | 12h à 13h30</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> En ligne</span> <strong>Langue</strong>: Anglais</p>
-				</li>
-				<li data-wb-tags="langue__anglais location__toronto jour_mardi">
-					<h3>Mythbusting Federal Government Procurement and Overview of Innovation for Defence, Excellence and rity (IDEaS)</h3>
-					<p>Mardi le 30 août 2022 | 10h à 11h</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> Toronto</span> <strong>Langue</strong>: Anglais</p>
-				</li>
-				<li data-wb-tags="langue__francais location__montreal jour_mardi">
-					<h3>Register as supplier and find opportunities on BuyAndSell.gc.ca</h3>
-					<p>Mardi le 30 août 2022 | 13h30 à 15h</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> Montréal</span> <strong>Langue</strong>: Français</p>
-				</li>
-				<li data-wb-tags="langue__anglais location__toronto jour_mercredi">
-					<h3>Federal Procurement Virtual Drop-in Café</h3>
-					<p>Mercredi le 31 août 2022 | 15h à 16h</p>
-					<p><span><strong>Emplacement&nbsp;:</strong> Toronto</span> <strong>Langue</strong>: Anglais</p>
-				</li>
+			<ul class="list-unstyled events-list wb-tagfilter-items" data-wb-json='{
+				"url": "data_fr.json#/events",
+				"mapping": [
+					{ "selector": "li", "attr": "data-wb-tags", "value": "/tags" },
+					{ "selector": "h3", "value": "/title" },
+					{ "selector": ".event-date", "value": "/date" },
+					{ "selector": ".event-time", "value": "/time" },
+					{ "selector": ".event-location", "value": "/location" },
+					{ "selector": ".event-language", "value": "/language" }
+				]
+			}'>
+				<template>
+					<li data-wb-tags="">
+						<h3></h3>
+						<p><span class="event-date"></span> | <span class="event-time"></span></p>
+						<p><strong>Emplacement:</strong> <span class="event-location"></span>, <strong>Langue</strong>: <span class="event-language"></span></p>
+					</li>
+				</template>
 			</ul>
 		</div>
 	</div>
@@ -203,12 +150,12 @@
 							&lt;/li>
 							&lt;li class="radio">
 								&lt;label>
-									&lt;input type="radio" name="langue" class="wb-tagfilter-ctrl" value="langue__francais"> Français
+									&lt;input type="radio" name="langue" class="wb-tagfilter-ctrl" value="language__french"> Français
 								&lt;/label>
 							&lt;/li>
 							&lt;li class="radio">
 								&lt;label>
-									&lt;input type="radio" name="langue" class="wb-tagfilter-ctrl" value="langue__anglais"> Anglais
+									&lt;input type="radio" name="langue" class="wb-tagfilter-ctrl" value="language__english"> Anglais
 								&lt;/label>
 							&lt;/li>
 						&lt;/ul>
@@ -224,8 +171,8 @@
 								&lt;/label>
 							&lt;/li>
 							&lt;li class="checkbox">
-								&lt;label for="location__enline">
-									&lt;input type="checkbox" name="location" id="location__enline" class="wb-tagfilter-ctrl" value="location__enline"> En ligne
+								&lt;label for="location__online">
+									&lt;input type="checkbox" name="location" id="location__online" class="wb-tagfilter-ctrl" value="location__online"> En ligne
 								&lt;/label>
 							&lt;/li>
 							&lt;li class="checkbox">
@@ -250,89 +197,36 @@
 					&lt;label for="jourListe">Jour de la semaine&lt;/label>
 					&lt;select id="jourListe" name="jour" class="form-control full-width wb-tagfilter-ctrl">
 						&lt;option value="">Tous&lt;/option>
-						&lt;option value="jour_lundi">Lundi&lt;/option>
-						&lt;option value="jour_mardi">Mardi&lt;/option>
-						&lt;option value="jour_mercredi">Mercredi&lt;/option>
-						&lt;option value="jour_jeudi">Jeudi&lt;/option>
-						&lt;option value="jour_vendredi">Vendredi&lt;/option>
-						&lt;option value="jour_samedi">Samedi&lt;/option>
-						&lt;option value="jour_dimanche">Dimanche&lt;/option>
+						&lt;option value="dayOTW_monday">Lundi&lt;/option>
+						&lt;option value="dayOTW_tuesday">Mardi&lt;/option>
+						&lt;option value="dayOTW_wednesday">Mercredi&lt;/option>
+						&lt;option value="dayOTW_thursday">Jeudi&lt;/option>
+						&lt;option value="dayOTW_friday">Vendredi&lt;/option>
+						&lt;option value="dayOTW_saturday">Samedi&lt;/option>
+						&lt;option value="dayOTW_sunday">Dimanche&lt;/option>
 					&lt;/select>
 				&lt;/div>
 			&lt;/details>
 		&lt;/div>
 		&lt;div class="col-xs-12 col-sm-8 col-lg-9">
-			&lt;ul class="list-unstyled events-list wb-tagfilter-items">
-				&lt;li data-wb-tags="langue__anglais langue__francais location__enline jour_vendredi">
-					&lt;h3>Ask PAC Anything!&lt;/h3>
-					&lt;p>Vendredi le 5 août 2022 | 12h à 13h&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> En ligne&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais, Français&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__anglais location__vancouver jour_mercredi">
-					&lt;h3>Bidding on Opportunities&lt;/h3>
-					&lt;p>Mercredi le 10 août 2022 | 14h à 15h30&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> Vancouver&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__anglais location__ottawa jour_jeudi">
-					&lt;h3>Doing business with the Government of Canada (Webinar)&lt;/h3>
-					&lt;p>Jeudi le 11 août 2022 | 12h à 14h&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> Ottawa&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__anglais location__enline jour_vendredi">
-					&lt;h3>Ask PAC Anything!&lt;/h3>
-					&lt;p>Vendredi le 12 août 2022 | 12h à 13h&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> En ligne&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__anglais location__ottawa jour_jeudi">
-					&lt;h3>Bidding on opportunities (Webinar)&lt;/h3>
-					&lt;p>Jeudi le 18 août 2022 | 12h à 14h&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> Ottawa&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__anglais location__enline jour_vendredi">
-					&lt;h3>Ask PAC Anything!&lt;/h3>
-					&lt;p>Vendredi le 19 août 2022 | 12h à 13h&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> En ligne&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__francais location__ottawa jour_jeudi">
-					&lt;h3>Workshop to register in the Supplier Registration Information (SRI) system and in the Indigenous ness Directory (IBD) for Indigenous-led businesses&lt;/a>&lt;/h3>
-					&lt;p>Jeudi le 25 août 2022 | 9h30 à 11h&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> Ottawa&lt;/span> &lt;strong>Langue&lt;/strong>: Français&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__anglais location__ottawa location__montreal jour_jeudi">
-					&lt;h3>Workshop to register in the Supplier Registration Information (SRI) system and in the Indigenous ness Directory (IBD) for Indigenous-led businesses&lt;/a>&lt;/h3>
-					&lt;p>Jeudi le 25 août 2022 | 13h à 14h30&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> Ottawa et Montréal&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__francais location__montreal jour_jeudi">
-					&lt;h3>Doing Business with the Government of Canada&lt;/h3>
-					&lt;p>Jeudi le 25 août 2022 | 13h30 à 15h&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> Montréal&lt;/span> &lt;strong>Langue&lt;/strong>: Français&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__anglais location__vancouver jour_jeudi">
-					&lt;h3>Doing Business with the Government of Canada&lt;/h3>
-					&lt;p>Jeudi le 25 août 2022 | 14h à 15h30&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> Vancouver&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__anglais location__enline jour_vendredi">
-					&lt;h3>Ask PAC Anything!&lt;/h3>
-					&lt;p>Vendredi le 26 août 2022 | 12h à 13h30&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> En ligne&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__anglais location__toronto jour_mardi">
-					&lt;h3>Mythbusting Federal Government Procurement and Overview of Innovation for Defence, Excellence and rity (IDEaS)&lt;/a> &lt;/h3>
-					&lt;p>Mardi le 30 août 2022 | 10h à 11h&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> Toronto&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__francais location__montreal jour_mardi">
-					&lt;h3>Register as supplier and find opportunities on BuyAndSell.gc.ca&lt;/h3>
-					&lt;p>Mardi le 30 août 2022 | 13h30 à 15h&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> Montréal&lt;/span> &lt;strong>Langue&lt;/strong>: Français&lt;/p>
-				&lt;/li>
-				&lt;li data-wb-tags="langue__anglais location__toronto jour_mercredi">
-					&lt;h3>Federal Procurement Virtual Drop-in Café&lt;/h3>
-					&lt;p>Mercredi le 31 août 2022 | 15h à 16h&lt;/p>
-					&lt;p>&lt;span>&lt;strong>Emplacement&nbsp;:&lt;/strong> Toronto&lt;/span> &lt;strong>Langue&lt;/strong>: Anglais&lt;/p>
-				&lt;/li>
+			&lt;ul class="list-unstyled events-list wb-tagfilter-items" data-wb-json='{
+				"url": "data_fr.json#/events",
+				"mapping": [
+					{ "selector": "li", "attr": "data-wb-tags", "value": "/tags" },
+					{ "selector": "h3", "value": "/title" },
+					{ "selector": ".event-date", "value": "/date" },
+					{ "selector": ".event-time", "value": "/time" },
+					{ "selector": ".event-location", "value": "/location" },
+					{ "selector": ".event-language", "value": "/language" }
+				]
+			}'>
+				&lt;template>
+					&lt;li data-wb-tags="">
+						&lt;h3>&lt;/h3>
+						&lt;p>&lt;span class="event-date">&lt;/span> | &lt;span class="event-time">&lt;/span>&lt;/p>
+						&lt;p>&lt;strong>Emplacement:&lt;/strong> &lt;span class="event-location">&lt;/span>, &lt;strong>Langue&lt;/strong>: &lt;span class="event-language">&lt;/span>&lt;/p>
+					&lt;/li>
+				&lt;/template>
 			&lt;/ul>
 		&lt;/div>
 	&lt;/div>

--- a/src/plugins/tagfilter/tagfilter.js
+++ b/src/plugins/tagfilter/tagfilter.js
@@ -7,6 +7,8 @@
 ( function( $, window, document, wb ) {
 "use strict";
 
+let wait;
+
 const componentName = "wb-tagfilter",
 	selector = ".provisional." + componentName,
 	selectorCtrl = "." + componentName + "-ctrl",
@@ -30,8 +32,6 @@ const componentName = "wb-tagfilter",
 			if ( taggedItemsWrapper ) {
 				taggedItemsWrapper.id = taggedItemsWrapper.id || wb.getId(); // Ensure the element has an ID
 				taggedItemsWrapper.setAttribute( "aria-live", "polite" );
-			} else {
-				console.warn( componentName + ": You have to identify the wrapper of your tagged elements using the class 'wb-tagfilter-items'." );
 			}
 
 			// Handle filters
@@ -41,15 +41,11 @@ const componentName = "wb-tagfilter",
 				filterControls.forEach( function( item ) {
 					item.setAttribute( "aria-controls", taggedItemsWrapper.id );
 				} );
-			} else {
-				console.warn( componentName + ": You have no defined filter." );
 			}
 
 			// Handle tagged items
 			if ( taggedItems.length ) {
 				elm.items = buildTaggedItemsArr( taggedItems );
-			} else {
-				console.warn( componentName + ": You have no tagged items. Please add tags using the 'data-wb-tags' attribute." );
 			}
 
 			// Update list of visible items (in case of predefined filters)
@@ -256,6 +252,20 @@ $document.on( "change", selectorCtrl, function( event )  {
 
 	// Update list of visible items
 	update( $elm );
+} );
+
+// Reinitialize tagfilter if content on the page has been updated
+$document.on( "wb-contentupdated", selector, function() {
+	let that = this;
+
+	if ( wait ) {
+		clearTimeout( wait );
+	}
+
+	wait = setTimeout( function() {
+		that.classList.remove( "wb-init", componentName + "-inited" );
+		$( that ).trigger( "wb-init." + componentName );
+	}, 100 );
 } );
 
 $document.on( "timerpoke.wb " + initEvent, selector, init );


### PR DESCRIPTION
Adding feature to reinitialize Tagfilter plugin when content on the page has been added through data-json.

Also removing warning messages as it might happen that the items or filters are added through data-json.