### PR TITLE
Data-ajax - Add flag to HTML encode the ajaxed content

### DIFF
--- a/site/pages/docs/ref/data-ajax/data-ajax-en.hbs
+++ b/site/pages/docs/ref/data-ajax/data-ajax-en.hbs
@@ -186,6 +186,19 @@
 				</td>
 			</tr>
 			<tr>
+				<td><code>encode</code></td>
+				<td>Flag to encode the HTML file being ajaxed in.</td>
+				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "encode": true }'</code></td>
+				<td>
+					<dl>
+						<dt>Default</dt>
+						<dd>False, the ajaxed file are not encoded</dd>
+						<dt><code>true</code></dt>
+						<dd>Will encode the characted <code>&lt;</code> into the character <code>&amp;lt;</code> which allow to show the code source of the ajaxed content.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
 				<td><code>nocache</code></td>
 				<td>Prevent caching. Prior using the functionality, use the various caching strategies that can be set and communicated through http header from your server, as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>. Also, please note that some server may not like to have an query appended to his url and you may get an HTTP error like "400 Bad Request" or "404 Not Found". Like a page served by a domino server will return 404 error if the query string do not start with "<code>?open</code>", "<code>?openDocument</code>" or "<code>?readForm</code>".</td>
 				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace", "nocache": true }'</code> or <code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace", "nocache": "nocache" }'</code>

--- a/site/pages/docs/ref/data-ajax/data-ajax-fr.hbs
+++ b/site/pages/docs/ref/data-ajax/data-ajax-fr.hbs
@@ -189,6 +189,19 @@
 				</td>
 			</tr>
 			<tr>
+				<td><code>encode</code></td>
+				<td>Flag to encode the HTML file being ajaxed in.</td>
+				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "encode": true }'</code></td>
+				<td>
+					<dl>
+						<dt>Default</dt>
+						<dd>False, the ajaxed file are not encoded</dd>
+						<dt><code>true</code></dt>
+						<dd>Will encode the characted <code>&lt;</code> into the character <code>&amp;lt;</code> which allow to show the code source of the ajaxed content.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
 				<td><code>nocache</code></td>
 				<td>Prevent caching. Prior using the functionality, use the various caching strategies that can be set and communicated through http header from your server, as defined in <a href="https://tools.ietf.org/html/rfc7234#section-5">section 5 of RFC7234</a>. Also, please note that some server may not like to have an query appended to his url and you may get an HTTP error like "400 Bad Request" or "404 Not Found". Like a page served by a domino server will return 404 error if the query string do not start with "<code>?open</code>", "<code>?openDocument</code>" or "<code>?readForm</code>".</td>
 				<td><code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace", "nocache": true }'</code> or <code>data-wb-ajax='{ "url": "location/of/ajax/fragment/file.html", "type": "replace", "nocache": "nocache" }'</code>

--- a/src/plugins/ajax-fetch/ajax-fetch.js
+++ b/src/plugins/ajax-fetch/ajax-fetch.js
@@ -84,6 +84,7 @@ $document.on( "ajax-fetch.wb", function( event ) {
 				response = $( response );
 
 				fetchData.response = response;
+				fetchData.hasSelector = !!selector;
 				fetchData.status = status;
 				fetchData.xhr = xhr;
 

--- a/src/plugins/data-ajax/data-ajax-en.hbs
+++ b/src/plugins/data-ajax/data-ajax-en.hbs
@@ -334,10 +334,11 @@
 
 			<section>
 				<h4>data-ajax-extra-en.html</h4>
-				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
-	&lt;h4&gt;I was ajaxed in&lt;/h4&gt;
-	&lt;p&gt;I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in. I was ajaxed in.&lt;/p&gt;
-&lt;/section&gt;</code></pre>
+				<pre id="encodeme"><code data-wb-ajax='{ "encode": true, "url": "ajax/data-ajax-extra-en.html", "type": "replace" }'></code></pre>
+
+				<h5>Source code of this code sample</h5>
+				<p>It demo the use of the configuration <code>encode</code></p>
+				<pre><code data-wb-ajax='{ "encode": true, "url": "data-ajax-en.html #encodeme", "type": "replace" }'></code></pre>
 			</section>
 		</details>
 </section>

--- a/src/plugins/data-ajax/data-ajax-fr.hbs
+++ b/src/plugins/data-ajax/data-ajax-fr.hbs
@@ -331,10 +331,11 @@
 
 			<section>
 				<h4>data-ajax-extra-fr.html</h4>
-				<pre><code>&lt;section class=&quot;ajaxed-in&quot;&gt;
-	&lt;h4&gt;J'ai été affiché via Ajax&lt;/h4&gt;
-	&lt;p&gt;J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax. J'ai été affiché via Ajax.&lt;/p&gt;
-&lt;/section&gt;</code></pre>
+				<pre id="encodeme"><code data-wb-ajax='{ "encode": true, "url": "ajax/data-ajax-extra-fr.html", "type": "replace" }'></code></pre>
+
+				<h5>Code source de cet exemple</h5>
+				<p>Ceci est une démo qui illustre l'utilisation de la configuration <code>encode</code></p>
+				<pre><code data-wb-ajax='{ "encode": true, "url": "data-ajax-fr.html #encodeme", "type": "replace" }'></code></pre>
 			</section>
 		</details>
 </section>

--- a/src/plugins/data-ajax/data-ajax.js
+++ b/src/plugins/data-ajax/data-ajax.js
@@ -178,11 +178,21 @@ var componentName = "wb-data-ajax",
 		var $elm = $( elm ),
 			ajxInfo = getAjxInfo( elm ),
 			ajaxType = ajxInfo.type,
-			content, jQueryCaching;
+			content, jQueryCaching,
+			settings = wb.getData( $( elm ), shortName ) || {},
+			doEncode = settings.encode,
+			hasSelector = fetchObj.hasSelector;
 
 		// ajax-fetched event
 		content = fetchObj.response;
 		if ( content &&  content.length > 0 ) {
+
+			// If the fetched content need to be encoded
+			if ( doEncode && hasSelector ) {
+				content = content.html().replaceAll( "<", "&lt;" );
+			} else if ( doEncode && !hasSelector ) {
+				content = fetchObj.xhr.responseText.replaceAll( "<", "&lt;" );
+			}
 
 			//Prevents the force caching of nested resources
 			jQueryCaching = jQuery.ajaxSettings.cache;


### PR DESCRIPTION
 Add flag to HTML encode the ajaxed content

This feature is needed to support and allow the full implementation of the GCWeb Global header documentation prototype as discussed with DTO.