### PR TITLE
Exit script - Hiding the page redirection from the web address bar

### DIFF
--- a/site/pages/docs/ref/exitscript/exiturl-en.hbs
+++ b/site/pages/docs/ref/exitscript/exiturl-en.hbs
@@ -11,10 +11,15 @@
 	"dateModified": "2020-06-17"
 }
 ---
-<p>Your original destination was: <span class="wb-exitscript wb-exitscript-urlparam"></span></p>
+<p>Dear Visitor,</p>
+
+<p>Thank you for visiting our website. We want to inform you that by clicking on the following link, you will be directed away from our site to another web page. Please note that we are not responsible for the content or privacy practices of the external website you are about to visit.</p>
+
+<p><span class="wb-exitscript wb-exitscript-urlparam"></span></p>
+
+<p><a href="../../../demos/exitscript/exitscript-en.html">Return to the plugin example page</a></p>
+
 <details class="mrgn-bttm-md">
 <summary>View code</summary>
-	<pre><code>
-	&lt;p&gt;Your original destination was: &lt;span class="wb-exitscript wb-exitscript-exiturlparam"&gt;&lt;/span&gt;&lt;/p&gt;
-	</code></pre>
+	<pre><code>&lt;p&gt;&lt;span class="wb-exitscript wb-exitscript-exiturlparam"&gt;&lt;/span&gt;&lt;/p&gt;</code></pre>
 </details>

--- a/site/pages/docs/ref/exitscript/exiturl-fr.hbs
+++ b/site/pages/docs/ref/exitscript/exiturl-fr.hbs
@@ -11,12 +11,15 @@
 	"dateModified": "2020-06-17"
 }
 ---
-<div lang="en">
-<p>Your original destination was: <span class="wb-exitscript wb-exitscript-urlparam"></span></p>
+<p>Cher visiteur,</p>
+
+<p>Merci de visiter notre site web. Nous tenons à vous informer qu'en cliquant sur le lien suivant, vous serez redirigé(e) hors de notre site vers une autre page web. Veuillez noter que nous ne sommes pas responsables du contenu ou des pratiques en matière de confidentialité du site externe que vous vous apprêtez à visiter.</p>
+
+<p><span class="wb-exitscript wb-exitscript-urlparam"></span></p>
+
+<p><a href="../../../demos/exitscript/exitscript-fr.html">Retourné à la page d'exemple du plugiciel</a></p>
+
 <details class="mrgn-bttm-md">
 <summary>View code</summary>
-	<pre><code>
-	&lt;p&gt;Your original destination was: &lt;span class="wb-exitscript wb-exitscript-exiturlparam"&gt;&lt;/span&gt;&lt;/p&gt;
-	</code></pre>
+	<pre><code>&lt;p&gt;&lt;span class="wb-exitscript wb-exitscript-exiturlparam"&gt;&lt;/span&gt;&lt;/p&gt;</code></pre>
 </details>
-</div>

--- a/site/pages/docs/ref/exitscript/exiturl-fr.hbs
+++ b/site/pages/docs/ref/exitscript/exiturl-fr.hbs
@@ -13,13 +13,13 @@
 ---
 <p>Cher visiteur,</p>
 
-<p>Merci de visiter notre site web. Nous tenons à vous informer qu'en cliquant sur le lien suivant, vous serez redirigé(e) hors de notre site vers une autre page web. Veuillez noter que nous ne sommes pas responsables du contenu ou des pratiques en matière de confidentialité du site externe que vous vous apprêtez à visiter.</p>
+<p>Merci d'avoir visité notre site web. Nous tenons à vous informer qu'en cliquant sur le lien suivant, vous serez redirigé(e) hors de notre site vers une autre page web. Veuillez noter que nous ne sommes pas responsables du contenu ou des pratiques en matière de confidentialité du site externe que vous vous apprêtez à visiter.</p>
 
 <p><span class="wb-exitscript wb-exitscript-urlparam"></span></p>
 
