### PR TITLE
Update tables.js to add top for datatable DOM

### DIFF
--- a/src/plugins/tables/tables-en.hbs
+++ b/src/plugins/tables/tables-en.hbs
@@ -971,7 +971,8 @@
 		</tbody>
 	</table>
 
-	<p>Adding the pagination at the top of the table and keeping it at the bottom</p>
+	<h4>With top pagination example</h4>
+	<p>Adding the pagination at the top of the table and keeping it at the bottom by using the following configuration: <code>data-wb-tables='{"ordering" : false, "dom":"&lt;\u0027top\u0027pfil>rt&lt;\u0027bottom\u0027p>&lt;\u0027clear\u0027>"}'</code></p>
 	<table class="wb-tables table table-bordered table-striped" data-wb-tables='{"ordering" : false, "dom":"<\u0027top\u0027pfil>rt<\u0027bottom\u0027p><\u0027clear\u0027>"}'>
 		<thead>
 			<tr>

--- a/src/plugins/tables/tables-en.hbs
+++ b/src/plugins/tables/tables-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "tables",
 	"parentdir": "tables",
 	"altLangPrefix": "tables",
-	"dateModified": "2022-11-29"
+	"dateModified": "2023-12-11"
 }
 ---
 <section>
@@ -970,6 +970,127 @@
 			</tr>
 		</tbody>
 	</table>
+
+	<p>Adding the pagination at the top of the table and keeping it at the bottom</p>
+	<table class="wb-tables table table-bordered table-striped" data-wb-tables='{"ordering" : false, "dom":"<\u0027top\u0027pfil>rt<\u0027bottom\u0027p><\u0027clear\u0027>"}'>
+		<thead>
+			<tr>
+				<th>Rendering engine</th>
+				<th>Browser</th>
+				<th>Platform(s)</th>
+				<th>Engine version</th>
+				<th>CSS grade</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="gradeX">
+				<td>Trident</td>
+				<td>Internet Explorer 4.0</td>
+				<td>Win 95+</td>
+				<td class="center">4</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Trident</td>
+				<td>Internet Explorer 5.0</td>
+				<td>Win 95+</td>
+				<td class="center">5</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet Explorer 5.5</td>
+				<td>Win 95+</td>
+				<td class="center">5.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet Explorer 6</td>
+				<td>Win 98+</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet Explorer 7</td>
+				<td>Win XP SP2+</td>
+				<td class="center">7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>AOL browser (AOL desktop)</td>
+				<td>Win XP</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.5</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 2.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 3.0</td>
+				<td>Win 2k+ / OSX.3+</td>
+				<td class="center">1.9</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.0</td>
+				<td>OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.5</td>
+				<td>OSX.3+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape 7.2</td>
+				<td>Win 95+ / Mac OS 8.6-9.2</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Browser 8</td>
+				<td>Win 98SE+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Navigator 9</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+		</tbody>
+	</table>
+
 	<h3>Filtering Examples</h3>
 	<p>Find the plugin for the action you need:</p>
 	<ul>

--- a/src/plugins/tables/tables-fr.hbs
+++ b/src/plugins/tables/tables-fr.hbs
@@ -979,7 +979,8 @@
 		</tbody>
 	</table>
 
-	<p>Ajouter la pagination au-dessus du tableau en le gardant en dessous.</p>
+	<h4>Exemple avec une pagination en haut du tableau</h4>
+	<p>Ajouter la pagination au-dessus du tableau en le gardant en dessous en utilisant la configuration suivante: <code>data-wb-tables='{"ordering" : false, "dom":"&lt;\u0027top\u0027pfil>rt&lt;\u0027bottom\u0027p>&lt;\u0027clear\u0027>"}'</code></p>
 	<table class="wb-tables table table-bordered table-striped" data-wb-tables='{"ordering" : false, "dom":"<\u0027top\u0027pfil>rt<\u0027bottom\u0027p><\u0027clear\u0027>"}'>
 		<thead>
 			<tr>

--- a/src/plugins/tables/tables-fr.hbs
+++ b/src/plugins/tables/tables-fr.hbs
@@ -979,7 +979,7 @@
 		</tbody>
 	</table>
 
