### PR TITLE
Bootstrap overrides: Rework table-responsive override

### DIFF
--- a/src/base/bootstrap-overrides/_core-tables.scss
+++ b/src/base/bootstrap-overrides/_core-tables.scss
@@ -15,6 +15,20 @@ caption {
 
 
 // Not ported from, but inline with Bootstrap 4: Makes the table to scroll horizontally and makes the content wrap in any viewport including small devices (under 768px)
-.table-responsive > .table, th, td {
-	white-space: normal;
+.table-responsive {
+	@media screen and (max-width: $screen-xs-max) {
+		> .table {
+			// Undo Bootstrap 3.x's nowrap selector (removed in Bootstrap 4.0)
+			> thead,
+			> tbody,
+			> tfoot {
+				> tr {
+					> th,
+					> td {
+						white-space: initial;
+					}
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Bootstrap 3.x's ``table-responsive`` class uses ``white-space: nowrap;`` on ``th`` and ``td`` elements in extra-small view. That hinders usability and undermines the purpose of responsive tables.

For example:
* It may cause tables to become wider in extra-small view than in larger views (if any cells get wrapped in the latter)
* Table cells containing long lines of text (like sentences or paragraphs) stop wrapping... which makes horizontal scrolling much more annoying than it should be. Imagine needing to horizontally-scroll through 2-4 screens' worth of width just to get through one table column...

Bootstrap 4.0 eventually fixed it by removing the ``nowrap`` selector in https://github.com/twbs/bootstrap/commit/547f16b58e54375b1d523cc6e2153993bf731875#diff-d546efca16e3ba712b18fc38c2dacde93f4395a8554db3c49cf3c7103770d446L187-L198.

#9479 set out to backport Bootstrap 4.0's change to WET, but ran into the following hurdles:
* A bug in #9195 (fixed by #9698) prevented the override's selector from appearing in WET's compiled CSS
* The override's selector wasn't specific-enough to overtake Bootstrap 3.x's ``nowrap`` selector
* The PR was initially created with DataTables in mind... which is only affected by Bootstrap 3.x's ``nowrap`` selector in noscript/basic HTML mode (JS mode causes DataTables to inject an extra div between the ``table-responsive`` container and the table - which prevents the ``nowrap`` selector from matching)
* The issues were overlooked during final PR testing

This fixes the ``nowrap`` issue by replacing #9479's override selector with one based on Bootstrap 3.x's ``nowrap`` selector.

Depends on #9698.