### PR TITLE
Tagfilter: Fixing issues with paginate and no result with data-json

### DIFF
--- a/src/plugins/tagfilter/_base.scss
+++ b/src/plugins/tagfilter/_base.scss
@@ -15,3 +15,8 @@
 .wb-tagfilter-items:has(+ .wb-tagfilter-noresult):not(:has([data-wb-tags]:not(.wb-tgfltr-out, .wb-fltr-out))) {
 	display: none;
 }
+
+// Hide no result element when no tagged items are defined
+html:not(.wb-disable) .wb-tagfilter-items:not(:has([data-wb-tags])) + .wb-tagfilter-noresult {
+	display: none !important;
+}

--- a/src/plugins/tagfilter/tagfilter-edge-cases-en.hbs
+++ b/src/plugins/tagfilter/tagfilter-edge-cases-en.hbs
@@ -1,0 +1,241 @@
+---
+{
+"title": "Tag filter edge cases",
+"language": "en",
+"description": "List of Tagfilter edge cases",
+"tag": "filter",
+"parentdir": "tagfilter",
+"altLangPrefix": "tagfilter-edge-cases",
+"dateModified": "2023-07-10"
+}
+---
+
+<span class="wb-prettify all-pre"></span>
+
+<h2>On this page:</h2>
+<ul>
+	<li><a href="#filteredEventsList">Example 1 - Events list with pagination and data-json</a></li>
+</ul>
+
+<section id="filteredEventsList" class="wb-tagfilter wb-paginate provisional" data-wb-paginate='{
+	"itemsPerPage": 5,
+	"section": ".events-list",
+	"selector": "li",
+	"uiTarget": "#filteredEventsListPagination"
+}'>
+	<h2>Example 1 - Events list</h2>
+	<div class="row">
+		<div class="col-xs-12 col-sm-4 col-lg-3">
+			<details open>
+				<summary>
+					<h3>Filter options</h3>
+				</summary>
+				<div class="form-group mrgn-bttm-0">
+					<fieldset>
+						<legend class="h5 mrgn-tp-0"><span class="field-name">Language</span></legend>
+						<ul class="list-unstyled">
+							<li class="radio">
+								<label>
+									<input type="radio" name="language" class="wb-tagfilter-ctrl" value="" checked> All
+								</label>
+							</li>
+							<li class="radio">
+								<label>
+									<input type="radio" name="language" class="wb-tagfilter-ctrl" value="language__french"> French
+								</label>
+							</li>
+							<li class="radio">
+								<label>
+									<input type="radio" name="language" class="wb-tagfilter-ctrl" value="language__english"> English
+								</label>
+							</li>
+						</ul>
+					</fieldset>
+				</div>
+				<div class="form-group mrgn-bttm-0">
+					<fieldset>
+						<legend class="h5 mrgn-tp-0"><span class="field-name">Event location</span></legend>
+						<ul class="list-unstyled">
+							<li class="checkbox">
+								<label>
+									<input type="checkbox" name="location" class="wb-tagfilter-ctrl" value="location__montreal"> Montreal
+								</label>
+							</li>
+							<li class="checkbox">
+								<label>
+									<input type="checkbox" name="location" class="wb-tagfilter-ctrl" value="location__online"> Online
+								</label>
+							</li>
+							<li class="checkbox">
+								<label>
+									<input type="checkbox" name="location" class="wb-tagfilter-ctrl" value="location__ottawa"> Ottawa
+								</label>
+							</li>
+							<li class="checkbox">
+								<label>
+									<input type="checkbox" name="location" class="wb-tagfilter-ctrl" value="location__toronto"> Toronto
+								</label>
+							</li>
+							<li class="checkbox">
+								<label>
+									<input type="checkbox" name="location" class="wb-tagfilter-ctrl" value="location__vancouver"> Vancouver
+								</label>
+							</li>
+						</ul>
+					</fieldset>
+				</div>
+				<div class="form-group mrgn-bttm-0">
+					<label for="dayList">Day of the week</label>
+					<select id="dayList" name="dayOTW" class="form-control full-width wb-tagfilter-ctrl">
+						<option value="">All</option>
+						<option value="dayOTW_monday">Monday</option>
+						<option value="dayOTW_tuesday">Tuesday</option>
+						<option value="dayOTW_wednesday">Wednedsday</option>
+						<option value="dayOTW_thursday">Thursday</option>
+						<option value="dayOTW_friday">Friday</option>
+						<option value="dayOTW_saturday">Saturday</option>
+						<option value="dayOTW_sunday">Sunday</option>
+					</select>
+				</div>
+			</details>
+		</div>
+		<div class="col-xs-12 col-sm-8 col-lg-9">
+			<ul class="list-unstyled events-list wb-tagfilter-items" data-wb-json='{
+				"url": "data_en.json#/events",
+				"mapping": [
+					{ "selector": "li", "attr": "data-wb-tags", "value": "/tags" },
+					{ "selector": "h3", "value": "/title" },
+					{ "selector": ".event-date", "value": "/date" },
+					{ "selector": ".event-time", "value": "/time" },
+					{ "selector": ".event-location", "value": "/location" },
+					{ "selector": ".event-language", "value": "/language" }
+				]
+			}'>
+				<template>
+					<li data-wb-tags="">
+						<h3></h3>
+						<p><span class="event-date"></span> | <span class="event-time"></span></p>
+						<p><strong>Location:</strong> <span class="event-location"></span>, <strong>Language</strong>: <span class="event-language"></span></p>
+					</li>
+				</template>
+			</ul>
+			<div class="wb-tagfilter-noresult">
+				<p>No item match this combination of filters.</p>
+			</div>
+			<div id="filteredEventsListPagination"></div>
+		</div>
+	</div>
+</section>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;section id="filteredEventsList" class="wb-tagfilter wb-paginate provisional" data-wb-paginate='{
+	"itemsPerPage": 5,
+	"section": ".events-list",
+	"selector": "li",
+	"uiTarget": "#filteredEventsListPagination"
+}'>
+	&lt;h2>Example 1 - Events list&lt;/h2>
+	&lt;div class="row">
+		&lt;div class="col-xs-12 col-sm-4 col-lg-3">
+			&lt;details open>
+				&lt;summary>
+					&lt;h3>Filter options&lt;/h3>
+				&lt;/summary>
+				&lt;div class="form-group mrgn-bttm-0">
+					&lt;fieldset>
+						&lt;legend class="h5 mrgn-tp-0">&lt;span class="field-name">Language&lt;/span>&lt;/legend>
+						&lt;ul class="list-unstyled">
+							&lt;li class="radio">
+								&lt;label>
+									&lt;input type="radio" name="language" class="wb-tagfilter-ctrl" value="" checked> All
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="radio">
+								&lt;label>
+									&lt;input type="radio" name="language" class="wb-tagfilter-ctrl" value="language__french"> French
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="radio">
+								&lt;label>
+									&lt;input type="radio" name="language" class="wb-tagfilter-ctrl" value="language__english"> English
+								&lt;/label>
+							&lt;/li>
+						&lt;/ul>
+					&lt;/fieldset>
+				&lt;/div>
+				&lt;div class="form-group mrgn-bttm-0">
+					&lt;fieldset>
+						&lt;legend class="h5 mrgn-tp-0">&lt;span class="field-name">Event location&lt;/span>&lt;/legend>
+						&lt;ul class="list-unstyled">
+							&lt;li class="checkbox">
+								&lt;label>
+									&lt;input type="checkbox" name="location" class="wb-tagfilter-ctrl" value="location__montreal"> Montreal
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="checkbox">
+								&lt;label>
+									&lt;input type="checkbox" name="location" class="wb-tagfilter-ctrl" value="location__online"> Online
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="checkbox">
+								&lt;label>
+									&lt;input type="checkbox" name="location" class="wb-tagfilter-ctrl" value="location__ottawa"> Ottawa
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="checkbox">
+								&lt;label>
+									&lt;input type="checkbox" name="location" class="wb-tagfilter-ctrl" value="location__toronto"> Toronto
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="checkbox">
+								&lt;label>
+									&lt;input type="checkbox" name="location" class="wb-tagfilter-ctrl" value="location__vancouver"> Vancouver
+								&lt;/label>
+							&lt;/li>
+						&lt;/ul>
+					&lt;/fieldset>
+				&lt;/div>
+				&lt;div class="form-group mrgn-bttm-0">
+					&lt;label for="dayList">Day of the week&lt;/label>
+					&lt;select id="dayList" name="dayOTW" class="form-control full-width wb-tagfilter-ctrl">
+						&lt;option value="">All&lt;/option>
+						&lt;option value="dayOTW_monday">Monday&lt;/option>
+						&lt;option value="dayOTW_tuesday">Tuesday&lt;/option>
+						&lt;option value="dayOTW_wednesday">Wednedsday&lt;/option>
+						&lt;option value="dayOTW_thursday">Thursday&lt;/option>
+						&lt;option value="dayOTW_friday">Friday&lt;/option>
+						&lt;option value="dayOTW_saturday">Saturday&lt;/option>
+						&lt;option value="dayOTW_sunday">Sunday&lt;/option>
+					&lt;/select>
+				&lt;/div>
+			&lt;/details>
+		&lt;/div>
+		&lt;div class="col-xs-12 col-sm-8 col-lg-9">
+			&lt;ul class="list-unstyled events-list wb-tagfilter-items" data-wb-json='{
+				"url": "data_en.json#/events",
+				"mapping": [
+					{ "selector": "li", "attr": "data-wb-tags", "value": "/tags" },
+					{ "selector": "h3", "value": "/title" },
+					{ "selector": ".event-date", "value": "/date" },
+					{ "selector": ".event-time", "value": "/time" },
+					{ "selector": ".event-location", "value": "/location" },
+					{ "selector": ".event-language", "value": "/language" }
+				]
+			}'>
+				&lt;template>
+					&lt;li data-wb-tags="">
+						&lt;h3>&lt;/h3>
+						&lt;p>&lt;span class="event-date">&lt;/span> | &lt;span class="event-time">&lt;/span>&lt;/p>
+						&lt;p>&lt;strong>Location:&lt;/strong> &lt;span class="event-location">&lt;/span>, &lt;strong>Language&lt;/strong>: &lt;span class="event-language">&lt;/span>&lt;/p>
+					&lt;/li>
+				&lt;/template>
+			&lt;/ul>
+			&lt;div class="wb-tagfilter-noresult">
+				&lt;p>No item match this combination of filters.&lt;/p>
+			&lt;/div>
+			&lt;div id="filteredEventsListPagination">&lt;/div>
+		&lt;/div>
+	&lt;/div>
+&lt;/section></code></pre>
+</details>

