### PR TITLE
Form validation: Translate maxWords demo's French label

### DIFF
--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2022-04-13"
+	"dateModified": "2023-12-04"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -278,7 +278,7 @@
 				</details>
 
 				<div class="form-group">
-					<label for="word1"><span class="field-name">Maximum of 10 words</span></label>
+					<label for="word1"><span class="field-name">Maximum de 10 mots</span></label>
 					<input class="form-control" id="word1" name="word1" type="text" data-rule-maxWords="10" />
 				</div>
 				<details class="mrgn-bttm-md">


### PR DESCRIPTION
#6952 previously translated the code sample's label, but missed the demo's counterpart.

This copies the code sample's label content over to the demo.