### PR TITLE
Twitter embedded timeline: Add "verified" account example

### DIFF
--- a/src/plugins/twitter/twitter-en.hbs
+++ b/src/plugins/twitter/twitter-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "twitter",
 	"parentdir": "twitter",
 	"altLangPrefix": "twitter",
-	"dateModified": "2017-02-07"
+	"dateModified": "2023-11-14"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -18,17 +18,42 @@
 </section>
 
 <section>
-	<h2>Example: Embedded User Timeline</h2>
-	<div class="wb-twitter">
-		<a class="twitter-timeline" href="https://twitter.com/WebExpToolkit" data-tweet-limit="3">Tweets by @WebExpToolkit</a>
-	</div>
+	<h2>Examples: Profile timeline</h2>
 
-	<section>
-		<h3>Code</h3>
-		<pre><code>&lt;div class=&quot;wb-twitter&quot;&gt;
+	<div class="row">
+		<section class="col-md-6">
+			<h3>Standard account</h3>
+			<div class="wb-twitter">
+				<a class="twitter-timeline" href="https://twitter.com/WebExpToolkit" data-tweet-limit="3">Tweets by @WebExpToolkit</a>
+			</div>
+			<section>
+				<h4>Code</h4>
+				<pre><code>&lt;div class=&quot;wb-twitter&quot;&gt;
 &lt;a class=&quot;twitter-timeline&quot; href=&quot;https://twitter.com/WebExpToolkit&quot; data-tweet-limit=&quot;3&quot; &gt;Tweets by @WebExpToolkit&lt;/a&gt;
 &lt;/div&gt;</code></pre>
-	</section>
+			</section>
+		</section>
 
-	<p>Twitter Developer Documentation: <a href="https://dev.twitter.com/web/embedded-timelines/user">Embedded User Timeline</a></p>
+		<section class="col-md-6">
+			<h3>"Verified" account</h3>
+			<div class="wb-twitter">
+				<a class="twitter-timeline" href="https://twitter.com/Canada" data-height="fb-page">Tweets by @Canada</a>
+			</div>
+			<section>
+				<h4>Code</h4>
+				<pre><code>&lt;div class=&quot;wb-twitter&quot;&gt;
+	&lt;a class=&quot;twitter-timeline&quot; href=&quot;https://twitter.com/Canada&quot; data-height=&quot;fb-page&quot;&gt;Tweets by @Canada&lt;/a&gt;
+&lt;/div&gt;</code></pre>
+			</section>
+		</section>
+	</div>
+</section>
+
+<section>
+	<h2>Twitter developer documentation</h2>
+	<ul>
+		<li><a rel="external" href="https://developer.twitter.com/en/docs/twitter-for-websites/timelines/overview">Timelines overview</a></li>
+		<li><a rel="external" href="https://developer.twitter.com/en/docs/twitter-for-websites/supported-languages">Supported languages and browsers</a></li>
+		<li><a rel="external" href="https://developer.twitter.com/en/docs/twitter-for-websites/webpage-properties">Webpage properties</a></li>
+	</ul>
 </section>

--- a/src/plugins/twitter/twitter-fr.hbs
+++ b/src/plugins/twitter/twitter-fr.hbs
@@ -3,11 +3,11 @@
 	"title": "Chronologie intégrée Twitter",
 	"language": "fr",
 	"category": "Plugiciels",
-	"description": "Affiche des chronologies intégrées Twitter.",
+	"description": "Aide avec l’implémentation des chronologies intégrées Twitter.",
 	"tag": "twitter",
 	"parentdir": "twitter",
 	"altLangPrefix": "twitter",
-	"dateModified": "2014-08-01"
+	"dateModified": "2023-11-14"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -17,21 +17,43 @@
 	<p>Ce plugiciel aide à afficher des chronologies intégrées Twitter.</p>
 </section>
 
-<div lang="en">
-<p><strong>Needs translation</strong></p>
 <section>
-	<h2>Example: Embedded User Timeline</h2>
-	<div class="wb-twitter">
-		<a class="twitter-timeline" href="https://twitter.com/WebExpToolkit" data-tweet-limit="3">Tweets by @WebExpToolkit</a>
-	</div>
+	<h2>Exemples&nbsp;: Chronologie de profil</h2>
 
-	<section>
-		<h3>Code</h3>
-		<pre><code>&lt;div class=&quot;wb-twitter&quot;&gt;
-&lt;a class=&quot;twitter-timeline&quot; href=&quot;https://twitter.com/WebExpToolkit&quot; data-tweet-limit=&quot;3&quot; &gt;Tweets by @WebExpToolkit&lt;/a&gt;
+	<div class="row">
+		<section class="col-md-6">
+			<h3>Compte standard</h3>
+			<div class="wb-twitter">
+				<a class="twitter-timeline" href="https://twitter.com/WebExpToolkit" data-tweet-limit="3">Tweets de @WebExpToolkit</a>
+			</div>
+			<section>
+				<h4>Code</h4>
+				<pre><code>&lt;div class=&quot;wb-twitter&quot;&gt;
+&lt;a class=&quot;twitter-timeline&quot; href=&quot;https://twitter.com/WebExpToolkit&quot; data-tweet-limit=&quot;3&quot; &gt;Tweets de @WebExpToolkit&lt;/a&gt;
 &lt;/div&gt;</code></pre>
-	</section>
+			</section>
+		</section>
 
-	<p>Twitter Developer Documentation: <a href="https://dev.twitter.com/web/embedded-timelines/user">Embedded User Timeline</a></p>
+		<section class="col-md-6">
+			<h3>Compte «&nbsp;certifié&nbsp;»</h3>
+			<div class="wb-twitter">
+				<a class="twitter-timeline" href="https://twitter.com/Canada" data-height="fb-page">Tweets de @Canada</a>
+			</div>
+			<section>
+				<h4>Code</h4>
+				<pre><code>&lt;div class=&quot;wb-twitter&quot;&gt;
+	&lt;a class=&quot;twitter-timeline&quot; href=&quot;https://twitter.com/Canada&quot; data-height=&quot;fb-page&quot;&gt;Tweets de @Canada&lt;/a&gt;
+&lt;/div&gt;</code></pre>
+			</section>
+		</section>
+	</div>
 </section>
-</div>
+
+<section>
+	<h2>Documentation destinée aux développeurs Twitter</h2>
+	<ul>
+		<li><a rel="external" href="https://developer.twitter.com/en/docs/twitter-for-websites/timelines/overview">Aperçu des chronologies (anglais seulement)</a></li>
+		<li><a rel="external" href="https://developer.twitter.com/en/docs/twitter-for-websites/supported-languages">Langues et navigateurs compatibles (anglais seulement)</a></li>
+		<li><a rel="external" href="https://developer.twitter.com/en/docs/twitter-for-websites/webpage-properties">Propriétés de page Web (anglais seulement)</a></li>
+	</ul>
+</section>


### PR DESCRIPTION
Timeline widgets currently work differently between standard and "verified" Twitter accounts:
* Standard accounts: Shows a "Nothing to see here - yet" placeholder message
* "Verified" accounts: Shows top 100 most-liked tweets (ignores ``data-tweet-limit`` attribute)

This adds a second timeline for @Canada ("verified" government account) to demonstrate the difference between both "types" of account timelines.

Other changes:
* Use a ``data-height="fb-page"`` attribute for the "verified" account example (via #9691)
* Adjust nearby content to be more presentable:
  * Revise example heading (change to plural, update timeline's official name, use sentence case)
  * Revamp Twitter docs link into an expanded section
* Update French translations:
  * Translate main page content
  * Update outdated page description translation