### PR TITLE
Geomap: adding zoom to bounding box on load option

### DIFF
--- a/site/pages/docs/ref/geomap/geomap-en.hbs
+++ b/site/pages/docs/ref/geomap/geomap-en.hbs
@@ -143,6 +143,19 @@
 						<td>String</td>
 						<td>Path to local or remote JavaScript configuration file that lists feature layers that are to be added to the map.</td>
 					</tr>
+					<tr>
+						<td><code>mapExtent</code></td>
+						<td>String</td>
+						<td>Text containing the Latitude and Longitude coordinate of the bounding box in the following order:
+							<ol>
+								<li>Latitude of bottom-left corner</li>
+								<li>Longitude of bottom-left corner</li>
+								<li>Latitude of top-right corner</li>
+								<li>Longitude of top-right corner</li>
+							</ol>
+							For example: "63, -110, 50, -128"
+						</td>
+					</tr>
 				</tbody>
 			</table>
 		</section>

--- a/site/pages/docs/ref/geomap/geomap-fr.hbs
+++ b/site/pages/docs/ref/geomap/geomap-fr.hbs
@@ -146,6 +146,19 @@
 						<td>String</td>
 						<td>Path to local or remote JavaScript configuration file that lists feature layers that are to be added to the map.</td>
 					</tr>
+					<tr>
+						<td><code>mapExtent</code></td>
+						<td>String</td>
+						<td>Text containing the Latitude and Longitude coordinate of the bounding box in the following order:
+							<ol>
+								<li>Latitude of bottom-left corner</li>
+								<li>Longitude of bottom-left corner</li>
+								<li>Latitude of top-right corner</li>
+								<li>Longitude of top-right corner</li>
+							</ol>
+							For example: "63, -110, 50, -128"
+						</td>
+					</tr>
 				</tbody>
 			</table>
 		</section>

--- a/src/plugins/deps/geomap-lib.js
+++ b/src/plugins/deps/geomap-lib.js
@@ -192,8 +192,10 @@ var componentName = "wb-geomap",
 		// Add map layers
 		this.addMapLayers();
 
-		// If an extent was configured, fit the map to it
-		if ( viewOptions.extent ) {
+		// If an extent was configured, fit the map to it (use mapExtent property, then basemap.extent)
+		if ( this.settings.mapExtent ) {
+			this.zoomAOI( this.settings.mapExtent );
+		} else if ( viewOptions.extent ) {
 			this.map.getView().fit( viewOptions.extent, this.map.getSize() );
 		}
 

--- a/src/plugins/geomap/geomap-en.hbs
+++ b/src/plugins/geomap/geomap-en.hbs
@@ -30,6 +30,7 @@
 			<li><a href="#osm">OSM basemap example</a></li>
 			<li><a href="#tile-source">Tile Source (XYZ) basemap example</a></li>
 			<li><a href="#filtering">Filtering example</a></li>
+			<li><a href="#aoiZoomOnLoad">Zoom to AOI on page load (extent)</a></li>
 		</ul>
 	</div>
 </div>
@@ -1299,6 +1300,56 @@ var wet_boew_geomap = {
 			&lt;/div&gt;
 		&lt;/div&gt;
 	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+		</details>
+	</section>
+</section>
+
+<section id="aoiZoomOnLoad">
+	<h2>Zoom to AOI on page load (extent)</h2>
+
+	<form class="wb-geomap-filter form-inline mrgn-bttm-md" data-bind-to="bc-geomap">
+		<div class="form-group">
+			<label for="zoomBCArea">B.C. Regions:</label>
+			<select class="form-control" data-filter="aoi" id="zoomBCArea">
+				<option value="63 -110 50 -128" selected>Select a region</option>
+				<option value="61 -124 55.33 -140.6">North</option>
+				<option value="50.802 -123.316 48.312 -128.578">Vancouver Island and Coast</option>
+				<option value="50.2806 -121.7203 49.0199 -124.4421">Lower Mainland</option>
+				<option value="52.4999 -118.5493 48.9964 -114.0535">Southern Interior</option>
+			</select>
+		</div>
+		<button aria-controls="bc-geomap" class="btn btn-primary" type="submit">Filter</button>
+		<button class="btn btn-link" type="reset">Reset page to defaults</button>
+	</form>
+	<div class="wb-geomap" id="bc-geomap" data-wb-geomap='{
+		"mapExtent": "63, -110, 50, -128"
+	}'>
+		<div class="wb-geomap-map"></div>
+	</div>
+
+	<section>
+		<h3>Code</h3>
+		<details>
+			<summary>View code</summary>
+			<pre><code>&lt;form class="wb-geomap-filter form-inline mrgn-bttm-md" data-bind-to="bc-geomap"&gt;
+	&lt;div class="form-group"&gt;
+		&lt;label for="zoomBCArea"&gt;B.C. Regions:&lt;/label&gt;
+		&lt;select class="form-control" data-filter="aoi" id="zoomBCArea"&gt;
+			&lt;option value="63 -110 50 -128" selected&gt;Select a region&lt;/option&gt;
+			&lt;option value="61 -124 55.33 -140.6"&gt;North&lt;/option&gt;
+			&lt;option value="50.802 -123.316 48.312 -128.578"&gt;Vancouver Island and Coast&lt;/option&gt;
+			&lt;option value="50.2806 -121.7203 49.0199 -124.4421"&gt;Lower Mainland&lt;/option&gt;
+			&lt;option value="52.4999 -118.5493 48.9964 -114.0535"&gt;Southern Interior&lt;/option&gt;
+		&lt;/select&gt;
+	&lt;/div&gt;
+	&lt;button aria-controls="bc-geomap" class="btn btn-primary" type="submit"&gt;Filter&lt;/button&gt;
+	&lt;button class="btn btn-link" type="reset"&gt;Reset page to defaults&lt;/button&gt;
+&lt;/form&gt;
+&lt;div class="wb-geomap" id="bc-geomap" data-wb-geomap='{
+	"mapExtent": "63, -110, 50, -128"
+}'&gt;
+	&lt;div class="wb-geomap-map"&gt;&lt;/div&gt;
 &lt;/div&gt;</code></pre>
 		</details>
 	</section>

