### PR TITLE
Formvalid: adding working examples for radios and checkboxes

### DIFF
--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -484,25 +484,24 @@
 <hr>
 <section>
 <!-- checkbox in list item -->
-	<h2>Examples of stacked and horizontal forms using list items as container</h2>
+	<h2>Various examples of stacked and horizontal forms</h2>
 	<div class="wb-frmvld">
 		<form action="#" method="get" id="validation-example-2">
-
-<!-- checkbox in list item with implicit labels-->
+			<!-- checkbox in list item with implicit labels-->
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Stacked checkboxes in a <code>&lt;li&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
 				<ul class="form-group list-unstyled">
 					<li class="checkbox">
-						<label for="fruits1a"><input type="checkbox" name="example1" value="1" id="fruits1a" required="required" />Apple</label>
+						<label for="example1a"><input type="checkbox" name="example1" value="1" id="example1a" required="required" />Apple</label>
 					</li>
 					<li class="checkbox">
-						<label for="fruits2a"><input type="checkbox" name="example1" value="2" id="fruits2a" />Orange</label>
+						<label for="example1b"><input type="checkbox" name="example1" value="2" id="example1b" />Orange</label>
 					</li>
 					<li class="checkbox">
-						<label for="fruits3a"><input type="checkbox" name="example1" value="3" id="fruits3a" />Kiwi</label>
+						<label for="example1c"><input type="checkbox" name="example1" value="3" id="example1c" />Kiwi</label>
 					</li>
 					<li class="checkbox">
-						<label for="fruits4a"><input type="checkbox" name="example1" value="4" id="fruits4a" />Other</label>
+						<label for="example1d"><input type="checkbox" name="example1" value="4" id="example1d" />Other</label>
 					</li>
 				</ul>
 			</fieldset>
@@ -515,37 +514,37 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked checkboxes in a &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits1a"&gt;&lt;input type="checkbox" name="example1" value="1" id="fruits1a" required="required" /&gt;Apple&lt;/label&gt;
+					&lt;label for="example1a"&gt;&lt;input type="checkbox" name="example1" value="1" id="example1a" required="required" /&gt;Apple&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits2a"&gt;&lt;input type="checkbox" name="example1" value="2" id="fruits2a" /&gt;Orange&lt;/label&gt;
+					&lt;label for="example1b"&gt;&lt;input type="checkbox" name="example1" value="2" id="example1b" /&gt;Orange&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits3a"&gt;&lt;input type="checkbox" name="example1" value="3" id="fruits3a" /&gt;Kiwi&lt;/label&gt;
+					&lt;label for="example1c"&gt;&lt;input type="checkbox" name="example1" value="3" id="example1c" /&gt;Kiwi&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits4a"&gt;&lt;input type="checkbox" name="example1" value="4" id="fruits4a" /&gt;Other&lt;/label&gt;
+					&lt;label for="example1d"&gt;&lt;input type="checkbox" name="example1" value="4" id="example1d" /&gt;Other&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
 		&lt;/fieldset&gt;</code></pre>
 				<div class="well well-sm"><strong>Note:</strong> The <code>for</code> attribute in the labels is optional for this pattern</div>
 			</details>
 
-<!-- radio in a list with implicit labels -->
+			<!-- radio in a list with implicit labels -->
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Stacked radio buttons in a <code>&lt;li&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
 				<ul class="form-group list-unstyled">
 					<li class="radio">
-						<label for="fruits1b"><input type="radio" name="example2" value="1" id="fruits1b" required="required" />Apple</label>
+						<label for="example2a"><input type="radio" name="example2" value="1" id="example2a" required="required" />Apple</label>
 					</li>
 					<li class="radio">
-						<label for="fruits2b"><input type="radio" name="example2" value="2" id="fruits2b" />Orange</label>
+						<label for="example2b"><input type="radio" name="example2" value="2" id="example2b" />Orange</label>
 					</li>
 					<li class="radio">
-						<label for="fruits3b"><input type="radio" name="example2" value="3" id="fruits3b" />Kiwi</label>
+						<label for="example2c"><input type="radio" name="example2" value="3" id="example2c" />Kiwi</label>
 					</li>
 					<li class="radio">
-						<label for="fruits4b"><input type="radio" name="example2" value="4" id="fruits4b" />Other</label>
+						<label for="example2d"><input type="radio" name="example2" value="4" id="example2d" />Other</label>
 					</li>
 				</ul>
 			</fieldset>
@@ -558,36 +557,36 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked radio buttons in a &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits1b"&gt;&lt;input type="radio" name="example2" value="1" id="fruits1b" required="required" /&gt;Apple&lt;/label&gt;
+					&lt;label for="example2a"&gt;&lt;input type="radio" name="example2" value="1" id="example2a" required="required" /&gt;Apple&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits2b"&gt;&lt;input type="radio" name="example2" value="2" id="fruits2b" /&gt;Orange&lt;/label&gt;
+					&lt;label for="example2b"&gt;&lt;input type="radio" name="example2" value="2" id="example2b" /&gt;Orange&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits3b"&gt;&lt;input type="radio" name="example2" value="3" id="fruits3b" /&gt;Kiwi&lt;/label&gt;
+					&lt;label for="example2c"&gt;&lt;input type="radio" name="example2" value="3" id="example2c" /&gt;Kiwi&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits4b"&gt;&lt;input type="radio" name="example2" value="4" id="fruits4b" /&gt;Other&lt;/label&gt;
+					&lt;label for="example2d"&gt;&lt;input type="radio" name="example2" value="4" id="example2d" /&gt;Other&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
 		&lt;/fieldset&gt;</code></pre>
 				<div class="well well-sm"><strong>Note:</strong> The <code>for</code> attribute in the labels is optional for this pattern</div>
 			</details>
 
-<!-- checkbox in div pattern with implicit labels-->
+			<!-- checkbox in div pattern with implicit labels-->
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Stacked checkboxes in a <code>&lt;div&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
 				<div class="checkbox">
