### PR TITLE
data-json: fixing issue with null value

### DIFF
--- a/src/plugins/wb-data-json/data-json-en.hbs
+++ b/src/plugins/wb-data-json/data-json-en.hbs
@@ -285,3 +285,6 @@
 	&lt;/figure&gt;
 &lt;/div&gt;</code></pre>
 </details>
+
+<h2>Special test case examples</h2>
+<p><a href="test-case-en.html">Consult the special test case examples webpage</a></p>

--- a/src/plugins/wb-data-json/data-json-fr.hbs
+++ b/src/plugins/wb-data-json/data-json-fr.hbs
@@ -288,3 +288,6 @@
 	&lt;/figure&gt;
 &lt;/div&gt;</code></pre>
 </details>
+
+<h2>Exemple d'essaie spéciale</h2>
+<p><a href="test-case-fr.html">Consulter la page d'exemple d'essaie spéciale</a></p>

--- a/src/plugins/wb-data-json/data-json.js
+++ b/src/plugins/wb-data-json/data-json.js
@@ -289,7 +289,7 @@ var componentName = "wb-data-json",
 				content = [ content ];
 			} else {
 				content = $.map( content, function( val, index ) {
-					if ( typeof val === "object" && !$.isArray( val ) ) {
+					if ( val && typeof val === "object" && !$.isArray( val ) ) {
 						if ( !val[ "@id" ] ) {
 							val[ "@id" ] = index;
 						}
@@ -853,7 +853,7 @@ var componentName = "wb-data-json",
 		var value = getRawValue( source, pointer );
 
 		// for JSON-LD @value support
-		if ( typeof value === "object" && value !== null && value[ "@value" ] ) {
+		if ( typeof value === "object" && value !== null && Object.prototype.hasOwnProperty.call( value, "@value" ) ) {
 			value = value[ "@value" ];
 		}
 

--- a/src/plugins/wb-data-json/demo/test-case.json
+++ b/src/plugins/wb-data-json/demo/test-case.json
@@ -1,0 +1,19 @@
+{
+  "alpha2": {
+      "@id": "_:beta",
+      "@value": null
+  },
+  "alpha": {
+      "beta": null
+  },
+  "beta": [
+    {
+      "itm1": "Value 1",
+      "itm2": null
+    },
+    {
+      "itm1": "Value 2",
+      "itm2": null
+    }
+  ]
+}

--- a/src/plugins/wb-data-json/test-case-en.hbs
+++ b/src/plugins/wb-data-json/test-case-en.hbs
@@ -1,0 +1,126 @@
+---
+{
+	"title": "Special test case for Data JSON",
+	"language": "en",
+	"description": "To validate some special edge case and to ensure the plugin work as expected.",
+	"tag": "data-json",
+	"parentdir": "wb-data-json",
+	"altLangPage": "test-case-fr.html",
+	"dateModified": "2023-08-22"
+}
+---
+<nav>
+	<ul>
+		<li><a href="data-json-en.html">Data JSON</a></li>
+		<li><a href="template-en.html">HTML 5 template</a></li>
+		<li><a href="conditional-en.html">Conditional template</a></li>
+	</ul>
+</nav>
+
+<p>This page is a test page to validate some special edge case and to ensure the plugin work as expected.</p>
+
+<h2>Test case for <a href="https://github.com/wet-boew/wet-boew/pull/9651">PR 9651</a></h2>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Test demo</p>
+		<div data-wb-json='{
+			"url": "demo/test-case.json#/alpha",
+			"mapping": [
+				{
+					"selector": "p"
+				}
+			]
+		}'>
+			<template>
+				<p>This paragraph content are not replaced because it is a <code>null</code> value</p>
+			</template>
+		</div>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo</p>
+		<p>This paragraph content are not replaced because it is a <code>null</code> value</p>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<div class="row">
+		<div class="col-md-6">
+			<p>JSON content</p>
+			<pre><code>{
+	"alpha": {
+		"beta": null
+	}
+}</code></pre>
+		</div>
+		<div class="col-md-6">
+			<p>Data JSON configuration</p>
+			<pre><code>{
+	"url": "demo/test-case.json#/alpha",
+	"mapping": [
+		{
+			"selector": "p"
+		}
+	]
+}</code></pre>
+		</div>
+	</div>
+</details>
+
+
+<h2>Test case for <a href="https://github.com/wet-boew/wet-boew/pull/9649">PR 9649</a></h2>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Test demo</p>
+		<div data-wb-json='{
+			"url": "demo/test-case.json#/beta",
+			"mapping": [
+				{ "selector": "[data-itm1]", "value": "/itm1" },
+				{ "selector": "[data-itm2]", "value": "/itm2" }
+			]
+		}'>
+			<template>
+				<p>Itm1: <span data-itm1>Not defined</span>; Value: <span data-itm2>Not defined</span></p>
+			</template>
+		</div>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo</p>
+		<p>Itm1: <span data-itm1>Value 1</span>; Value: <span data-itm2>Not defined</span></p>
+		<p>Itm1: <span data-itm1>Value 2</span>; Value: <span data-itm2>Not defined</span></p>
+	</div>
+</div>
+
+
+<details>
+	<summary>Source code</summary>
+	<div class="row">
+		<div class="col-md-6">
+			<p>JSON content</p>
+			<pre><code>{
+	"beta": [
+	{
+		"itm1": "Value 1",
+		"itm2": null
+	},
+	{
+		"itm1": "Value 2",
+		"itm2": null
+	}
+	]
+}</code></pre>
+		</div>
+		<div class="col-md-6">
+			<p>Data JSON configuration</p>
+			<pre><code>{
+	"url": "demo/test-case.json#/beta",
+	"mapping": [
+		{ "selector": "[data-itm1]", "value": "/itm1" },
+		{ "selector": "[data-itm2]", "value": "/itm2" }
+	]
+}</code></pre>
+		</div>
+	</div>
+</details>

--- a/src/plugins/wb-data-json/test-case-fr.hbs
+++ b/src/plugins/wb-data-json/test-case-fr.hbs
@@ -1,0 +1,130 @@
+---
+{
+	"title": "Case d'essaie spéciale pour Data JSON",
+	"language": "fr",
+	"description": "Afin de valider des cas précis et pour s'assurer que le plugin fonctionne tel que prévu.",
+	"tag": "data-json",
+	"parentdir": "wb-data-json",
+	"altLangPage": "test-case-en.html",
+	"dateModified": "2023-08-22"
+}
+---
+<nav>
+	<ul>
+		<li><a href="data-json-fr.html">Data JSON</a></li>
+		<li><a href="template-fr.html">Gabarit HTML 5</a></li>
+		<li><a href="conditional-fr.html">Gabarit conditionel</a></li>
+	</ul>
+</nav>
+
+<p>Cette page est une page d'essai afin de valider des cas précis et pour s'assurer que le plugin fonctionne tel que prévu.</p>
+
+<p>Le contenu suivant est seulement disponible en anglais.</p>
+
+<div lang="en">
+<h2>Test case for <a href="https://github.com/wet-boew/wet-boew/pull/9651">PR 9651</a></h2>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Test demo</p>
+		<div data-wb-json='{
+			"url": "demo/test-case.json#/alpha",
+			"mapping": [
+				{
+					"selector": "p"
+				}
+			]
+		}'>
+			<template>
+				<p>This paragraph content are not replaced because it is a <code>null</code> value</p>
+			</template>
+		</div>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo</p>
+		<p>This paragraph content are not replaced because it is a <code>null</code> value</p>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<div class="row">
+		<div class="col-md-6">
+			<p>JSON content</p>
+			<pre><code>{
+	"alpha": {
+		"beta": null
+	}
+}</code></pre>
+		</div>
+		<div class="col-md-6">
+			<p>Data JSON configuration</p>
+			<pre><code>{
+	"url": "demo/test-case.json#/alpha",
+	"mapping": [
+		{
+			"selector": "p"
+		}
+	]
+}</code></pre>
+		</div>
+	</div>
+</details>
+
+
+<h2>Test case for <a href="https://github.com/wet-boew/wet-boew/pull/9649">PR 9649</a></h2>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Test demo</p>
+		<div data-wb-json='{
+			"url": "demo/test-case.json#/beta",
+			"mapping": [
+				{ "selector": "[data-itm1]", "value": "/itm1" },
+				{ "selector": "[data-itm2]", "value": "/itm2" }
+			]
+		}'>
+			<template>
+				<p>Itm1: <span data-itm1>Not defined</span>; Value: <span data-itm2>Not defined</span></p>
+			</template>
+		</div>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo</p>
+		<p>Itm1: <span data-itm1>Value 1</span>; Value: <span data-itm2>Not defined</span></p>
+		<p>Itm1: <span data-itm1>Value 2</span>; Value: <span data-itm2>Not defined</span></p>
+	</div>
+</div>
+
+
+<details>
+	<summary>Source code</summary>
+	<div class="row">
+		<div class="col-md-6">
+			<p>JSON content</p>
+			<pre><code>{
+	"beta": [
+	{
+		"itm1": "Value 1",
+		"itm2": null
+	},
+	{
+		"itm1": "Value 2",
+		"itm2": null
+	}
+	]
+}</code></pre>
+		</div>
+		<div class="col-md-6">
+			<p>Data JSON configuration</p>
+			<pre><code>{
+	"url": "demo/test-case.json#/beta",
+	"mapping": [
+		{ "selector": "[data-itm1]", "value": "/itm1" },
+		{ "selector": "[data-itm2]", "value": "/itm2" }
+	]
+}</code></pre>
+		</div>
+	</div>
+</details>
+</div>

--- a/src/plugins/wb-jsonmanager/demo/test-case.json
+++ b/src/plugins/wb-jsonmanager/demo/test-case.json
@@ -1,0 +1,8 @@
+{
+  "ref": {
+    "itm1": "Value 1",
+    "itm2": "Value 2",
+    "itm3": "Value 3"
+  },
+  "alpha": "itm2"
+}

--- a/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
@@ -1157,3 +1157,6 @@
 	&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 </details>
+
+<h2>Special test case examples</h2>
+<p><a href="test-case-en.html">Consult the special test case examples webpage</a></p>

--- a/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
@@ -1152,3 +1152,6 @@
 	&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 </details>
+
+<h2>Exemple d'essaie spéciale</h2>
+<p><a href="test-case-fr.html">Consulter la page d'exemple d'essaie spéciale</a></p>

--- a/src/plugins/wb-jsonmanager/test-case-en.hbs
+++ b/src/plugins/wb-jsonmanager/test-case-en.hbs
@@ -1,0 +1,82 @@
+---
+{
+	"title": "Special test case for JSON manager",
+	"language": "en",
+	"description": "To validate some special edge case and to ensure the plugin work as expected.",
+	"tag": "jsonmanager",
+	"parentdir": "wb-jsonmanager",
+	"altLangPage": "test-case-fr.html",
+	"dateModified": "2023-08-22"
+}
+---
+
+<p>This page is a test page to validate some special edge case and to ensure the plugin work as expected.</p>
+
+<h2>Test case for <a href="https://github.com/wet-boew/wet-boew/pull/9649">PR 9649</a></h2>
+
+<div data-wb-jsonmanager='{
+	"name": "swapEx",
+	"url": "demo/test-case.json",
+	"patches": [
+		{ "op": "wb-swap", "path": "/alpha", "ref": "/ref" }
+	]
+}'></div>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Test demo</p>
+		<div data-wb-json='{
+			"url": "#[swapEx]/alpha",
+			"mapping": [
+				{
+					"selector": "p"
+				}
+			]
+		}'>
+			<template>
+				<p>This paragraph content was not replaced</p>
+			</template>
+		</div>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo</p>
+		<p>Value 2</p>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<div class="row">
+		<div class="col-md-6">
+			<p>JSON content</p>
+			<pre><code>{
+	"ref": {
+		"itm1": "Value 1",
+		"itm2": "Value 2",
+		"itm3": "Value 3"
+
+	},
+	"alpha": "itm2"
+}</code></pre>
+		</div>
+		<div class="col-md-6">
+			<p>JSON manager configuration</p>
+			<pre><code>{
+	"name": "swapEx",
+	"url": "demo/test-case.json",
+	"patches": [
+		{ "op": "wb-swap", "path": "/alpha", "ref": "/ref" }
+	]
+}</code></pre>
+			<p>Data JSON configuration</p>
+			<pre><code>{
+	"url": "#[swapEx]/alpha",
+	"mapping": [
+		{
+			"selector": "p"
+		}
+	]
+}</code></pre>
+		</div>
+	</div>
+</details>