--- a/src/plugins/geomap/geomap-fr.hbs
+++ b/src/plugins/geomap/geomap-fr.hbs
@@ -29,7 +29,8 @@
 			<li><a href="#esri-rest">Exemple de carte ESRI REST</a></li>
 			<li><a href="#osm">Exemple de carte de base OSM</a></li>
 			<li><a href="#carte-xyz">Exemple de carte de base XYZ</a></li>
-			<li><a href="#filtrer">Filtrer la cartre</a></li>
+			<li><a href="#filtrer">Filtrer la carte</a></li>
+			<li><a href="#aoiZoomOnLoad">Zoom à AOI au chargement de la page (étendue)</a></li>
 		</ul>
 	</div>
 </div>
@@ -817,7 +818,7 @@ var wet_boew_geomap = {
 </section>
 
 <section>
-	<h2 id="filtrer">Filtrer la cartre</h2>
+	<h2 id="filtrer">Filtrer la carte</h2>
 
 	<form class="wb-geomap-filter form-inline mrgn-bttm-md" data-bind-to="sample_map_filter">
 		<div class="form-group">
@@ -1287,6 +1288,56 @@ var wet_boew_geomap = {
 			&lt;/div&gt;
 		&lt;/div&gt;
 	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+		</details>
+	</section>
+</section>
+
+<section id="aoiZoomOnLoad">
+	<h2>Zoom à AOI au chargement de la page (étendue)</h2>
+
+	<form class="wb-geomap-filter form-inline mrgn-bttm-md" data-bind-to="bc-geomap">
+		<div class="form-group">
+			<label for="zoomBCArea">Régions de C.-B.:</label>
+			<select class="form-control" data-filter="aoi" id="zoomBCArea">
+				<option value="63 -110 50 -128" selected>Sélectionnez une région</option>
+				<option value="61 -124 55.33 -140.6">Nord</option>
+				<option value="50.802 -123.316 48.312 -128.578">Île de Vancouver et la côte</option>
+				<option value="50.2806 -121.7203 49.0199 -124.4421">Basse-terre continentale</option>
+				<option value="52.4999 -118.5493 48.9964 -114.0535">Intérieur sud</option>
+			</select>
+		</div>
+		<button aria-controls="bc-geomap" class="btn btn-primary" type="submit">Filtrer</button>
+		<button class="btn btn-link" type="reset">Réinitialiser la page aux valeurs par défaut</button>
+	</form>
+	<div class="wb-geomap" id="bc-geomap" data-wb-geomap='{
+		"mapExtent": "63, -110, 50, -128"
+	}'>
+		<div class="wb-geomap-map"></div>
+	</div>
+
+	<section>
+		<h3>Code</h3>
+		<details>
+			<summary>Visualiser le code</summary>
+			<pre><code>&lt;form class="wb-geomap-filter form-inline mrgn-bttm-md" data-bind-to="bc-geomap"&gt;
+	&lt;div class="form-group"&gt;
+		&lt;label for="zoomBCArea"&gt;Régions de C.-B.:&lt;/label&gt;
+		&lt;select class="form-control" data-filter="aoi" id="zoomBCArea"&gt;
+			&lt;option value="63 -110 50 -128" selected&gt;Sélectionnez une région&lt;/option&gt;
+			&lt;option value="61 -124 55.33 -140.6"&gt;Nord&lt;/option&gt;
+			&lt;option value="50.802 -123.316 48.312 -128.578"&gt;Île de Vancouver et la côte&lt;/option&gt;
+			&lt;option value="50.2806 -121.7203 49.0199 -124.4421"&gt;Basse-terre continentale&lt;/option&gt;
+			&lt;option value="52.4999 -118.5493 48.9964 -114.0535"&gt;Intérieur sud&lt;/option&gt;
+		&lt;/select&gt;
+	&lt;/div&gt;
+	&lt;button aria-controls="bc-geomap" class="btn btn-primary" type="submit"&gt;Filtrer&lt;/button&gt;
+	&lt;button class="btn btn-link" type="reset"&gt;Réinitialiser la page aux valeurs par défaut&lt;/button&gt;
+&lt;/form&gt;
+&lt;div class="wb-geomap" id="bc-geomap" data-wb-geomap='{
+	"mapExtent": "63, -110, 50, -128"
+}'&gt;
+	&lt;div class="wb-geomap-map"&gt;&lt;/div&gt;
 &lt;/div&gt;</code></pre>
 		</details>
 	</section>


### PR DESCRIPTION
Adding `mapExtent` configuration option to allow users to zoom to a specific area on page load.