-					<label for="fruits1c"><input type="checkbox" name="example3" value="1" id="fruits1c" required="required" />Apple</label>
+					<label for="example3a"><input type="checkbox" name="example3" value="1" id="example3a" required="required" />Apple</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits2c"><input type="checkbox" name="example3" value="2" id="fruits2c" />Orange</label>
+					<label for="example3b"><input type="checkbox" name="example3" value="2" id="example3b" />Orange</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits3c"><input type="checkbox" name="example3" value="3" id="fruits3c" />Kiwi</label>
+					<label for="example3c"><input type="checkbox" name="example3" value="3" id="example3c" />Kiwi</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits4c"><input type="checkbox" name="example3" value="4" id="fruits4c" />Other</label>
+					<label for="example3d"><input type="checkbox" name="example3" value="4" id="example3d" />Other</label>
 				</div>
 			</fieldset>
 			<details class="mrgn-bttm-md">
@@ -598,40 +597,79 @@
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked checkboxes in a &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits1c"&gt;&lt;input type="checkbox" name="example3" value="1" id="fruits1c" required="required" /&gt;Apple&lt;/label&gt;
+				&lt;label for="example3a"&gt;&lt;input type="checkbox" name="example3" value="1" id="example3a" required="required" /&gt;Apple&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits2c"&gt;&lt;input type="checkbox" name="example3" value="2" id="fruits2c" /&gt;Orange&lt;/label&gt;
+				&lt;label for="example3b"&gt;&lt;input type="checkbox" name="example3" value="2" id="example3b" /&gt;Orange&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits3c"&gt;&lt;input type="checkbox" name="example3" value="3" id="fruits3c" /&gt;Kiwi&lt;/label&gt;
+				&lt;label for="example3c"&gt;&lt;input type="checkbox" name="example3" value="3" id="example3c" /&gt;Kiwi&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits4c"&gt;&lt;input type="checkbox" name="example3" value="4" id="fruits4c" /&gt;Other&lt;/label&gt;
+				&lt;label for="example3d"&gt;&lt;input type="checkbox" name="example3" value="4" id="example3d" /&gt;Other&lt;/label&gt;
 			&lt;/div&gt;
 		&lt;/fieldset&gt;</code></pre>
 				<div class="well well-sm"><strong>Note:</strong> The <code>for</code> attribute in the labels is optional for this pattern</div>
 			</details>
 
-<!-- checkbox in list item with explicit labels-->
+			<!-- radio buttons in div pattern with implicit labels-->
+			<fieldset class="chkbxrdio-grp">
+				<legend class="required"><span class="field-name">Stacked radio buttons in a <code>&lt;div&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
+				<div class="radio">
+					<label for="example4a"><input type="radio" name="example4" value="1" id="example4a" required="required" />Apple</label>
+				</div>
+				<div class="radio">
+					<label for="example4b"><input type="radio" name="example4" value="2" id="example4b" />Orange</label>
+				</div>
+				<div class="radio">
+					<label for="example4c"><input type="radio" name="example4" value="3" id="example4c" />Kiwi</label>
+				</div>
+				<div class="radio">
+					<label for="example4d"><input type="radio" name="example4" value="4" id="example4d" />Other</label>
+				</div>
+			</fieldset>
+			<details class="mrgn-bttm-md">
+				<summary>View code</summary>
+				<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+		...
+		&lt;fieldset class="chkbxrdio-grp"&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Stacked radio buttons in a &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="example4a"&gt;&lt;input type="radio" name="example4" value="1" id="example4a" required="required" /&gt;Apple&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="example4b"&gt;&lt;input type="radio" name="example4" value="2" id="example4b" /&gt;Orange&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="example4c"&gt;&lt;input type="radio" name="example4" value="3" id="example4c" /&gt;Kiwi&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="example4d"&gt;&lt;input type="radio" name="example4" value="4" id="example4d" /&gt;Other&lt;/label&gt;
+			&lt;/div&gt;
+		&lt;/fieldset&gt;</code></pre>
+				<div class="well well-sm"><strong>Note:</strong> The <code>for</code> attribute in the labels is optional for this pattern</div>
+			</details>
+
+			<!-- checkbox in list item with explicit labels-->
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Horizontal checkboxes in a <code>&lt;li&gt;</code> pattern with explicit labels</span> <strong class="required">(required)</strong></legend>
 				<ul class="form-inline list-unstyled">
 					<li class="label-inline">
-						<input type="checkbox" name="example4" value="1" id="fruits5" required="required" />
-						<label for="fruits5">Apple</label>
+						<input type="checkbox" name="example5" value="1" id="example5a" required="required" />
+						<label for="example5a">Apple</label>
 					</li>
 					<li class="label-inline">
-						<input type="checkbox" name="example4" value="2" id="fruits6" />
-						<label for="fruits6">Orange</label>
+						<input type="checkbox" name="example5" value="2" id="example5b" />
+						<label for="example5b">Orange</label>
 					</li>
 					<li class="label-inline">
-						<input type="checkbox" name="example4" value="3" id="fruits7" />
-						<label for="fruits7">Kiwi</label>
+						<input type="checkbox" name="example5" value="3" id="example5c" />
+						<label for="example5c">Kiwi</label>
 					</li>
 					<li class="label-inline">
-						<input type="checkbox" name="example4" value="4" id="fruits8" />
-						<label for="fruits8">Other</label>
+						<input type="checkbox" name="example5" value="4" id="example5d" />
+						<label for="example5d">Other</label>
 					</li>
 				</ul>
 			</fieldset>
@@ -644,32 +682,104 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal checkboxes in a &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; pattern with explicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-inline list-unstyled"&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="checkbox" name="example4" value="1" id="fruits5" required="required" /&gt;
-					&lt;label for="fruits5"&gt;Apple&lt;/label&gt;
+					&lt;input type="checkbox" name="example5" value="1" id="example5a" required="required" /&gt;
+					&lt;label for="example5a"&gt;Apple&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="checkbox" name="example4" value="2" id="fruits6" /&gt;
-					&lt;label for="fruits6"&gt;Orange&lt;/label&gt;
+					&lt;input type="checkbox" name="example5" value="2" id="example5b" /&gt;
+					&lt;label for="example5b"&gt;Orange&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="checkbox" name="example4" value="3" id="fruits7" /&gt;
-					&lt;label for="fruits7"&gt;Kiwi&lt;/label&gt;
+					&lt;input type="checkbox" name="example5" value="3" id="example5c" /&gt;
+					&lt;label for="example5c"&gt;Kiwi&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="checkbox" name="example4" value="4" id="fruits8" /&gt;
-					&lt;label for="fruits8"&gt;Other&lt;/label&gt;
+					&lt;input type="checkbox" name="example5" value="4" id="example5d" /&gt;
+					&lt;label for="example5d"&gt;Other&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>
 
