### PR TITLE
Data-JSON - Correctif pour l'example 'sous-modèle'

### DIFF
--- a/src/plugins/wb-data-json/template-fr.hbs
+++ b/src/plugins/wb-data-json/template-fr.hbs
@@ -371,7 +371,7 @@
 				]
 			},
 
-			{ "selector": "ul", "value": "/passetemps", "queryall": "li" }
+			{ "selector": "ul[data-array]", "value": "/passetemps", "queryall": "li" }
 		]
 	}'>
 	<template>
@@ -384,7 +384,7 @@
 			<ul data-object>
 			</ul>
 			<h4>Hobby:</h4>
-			<ul class="lst-spcd"> <!-- Sous-modèle (Itération de liste) -->
+			<ul class="lst-spcd" data-array> <!-- Sous-modèle (Itération de liste) -->
 				<template>
 					<li></li>
 				</template>


### PR DESCRIPTION
Corrige l'example pratique du "sous-modèle" en français.