--- a/src/plugins/wb-jsonmanager/test-case-fr.hbs
+++ b/src/plugins/wb-jsonmanager/test-case-fr.hbs
@@ -1,0 +1,87 @@
+---
+{
+	"title": "Case d'essaie spéciale pour Data JSON",
+	"language": "fr",
+	"description": "Afin de valider des cas précis et pour s'assurer que le plugin fonctionne tel que prévu.",
+	"tag": "jsonmanager",
+	"parentdir": "wb-jsonmanager",
+	"altLangPage": "test-case-en.html",
+	"dateModified": "2023-08-22"
+}
+---
+
+<p>Cette page est une page d'essai afin de valider des cas précis et pour s'assurer que le plugin fonctionne tel que prévu.</p>
+
+<p>Le contenu suivant est seulement disponible en anglais.</p>
+
+<div lang="en">
+
+<h2>Test case for <a href="https://github.com/wet-boew/wet-boew/pull/9649">PR 9649</a></h2>
+
+<div data-wb-jsonmanager='{
+	"name": "swapEx",
+	"url": "demo/test-case.json",
+	"patches": [
+		{ "op": "wb-swap", "path": "/alpha", "ref": "/ref" }
+	]
+}'></div>
+
+<div class="row">
+	<div class="col-md-6">
+		<p>Test demo</p>
+		<div data-wb-json='{
+			"url": "#[swapEx]/alpha",
+			"mapping": [
+				{
+					"selector": "p"
+				}
+			]
+		}'>
+			<template>
+				<p>This paragraph content was not replaced</p>
+			</template>
+		</div>
+	</div>
+	<div class="col-md-6">
+		<p>Expectation of the preceding demo</p>
+		<p>Value 2</p>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<div class="row">
+		<div class="col-md-6">
+			<p>JSON content</p>
+			<pre><code>{
+	"ref": {
+		"itm1": "Value 1",
+		"itm2": "Value 2",
+		"itm3": "Value 3"
+
+	},
+	"alpha": "itm2"
+}</code></pre>
+		</div>
+		<div class="col-md-6">
+			<p>JSON manager configuration</p>
+			<pre><code>{
+	"name": "swapEx",
+	"url": "demo/test-case.json",
+	"patches": [
+		{ "op": "wb-swap", "path": "/alpha", "ref": "/ref" }
+	]
+}</code></pre>
+			<p>Data JSON configuration</p>
+			<pre><code>{
+	"url": "#[swapEx]/alpha",
+	"mapping": [
+		{
+			"selector": "p"
+		}
+	]
+}</code></pre>
+		</div>
+	</div>
+</details>
+</div>


### PR DESCRIPTION
Fixing issue where Data-JSON would throw an error when the value of a property is equal to `null`.

Related to WET-408