### PR TITLE
Data-JSON: do not display null values on JSON render

### DIFF
--- a/src/plugins/wb-data-json/data-json.js
+++ b/src/plugins/wb-data-json/data-json.js
@@ -784,8 +784,8 @@ var componentName = "wb-data-json",
 
 				cached_value = getValue( cached_value );
 
-				// Serialize the value if it is an JS object
-				if ( typeof cached_value === "object" ) {
+				// Serialize the value if it is an JS object and its not a null object
+				if ( typeof cached_value === "object" &&  cached_value !== null ) {
 					cached_value = JSON.stringify( cached_value );
 				}
 
@@ -865,11 +865,13 @@ var componentName = "wb-data-json",
 			value = placeholderText.replace( mappingConfig.placeholder, value );
 		}
 
-		// Set the value to the node
-		if ( mappingConfig.isHTML ) {
-			element.innerHTML = value;
-		} else {
-			element.textContent = value;
+		// Exclude null values and replace with default text
+		if ( value !== null ) {
+			if ( mappingConfig.isHTML ) {
+				element.innerHTML = value;
+			} else {
+				element.textContent = value;
+			}
 		}
 	},
 

--- a/src/plugins/wb-data-json/demo/data-en.json
+++ b/src/plugins/wb-data-json/demo/data-en.json
@@ -69,5 +69,11 @@
         }
       }
     }
-  }
+  },
+  "withNullAndHtml": [
+    { "name": "Item 1", "prop": "<strong>red</strong>" },
+    { "name": "Item with null value", "prop": null },
+    { "name": "Item 3", "prop": "yellow" },
+    { "name": "Item with null value", "prop": null }
+  ]
 }

--- a/src/plugins/wb-data-json/demo/data-fr.json
+++ b/src/plugins/wb-data-json/demo/data-fr.json
@@ -69,5 +69,11 @@
         }
       }
     }
-  }
+  },
+  "avecNullEtHtml": [
+    { "nom": "Item 1", "prop": "<strong>rouge</strong>" },
+    { "nom": "Item with null value", "prop": null },
+    { "nom": "Item 3", "prop": "jaune" },
+    { "nom": "Item with null value", "prop": null }
+  ]
 }

--- a/src/plugins/wb-data-json/template-en.hbs
+++ b/src/plugins/wb-data-json/template-en.hbs
@@ -347,6 +347,77 @@
 &lt;/template&gt;</code></pre>
 </details>
 
+<h3>Render JSON having null values</h3>
+
+<div class="row">
+	<div class="col-md-6">
+		<span class="text-muted">With the HTML rendering</span>
+		<dl class="dl-horizontal" data-wb-json='{
+				"url": "demo/data-en.json#/withNullAndHtml",
+				"mapping": [
+					{ "selector": "dt", "value": "/name" },
+					{ "selector": "dd", "value": "/prop", "isHTML": true }
+				]
+			}'>
+			<template>
+				<dt></dt>
+				<dd>N/A</dd>
+			</template>
+		</dl>
+	</div>
+	<div class="col-md-6">
+		<span class="text-muted">Without the HTML rendering</span>
+		<dl class="dl-horizontal" data-wb-json='{
+				"url": "demo/data-en.json#/withNullAndHtml",
+				"mapping": [
+					{ "selector": "dt", "value": "/name" },
+					{ "selector": "dd", "value": "/prop" }
+				]
+			}'>
+			<template>
+				<dt></dt>
+				<dd>N/A</dd>
+			</template>
+		</dl>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class="row"&gt;
+	&lt;div class="col-md-6"&gt;
+		&lt;span class="text-muted"&gt;With the HTML rendering&lt;/span&gt;
+		&lt;dl class="dl-horizontal" data-wb-json='{
+				"url": "demo/data-en.json#/withNullAndHtml",
+				"mapping": [
+					{ "selector": "dt", "value": "/name" },
+					{ "selector": "dd", "value": "/prop", "isHTML": true }
+				]
+			}'&gt;
+			&lt;template&gt;
+				&lt;dt&gt;&lt;/dt&gt;
+				&lt;dd&gt;N/A&lt;/dd&gt;
+			&lt;/template&gt;
+		&lt;/dl&gt;
+	&lt;/div&gt;
+	&lt;div class="col-md-6"&gt;
+		&lt;span class="text-muted"&gt;Without the HTML rendering&lt;/span&gt;
+		&lt;dl class="dl-horizontal" data-wb-json='{
+				"url": "demo/data-en.json#/withNullAndHtml",
+				"mapping": [
+					{ "selector": "dt", "value": "/name" },
+					{ "selector": "dd", "value": "/prop" }
+				]
+			}'&gt;
+			&lt;template&gt;
+				&lt;dt&gt;&lt;/dt&gt;
+				&lt;dd&gt;N/A&lt;/dd&gt;
+			&lt;/template&gt;
+		&lt;/dl&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+</details>
+
 
 <h2>Sub template</h2>
 