-<!-- Radio inline list item with implicit labels-->
+			<!-- radio buttons in list item with explicit labels-->
+			<fieldset class="chkbxrdio-grp">
+				<legend class="required"><span class="field-name">Horizontal radio buttons in a <code>&lt;li&gt;</code> pattern with explicit labels</span> <strong class="required">(required)</strong></legend>
+				<ul class="form-inline list-unstyled">
+					<li class="label-inline">
+						<input type="radio" name="example6" value="1" id="example6a" required="required" />
+						<label for="example6a">Apple</label>
+					</li>
+					<li class="label-inline">
+						<input type="radio" name="example6" value="2" id="example6b" />
+						<label for="example6b">Orange</label>
+					</li>
+					<li class="label-inline">
+						<input type="radio" name="example6" value="3" id="example6c" />
+						<label for="example6c">Kiwi</label>
+					</li>
+					<li class="label-inline">
+						<input type="radio" name="example6" value="4" id="example6d" />
+						<label for="example6d">Other</label>
+					</li>
+				</ul>
+			</fieldset>
+			<details class="mrgn-bttm-md">
+				<summary>View code</summary>
+				<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+		...
+		&lt;fieldset class="chkbxrdio-grp"&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal radio buttons in a &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; pattern with explicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;ul class="form-inline list-unstyled"&gt;
+				&lt;li class="label-inline"&gt;
+					&lt;input type="radio" name="example6" value="1" id="example6a" required="required" /&gt;
+					&lt;label for="example6a"&gt;Apple&lt;/label&gt;
+				&lt;/li&gt;
+				&lt;li class="label-inline"&gt;
+					&lt;input type="radio" name="example6" value="2" id="example6b" /&gt;
+					&lt;label for="example6b"&gt;Orange&lt;/label&gt;
+				&lt;/li&gt;
+				&lt;li class="label-inline"&gt;
+					&lt;input type="radio" name="example6" value="3" id="example6c" /&gt;
+					&lt;label for="example6c"&gt;Kiwi&lt;/label&gt;
+				&lt;/li&gt;
+				&lt;li class="label-inline"&gt;
+					&lt;input type="radio" name="example6" value="4" id="example6d" /&gt;
+					&lt;label for="example6d"&gt;Other&lt;/label&gt;
+				&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/fieldset&gt;</code></pre>
+			</details>
+
+			<!-- Checkboxes inline with implicit labels-->
+			<fieldset class="form-inline chkbxrdio-grp">
+				<legend class="required"><span class="field-name">Horizontal checkboxes in a <code>&lt;label&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
+				<label for="example7a" class="checkbox-inline"><input type="checkbox" name="example7" value="1" id="example7a" required="required" />Smartphone</label>
+				<label for="example7b" class="checkbox-inline"><input type="checkbox" name="example7" value="2" id="example7b" />Laptop</label>
+				<label for="example7c" class="checkbox-inline"><input type="checkbox" name="example7" value="3" id="example7c" />Voice assistant</label>
+				<label for="example7d" class="checkbox-inline"><input type="checkbox" name="example7" value="4" id="example7d" />Fusion reactor</label>
+			</fieldset>
+			<details class="mrgn-bttm-md mrgn-tp-md">
+				<summary>View code</summary>
+				<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+		...
+		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal checkboxes in a &lt;code&gt;&amp;lt;label&gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;label for="example7a" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="1" id="example7a" required="required" /&gt;Smartphone&lt;/label&gt;
+			&lt;label for="example7b" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="2" id="example7b" /&gt;Laptop&lt;/label&gt;
+			&lt;label for="example7c" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="3" id="example7c" /&gt;Voice assistant&lt;/label&gt;
+			&lt;label for="example7d" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="4" id="example7d" /&gt;Fusion reactor&lt;/label&gt;
+		&lt;/fieldset&gt;</code></pre>
+			</details>
+
+			<!-- Radio buttons inline with implicit labels-->
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Horizontal radio buttons in a <code>&lt;label&gt;</code> pattern with implicit labels</span> <strong class="required">(required)</strong></legend>
-				<label for="tech1" class="radio-inline"><input type="radio" name="example5" value="1" id="tech1" required="required" />Smartphone</label>
-				<label for="tech2" class="radio-inline"><input type="radio" name="example5" value="2" id="tech2" />Laptop</label>
-				<label for="tech3" class="radio-inline"><input type="radio" name="example5" value="3" id="tech3" />Voice assistant</label>
-				<label for="tech4" class="radio-inline"><input type="radio" name="example5" value="4" id="tech4" />Fusion reactor</label>
+				<label for="example8a" class="radio-inline"><input type="radio" name="example8" value="1" id="example8a" required="required" />Smartphone</label>
+				<label for="example8b" class="radio-inline"><input type="radio" name="example8" value="2" id="example8b" />Laptop</label>
+				<label for="example8c" class="radio-inline"><input type="radio" name="example8" value="3" id="example8c" />Voice assistant</label>
+				<label for="example8d" class="radio-inline"><input type="radio" name="example8" value="4" id="example8d" />Fusion reactor</label>
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>View code</summary>
@@ -678,31 +788,31 @@
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal radio buttons in a &lt;code&gt;&amp;lt;label&gt;&lt;/code&gt; pattern with implicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
-			&lt;label for="tech1" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="1" id="tech1" required="required" /&gt;Smartphone&lt;/label&gt;
-			&lt;label for="tech2" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="2" id="tech2" /&gt;Laptop&lt;/label&gt;
-			&lt;label for="tech3" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="3" id="tech3" /&gt;Voice assistant&lt;/label&gt;
-			&lt;label for="tech4" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="4" id="tech4" /&gt;Fusion reactor&lt;/label&gt;
+			&lt;label for="example8a" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="1" id="example8a" required="required" /&gt;Smartphone&lt;/label&gt;
+			&lt;label for="example8b" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="2" id="example8b" /&gt;Laptop&lt;/label&gt;
+			&lt;label for="example8c" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="3" id="example8c" /&gt;Voice assistant&lt;/label&gt;
+			&lt;label for="example8d" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="4" id="example8d" /&gt;Fusion reactor&lt;/label&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>
 