-<p><a href="../../../demos/exitscript/exitscript-fr.html">Retourné à la page d'exemple du plugiciel</a></p>
+<p><a href="../../../demos/exitscript/exitscript-fr.html">Retourner à la page d'exemple du plugiciel</a></p>
 
 <details class="mrgn-bttm-md">
-<summary>View code</summary>
+<summary>Cosulter le code</summary>
 	<pre><code>&lt;p&gt;&lt;span class="wb-exitscript wb-exitscript-exiturlparam"&gt;&lt;/span&gt;&lt;/p&gt;</code></pre>
 </details>

--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -166,7 +166,7 @@ wb.addSkipLink = function( text, attr, isBtn, isLast ) {
 
 } )( jQuery, wb );
 
-( function( wb ) {
+( function( wb, window ) {
 
 "use strict";
 
@@ -1140,7 +1140,70 @@ wb.string = {
 			str = "0" + str;
 		}
 		return str;
+	},
+
+	/*
+	 * Convert a base64 string into an ArrayBuffer (Note: this function are not fully UTF-8 supported and may create interoperability issue)
+	 * ref. https://www.isummation.com/blog/convert-arraybuffer-to-base64-string-and-vice-versa/
+	 * @memberof wb.string
+	 * @param {string} Base64 browser encoded
+	 * @return {ArrayBuffer} string converted into ArrayBuffer
+	 */
+	base64ToArrayBuffer: function( base64 ) {
+		var binary_string = window.atob( base64 ),
+			len = binary_string.length,
+			bytes = new Uint8Array( len ),
+			i;
+		for ( i = 0; i < len; i++ ) {
+			bytes[ i ] = binary_string.charCodeAt( i );
+		}
+		return bytes.buffer;
+	},
+
+	/*
+	 * Convert an ArrayBuffer into base64 string (Note: this function are not fully UTF-8 supported and may create interoperability issue)
+	 * ref. https://www.isummation.com/blog/convert-arraybuffer-to-base64-string-and-vice-versa/
+	 * @memberof wb.string
+	 * @param {ArrayBuffer}
+	 * @return {string} ArrayBuffer converted into base64 string
+	 */
+	arrayBufferToBase64: function( buffer ) {
+		var binary = "",
+			bytes = new Uint8Array( buffer ),
+			len = bytes.byteLength,
+			i;
+		for ( i = 0; i < len; i++ ) {
+			binary += String.fromCharCode( bytes[ i ] );
+		}
+		return window.btoa( binary );
+	},
+
+	/*
+	 * Convert an hexadecimal string into an ArrayBuffer
+	 * ref. https://stackoverflow.com/questions/38987784/how-to-convert-a-hexadecimal-string-to-uint8array-and-back-in-javascript/50868276#50868276
+	 * @memberof wb.string
+	 * @param {string} Encoded string in hexadecimal
+	 * @return {Uint8Array} Binary array buffer
+	 */
+	fromHexString: function( hexString ) {
+		return hexString === null ? null : Uint8Array.from( hexString.match( /.{1,2}/g ).map( function( byte ) {
+			return parseInt( byte, 16 );
+		} ) );
+	},
+
+	/*
+	 * Convert an ArrayBuffer into an hexadecimal string
+	 * ref. https://stackoverflow.com/questions/38987784/how-to-convert-a-hexadecimal-string-to-uint8array-and-back-in-javascript/50868276#50868276
+	 * @memberof wb.string
+	 * @param {Uint8Array} Binary array buffer
+	 * @return {string} Encoded string in hexadecimal
+	 */
+	toHexString: function( bytes ) {
+		return bytes.reduce( function( str, byte ) {
+			return str + byte.toString( 16 ).padStart( 2, "0" );
+		}, "" );
 	}
+
 };
 
 /*
@@ -1363,7 +1426,7 @@ wb.findPotentialPII = function( str, scope, opts ) {
 	return toClean && isFound ? str : isFound;
 };
 
-} )( wb );
+} )( wb, window );
 
 ( function( $, undef ) {
 "use strict";

--- a/src/core/test.js
+++ b/src/core/test.js
@@ -12,7 +12,7 @@
  * nested in other test suites if you want to use the same setup `before()` and
  * teardown `after()` for more than one test suite (as is the case below.)
  */
-describe( "findPotentialPII test suite", function() {
+describe( "wb.core helpers test suite", function() {
 	var sandbox = sinon.createSandbox();
 
 	before( function() {
@@ -92,6 +92,58 @@ describe( "findPotentialPII test suite", function() {
 			expect( wb.findPotentialPII( "email:1@example.com, phone:514-514-5144, postal code:K2C-3N2, case number:123456", { email: 1, postalCode: 1 }, { useFullBlock: 1 } ) ).to.equal( "email:█████████████, phone:514-514-5144, postal code:███████, case number:123456" );
 		} );
 
+
+	} );
+
+	/*
+	 * Test wb string helpers
+	 */
+	describe( "wb.string helpers", function() {
+
+		before( function() {
+		} );
+
+		after( function() {
+		} );
+
+		// arrayBufferToBase64
+		it( "arrayBufferToBase64: Should convert arrayBuffer into Base64", function() {
+			expect( wb.string.arrayBufferToBase64( new Uint8Array( [ 21, 31 ] ) ) ).to.equal( "FR8=" );
+		} );
+
+		// base64ToArrayBuffer
+		it( "base64ToArrayBuffer: Should convert base64 string into array buffer", function() {
+			var retValue = wb.string.base64ToArrayBuffer( "FR8=" );
+			expect( retValue.byteLength ).to.equal( 2 ); // Valid its return an ArrayBuffer
+
+			// Check the integrity
+			var arr = new Uint8Array( retValue );
+			expect( arr[ 0 ] ).to.equal( 21 );
+			expect( arr[ 1 ] ).to.equal( 31 );
+			expect( arr[ 2 ] ).to.be.an( "undefined" );
+		} );
+
+		// toHexString
+		it( "toHexString: Should convert arrayBuffer into hexadecimal string", function() {
+			expect( wb.string.toHexString( new Uint8Array( [ 21, 31 ] ) ) ).to.equal( "151f" );
+		} );
+
+		// fromHexString
+		it( "fromHexString: should convert hexadecimal string into array buffer", function() {
+			var retValue = wb.string.fromHexString( "151f" );
+			expect( retValue.byteLength ).to.equal( 2 ); // Valid its return an ArrayBuffer
+			expect( retValue.buffer.byteLength ).to.equal( 2 ); // Valid its inheriting from ArrayBuffer
+
+			// Check the integrity
+			expect( retValue[ 0 ] ).to.equal( 21 );
+			expect( retValue[ 1 ] ).to.equal( 31 );
+			expect( retValue[ 2 ] ).to.be.an( "undefined" );
+		} );
+
+		// fromHexString (param is null)
+		it( "fromHexString: Should return null when passing a null parameter", function() {
+			expect( wb.string.fromHexString( null ) ).to.be.equal( null );
+		} );
 
 	} );
 

--- a/src/plugins/exitscript/exitscript-en.hbs
+++ b/src/plugins/exitscript/exitscript-en.hbs
@@ -44,7 +44,7 @@
 	</code></pre>
 </details>
 <p>Scenario – 3: <a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-en.html"}'>http://csszengarden.com/219</a></p>
-<p>In this scenario a middle page opens in the same window with a link to the non-secure site.</p>
+<p>In this scenario a middle page opens in the same window with a link to the external site.</p>
 <details class="mrgn-bttm-md">
 <summary>View code</summary>
 	<pre><code>

--- a/src/plugins/exitscript/exitscript-fr.hbs
+++ b/src/plugins/exitscript/exitscript-fr.hbs
@@ -27,7 +27,7 @@
 <dd>_self</dd>
 </dl>
 <p>Scénario – 1: <a href="http://csszengarden.com/219" class="wb-exitscript">http://csszengarden.com/219</a></p>
-<p>Ce scénario affiche une fenêtre modale avec le message, “Vous êtes sur le point de quitter un site sécurisé. Voulez-vous continuer?”</p>
+<p>Ce scénario affiche une fenêtre modale avec le message suivant&nbsp;: “Vous êtes sur le point de quitter un site sécurisé. Voulez-vous continuer?”</p>
 <details class="mrgn-bttm-md">
 <summary>Consulter le code</summary>
 	<pre><code>
@@ -35,7 +35,7 @@
 	</code></pre>
 </details>
 <p>Scénario – 2: <a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank">http://csszengarden.com/219</a></p>
-<p>Ce scénario affiche une fenêtre modale avec le message, “Vous êtes sur le point de quitter un site sécurisé. Voulez-vous continuer? Le lien s'ouvrira dans une nouvelle fenêtre de navigateur”</p>
+<p>Ce scénario affiche une fenêtre modale avec le message suivant&nbsp;: “Vous êtes sur le point de quitter un site sécurisé. Voulez-vous continuer? Le lien s'ouvrira dans une nouvelle fenêtre de navigateur”</p>
 <details class="mrgn-bttm-md">
 <summary>Consulter le code</summary>
 	<pre><code>
@@ -50,27 +50,28 @@
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
 </details>
-<p>Scénario – 4: <a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'>http://csszengarden.com/219</a>. Le lien va ouvrir une page intermédiaire dans une nouvelle fenêtre du fureteur afin d'avisé que l'utilisateur quitte le site web.</p>
+<p>Scénario – 4: <a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'>http://csszengarden.com/219</a></p>
+<p>Dans ce scénario, le lien ouvrira une page intermédiaire dans une nouvelle fenêtre du navigateur afin d'aviser l'utilisateur qu'il est sur le point de quitter le site web.</p>
 <details class="mrgn-bttm-md">
 <summary>Consulter le code</summary>
 	<pre><code>
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
 </details>
-<p>Cet example affiche une message personalisé dans la fenêtre modale.</p>
-<p><a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"i18n": { "exitMsg": "Ceci est un message personalisé.", "cancelBtn": "Non merci", "yesBtn": "Oui S.V.P." }}'>http://csszengarden.com/219</a></p>
+<p>Cet exemple affiche un message personnalisé dans la fenêtre modale.</p>
+<p><a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"i18n": { "exitMsg": "Ceci est un message personnalisé.", "cancelBtn": "Non merci", "yesBtn": "Oui S.V.P." }}'>http://csszengarden.com/219</a></p>
 <details class="mrgn-bttm-md">
 <summary>Consulter le code</summary>
 	<pre><code>
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{
 	"i18n":{
-	"exitMsg": "Ceci est un message personalisé.",
+	"exitMsg": "Ceci est un message personnalisé.",
 	"cancelBtn": "Non merci",
 	"yesBtn": "Oui S.V.P." }
 	}'&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
 </details>
-<p>Les auteurs peuvent configurer les étiquettes des boutons, le titre de la boîte de message, et personaliser un message.</p>
+<p>Les auteurs peuvent configurer les étiquettes des boutons, le titre de la boîte de message et personnaliser un message.</p>
 <p><a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"i18n": { "msgboxHeader": "Avertissement de sortie", "cancelBtn": "Non merci", "yesBtn": "Oui S.V.P." }}'>http://csszengarden.com/219</a></p>
 <details class="mrgn-bttm-md">
 <summary>Consulter le code</summary>

--- a/src/plugins/exitscript/exitscript-fr.hbs
+++ b/src/plugins/exitscript/exitscript-fr.hbs
@@ -26,62 +26,59 @@
 <dt>target</dt>
 <dd>_self</dd>
 </dl>
-<div lang="en">
-<p>Scenario – 1: <a href="http://csszengarden.com/219" class="wb-exitscript">http://csszengarden.com/219</a></p>
-<p>This scenario displays a modal dialog with a message, “You are about to leave a secure site, do you wish to continue?”</p>
+<p>Scénario – 1: <a href="http://csszengarden.com/219" class="wb-exitscript">http://csszengarden.com/219</a></p>
+<p>Ce scénario affiche une fenêtre modale avec le message, “Vous êtes sur le point de quitter un site sécurisé. Voulez-vous continuer?”</p>
 <details class="mrgn-bttm-md">
-<summary>View code</summary>
+<summary>Consulter le code</summary>
 	<pre><code>
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript"&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
 </details>
-<p>Scenario – 2: <a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank">http://csszengarden.com/219</a></p>
-<p>This scenario displays a modal dialog with a message, “You are about to leave a secure site, do you wish to continue? The link will open in a new browser window.”</p>
+<p>Scénario – 2: <a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank">http://csszengarden.com/219</a></p>
+<p>Ce scénario affiche une fenêtre modale avec le message, “Vous êtes sur le point de quitter un site sécurisé. Voulez-vous continuer? Le lien s'ouvrira dans une nouvelle fenêtre de navigateur”</p>
 <details class="mrgn-bttm-md">
-<summary>View code</summary>
+<summary>Consulter le code</summary>
 	<pre><code>
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank"&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
 </details>
-<p>Scenario – 3: <a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'>http://csszengarden.com/219</a></p>
-<p>In this scenario a middle page opens in the same window with a link to the non-secure site.</p>
+<p>Scénario – 3: <a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'>http://csszengarden.com/219</a></p>
+<p>Dans ce scénario, la page intermédiaire s'ouvre dans la même fenêtre et ce dernier contiendra un lien vers le site web externe.</p>
 <details class="mrgn-bttm-md">
-<summary>View code</summary>
+<summary>Consulter le code</summary>
 	<pre><code>
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
 </details>
-<p>Scenario – 4: <a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'>http://csszengarden.com/219</a>. The link will open in a new browser window.</p>
-<p>In this scenario a middle page opens in a new window with a link to the non-secure site.</p>
+<p>Scénario – 4: <a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'>http://csszengarden.com/219</a>. Le lien va ouvrir une page intermédiaire dans une nouvelle fenêtre du fureteur afin d'avisé que l'utilisateur quitte le site web.</p>
 <details class="mrgn-bttm-md">
-<summary>View code</summary>
+<summary>Consulter le code</summary>
 	<pre><code>
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript" target="_blank" data-wb-exitscript='{"url": "../../docs/ref/exitscript/exiturl-fr.html"}'&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
 </details>
-<p>This example shows a custom message</p>
-<p><a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"i18n": { "exitMsg": "This is a custom message.", "cancelBtn": "Nope", "yesBtn": "Sure" }}'>http://csszengarden.com/219</a></p>
+<p>Cet example affiche une message personalisé dans la fenêtre modale.</p>
+<p><a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"i18n": { "exitMsg": "Ceci est un message personalisé.", "cancelBtn": "Non merci", "yesBtn": "Oui S.V.P." }}'>http://csszengarden.com/219</a></p>
 <details class="mrgn-bttm-md">
-<summary>View code</summary>
+<summary>Consulter le code</summary>
 	<pre><code>
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{
 	"i18n":{
-	"exitMsg": "This is a custom message.",
-	"cancelBtn": "Nope",
-	"yesBtn": "Sure" }
+	"exitMsg": "Ceci est un message personalisé.",
+	"cancelBtn": "Non merci",
+	"yesBtn": "Oui S.V.P." }
 	}'&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
 </details>