-	<p>Ajouter la pagination dans au-dessus du tableau en le gardant en dessous.</p>
+	<p>Ajouter la pagination au-dessus du tableau en le gardant en dessous.</p>
 	<table class="wb-tables table table-bordered table-striped" data-wb-tables='{"ordering" : false, "dom":"<\u0027top\u0027pfil>rt<\u0027bottom\u0027p><\u0027clear\u0027>"}'>
 		<thead>
 			<tr>

--- a/src/plugins/tables/tables-fr.hbs
+++ b/src/plugins/tables/tables-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "tables",
 	"parentdir": "tables",
 	"altLangPrefix": "tables",
-	"dateModified": "2022-11-29"
+	"dateModified": "2023-12-11"
 }
 ---
 
@@ -978,6 +978,131 @@
 			</tr>
 		</tbody>
 	</table>
+
+	<p>Ajouter la pagination dans au-dessus du tableau en le gardant en dessous.</p>
+	<table class="wb-tables table table-bordered table-striped" data-wb-tables='{"ordering" : false, "dom":"<\u0027top\u0027pfil>rt<\u0027bottom\u0027p><\u0027clear\u0027>"}'>
+		<thead>
+			<tr>
+				<th>Moteur de rendu</th>
+				<th>Navigateur</th>
+				<th>Platformes</th>
+				<th>Version de moteur</th>
+				<th>Niveau de CSS</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr class="gradeX">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 4.0</td>
+				<td>Win 95+</td>
+				<td class="center">4</td>
+				<td class="center">X</td>
+			</tr>
+			<tr class="gradeC">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 5.0</td>
+				<td>Win 95+</td>
+				<td class="center">5</td>
+				<td class="center">C</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 5.5</td>
+				<td>Win 95+</td>
+				<td class="center">5.5</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet
+					Explorer 6</td>
+				<td>Win 98+</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Internet Explorer 7</td>
+				<td>Win XP SP2+</td>
+				<td class="center">7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Trident</td>
+				<td>Navigateur AOL (AOL desktop)</td>
+				<td>Win XP</td>
+				<td class="center">6</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 1.5</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 2.0</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Firefox 3.0</td>
+				<td>Win 2k+ / OSX.3+</td>
+				<td class="center">1.9</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.0</td>
+				<td>OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Camino 1.5</td>
+				<td>OSX.3+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape 7.2</td>
+				<td>Win 95+ / Mac OS 8.6-9.2</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Browser 8</td>
+				<td>Win 98SE+</td>
+				<td class="center">1.7</td>
+				<td class="center">A</td>
+			</tr>
+			<tr class="gradeA">
+				<td>Gecko</td>
+				<td>Netscape Navigator 9</td>
+				<td>Win 98+ / OSX.2+</td>
+				<td class="center">1.8</td>
+				<td class="center">A</td>
+			</tr>
+		</tbody>
+	</table>
+
 	<h3>Filtering Examples</h3>
 	<p>Find the plugin for the action you need:</p>
 	<ul>

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -179,6 +179,7 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 		// Make sure Pagination is visible
 		pagination.removeClass( "hidden" );
 		pagination_top.removeClass( "hidden" );
+
 		// Update Pagination List
 		for ( var i = 0; i < paginate_buttons.length; i++ ) {
 			var item = li.cloneNode( true );

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -126,6 +126,46 @@ var componentName = "wb-tables",
 				}
 			} );
 		}
+	},
+	updatePaginationMarkup = function( $pagination, setFocusOnId ) {
+
+		var ol = document.createElement( "OL" ),
+			li = document.createElement( "LI" ),
+			paginate_buttons = $pagination.find( ".paginate_button" ),
+			navFocusOnId = setFocusOnId || $pagination.get( 0 ).id;
+
+		// Update Pagination List
+		for ( var i = 0; i < paginate_buttons.length; i++ ) {
+			var item = li.cloneNode( true );
+			item.appendChild( paginate_buttons[ i ] );
+			ol.appendChild( item );
+		}
+
+		ol.className = "pagination mrgn-tp-0 mrgn-bttm-0";
+		$pagination.empty();
+		$pagination.append( ol );
+
+		// Update the aria-pressed properties on the pagination buttons
+		// Should be pushed upstream to DataTables
+		$pagination.find( ".paginate_button" )
+			.attr( {
+				"href": "#" + navFocusOnId
+			} )
+
+			// This is required to override the datatable.js (v1.10.13) behavior to cancel the event propagation on anchor element.
+			.on( "keypress", function( evn ) {
+				if ( evn.keyCode === 13 ) {
+					window.location = evn.target.href;
+				}
+			} )
+
+			.not( ".previous, .next" )
+			.attr( "aria-pressed", "false" )
+			.html( function( index, oldHtml ) {
+				return "<span class='wb-inv'>" + i18nText.paginate.page + " </span>" + oldHtml;
+			} )
+			.filter( ".current" )
+			.attr( "aria-pressed", "true" );
 	};
 
 // Bind the init event of the plugin