-<!-- checkbox inline list item with explicit labels-->
+			<!-- checkboxes inline with explicit labels-->
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Horizontal checkboxes in a <code>&lt;div&gt;</code> pattern with explicit labels</span> <strong class="required">(required)</strong></legend>
 				<div class="label-inline">
-					<input type="checkbox" name="example6" value="1" id="tech5" required="required" />
-					<label for="tech5">Smartphone</label>
+					<input type="checkbox" name="example9" value="1" id="example9a" required="required" />
+					<label for="example9a">Smartphone</label>
 				</div>
 				<div class="label-inline">
-					<input type="checkbox" name="example6" value="2" id="tech6" />
-					<label for="tech6">Laptop</label>
+					<input type="checkbox" name="example9" value="2" id="example9b" />
+					<label for="example9b">Laptop</label>
 				</div>
 				<div class="label-inline">
-					<input type="checkbox" name="example6" value="3" id="tech7" />
-					<label for="tech7">Voice assistant</label>
+					<input type="checkbox" name="example9" value="3" id="example9c" />
+					<label for="example9c">Voice assistant</label>
 				</div>
 				<div class="label-inline">
-					<input type="checkbox" name="example6" value="4" id="tech8" />
-					<label for="tech8">Fusion reactor</label>
+					<input type="checkbox" name="example9" value="4" id="example9d" />
+					<label for="example9d">Fusion reactor</label>
 				</div>
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
@@ -713,20 +823,66 @@
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal checkboxes in a &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; pattern with explicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="checkbox" name="example6" value="1" id="tech5" required="required" /&gt;
-				&lt;label for="tech5"&gt;Smartphone&lt;/label&gt;
+				&lt;input type="checkbox" name="example9" value="1" id="example9a" required="required" /&gt;
+				&lt;label for="example9a"&gt;Smartphone&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="checkbox" name="example6" value="2" id="tech6" /&gt;
-				&lt;label for="tech6"&gt;Laptop&lt;/label&gt;
+				&lt;input type="checkbox" name="example9" value="2" id="example9b" /&gt;
+				&lt;label for="example9b"&gt;Laptop&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="checkbox" name="example6" value="3" id="tech7" /&gt;
-				&lt;label for="tech7"&gt;Voice assistant&lt;/label&gt;
+				&lt;input type="checkbox" name="example9" value="3" id="example9c" /&gt;
+				&lt;label for="example9c"&gt;Voice assistant&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="checkbox" name="example6" value="4" id="tech8" /&gt;
-				&lt;label for="tech8"&gt;Fusion reactor&lt;/label&gt;
+				&lt;input type="checkbox" name="example9" value="4" id="example9d" /&gt;
+				&lt;label for="example9d"&gt;Fusion reactor&lt;/label&gt;
+			&lt;/div&gt;
+		&lt;/fieldset&gt;</code></pre>
+			</details>
+
+			<!-- radio buttons inline with explicit labels-->
+			<fieldset class="form-inline chkbxrdio-grp">
+				<legend class="required"><span class="field-name">Horizontal radio buttons in a <code>&lt;div&gt;</code> pattern with explicit labels</span> <strong class="required">(required)</strong></legend>
+				<div class="label-inline">
+					<input type="radio" name="example10" value="1" id="example10a" required="required" />
+					<label for="example10a">Smartphone</label>
+				</div>
+				<div class="label-inline">
+					<input type="radio" name="example10" value="2" id="example10b" />
+					<label for="example10b">Laptop</label>
+				</div>
+				<div class="label-inline">
+					<input type="radio" name="example10" value="3" id="example10c" />
+					<label for="example10c">Voice assistant</label>
+				</div>
+				<div class="label-inline">
+					<input type="radio" name="example10" value="4" id="example10d" />
+					<label for="example10d">Fusion reactor</label>
+				</div>
+			</fieldset>
+			<details class="mrgn-bttm-md mrgn-tp-md">
+				<summary>View code </summary>
+				<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+		...
+		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Horizontal radio buttons in a &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; pattern with explicit labels&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;div class="label-inline"&gt;
+				&lt;input type="radio" name="example10" value="1" id="example10a" required="required" /&gt;
+				&lt;label for="example10a"&gt;Smartphone&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="label-inline"&gt;
+				&lt;input type="radio" name="example10" value="2" id="example10b" /&gt;
+				&lt;label for="example10b"&gt;Laptop&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="label-inline"&gt;
+				&lt;input type="radio" name="example10" value="3" id="example10c" /&gt;
+				&lt;label for="example10c"&gt;Voice assistant&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="label-inline"&gt;
+				&lt;input type="radio" name="example10" value="4" id="example10d" /&gt;
+				&lt;label for="example10d"&gt;Fusion reactor&lt;/label&gt;
 			&lt;/div&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -484,25 +484,25 @@
 <hr>
 <section>
 <!-- checkbox in list item -->
-	<h2>Exemples de formulaires verticaux et horizontaux utilisant des éléments de liste comme contenants</h2>
+	<h2>Exemples variés de formulaires verticaux et horizontaux</h2>
 	<div class="wb-frmvld">
 		<form action="#" method="get" id="validation-example-2">
 
-<!-- checkbox in list item with implicit labels-->
+			<!-- checkbox in list item with implicit labels-->
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Cases à cocher empilées dans un modèle d'éléments <code>&lt;li&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<ul class="form-group list-unstyled">
 					<li class="checkbox">
-						<label for="fruits1a"><input type="checkbox" name="example1" value="1" id="fruits1a" required="required" />Pomme</label>
+						<label for="example1a"><input type="checkbox" name="example1" value="1" id="example1a" required="required" />Pomme</label>
 					</li>
 					<li class="checkbox">
-						<label for="fruits2a"><input type="checkbox" name="example1" value="2" id="fruits2a" />Orange</label>
+						<label for="example1b"><input type="checkbox" name="example1" value="2" id="example1b" />Orange</label>
 					</li>
 					<li class="checkbox">
-						<label for="fruits3a"><input type="checkbox" name="example1" value="3" id="fruits3a" />Kiwi</label>
+						<label for="example1c"><input type="checkbox" name="example1" value="3" id="example1c" />Kiwi</label>
 					</li>
 					<li class="checkbox">
