### PR TITLE
Tagfilter: fixing no result element blink on load with Data-JSON

### DIFF
--- a/src/plugins/tagfilter/tagfilter.js
+++ b/src/plugins/tagfilter/tagfilter.js
@@ -284,7 +284,7 @@ $document.on( "wb-contentupdated", selector, function( event, data )  {
 	if ( supportsHas === "false" ) {
 		let noResultItem = this.querySelector( "." + noResultWrapperClass );
 
-		if ( noResultItem ) {
+		if ( noResultItem && this.items.length > 0 ) {
 			let visibleItems = this.querySelectorAll( "." + itemsWrapperClass + " " + "[data-wb-tags]:not(." + tgFilterOutClass + ", ." + filterOutClass + ")" );
 
 			if ( visibleItems.length < 1 ) {


### PR DESCRIPTION
Fixing rare issue where the "No result" element would briefly appear on page load when loading items from Data-JSON before the items would show up. 

Only happens on Firefox since it does not support the `:has()` CSS selector.

Changes related to WET-405.