-<p>Users can change button labels, message box title, and set a custom message</p>
-<p><a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"i18n": { "msgboxHeader": "Avertissement de sortie", "cancelBtn": "Nope", "yesBtn": "Sure" }}'>http://csszengarden.com/219</a></p>
+<p>Les auteurs peuvent configurer les étiquettes des boutons, le titre de la boîte de message, et personaliser un message.</p>
+<p><a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{"i18n": { "msgboxHeader": "Avertissement de sortie", "cancelBtn": "Non merci", "yesBtn": "Oui S.V.P." }}'>http://csszengarden.com/219</a></p>
 <details class="mrgn-bttm-md">
-<summary>View code</summary>
+<summary>Consulter le code</summary>
 	<pre><code>
 	&lt;a href="http://csszengarden.com/219" class="wb-exitscript" data-wb-exitscript='{
 	"i18n":{ "msgboxHeader": "Avertissement de sortie",
-	"cancelBtn": "Nope",
-	"yesBtn": "Sure" }
+	"cancelBtn": "Non merci",
+	"yesBtn": "Oui S.V.P." }
 	}'&gt;http://csszengarden.com/219&lt;/a&gt;
 	</code></pre>
 </details>
-</div>

--- a/src/plugins/exitscript/exitscript.js
+++ b/src/plugins/exitscript/exitscript.js
@@ -4,13 +4,14 @@
 * @license wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
 * @author @ipaksc
 */