-						<label for="fruits4a"><input type="checkbox" name="example1" value="4" id="fruits4a" />Autre</label>
+						<label for="example1d"><input type="checkbox" name="example1" value="4" id="example1d" />Autre</label>
 					</li>
 				</ul>
 			</fieldset>
@@ -515,37 +515,37 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher empilées dans un modèle d'éléments &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits1a"&gt;&lt;input type="checkbox" name="example1" value="1" id="fruits1a" required="required" /&gt;Pomme&lt;/label&gt;
+					&lt;label for="example1a"&gt;&lt;input type="checkbox" name="example1" value="1" id="example1a" required="required" /&gt;Pomme&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits2a"&gt;&lt;input type="checkbox" name="example1" value="2" id="fruits2a" /&gt;Orange&lt;/label&gt;
+					&lt;label for="example1b"&gt;&lt;input type="checkbox" name="example1" value="2" id="example1b" /&gt;Orange&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits3a"&gt;&lt;input type="checkbox" name="example1" value="3" id="fruits3a" /&gt;Kiwi&lt;/label&gt;
+					&lt;label for="example1c"&gt;&lt;input type="checkbox" name="example1" value="3" id="example1c" /&gt;Kiwi&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="checkbox"&gt;
-					&lt;label for="fruits4a"&gt;&lt;input type="checkbox" name="example1" value="4" id="fruits4a" /&gt;Autre&lt;/label&gt;
+					&lt;label for="example1d"&gt;&lt;input type="checkbox" name="example1" value="4" id="example1d" /&gt;Autre&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
 		&lt;/fieldset&gt;</code></pre>
 				<div class="well well-sm"><strong>Remarque&nbsp;:</strong> L'attribut <code>for</code> dans les étiquettes est facultatif pour ce modèle</div>
 			</details>
 
-<!-- radio in a list with implicit labels -->
+			<!-- radio buttons in a list with implicit labels -->
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Boutons radio verticaux dans un modèle d'éléments <code>&lt;li&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<ul class="form-group list-unstyled">
 					<li class="radio">
-						<label for="fruits1b"><input type="radio" name="example2" value="1" id="fruits1b" required="required" />Pomme</label>
+						<label for="example2a"><input type="radio" name="example2" value="1" id="example2a" required="required" />Pomme</label>
 					</li>
 					<li class="radio">
-						<label for="fruits2b"><input type="radio" name="example2" value="2" id="fruits2b" />Orange</label>
+						<label for="example2b"><input type="radio" name="example2" value="2" id="example2b" />Orange</label>
 					</li>
 					<li class="radio">
-						<label for="fruits3b"><input type="radio" name="example2" value="3" id="fruits3b" />Kiwi</label>
+						<label for="example2c"><input type="radio" name="example2" value="3" id="example2c" />Kiwi</label>
 					</li>
 					<li class="radio">
-						<label for="fruits4b"><input type="radio" name="example2" value="4" id="fruits4b" />Autre</label>
+						<label for="example2d"><input type="radio" name="example2" value="4" id="example2d" />Autre</label>
 					</li>
 				</ul>
 			</fieldset>
@@ -558,36 +558,36 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radio verticaux dans un modèle d'éléments &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-group list-unstyled"&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits1b"&gt;&lt;input type="radio" name="example2" value="1" id="fruits1b" required="required" /&gt;Pomme&lt;/label&gt;
+					&lt;label for="example2a"&gt;&lt;input type="radio" name="example2" value="1" id="example2a" required="required" /&gt;Pomme&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits2b"&gt;&lt;input type="radio" name="example2" value="2" id="fruits2b" /&gt;Orange&lt;/label&gt;
+					&lt;label for="example2b"&gt;&lt;input type="radio" name="example2" value="2" id="example2b" /&gt;Orange&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits3b"&gt;&lt;input type="radio" name="example2" value="3" id="fruits3b" /&gt;Kiwi&lt;/label&gt;
+					&lt;label for="example2c"&gt;&lt;input type="radio" name="example2" value="3" id="example2c" /&gt;Kiwi&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="radio"&gt;
-					&lt;label for="fruits4b"&gt;&lt;input type="radio" name="example2" value="4" id="fruits4b" /&gt;Autre&lt;/label&gt;
+					&lt;label for="example2d"&gt;&lt;input type="radio" name="example2" value="4" id="example2d" /&gt;Autre&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
 		&lt;/fieldset&gt;</code></pre>
 				<div class="well well-sm"><strong>Remarque&nbsp;:</strong> L'attribut <code>for</code> dans les étiquettes est facultatif pour ce modèle</div>
 			</details>
 
-<!-- checkbox in div pattern with implicit labels-->
+			<!-- checkbox in div pattern with implicit labels-->
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Cases à cocher empilées dans un modèle d’éléments <code>&lt;div&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="checkbox">
-					<label for="fruits1c"><input type="checkbox" name="example3" value="1" id="fruits1c" required="required" />Pomme</label>
+					<label for="example3a"><input type="checkbox" name="example3" value="1" id="example3a" required="required" />Pomme</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits2c"><input type="checkbox" name="example3" value="2" id="fruits2c" />Orange</label>
+					<label for="example3b"><input type="checkbox" name="example3" value="2" id="example3b" />Orange</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits3c"><input type="checkbox" name="example3" value="3" id="fruits3c" />Kiwi</label>
+					<label for="example3c"><input type="checkbox" name="example3" value="3" id="example3c" />Kiwi</label>
 				</div>
 				<div class="checkbox">
-					<label for="fruits4c"><input type="checkbox" name="example3" value="4" id="fruits4c" />Autre</label>
+					<label for="example3d"><input type="checkbox" name="example3" value="4" id="example3d" />Autre</label>
 				</div>
 			</fieldset>
 			<details class="mrgn-bttm-md">
@@ -598,40 +598,79 @@
 		&lt;fieldset class="chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher empilées dans un modèle d’éléments &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits1c"&gt;&lt;input type="checkbox" name="example3" value="1" id="fruits1c" required="required" /&gt;Pomme&lt;/label&gt;
