### PR TITLE
Data-JSON, JSON manager extrator - Support null mapping

### DIFF
--- a/site/pages/docs/ref/wb-data-json/wb-data-json-en.hbs
+++ b/site/pages/docs/ref/wb-data-json/wb-data-json-en.hbs
@@ -684,6 +684,7 @@
 		<td>
 			<p>When queryall is not specified, it's is an array of string with a the JSON pointer. (Equivalent to the value in the Mapping object)</p>
 			<p>A mapping object can contain another mapping object to support sub-template. That inner mapping can also contain it's own <code>queryall</code> configuration.</p>
+			<p>When its value is explicitly set to <code>null</code>, the associated template object won't be used to map data.</p>
 		</td>
 	</tr>
 

--- a/site/pages/docs/ref/wb-data-json/wb-data-json-fr.hbs
+++ b/site/pages/docs/ref/wb-data-json/wb-data-json-fr.hbs
@@ -687,6 +687,7 @@
 		<td>
 			<p>When queryall is not specified, it's is an array of string with a the JSON pointer. (Equivalent to the value in the Mapping object)</p>
 			<p>A mapping object can contain another mapping object to support sub-template. That inner mapping can also contain it's own <code>queryall</code> configuration.</p>
+			<p>When its value is explicitly set to <code>null</code>, the associated template object won't be used to map data.</p>
 		</td>
 	</tr>
 

--- a/src/plugins/wb-data-json/conditional-en.hbs
+++ b/src/plugins/wb-data-json/conditional-en.hbs
@@ -1053,6 +1053,62 @@
 &lt;/div></code></pre>
 </details>
 
+<h2>Show template content conditionally</h2>
+<p>Display template content without using it to map json data.</p>
+<div class="row">
+	<div class="col-md-6">
+		<p>Demo:</p>
+		<div data-wb-json='{
+				"url": "demo/conditional-2.json",
+				"streamline": true,
+				"mapping": [
+					{
+						"template": "[data-show-conditional-only]",
+						"test": "fn:isLiteral",
+						"assess": "/beta",
+						"mapping": null
+					}
+				]
+			}'>
+			<template data-show-conditional-only>
+				<p>Working</p>
+			</template>
+		</div>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo.</p>
+		<p>Working</p>
+	</div>
+</div>
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class=&quot;row&quot;&gt;
+	&lt;div class=&quot;col-md-6&quot;&gt;
+		&lt;p&gt;Demo:&lt;/p&gt;
+		&lt;div data-wb-json='{
+				&quot;url&quot;: &quot;demo/conditional-2.json&quot;,
+				&quot;streamline&quot;: true,
+				&quot;mapping&quot;: [
+					{
+						&quot;template&quot;: &quot;[data-show-conditional-only]&quot;,
+						&quot;test&quot;: &quot;fn:isLiteral&quot;,
+						&quot;assess&quot;: &quot;/beta&quot;,
+						&quot;mapping&quot;: null
+					}
+				]
+			}'&gt;
+			&lt;template data-show-conditional-only&gt;
+				&lt;p&gt;Working&lt;/p&gt;
+			&lt;/template&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+	&lt;div class=&quot;col-md-6&quot;&gt;
+		&lt;p&gt;Expectation of the preceding demo.&lt;/p&gt;
+		&lt;p&gt;Working&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
 <h2>Location of the merged template</h2>
 
 <p>By default, when the configuration is not streamlined, the content created with the initial template are appended to the element.</p>

--- a/src/plugins/wb-data-json/conditional-fr.hbs
+++ b/src/plugins/wb-data-json/conditional-fr.hbs
@@ -1053,6 +1053,62 @@
 &lt;/div></code></pre>
 </details>
 