-( function( $, window, wb ) {
+( function( $, window, wb, crypto ) {
 "use strict";
 var componentName = "wb-exitscript",
 	selector = "." + componentName,
 	initEvent = "wb-init" + selector,
 	$document = wb.doc,
 	exiturlparam = componentName + "-urlparam",
+	keyForKeyHolder = componentName + "key",
 	moDalId = componentName + "-modal",
 	i18n,
 	i18nDict = {
@@ -41,7 +42,9 @@ var componentName = "wb-exitscript",
 			settings,
 			queryString = window.location.search,
 			urlParams = new URLSearchParams( queryString ),
-			originalURL = urlParams.get( "exturl" ),
+			counterInUrl = wb.string.fromHexString( urlParams.get( "exturl" ) ),
+			encrytedUrl = localStorage.getItem( componentName ),
+			jwt = JSON.parse( localStorage.getItem( keyForKeyHolder ) ),
 			$elm;
 		if ( elm ) {
 			$elm = $( elm );
@@ -54,16 +57,90 @@ var componentName = "wb-exitscript",
 
 			$elm.data( componentName, settings );
 
-			if ( settings.url ) {
-				$( this ).attr( "href", settings.url + "?exturl=" +  encodeURIComponent( this.href ) );
+			if ( settings.url && crypto ) {
+
+				crypto.subtle.generateKey(
+					{
+						name: "AES-CTR",
+						length: 256
+					},
+					true,
+					[ "encrypt", "decrypt" ]
+				).then( function( keyToEncryp ) {
+
+					var enc, messageEncoded, counter;
+
+					// Save the key in the anchor
+					crypto.subtle.exportKey( "jwk", keyToEncryp )
+						.then( function( exportedJwtKey ) {
+							elm[ keyForKeyHolder ] = exportedJwtKey;
+						} );
+
+					// Encrypt the URL
+					enc = new TextEncoder();
+					messageEncoded = enc.encode( elm.href );
+					counter = crypto.getRandomValues( new Uint8Array( 16 ) );
+					crypto.subtle.encrypt(
+						{
+							name: "AES-CTR",
+							counter: counter,
+							length: 64
+						},
+						keyToEncryp,
+						messageEncoded
+					).then( function( ciphertext ) {
+						elm[ componentName ] = ciphertext;
+					} );
+
+					// Change the link URL by passing the counter as a key
+					$elm.attr( "href", settings.url + "?exturl=" + wb.string.toHexString( counter ) );
+				} );
+
 			}
 
 			i18n = i18nDict[ wb.lang || "en" ];
 
 			// This conditional statement for a middle static exit page, to retrieve the URL to the non-secure site.
-			if ( $elm.hasClass( exiturlparam ) ) {
-				this.outerHTML = "<a href='" + originalURL + "'>" + originalURL + "</a>";
+			if ( $elm.hasClass( exiturlparam ) && encrytedUrl !== null && jwt !== null ) {
+
+				crypto.subtle.importKey(
+					"jwk",
+					jwt,
+					{
+						name: "AES-CTR",
+						length: 256
+					},
+					true,
+					[ "decrypt" ]
+				).then( function( key ) {
+
+					crypto.subtle.decrypt(
+						{
+							name: "AES-CTR",
+							counter: counterInUrl,
+							length: 64
+						},
+						key,
+						wb.string.base64ToArrayBuffer( encrytedUrl )
+					).then( function( decrypted ) {
+
+						var dec = new TextDecoder(),
+							urlToRedirect = dec.decode( decrypted );
+
+						// Check if the decrypted message is an valid URL and silently fail if the pattern don't match
+						if ( urlToRedirect.match( /^(http|https):\/\//g ) ) {
+							elm.outerHTML = "<a href='" + urlToRedirect + "'>" + urlToRedirect + "</a>";
+						}
+
+					} );
+				} );
+
 			}
+
+			// Remove the plugin data and ensure it is removed from the localstorage
+			localStorage.removeItem( componentName );
+			localStorage.removeItem( keyForKeyHolder );
+
 			wb.ready( $elm, componentName );
 		}
 	};
@@ -137,6 +214,11 @@ $document.on( "click", selector, function( event ) {
 
 		] );
 
+	} else if ( crypto && this[ componentName ] ) {
+
+		// Save to localstorage, the plugin init will ensure this data is only used once
+		localStorage.setItem( componentName, wb.string.arrayBufferToBase64( this[ componentName ] ) );
+		localStorage.setItem( keyForKeyHolder, JSON.stringify( this[ keyForKeyHolder ] ) );
 	}
 
 } );
@@ -147,4 +229,4 @@ $document.on( "timerpoke.wb " + initEvent, selector, init );
 // Add the timer poke to initialize the plugin
 wb.add( selector );
 
-} )( jQuery, window, wb );
+} )( jQuery, window, wb, crypto );