--- a/src/plugins/tagfilter/tagfilter-edge-cases-fr.hbs
+++ b/src/plugins/tagfilter/tagfilter-edge-cases-fr.hbs
@@ -1,0 +1,241 @@
+---
+{
+"title": "Cas particuliers de filtre de balise",
+"language": "fr",
+"description": "Liste de cas particuliers de filtre de balise",
+"tag": "filter",
+"parentdir": "tagfilter",
+"altLangPrefix": "tagfilter-edge-cases",
+"dateModified": "2023-07-10"
+}
+---
+
+<span class="wb-prettify all-pre"></span>
+
+<h2>Sur cette page:</h2>
+<ul>
+	<li><a href="#filteredEventsList">Exemple 1 - liste d'événements avec pagination et data-json</a></li>
+</ul>
+
+<section id="filteredEventsList" class="wb-tagfilter wb-paginate provisional" data-wb-paginate='{
+	"itemsPerPage": 5,
+	"section": ".events-list",
+	"selector": "li",
+	"uiTarget": "#filteredEventsListPagination"
+}'>
+	<h2>Exemple 1 - Liste d'événements</h2>
+	<div class="row">
+		<div class="col-xs-12 col-sm-4 col-lg-3">
+			<details open>
+				<summary>
+					<h3>Options de filtre</h3>
+				</summary>
+				<div class="form-group mrgn-bttm-0">
+					<fieldset>
+						<legend class="h5 mrgn-tp-0"><span class="field-name">Langue</span></legend>
+						<ul class="list-unstyled">
+							<li class="radio">
+								<label>
+									<input type="radio" name="langue" class="wb-tagfilter-ctrl" value="" checked> Toutes
+								</label>
+							</li>
+							<li class="radio">
+								<label>
+									<input type="radio" name="langue" class="wb-tagfilter-ctrl" value="language__french"> Français
+								</label>
+							</li>
+							<li class="radio">
+								<label>
+									<input type="radio" name="langue" class="wb-tagfilter-ctrl" value="language__english"> Anglais
+								</label>
+							</li>
+						</ul>
+					</fieldset>
+				</div>
+				<div class="form-group mrgn-bttm-0">
+					<fieldset>
+						<legend class="h5 mrgn-tp-0"><span class="field-name">Emplacement</span></legend>
+						<ul class="list-unstyled">
+							<li class="checkbox">
+								<label for="location__montreal">
+									<input type="checkbox" name="location" id="location__montreal" class="wb-tagfilter-ctrl" value="location__montreal"> Montréal
+								</label>
+							</li>
+							<li class="checkbox">
+								<label for="location__online">
+									<input type="checkbox" name="location" id="location__online" class="wb-tagfilter-ctrl" value="location__online"> En ligne
+								</label>
+							</li>
+							<li class="checkbox">
+								<label for="location__ottawa">
+									<input type="checkbox" name="location" id="location__ottawa" class="wb-tagfilter-ctrl" value="location__ottawa"> Ottawa
+								</label>
+							</li>
+							<li class="checkbox">
+								<label for="location__toronto">
+									<input type="checkbox" name="location" id="location__toronto" class="wb-tagfilter-ctrl" value="location__toronto"> Toronto
+								</label>
+							</li>
+							<li class="checkbox">
+								<label for="location__vancouver">
+									<input type="checkbox" name="location" id="location__vancouver" class="wb-tagfilter-ctrl" value="location__vancouver"> Vancouver
+								</label>
+							</li>
+						</ul>
+					</fieldset>
+				</div>
+				<div class="form-group mrgn-bttm-0">
+					<label for="jourListe">Jour de la semaine</label>
+					<select id="jourListe" name="jour" class="form-control full-width wb-tagfilter-ctrl">
+						<option value="">Tous</option>
+						<option value="dayOTW_monday">Lundi</option>
+						<option value="dayOTW_tuesday">Mardi</option>
+						<option value="dayOTW_wednesday">Mercredi</option>
+						<option value="dayOTW_thursday">Jeudi</option>
+						<option value="dayOTW_friday">Vendredi</option>
+						<option value="dayOTW_saturday">Samedi</option>
+						<option value="dayOTW_sunday">Dimanche</option>
+					</select>
+				</div>
+			</details>
+		</div>
+		<div class="col-xs-12 col-sm-8 col-lg-9">
+			<ul class="list-unstyled events-list wb-tagfilter-items" data-wb-json='{
+				"url": "data_fr.json#/events",
+				"mapping": [
+					{ "selector": "li", "attr": "data-wb-tags", "value": "/tags" },
+					{ "selector": "h3", "value": "/title" },
+					{ "selector": ".event-date", "value": "/date" },
+					{ "selector": ".event-time", "value": "/time" },
+					{ "selector": ".event-location", "value": "/location" },
+					{ "selector": ".event-language", "value": "/language" }
+				]
+			}'>
+				<template>
+					<li data-wb-tags="">
+						<h3></h3>
+						<p><span class="event-date"></span> | <span class="event-time"></span></p>
+						<p><strong>Emplacement:</strong> <span class="event-location"></span>, <strong>Langue</strong>: <span class="event-language"></span></p>
+					</li>
+				</template>
+			</ul>
+			<div class="wb-tagfilter-noresult">
+				<p>Aucun item ne correspond à cette combinaison de filtres.</p>
+			</div>
+			<div id="filteredEventsListPagination"></div>
+		</div>
+	</div>
+</section>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;section id="filteredEventsList" class="wb-tagfilter wb-paginate provisional" data-wb-paginate='{
+	"itemsPerPage": 5,
+	"section": ".events-list",
+	"selector": "li",
+	"uiTarget": "#filteredEventsListPagination"
+}'>
+	&lt;h2>Exemple 1 - Liste d'événements&lt;/h2>
+	&lt;div class="row">
+		&lt;div class="col-xs-12 col-sm-4 col-lg-3">
+			&lt;details open>
+				&lt;summary>
+					&lt;h3>Options de filtre&lt;/h3>
+				&lt;/summary>
+				&lt;div class="form-group mrgn-bttm-0">
+					&lt;fieldset>
+						&lt;legend class="h5 mrgn-tp-0">&lt;span class="field-name">Langue&lt;/span>&lt;/legend>
+						&lt;ul class="list-unstyled">
+							&lt;li class="radio">
+								&lt;label>
+									&lt;input type="radio" name="langue" class="wb-tagfilter-ctrl" value="" checked> Toutes
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="radio">
+								&lt;label>
+									&lt;input type="radio" name="langue" class="wb-tagfilter-ctrl" value="language__french"> Français
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="radio">
+								&lt;label>
+									&lt;input type="radio" name="langue" class="wb-tagfilter-ctrl" value="language__english"> Anglais
+								&lt;/label>
+							&lt;/li>
+						&lt;/ul>
+					&lt;/fieldset>
+				&lt;/div>
+				&lt;div class="form-group mrgn-bttm-0">
+					&lt;fieldset>
+						&lt;legend class="h5 mrgn-tp-0">&lt;span class="field-name">Emplacement&lt;/span>&lt;/legend>
+						&lt;ul class="list-unstyled">
+							&lt;li class="checkbox">
+								&lt;label for="location__montreal">
+									&lt;input type="checkbox" name="location" id="location__montreal" class="wb-tagfilter-ctrl" value="location__montreal"> Montréal
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="checkbox">
+								&lt;label for="location__online">
+									&lt;input type="checkbox" name="location" id="location__online" class="wb-tagfilter-ctrl" value="location__online"> En ligne
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="checkbox">
+								&lt;label for="location__ottawa">
+									&lt;input type="checkbox" name="location" id="location__ottawa" class="wb-tagfilter-ctrl" value="location__ottawa"> Ottawa
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="checkbox">
+								&lt;label for="location__toronto">
+									&lt;input type="checkbox" name="location" id="location__toronto" class="wb-tagfilter-ctrl" value="location__toronto"> Toronto
+								&lt;/label>
+							&lt;/li>
+							&lt;li class="checkbox">
+								&lt;label for="location__vancouver">
+									&lt;input type="checkbox" name="location" id="location__vancouver" class="wb-tagfilter-ctrl" value="location__vancouver"> Vancouver
+								&lt;/label>
+							&lt;/li>
+						&lt;/ul>
+					&lt;/fieldset>
+				&lt;/div>
+				&lt;div class="form-group mrgn-bttm-0">
+					&lt;label for="jourListe">Jour de la semaine&lt;/label>
+					&lt;select id="jourListe" name="jour" class="form-control full-width wb-tagfilter-ctrl">
+						&lt;option value="">Tous&lt;/option>
+						&lt;option value="dayOTW_monday">Lundi&lt;/option>
+						&lt;option value="dayOTW_tuesday">Mardi&lt;/option>
+						&lt;option value="dayOTW_wednesday">Mercredi&lt;/option>
+						&lt;option value="dayOTW_thursday">Jeudi&lt;/option>
+						&lt;option value="dayOTW_friday">Vendredi&lt;/option>
+						&lt;option value="dayOTW_saturday">Samedi&lt;/option>
+						&lt;option value="dayOTW_sunday">Dimanche&lt;/option>
+					&lt;/select>
+				&lt;/div>
+			&lt;/details>
+		&lt;/div>
+		&lt;div class="col-xs-12 col-sm-8 col-lg-9">
+			&lt;ul class="list-unstyled events-list wb-tagfilter-items" data-wb-json='{
+				"url": "data_fr.json#/events",
+				"mapping": [
+					{ "selector": "li", "attr": "data-wb-tags", "value": "/tags" },
+					{ "selector": "h3", "value": "/title" },
+					{ "selector": ".event-date", "value": "/date" },
+					{ "selector": ".event-time", "value": "/time" },
+					{ "selector": ".event-location", "value": "/location" },
+					{ "selector": ".event-language", "value": "/language" }
+				]
+			}'>
+				&lt;template>
+					&lt;li data-wb-tags="">
+						&lt;h3>&lt;/h3>
+						&lt;p>&lt;span class="event-date">&lt;/span> | &lt;span class="event-time">&lt;/span>&lt;/p>
+						&lt;p>&lt;strong>Emplacement:&lt;/strong> &lt;span class="event-location">&lt;/span>, &lt;strong>Langue&lt;/strong>: &lt;span class="event-language">&lt;/span>&lt;/p>
+					&lt;/li>
+				&lt;/template>
+			&lt;/ul>
+			&lt;div class="wb-tagfilter-noresult">
+				&lt;p>Aucun item ne correspond à cette combinaison de filtres.&lt;/p>
+			&lt;/div>
+			&lt;div id="filteredEventsListPagination">&lt;/div>
+		&lt;/div>
+	&lt;/div>
+&lt;/section></code></pre>
+</details>