+<h2>Affichage conditionel du contenu d'un gabarit</h2>
+<p>Affiche le contenu du gabarit (<code>&lt;template&gt;</code>) sans l'utiliser pour correspondre des données JSON.</p>
+<div class="row">
+	<div class="col-md-6">
+		<p>Démo:</p>
+		<div data-wb-json='{
+				"url": "demo/conditional-2.json",
+				"streamline": true,
+				"mapping": [
+					{
+						"template": "[data-show-conditional-only]",
+						"test": "fn:isLiteral",
+						"assess": "/beta",
+						"mapping": null
+					}
+				]
+			}'>
+			<template data-show-conditional-only>
+				<p>Fonctionne</p>
+			</template>
+		</div>
+	</div>
+	<div class="col-md-6">
+		<p>Résultat attendu de la démonstration précédente.</p>
+		<p>Fonctionne</p>
+	</div>
+</div>
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class=&quot;row&quot;&gt;
+	&lt;div class=&quot;col-md-6&quot;&gt;
+		&lt;p&gt;Démo:&lt;/p&gt;
+		&lt;div data-wb-json='{
+				&quot;url&quot;: &quot;demo/conditional-2.json&quot;,
+				&quot;streamline&quot;: true,
+				&quot;mapping&quot;: [
+					{
+						&quot;template&quot;: &quot;[data-show-conditional-only]&quot;,
+						&quot;test&quot;: &quot;fn:isLiteral&quot;,
+						&quot;assess&quot;: &quot;/beta&quot;,
+						&quot;mapping&quot;: null
+					}
+				]
+			}'&gt;
+			&lt;template data-show-conditional-only&gt;
+				&lt;p&gt;Fonctionne&lt;/p&gt;
+			&lt;/template&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;
+	&lt;div class=&quot;col-md-6&quot;&gt;
+		&lt;p&gt;Résultat attendu de la démonstration précédente.&lt;/p&gt;
+		&lt;p&gt;Fonctionne&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
 <h2>Emplacement du gabarit fusionné</h2>
 
 <p>Par défaut, lorsque la configuration n'est pas rationalisée, le contenu créé avec le gabarit initial est ajouté à l'élément.</p>

--- a/src/plugins/wb-data-json/data-json.js
+++ b/src/plugins/wb-data-json/data-json.js
@@ -647,7 +647,7 @@ var componentName = "wb-data-json",
 		}
 
 		// Check if there is some mapping configuration
-		if ( !mapping && !queryAll && !mappingConfig.template ) {
+		if ( !mapping && !queryAll && !mappingConfig.template && typeof mapping !== "object" ) {
 			return;
 		}
 
@@ -763,7 +763,7 @@ var componentName = "wb-data-json",
 				// Deep dive into the content if a mapping exist
 				dataIterator( cached_node, cached_value, j_cache );
 
-			} else if ( j_cache.mapping || j_cache.queryall ) {
+			} else if ( j_cache.mapping || j_cache.queryall || !j_cache.mapping && typeof j_cache.mapping === "object" ) {
 				try {
 
 					// Map the inner mapping
@@ -780,7 +780,7 @@ var componentName = "wb-data-json",
 				}
 			} else if ( !cached_node && typeof cached_value === "object" ) {
 				throw "cached_node: null";
-			} else {
+			} else if ( mappingConfig.mapping !== null ) {
 
 				cached_value = getValue( cached_value );
 

--- a/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
@@ -17,7 +17,6 @@
 </ul>
 -->
 <div class="wb-prettify all-pre"></div>
-
 <p>Manage dataset and apply JSON Patch.</p>
 
 <h2>Applying patch</h2>
@@ -1015,7 +1014,6 @@
 &lt;/div&gt;</code></pre>
 </details>
 
-
 <h3>Extract values from tag attributes or extract all specific tags values:</h3>
 <div data-wb-jsonmanager='{
 		"name": "ex3",
@@ -1026,7 +1024,8 @@
 						{ "path": "/formfields/externalReferer", "interface": "referer" },
 						{ "path": "/formfields/submissionPage", "interface": "locationHref" },
 						{ "selector": "h2", "path": "allH2", "selectAll":true },
-						{ "selector": "h3", "path": "allH3", "selectAll":true }
+						{ "selector": "h3", "path": "allH3", "selectAll":true },
+						{ "selector": "h1[data-not-found]", "path": "notfound" }
 					],
 		"patches": { "op": "wb-count", "path": "/allH3", "set": "/nbH3Total" }
 		}'>
@@ -1065,6 +1064,25 @@
 			<li></li>
 		</template>
 	</ul>
+	<p>Returning a <code>null</code> value when the element is not found by the CSS selector. Test (expect to return 'working'):
+		<span data-wb-json='{
+				"url": "#[ex3]",
+				"streamline": true,
+				"mapping": [
+					{
+						"template": "[data-not-found-result]",
+						"test": "fn:guessType",
+						"assess": "/notfound",
+						"expect": "undefined",
+						"mapping": null
+					}
+				]
+			}'>
+			<template data-not-found-result>
+				working
+			</template>
+		</span>
+	</p>
 </div>
 
 <details>