--- a/src/plugins/exitscript/exitscript.js
+++ b/src/plugins/exitscript/exitscript.js
@@ -43,7 +43,7 @@ var componentName = "wb-exitscript",
 			queryString = window.location.search,
 			urlParams = new URLSearchParams( queryString ),
 			counterInUrl = wb.string.fromHexString( urlParams.get( "exturl" ) ),
-			encrytedUrl = localStorage.getItem( componentName ),
+			encryptedUrl = localStorage.getItem( componentName ),
 			jwt = JSON.parse( localStorage.getItem( keyForKeyHolder ) ),
 			$elm;
 		if ( elm ) {
@@ -101,7 +101,7 @@ var componentName = "wb-exitscript",
 			i18n = i18nDict[ wb.lang || "en" ];
 
 			// This conditional statement for a middle static exit page, to retrieve the URL to the non-secure site.
-			if ( $elm.hasClass( exiturlparam ) && encrytedUrl !== null && jwt !== null ) {
+			if ( $elm.hasClass( exiturlparam ) && encryptedUrl !== null && jwt !== null ) {
 
 				crypto.subtle.importKey(
 					"jwk",
@@ -121,7 +121,7 @@ var componentName = "wb-exitscript",
 							length: 64
 						},
 						key,
-						wb.string.base64ToArrayBuffer( encrytedUrl )
+						wb.string.base64ToArrayBuffer( encryptedUrl )
 					).then( function( decrypted ) {
 
 						var dec = new TextDecoder(),


### PR DESCRIPTION
This change ensure the redirection URL are not in the page URL of the intermediate page (scenario 3 and scenario 4).

Type of change: **Patch**

Working example with this fix:
* https://universallabs.org/wet/labs/pr9692/unmin/demos/exitscript/exitscript-en.html
* https://universallabs.org/wet/labs/pr9692/unmin/demos/exitscript/exitscript-fr.html

cc @ahmad-shahid 

(reference number: wet-430)