### PR TITLE
Bootstrap overrides: Restore table overrides

### DIFF
--- a/src/base/_wet-boew.scss
+++ b/src/base/_wet-boew.scss
@@ -28,6 +28,7 @@
 @import "bootstrap-sass/assets/stylesheets/bootstrap/grid";
 @import "bootstrap-sass/assets/stylesheets/bootstrap/tables";
 @import "bootstrap-sass/assets/stylesheets/bootstrap/forms";
+@import "bootstrap-overrides/core-tables";
 @import "bootstrap-overrides/core-forms";
 @import "forms/base";
 @import "bootstrap-sass/assets/stylesheets/bootstrap/buttons";


### PR DESCRIPTION
They became orphaned in #9195 and had disappeared from WET's compiled CSS ever since.

This fixes it by adding a reference to ``src/base/bootstrap-overrides/_core-tables.scss`` in ``src/base/_wet-boew.scss``.