### PR TITLE
Data-JSON and JSON-Manage patch to fix release 4 0 66

### DIFF
--- a/src/plugins/wb-data-json/data-json.js
+++ b/src/plugins/wb-data-json/data-json.js
@@ -764,7 +764,7 @@ var componentName = "wb-data-json",
 			}
 
 			// Do the cache value contain special @type
-			if ( cached_value[ "@value" ] && cached_value[ "@type" ] ) {
+			if ( cached_value && cached_value[ "@value" ] && cached_value[ "@type" ] ) {
 				if ( !$.isArray( cached_value[ "@type" ] ) ) {
 					cached_value[ "@type" ] = [ cached_value[ "@type" ] ];
 				}

--- a/src/plugins/wb-jsonmanager/jsonmanager.js
+++ b/src/plugins/wb-jsonmanager/jsonmanager.js
@@ -166,7 +166,7 @@ var componentName = "wb-jsonmanager",
 				fn: function( obj, key, tree ) {
 					var val = obj[ key ],
 						ref = this.ref,
-						mainTree = this.mainTree,
+						mainTree = this.mainTree || obj,
 						path = this.path,
 						newVal,
 						refObject, refIsArray, valWasArray,


### PR DESCRIPTION
We noticed an issue with the data-json template which happen after the merge of subsequent PR that applied change to the same component.

Also, we noticed both issue through this page for the ACR tool: https://wet-boew.github.io/wet-boew/demos/acr/demo-wcag21/acr-wcag21-en.html

I am going to add some additional test case for the JSON manager change via another PR.