### PR TITLE
Build: Bump DataTables (datatables.net) to ~1.13.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2782,9 +2782,9 @@
       "dev": true
     },
     "datatables.net": {
-      "version": "1.11.4",
-      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.11.4.tgz",
-      "integrity": "sha512-z9LG4O0VYOYzp+rnArLExvnUWV8ikyWBcHYZEKDfVuz7BKxQdEq4a/tpO0Trbm+FL1+RY7UEIh+UcYNY/hwGxA==",
+      "version": "1.13.8",
+      "resolved": "https://registry.npmjs.org/datatables.net/-/datatables.net-1.13.8.tgz",
+      "integrity": "sha512-2pDamr+GUwPTby2OgriVB9dR9ftFKD2AQyiuCXzZIiG4d9KkKFQ7gqPfNmG7uj9Tc5kDf+rGj86do4LAb/V71g==",
       "requires": {
         "jquery": ">=1.7"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "bootstrap-sass": "3.4.1",
     "code-prettify": "^0.1.0",
-    "datatables.net": "1.11.4",
+    "datatables.net": "~1.13.8",
     "dompurify": "^2.4.4",
     "es5-shim": "2.3.0",
     "fast-json-patch": "github:wet-boew/JSON-Patch#wb1.0+1.1.4",


### PR DESCRIPTION
Added ``~`` since even though DataTables doesn't follow semver, it appears to adhere to ``#.x`` for major and ``#.#.x`` for minor/patch releases:
* https://datatables.net/forums/discussion/29315/please-use-semver
* https://cdn.datatables.net/releases.html

Fixes #9664 (1.13.2 added ``aria-current="page"`` to the active pagination link).

Related to #9051.