+				&lt;label for="example3a"&gt;&lt;input type="checkbox" name="example3" value="1" id="example3a" required="required" /&gt;Pomme&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits2c"&gt;&lt;input type="checkbox" name="example3" value="2" id="fruits2c" /&gt;Orange&lt;/label&gt;
+				&lt;label for="example3b"&gt;&lt;input type="checkbox" name="example3" value="2" id="example3b" /&gt;Orange&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits3c"&gt;&lt;input type="checkbox" name="example3" value="3" id="fruits3c" /&gt;Kiwi&lt;/label&gt;
+				&lt;label for="example3c"&gt;&lt;input type="checkbox" name="example3" value="3" id="example3c" /&gt;Kiwi&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="checkbox"&gt;
-				&lt;label for="fruits4c"&gt;&lt;input type="checkbox" name="example3" value="4" id="fruits4c" /&gt;Autre&lt;/label&gt;
+				&lt;label for="example3d"&gt;&lt;input type="checkbox" name="example3" value="4" id="example3d" /&gt;Autre&lt;/label&gt;
 			&lt;/div&gt;
 		&lt;/fieldset&gt;</code></pre>
 				<div class="well well-sm"><strong>Remarque&nbsp;:</strong> L'attribut <code>for</code> dans les étiquettes est facultatif pour ce modèle</div>
 			</details>
 
-<!-- checkbox in list item with explicit labels-->
+			<!-- radio buttons in div pattern with implicit labels-->
+			<fieldset class="chkbxrdio-grp">
+				<legend class="required"><span class="field-name">Boutons radios empilés dans un modèle d’éléments <code>&lt;div&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
+				<div class="radio">
+					<label for="example4a"><input type="radio" name="example4" value="1" id="example4a" required="required" />Pomme</label>
+				</div>
+				<div class="radio">
+					<label for="example4b"><input type="radio" name="example4" value="2" id="example4b" />Orange</label>
+				</div>
+				<div class="radio">
+					<label for="example4c"><input type="radio" name="example4" value="3" id="example4c" />Kiwi</label>
+				</div>
+				<div class="radio">
+					<label for="example4d"><input type="radio" name="example4" value="4" id="example4d" />Autre</label>
+				</div>
+			</fieldset>
+			<details class="mrgn-bttm-md">
+				<summary>Voir le code</summary>
+				<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+		...
+		&lt;fieldset class="chkbxrdio-grp"&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radios empilés dans un modèle d’éléments &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="example4a"&gt;&lt;input type="radio" name="example4" value="1" id="example4a" required="required" /&gt;Pomme&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="example4b"&gt;&lt;input type="radio" name="example4" value="2" id="example4b" /&gt;Orange&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="example4c"&gt;&lt;input type="radio" name="example4" value="3" id="example4c" /&gt;Kiwi&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="example4d"&gt;&lt;input type="radio" name="example4" value="4" id="example4d" /&gt;Autre&lt;/label&gt;
+			&lt;/div&gt;
+		&lt;/fieldset&gt;</code></pre>
+				<div class="well well-sm"><strong>Remarque&nbsp;:</strong> L'attribut <code>for</code> dans les étiquettes est facultatif pour ce modèle</div>
+			</details>
+
+			<!-- checkbox in list item with explicit labels-->
 			<fieldset class="chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Cases à cocher horizontales dans un modèle d'éléments <code>&lt;li&gt;</code> comportant des étiquettes explicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<ul class="form-inline list-unstyled">
 					<li class="label-inline">
-						<input type="checkbox" name="example4" value="1" id="fruits5" required="required" />
-						<label for="fruits5">Pomme</label>
+						<input type="checkbox" name="example5" value="1" id="example5a" required="required" />
+						<label for="example5a">Pomme</label>
 					</li>
 					<li class="label-inline">
-						<input type="checkbox" name="example4" value="2" id="fruits6" />
-						<label for="fruits6">Orange</label>
+						<input type="checkbox" name="example5" value="2" id="example5b" />
+						<label for="example5b">Orange</label>
 					</li>
 					<li class="label-inline">
-						<input type="checkbox" name="example4" value="3" id="fruits7" />
-						<label for="fruits7">Kiwi</label>
+						<input type="checkbox" name="example5" value="3" id="example5c" />
+						<label for="example5c">Kiwi</label>
 					</li>
 					<li class="label-inline">
-						<input type="checkbox" name="example4" value="4" id="fruits8" />
-						<label for="fruits8">Autre</label>
+						<input type="checkbox" name="example5" value="4" id="example5d" />
+						<label for="example5d">Autre</label>
 					</li>
 				</ul>
 			</fieldset>
@@ -644,32 +683,104 @@
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher horizontales dans un modèle d'éléments &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; comportant des étiquettes explicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;ul class="form-inline list-unstyled"&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="checkbox" name="example4" value="1" id="fruits5" required="required" /&gt;
-					&lt;label for="fruits5"&gt;Pomme&lt;/label&gt;
+					&lt;input type="checkbox" name="example5" value="1" id="example5a" required="required" /&gt;
+					&lt;label for="example5a"&gt;Pomme&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="checkbox" name="example4" value="2" id="fruits6" /&gt;
-					&lt;label for="fruits6"&gt;Orange&lt;/label&gt;
+					&lt;input type="checkbox" name="example5" value="2" id="example5b" /&gt;
+					&lt;label for="example5b"&gt;Orange&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="checkbox" name="example4" value="3" id="fruits7" /&gt;
-					&lt;label for="fruits7"&gt;Kiwi&lt;/label&gt;
+					&lt;input type="checkbox" name="example5" value="3" id="example5c" /&gt;
+					&lt;label for="example5c"&gt;Kiwi&lt;/label&gt;
 				&lt;/li&gt;
 				&lt;li class="label-inline"&gt;
-					&lt;input type="checkbox" name="example4" value="4" id="fruits8" /&gt;
-					&lt;label for="fruits8"&gt;Autre&lt;/label&gt;
+					&lt;input type="checkbox" name="example5" value="4" id="example5d" /&gt;
+					&lt;label for="example5d"&gt;Autre&lt;/label&gt;
 				&lt;/li&gt;
 			&lt;/ul&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>
 
