### PR TITLE
Data-json - Fix templating with null value

### DIFF
--- a/src/plugins/wb-data-json/data-json.js
+++ b/src/plugins/wb-data-json/data-json.js
@@ -819,7 +819,7 @@ var componentName = "wb-data-json",
 		var value = getRawValue( source, pointer );
 
 		// for JSON-LD @value support
-		if ( typeof value === "object" && value[ "@value" ] ) {
+		if ( typeof value === "object" && value !== null && value[ "@value" ] ) {
 			value = value[ "@value" ];
 		}
 


### PR DESCRIPTION
I find out today the current ACR report don't work because it do contains a null value and null value are interpreted as object.

This is patch to Data-JSON plugin and the [ACR English theoretical report](https://wet-boew.github.io/wet-boew/unmin/demos/acr/demo-wcag21/acr-wcag21-en.html) can be use as the test case