@@ -139,9 +179,7 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 		paginate_buttons = $elm.next( ".bottom" ).find( ".paginate_button" ),
 		pbLength = paginate_buttons.length,
 		pHasLF = pagination.find( ".last, .first" ).length === 2,
-		pHasPN = pagination.find( ".previous, .next" ).length === 2,
-		ol = document.createElement( "OL" ),
-		li = document.createElement( "LI" );
+		pHasPN = pagination.find( ".previous, .next" ).length === 2;
 
 	// Handle sorting/ordering
 	var order = $elm.dataTable( { "retrieve": true } ).api().order();
@@ -180,38 +218,8 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 		pagination.removeClass( "hidden" );
 		pagination_top.removeClass( "hidden" );
 
-		// Update Pagination List
-		for ( var i = 0; i < paginate_buttons.length; i++ ) {
-			var item = li.cloneNode( true );
-			item.appendChild( paginate_buttons[ i ] );
-			ol.appendChild( item );
-		}
-
-		ol.className = "pagination mrgn-tp-0 mrgn-bttm-0";
-		pagination.empty();
-		pagination.append( ol );
-
-		// Update the aria-pressed properties on the pagination buttons
-		// Should be pushed upstream to DataTables
-		$elm.next( ".bottom" ).find( ".paginate_button" )
-			.attr( {
-				"href": "#" + $elm.get( 0 ).id
-			} )
-
-			// This is required to override the datatable.js (v1.10.13) behavior to cancel the event propagation on anchor element.
-			.on( "keypress", function( evn ) {
-				if ( evn.keyCode === 13 ) {
-					window.location = evn.target.href;
-				}
-			} )
-
-			.not( ".previous, .next" )
-			.attr( "aria-pressed", "false" )
-			.html( function( index, oldHtml ) {
-				return "<span class='wb-inv'>" + i18nText.paginate.page + " </span>" + oldHtml;
-			} )
-			.filter( ".current" )
-			.attr( "aria-pressed", "true" );
+		updatePaginationMarkup( pagination, $elm.get( 0 ).id );
+		updatePaginationMarkup( pagination_top );
 	}
 
 	// Identify that the table has been updated

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -179,7 +179,6 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 		// Make sure Pagination is visible
 		pagination.removeClass( "hidden" );
 		pagination_top.removeClass( "hidden" );
-		
 		// Update Pagination List
 		for ( var i = 0; i < paginate_buttons.length; i++ ) {
 			var item = li.cloneNode( true );

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -135,6 +135,7 @@ $document.on( "timerpoke.wb " + initEvent, selector, init );
 $document.on( "draw.dt", selector, function( event, settings ) {
 	var $elm = $( event.target ),
 		pagination = $elm.next( ".bottom" ).find( "div:first-child" ),
+		pagination_top = $elm.prevAll( ".top" ).find( "div.dataTables_paginate" ),
 		paginate_buttons = $elm.next( ".bottom" ).find( ".paginate_button" ),
 		pbLength = paginate_buttons.length,
 		pHasLF = pagination.find( ".last, .first" ).length === 2,
@@ -172,11 +173,13 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 		)
 	) {
 		pagination.addClass( "hidden" );
+		pagination_top.addClass( "hidden" );
 	} else {
 
 		// Make sure Pagination is visible
 		pagination.removeClass( "hidden" );
-
+		pagination_top.removeClass( "hidden" );
+		
 		// Update Pagination List
 		for ( var i = 0; i < paginate_buttons.length; i++ ) {
 			var item = li.cloneNode( true );


### PR DESCRIPTION
More information in #9709

When you are adding the option DOM of Datatable, to add the pagination at the top of the table, when selecting more item than what the table is containing, 60 item vs 100 to show, the pagination stay at the top!

This just remove the pagination at the top like at the bottom.

Thanks to @wewhite 