-<!-- Radio inline list item with implicit labels-->
+			<!-- radio buttons in list item with explicit labels-->
+			<fieldset class="chkbxrdio-grp">
+				<legend class="required"><span class="field-name">Boutons radios horizontaux dans un modèle d'éléments <code>&lt;li&gt;</code> comportant des étiquettes explicites</span> <strong class="required">(obligatoire)</strong></legend>
+				<ul class="form-inline list-unstyled">
+					<li class="label-inline">
+						<input type="radio" name="example6" value="1" id="example6a" required="required" />
+						<label for="example6a">Pomme</label>
+					</li>
+					<li class="label-inline">
+						<input type="radio" name="example6" value="2" id="example6b" />
+						<label for="example6b">Orange</label>
+					</li>
+					<li class="label-inline">
+						<input type="radio" name="example6" value="3" id="example6c" />
+						<label for="example6c">Kiwi</label>
+					</li>
+					<li class="label-inline">
+						<input type="radio" name="example6" value="4" id="example6d" />
+						<label for="example6d">Autre</label>
+					</li>
+				</ul>
+			</fieldset>
+			<details class="mrgn-bttm-md">
+				<summary>Voir le code</summary>
+				<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+		...
+		&lt;fieldset class="chkbxrdio-grp"&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radios horizontaux dans un modèle d'éléments &lt;code&gt;&amp;lt;li&amp;gt;&lt;/code&gt; comportant des étiquettes explicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;ul class="form-inline list-unstyled"&gt;
+				&lt;li class="label-inline"&gt;
+					&lt;input type="radio" name="example6" value="1" id="example6a" required="required" /&gt;
+					&lt;label for="example6a"&gt;Pomme&lt;/label&gt;
+				&lt;/li&gt;
+				&lt;li class="label-inline"&gt;
+					&lt;input type="radio" name="example6" value="2" id="example6b" /&gt;
+					&lt;label for="example6b"&gt;Orange&lt;/label&gt;
+				&lt;/li&gt;
+				&lt;li class="label-inline"&gt;
+					&lt;input type="radio" name="example6" value="3" id="example6c" /&gt;
+					&lt;label for="example6c"&gt;Kiwi&lt;/label&gt;
+				&lt;/li&gt;
+				&lt;li class="label-inline"&gt;
+					&lt;input type="radio" name="example6" value="4" id="example6d" /&gt;
+					&lt;label for="example6d"&gt;Autre&lt;/label&gt;
+				&lt;/li&gt;
+			&lt;/ul&gt;
+		&lt;/fieldset&gt;</code></pre>
+			</details>
+
+			<!-- checkboxes inline with implicit labels-->
+			<fieldset class="form-inline chkbxrdio-grp">
+				<legend class="required"><span class="field-name">Cases à cocher horizontales dans un modèle d'éléments <code>&lt;label&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
+				<label for="example7a" class="checkbox-inline"><input type="checkbox" name="example7" value="1" id="example7a" required="required" />Téléphone intelligent</label>
+				<label for="example7b" class="checkbox-inline"><input type="checkbox" name="example7" value="2" id="example7b" />Ordinateur portatif</label>
+				<label for="example7c" class="checkbox-inline"><input type="checkbox" name="example7" value="3" id="example7c" />Système d’assistance vocale</label>
+				<label for="example7d" class="checkbox-inline"><input type="checkbox" name="example7" value="4" id="example7d" />Réacteur à fusion</label>
+			</fieldset>
+			<details class="mrgn-bttm-md mrgn-tp-md">
+				<summary>Voir le code</summary>
+				<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+		...
+		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher horizontales dans un modèle d'éléments &lt;code&gt;&amp;lt;label&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;label for="example7a" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="1" id="example7a" required="required" /&gt;Téléphone intelligent&lt;/label&gt;
+			&lt;label for="example7b" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="2" id="example7b" /&gt;Ordinateur portatif&lt;/label&gt;
+			&lt;label for="example7c" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="3" id="example7c" /&gt;Système d’assistance vocale&lt;/label&gt;
+			&lt;label for="example7d" class="checkbox-inline"&gt;&lt;input type="checkbox" name="example7" value="4" id="example7d" /&gt;Réacteur à fusion&lt;/label&gt;
+		&lt;/fieldset&gt;</code></pre>
+			</details>
+
+			<!-- radio buttons inline with implicit labels-->
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Boutons radio horizontaux dans un modèle d'éléments <code>&lt;label&gt;</code> comportant des étiquettes implicites</span> <strong class="required">(obligatoire)</strong></legend>
-				<label for="tech1" class="radio-inline"><input type="radio" name="example5" value="1" id="tech1" required="required" />Téléphone intelligent</label>
-				<label for="tech2" class="radio-inline"><input type="radio" name="example5" value="2" id="tech2" />Ordinateur portatif</label>
-				<label for="tech3" class="radio-inline"><input type="radio" name="example5" value="3" id="tech3" />Système d’assistance vocale</label>
-				<label for="tech4" class="radio-inline"><input type="radio" name="example5" value="4" id="tech4" />Réacteur à fusion</label>
+				<label for="example8a" class="radio-inline"><input type="radio" name="example8" value="1" id="example8a" required="required" />Téléphone intelligent</label>
+				<label for="example8b" class="radio-inline"><input type="radio" name="example8" value="2" id="example8b" />Ordinateur portatif</label>
+				<label for="example8c" class="radio-inline"><input type="radio" name="example8" value="3" id="example8c" />Système d’assistance vocale</label>
+				<label for="example8d" class="radio-inline"><input type="radio" name="example8" value="4" id="example8d" />Réacteur à fusion</label>
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
 				<summary>Voir le code</summary>
@@ -678,31 +789,31 @@
 		...
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radio horizontaux dans un modèle d'éléments &lt;code&gt;&amp;lt;label&amp;gt;&lt;/code&gt; comportant des étiquettes implicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
-			&lt;label for="tech1" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="1" id="tech1" required="required" /&gt;Téléphone intelligent&lt;/label&gt;
-			&lt;label for="tech2" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="2" id="tech2" /&gt;Ordinateur portatif&lt;/label&gt;
-			&lt;label for="tech3" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="3" id="tech3" /&gt;Système d’assistance vocale&lt;/label&gt;
-			&lt;label for="tech4" class="radio-inline"&gt;&lt;input type="radio" name="example5" value="4" id="tech4" /&gt;Réacteur à fusion&lt;/label&gt;
+			&lt;label for="example8a" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="1" id="example8a" required="required" /&gt;Téléphone intelligent&lt;/label&gt;
+			&lt;label for="example8b" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="2" id="example8b" /&gt;Ordinateur portatif&lt;/label&gt;
+			&lt;label for="example8c" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="3" id="example8c" /&gt;Système d’assistance vocale&lt;/label&gt;
+			&lt;label for="example8d" class="radio-inline"&gt;&lt;input type="radio" name="example8" value="4" id="example8d" /&gt;Réacteur à fusion&lt;/label&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>
 