--- a/src/plugins/tagfilter/tagfilter-en.hbs
+++ b/src/plugins/tagfilter/tagfilter-en.hbs
@@ -29,6 +29,7 @@
 	<li><a href="#filteredAppsList">Example 2 - Applications list</a></li>
 	<li><a href="#filteredFAQ">Example 3 - FAQ leveraging Filter plugin</a></li>
 	<li><a href="#filteredTable">Example 4 - Table</a></li>
+	<li><a href="#edgeCases">Edge case examples</a></li>
 </ul>
 
 <section id="filteredEventsList" class="wb-tagfilter provisional">
@@ -1107,3 +1108,8 @@
 	&lt;/table>
 &lt;/section></code></pre>
 </details>
+
+<section>
+	<h2 id="edgeCases">Edge case examples</h2>
+	Here is a <a href="tagfilter-edge-cases-en.html">list of edge case examples</a>.
+</section>

--- a/src/plugins/tagfilter/tagfilter-fr.hbs
+++ b/src/plugins/tagfilter/tagfilter-fr.hbs
@@ -26,6 +26,7 @@
 	<li><a href="#filteredAppsList">Exemple 2 - liste d'applications</a></li>
 	<li><a href="#filteredFAQ">Exemple 3 - FAQ utilisant le plugiciel Filtre</a></li>
 	<li><a href="#filteredTable">Exemple 4 - tableau</a></li>
