### PR TITLE
Footnotes: Demonstrate reference link in heading

### DIFF
--- a/src/plugins/footnotes/footnotes-en.hbs
+++ b/src/plugins/footnotes/footnotes-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "footnotes",
 	"parentdir": "footnotes",
 	"altLangPrefix": "footnotes",
-	"dateModified": "2023-06-19"
+	"dateModified": "2023-11-20"
 }
 ---
 <section>
@@ -27,9 +27,9 @@
 </section>
 
 <section>
-	<h2>Recommended usage</h2>
+	<h2>Recommended usage<sup id="fn4-1-rf"><a class="fn-lnk" href="#fn4"><span class="wb-inv">Footnote </span>4</a></sup></h2>
 	<ul>
-		<li>Implementing footnotes in Web pages<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Footnote </span>*</a></sup>&#160;<sup id="fn4-1-rf"><a class="fn-lnk" href="#fn4"><span class="wb-inv">Footnote </span>4</a></sup></li>
+		<li>Implementing footnotes in Web pages<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Footnote </span>*</a></sup></li>
 	</ul>
 </section>
 
@@ -85,9 +85,9 @@
 &lt;/section&gt;
 
 &lt;section&gt;
-	&lt;h2&gt;Recommended usage&lt;/h2&gt;
+	&lt;h2&gt;Recommended usage&lt;sup id=&quot;fn4-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn4&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;4&lt;/a&gt;&lt;/sup&gt;&lt;/h2&gt;
 	&lt;ul&gt;
-		&lt;li&gt;Implementing footnotes in Web pages&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&amp;#160;&lt;sup id=&quot;fn4-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn4&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;4&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+		&lt;li&gt;Implementing footnotes in Web pages&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Footnote &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 	&lt;/ul&gt;
 &lt;/section&gt;
 

--- a/src/plugins/footnotes/footnotes-fr.hbs
+++ b/src/plugins/footnotes/footnotes-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "footnotes",
 	"parentdir": "footnotes",
 	"altLangPrefix": "footnotes",
-	"dateModified": "2022-06-19"
+	"dateModified": "2023-11-20"
 }
 ---
 <section>
@@ -27,9 +27,9 @@
 </section>
 
 <section>
-	<h2>Utilisation recommandée</h2>
+	<h2>Utilisation recommandée<sup id="fn4-1-rf"><a class="fn-lnk" href="#fn4"><span class="wb-inv">Note de bas de page </span>4</a></sup></h2>
 		<ul>
-			<li>Exécuter les notes de bas de page dans les pages Web<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Note de bas de page </span>*</a></sup>&#160;<sup id="fn4-1-rf"><a class="fn-lnk" href="#fn4"><span class="wb-inv">Note de bas de page </span>4</a></sup></li>
+			<li>Exécuter les notes de bas de page dans les pages Web<sup id="fn*-rf"><a class="fn-lnk" href="#fn*"><span class="wb-inv">Note de bas de page </span>*</a></sup></li>
 		</ul>
 </section>
 
@@ -85,9 +85,9 @@
 &lt;/section&gt;
 
 &lt;section&gt;
-	&lt;h2&gt;Utilisation recommandée&lt;/h2&gt;
+	&lt;h2&gt;Utilisation recommandée&lt;sup id=&quot;fn4-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn4&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;4&lt;/a&gt;&lt;/sup&gt;&lt;/h2&gt;
 		&lt;ul&gt;
-			&lt;li&gt;Exécuter les notes de bas de page dans les pages Web&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&amp;#160;&lt;sup id=&quot;fn4-1-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn4&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;4&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
+			&lt;li&gt;Exécuter les notes de bas de page dans les pages Web&lt;sup id=&quot;fn*-rf&quot;&gt;&lt;a class=&quot;fn-lnk&quot; href=&quot;#fn*&quot;&gt;&lt;span class=&quot;wb-inv&quot;&gt;Note de bas de page &lt;/span&gt;*&lt;/a&gt;&lt;/sup&gt;&lt;/li&gt;
 		&lt;/ul&gt;
 &lt;/section&gt;
 


### PR DESCRIPTION
Using footnote reference links on headings is a valid use case, so let's demonstrate it.

This achieves it by moving footnote 4's second reference link onto its parent section's heading.