-<!-- checkbox inline list item with explicit labels-->
+			<!-- checkbox inline list item with explicit labels-->
 			<fieldset class="form-inline chkbxrdio-grp">
 				<legend class="required"><span class="field-name">Cases à cocher horizontales dans un modèle d’éléments <code>&lt;div&gt;</code> comportant des étiquettes explicites</span> <strong class="required">(obligatoire)</strong></legend>
 				<div class="label-inline">
-					<input type="checkbox" name="example6" value="1" id="tech5" required="required" />
-					<label for="tech5">Téléphone intelligent</label>
+					<input type="checkbox" name="example9" value="1" id="example9a" required="required" />
+					<label for="example9a">Téléphone intelligent</label>
 				</div>
 				<div class="label-inline">
-					<input type="checkbox" name="example6" value="2" id="tech6" />
-					<label for="tech6">Ordinateur portatif</label>
+					<input type="checkbox" name="example9" value="2" id="example9b" />
+					<label for="example9b">Ordinateur portatif</label>
 				</div>
 				<div class="label-inline">
-					<input type="checkbox" name="example6" value="3" id="tech7" />
-					<label for="tech7">Système d’assistance vocale</label>
+					<input type="checkbox" name="example9" value="3" id="example9c" />
+					<label for="example9c">Système d’assistance vocale</label>
 				</div>
 				<div class="label-inline">
-					<input type="checkbox" name="example6" value="4" id="tech8" />
-					<label for="tech8">Réacteur à fusion</label>
+					<input type="checkbox" name="example9" value="4" id="example9d" />
+					<label for="example9d">Réacteur à fusion</label>
 				</div>
 			</fieldset>
 			<details class="mrgn-bttm-md mrgn-tp-md">
@@ -713,20 +824,66 @@
 		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
 			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Cases à cocher horizontales dans un modèle d’éléments &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; comportant des étiquettes explicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="checkbox" name="example6" value="1" id="tech5" required="required" /&gt;
-				&lt;label for="tech5"&gt;Téléphone intelligent&lt;/label&gt;
+				&lt;input type="checkbox" name="example9" value="1" id="example9a" required="required" /&gt;
+				&lt;label for="example9a"&gt;Téléphone intelligent&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="checkbox" name="example6" value="2" id="tech6" /&gt;
-				&lt;label for="tech6"&gt;Ordinateur portatif&lt;/label&gt;
+				&lt;input type="checkbox" name="example9" value="2" id="example9b" /&gt;
+				&lt;label for="example9b"&gt;Ordinateur portatif&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="checkbox" name="example6" value="3" id="tech7" /&gt;
-				&lt;label for="tech7"&gt;Système d’assistance vocale&lt;/label&gt;
+				&lt;input type="checkbox" name="example9" value="3" id="example9c" /&gt;
+				&lt;label for="example9c"&gt;Système d’assistance vocale&lt;/label&gt;
 			&lt;/div&gt;
 			&lt;div class="label-inline"&gt;
-				&lt;input type="checkbox" name="example6" value="4" id="tech8" /&gt;
-				&lt;label for="tech8"&gt;Réacteur à fusion&lt;/label&gt;
+				&lt;input type="checkbox" name="example9" value="4" id="example9d" /&gt;
+				&lt;label for="example9d"&gt;Réacteur à fusion&lt;/label&gt;
+			&lt;/div&gt;
+		&lt;/fieldset&gt;</code></pre>
+			</details>
+
+			<!-- radio buttons inline list item with explicit labels-->
+			<fieldset class="form-inline chkbxrdio-grp">
+				<legend class="required"><span class="field-name">Boutons radios horizontaux dans un modèle d’éléments <code>&lt;div&gt;</code> comportant des étiquettes explicites</span> <strong class="required">(obligatoire)</strong></legend>
+				<div class="label-inline">
+					<input type="radio" name="example10" value="1" id="example10a" required="required" />
+					<label for="example10a">Téléphone intelligent</label>
+				</div>
+				<div class="label-inline">
+					<input type="radio" name="example10" value="2" id="example10b" />
+					<label for="example10b">Ordinateur portatif</label>
+				</div>
+				<div class="label-inline">
+					<input type="radio" name="example10" value="3" id="example10c" />
+					<label for="example10c">Système d’assistance vocale</label>
+				</div>
+				<div class="label-inline">
+					<input type="radio" name="example10" value="4" id="example10d" />
+					<label for="example10d">Réacteur à fusion</label>
+				</div>
+			</fieldset>
+			<details class="mrgn-bttm-md mrgn-tp-md">
+				<summary>Voir le code</summary>
+				<pre><code>&lt;div class="wb-frmvld"&gt;
+	&lt;form action="#" method="get" id="validation-example"&gt;
+		...
+		&lt;fieldset class="form-inline chkbxrdio-grp"&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Boutons radios horizontaux dans un modèle d’éléments &lt;code&gt;&amp;lt;div&amp;gt;&lt;/code&gt; comportant des étiquettes explicites&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;div class="label-inline"&gt;
+				&lt;input type="radio" name="example10" value="1" id="example10a" required="required" /&gt;
+				&lt;label for="example10a"&gt;Téléphone intelligent&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="label-inline"&gt;
+				&lt;input type="radio" name="example10" value="2" id="example10b" /&gt;
+				&lt;label for="example10b"&gt;Ordinateur portatif&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="label-inline"&gt;
+				&lt;input type="radio" name="example10" value="3" id="example10c" /&gt;
+				&lt;label for="example10c"&gt;Système d’assistance vocale&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="label-inline"&gt;
+				&lt;input type="radio" name="example10" value="4" id="example10d" /&gt;
+				&lt;label for="example10d"&gt;Réacteur à fusion&lt;/label&gt;
 			&lt;/div&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>


### PR DESCRIPTION
Adding a few working examples for the stacked and inline checkboxes and radios because it seems people were not using the correct HTML as some examples were missing.