@@ -1118,5 +1136,24 @@
 			&lt;li&gt;&lt;/li&gt;
 		&lt;/template&gt;
 	&lt;/ul&gt;
+	&lt;p&gt;Returning a &lt;code&gt;null&lt;/code&gt; value when the element is not found by the CSS selector. Test (expect to return 'working'):
+		&lt;span data-wb-json='{
+				&quot;url&quot;: &quot;#[ex3]&quot;,
+				&quot;streamline&quot;: true,
+				&quot;mapping&quot;: [
+					{
+						&quot;template&quot;: &quot;[data-not-found-result]&quot;,
+						&quot;test&quot;: &quot;fn:guessType&quot;,
+						&quot;assess&quot;: &quot;/notfound&quot;,
+						&quot;expect&quot;: &quot;undefined&quot;,
+						&quot;mapping&quot;: null
+					}
+				]
+			}'&gt;
+			&lt;template data-not-found-result&gt;
+				working
+			&lt;/template&gt;
+		&lt;/span&gt;
+	&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 </details>

--- a/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
@@ -1021,7 +1021,8 @@
 						{ "path": "/formfields/externalReferer", "interface": "referer" },
 						{ "path": "/formfields/submissionPage", "interface": "locationHref" },
 						{ "selector": "h2", "path": "allH2", "selectAll":true },
-						{ "selector": "h3", "path": "allH3", "selectAll":true }
+						{ "selector": "h3", "path": "allH3", "selectAll":true },
+						{ "selector": "h1[data-not-found]", "path": "notfound" }
 					],
 		"patches": { "op": "wb-count", "path": "/allH3", "set": "/nbH3Total" }
 	}'>
@@ -1058,6 +1059,25 @@
 			<li></li>
 		</template>
 	</ul>
+	<p>Retourne une valeur <code>null</code> lorsque l'élément n'est pas trouvé par le sélecteur CSS. Test (attendu l'affichage du mot 'fonctionne'):
+		<span data-wb-json='{
+				"url": "#[ex3]",
+				"streamline": true,
+				"mapping": [
+					{
+						"template": "[data-not-found-result]",
+						"test": "fn:guessType",
+						"assess": "/notfound",
+						"expect": "undefined",
+						"mapping": null
+					}
+				]
+			}'>
+			<template data-not-found-result>
+				fonctionne
+			</template>
+		</span>
+	</p>
 </div>
 
 <details>
@@ -1111,5 +1131,24 @@
 			&lt;li&gt;&lt;/li&gt;
 		&lt;/template&gt;
 	&lt;/ul&gt;
+	&lt;p&gt;Retourne une valeur &lt;code&gt;null&lt;/code&gt; lorsque l'élément n'est pas trouvé par le sélecteur CSS. Test (attendu l'affichage du mot 'fonctionne'):
+		&lt;span data-wb-json='{
+				&quot;url&quot;: &quot;#[ex3]&quot;,
+				&quot;streamline&quot;: true,
+				&quot;mapping&quot;: [
+					{
+						&quot;template&quot;: &quot;[data-not-found-result]&quot;,
+						&quot;test&quot;: &quot;fn:guessType&quot;,
+						&quot;assess&quot;: &quot;/notfound&quot;,
+						&quot;expect&quot;: &quot;undefined&quot;,
+						&quot;mapping&quot;: null
+					}
+				]
+			}'&gt;
+			&lt;template data-not-found-result&gt;
+				fonctionne
+			&lt;/template&gt;
+		&lt;/span&gt;
+	&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 </details>

--- a/src/plugins/wb-jsonmanager/jsonmanager.js
+++ b/src/plugins/wb-jsonmanager/jsonmanager.js
@@ -414,6 +414,12 @@ var componentName = "wb-jsonmanager",
 			},
 			manageObjDir = function( selector, selectedValue, json_return ) {
 				var arrPath = selector.path.split( "/" ).filter( Boolean );
+
+				// Check if selectedValue is an empty value returned by querySelectorAll
+				if ( selectedValue && selectedValue instanceof NodeList && selectedValue.length === 0 ) {
+					selectedValue = null;
+				}
+
 				if ( arrPath.length > 1 ) {
 					var pointer = "";
 					pointer = arrPath.pop();


### PR DESCRIPTION
Minor change for Data-JSON - Support null mapping to display template without further data processing
Patch change for JSON manager - Return null when trying to extract content from an inexistant HTML node