+	<li><a href="#edgeCases">Exemples de cas particuliers</a></li>
 </ul>
 
 <section id="filteredEventsList" class="wb-tagfilter provisional">
@@ -1128,3 +1129,8 @@
 	&lt;/table>
 &lt;/section></code></pre>
 </details>
+
+<section>
+	<h2 id="edgeCases">Exemples de cas particuliers</h2>
+	Voici une <a href="tagfilter-edge-cases-fr.html">liste d'exemples de cas particuliers</a>.
+</section>

--- a/src/plugins/tagfilter/tagfilter.js
+++ b/src/plugins/tagfilter/tagfilter.js
@@ -219,7 +219,7 @@ const componentName = "wb-tagfilter",
 		matchItemsToFilters( instance );
 		updateDOMItems( instance );
 
-		$( instance ).trigger( componentName + "-updated" );
+		$( instance ).trigger( "wb-contentupdated", [ { source: componentName } ] );
 	};
 
 // When a filter is updated
@@ -264,24 +264,23 @@ $document.on( "change", selectorCtrl, function( event )  {
 	update( elm );
 } );
 
-// Reinitialize tagfilter if content on the page has been updated
-$document.on( "wb-contentupdated", selector, function()  {
-	let that = this;
+$document.on( "wb-contentupdated", selector, function( event, data )  {
+	let that = this,
+		supportsHas = window.getComputedStyle( document.documentElement ).getPropertyValue( "--supports-has" ); // Get "--supports-has" CSS property
 
-	if ( wait ) {
-		clearTimeout( wait );
+	// Reinitialize tagfilter if content on the page has been updated by another plugin
+	if ( data.source !== componentName ) {
+		if ( wait ) {
+			clearTimeout( wait );
+		}
+
+		wait = setTimeout( function() {
+			that.classList.remove( "wb-init", componentName + "-inited" );
+			$( that ).trigger( "wb-init." + componentName );
+		}, 100 );
 	}
 
-	wait = setTimeout( function() {
-		that.classList.remove( "wb-init", componentName + "-inited" );
-		$( that ).trigger( "wb-init." + componentName );
-	}, 100 );
-} );
-
-// Show no result message if on Firefox -- Remove once Firefox supports ":has()"
-$document.on( componentName + "-updated", selector, function() {
-	let supportsHas = window.getComputedStyle( document.documentElement ).getPropertyValue( "--supports-has" ); // Get "--supports-has" CSS property
-
+	// Show no result message if on Firefox -- Remove once Firefox supports ":has()"
 	if ( supportsHas === "false" ) {
 		let noResultItem = this.querySelector( "." + noResultWrapperClass );
 


### PR DESCRIPTION
Issue: when having tagfilter and pagination on the same element, the pagination is not updated when items are filtered.
Solution: changing the event name to the standard name `"wb-contentupdated"` and adding data to the tagfilter event trigger only, to be able to differentiate it from other plugins.

Issue: when loading tagfilter items through `data-json`, the no result message is briefly visible on page load.
Solution: added CSS to hide the no result message when no tagged items are defined in the `.wb-tagfilter-items` element