### PR TITLE
Utility: dl-inline

### DIFF
--- a/src/base/bootstrap-overrides/_core.scss
+++ b/src/base/bootstrap-overrides/_core.scss
@@ -68,6 +68,16 @@ a {
 	}
 }
 
+.dl-inline {
+	dt, dd {
+		display: inline;
+	}
+
+	dd + dt {
+		margin-left: 15px;
+	}
+}
+
 /*
  *  Abbreviations with title attributes
  *  Workaround for abbreviations with titles using solid underlines in IE11/Edge in Bootstrap 3.4.0 (via normalize.css 4.0.1-8.0.1):

--- a/src/other/utility/utility-en.hbs
+++ b/src/other/utility/utility-en.hbs
@@ -27,6 +27,7 @@
 	<li><a href="#tables">Tables</a></li>
 	<li><a href="#miscellaneous">Miscellaneous</a></li>
 	<li><a href="#dl-horizontal">Horizontal description list</a></li>
+	<li><a href="#dl-inline">Inline description list</a></li>
 </ul>
 
 <h2 id="alignment">Alignment</h2>
@@ -538,4 +539,20 @@
 	<dd>Etiam at erat et sapien tempus vulputate.</dd>
 	<dt>A fews filling words that take space</dt>
 	<dd>Quisque tristique dui in ante mattis, nec commodo tortor eleifend.</dd>
+</dl>
+
+<h2 id="dl-inline">Inline description list</h2>
+<p>Inline description list used to display short terms and descriptions.</p>
+
+<dl class="dl-inline">
+	<dt>Term&nbsp;:</dt>
+	<dd>Short description</dd>
+	<dt>Term&nbsp;:</dt>
+	<dd>Short description</dd>
+	<dt>Term&nbsp;:</dt>
+	<dd>Short description</dd>
+	<dt>Term&nbsp;:</dt>
+	<dd>Short description</dd>
+	<dt>Term&nbsp;:</dt>
+	<dd>Short description</dd>
 </dl>

--- a/src/other/utility/utility-fr.hbs
+++ b/src/other/utility/utility-fr.hbs
@@ -26,6 +26,7 @@
 	<li><a href="#tables">Tables</a></li>
 	<li><a href="#divers">Divers</a></li>
 	<li><a href="#dl-horizontal">Liste descriptive horizontale</a></li>
+	<li><a href="#dl-inline">Liste descriptive en ligne</a></li>
 </ul>
 
 <h2 id="alignment">Alignement</h2>
@@ -533,4 +534,20 @@
 	<dd>Etiam at erat et sapien tempus vulputate.</dd>
 	<dt>Quelques mots afin de remplir de l'espace</dt>
 	<dd>Quisque tristique dui in ante mattis, nec commodo tortor eleifend.</dd>
+</dl>
+
+<h2 id="dl-inline">Liste descriptive en ligne</h2>
+<p>List descriptive en ligne utilisée pour afficher des termes et descriptions courts.</p>
+
+<dl class="dl-inline">
+	<dt>Terme&nbsp;:</dt>
+	<dd>Description courte</dd>
+	<dt>Terme&nbsp;:</dt>
+	<dd>Description courte</dd>
+	<dt>Terme&nbsp;:</dt>
+	<dd>Description courte</dd>
+	<dt>Terme&nbsp;:</dt>
+	<dd>Description courte</dd>
+	<dt>Terme&nbsp;:</dt>
+	<dd>Description courte</dd>
 </dl>


### PR DESCRIPTION
Adding utility class to description lists to be able to display terms and descriptions inline.

(In prevision of PSPC calendar of events)