--- a/src/plugins/wb-data-json/template-fr.hbs
+++ b/src/plugins/wb-data-json/template-fr.hbs
@@ -350,6 +350,76 @@
 &lt;/template&gt;</code></pre>
 </details>
 
+<h3>Affichage de JSON avec des valeurs nulles</h3>
+
+<div class="row">
+	<div class="col-md-6">
+		<span class="text-muted">Avec l'interprétation HTML</span>
+		<dl class="dl-horizontal" data-wb-json='{
+				"url": "demo/data-fr.json#/avecNullEtHtml",
+				"mapping": [
+					{ "selector": "dt", "value": "/nom" },
+					{ "selector": "dd", "value": "/prop", "isHTML": true }
+				]
+			}'>
+			<template>
+				<dt></dt>
+				<dd>N/D</dd>
+			</template>
+		</dl>
+	</div>
+	<div class="col-md-6">
+		<span class="text-muted">Sans l'interprétation HTML</span>
+		<dl class="dl-horizontal" data-wb-json='{
+				"url": "demo/data-fr.json#/avecNullEtHtml",
+				"mapping": [
+					{ "selector": "dt", "value": "/nom" },
+					{ "selector": "dd", "value": "/prop" }
+				]
+			}'>
+			<template>
+				<dt></dt>
+				<dd>N/D</dd>
+			</template>
+		</dl>
+	</div>
+</div>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;div class="row"&gt;
+	&lt;div class="col-md-6"&gt;
+		&lt;span class="text-muted"&gt;Avec le rendu HTML&lt;/span&gt;
+		&lt;dl class="dl-horizontal" data-wb-json='{
+				"url": "demo/data-fr.json#/avecNullEtHtml",
+				"mapping": [
+					{ "selector": "dt", "value": "/nom" },
+					{ "selector": "dd", "value": "/prop", "isHTML": true }
+				]
+			}'&gt;
+			&lt;template&gt;
+				&lt;dt&gt;&lt;/dt&gt;
+				&lt;dd&gt;N/D&lt;/dd&gt;
+			&lt;/template&gt;
+		&lt;/dl&gt;
+	&lt;/div&gt;
+	&lt;div class="col-md-6"&gt;
+		&lt;span class="text-muted"&gt;Sans le rendu HTML&lt;/span&gt;
+		&lt;dl class="dl-horizontal" data-wb-json='{
+				"url": "demo/data-fr.json#/avecNullEtHtml",
+				"mapping": [
+					{ "selector": "dt", "value": "/nom" },
+					{ "selector": "dd", "value": "/prop" }
+				]
+			}'&gt;
+			&lt;template&gt;
+				&lt;dt&gt;&lt;/dt&gt;
+				&lt;dd&gt;N/D&lt;/dd&gt;
+			&lt;/template&gt;
+		&lt;/dl&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+</details>
 
 <h2>Sous-modèle</h2>
 


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

In Data-JSON, null values are actually being displayed as “null” on the page. This solution will detect and ignore null values once the json values are rendered on the page
_WET-402_