### PR TITLE
Tables: adding option to filter with exact match

### DIFF
--- a/site/pages/docs/ref/tables/tables-en.hbs
+++ b/site/pages/docs/ref/tables/tables-en.hbs
@@ -61,6 +61,7 @@
 <section>
 	<h2>Configuration options</h2>
 	<p>All configuration options are detailed in the <a href="https://www.datatables.net/ref">DataTables documentation</a> and is fully accessible via the <code>data-wb-tables</code> attribute or <code>window[ "wb-tables" ]</code>.</p>
+	<p>To filter a table using the filter's exact value, add the attribute <code>data-exact="true"</code> to the filter. For example: <code>&lt;select class="form-control" id="filterName" name="filterName" data-column="0" data-exact="true">&lt;/select></code></p>
 </section>
 
 <section>

--- a/site/pages/docs/ref/tables/tables-fr.hbs
+++ b/site/pages/docs/ref/tables/tables-fr.hbs
@@ -63,6 +63,7 @@
 <section>
 	<h2>Configuration options</h2>
 	<p>All configuration options are detailed in the <a href="https://www.datatables.net/ref">DataTables documentation</a> and is fully accessible via the <code>data-wb-tables</code> attribute or <code>window[ "wb-tables" ]</code>.</p>
+	<p>To filter a table using the filter's exact value, add the attribute <code>data-exact="true"</code> to the filter. For example: <code>&lt;select class="form-control" id="filterName" name="filterName" data-column="0" data-exact="true">&lt;/select></code></p>
 </section>
 
 <section>

--- a/src/plugins/tables/ajax/datasource.json
+++ b/src/plugins/tables/ajax/datasource.json
@@ -334,7 +334,7 @@
     "TEASER": "On July 26, 2016 at about 7:00 p.m., a lockdown was put in place at Mountain Institution, a medium security federal institution, to enable staff members to conduct a general search.",
     "PUBDATE": "2016-07-28 09:07:00",
     "TYPE": "News Releases",
-    "DEPT": "Correctional Service Canada",
+    "DEPT": "Service Canada",
     "SUBJECT": "Health and Safety",
     "MINISTER": "Hon. Ralph Goodale",
     "AUDIENCE": "Media,General Public",

--- a/src/plugins/tables/tables-fltrs-en.hbs
+++ b/src/plugins/tables/tables-fltrs-en.hbs
@@ -50,7 +50,7 @@
 					</div>
 					<div class="form-group">
 						<label for="dt_department">Department</label>
-						<select class="form-control" id="dt_department" name="dt_department" data-column="2">
+						<select class="form-control" id="dt_department" name="dt_department" data-column="2" data-exact="true">
 							<option value="">From any department</option>
 							<option value="Agriculture and Agri-Food Canada">Agriculture and Agri-Food Canada</option>
 							<option value="Atlantic Canada Opportunities Agency">Atlantic Canada Opportunities Agency</option>
@@ -79,6 +79,7 @@
 							<option value="Transportation Safety Board of Canada">Transportation Safety Board of Canada</option>
 							<option value="Canadian Nuclear Safety Commission">Canadian Nuclear Safety Commission</option>
 							<option value="Transport Canada">Transport Canada</option>
+							<option value="Service Canada">Service Canada</option>
 							<option value="Treasury Board of Canada Secretariat">Treasury Board of Canada Secretariat</option>
 							<option value="Environment and Climate Change Canada">Environment and Climate Change Canada</option>
 							<option value="Finance Canada">Finance Canada</option>

--- a/src/plugins/tables/tables-fltrs-fr.hbs
+++ b/src/plugins/tables/tables-fltrs-fr.hbs
@@ -51,7 +51,7 @@
 					</div>
 					<div class="form-group">
 						<label for="dt_department">Department</label>
-						<select class="form-control" id="dt_department" name="dt_department" data-column="2">
+						<select class="form-control" id="dt_department" name="dt_department" data-column="2" data-exact="true">
 							<option value="">From any department</option>
 							<option value="Agriculture and Agri-Food Canada">Agriculture and Agri-Food Canada</option>
 							<option value="Atlantic Canada Opportunities Agency">Atlantic Canada Opportunities Agency</option>
@@ -80,6 +80,7 @@
 							<option value="Transportation Safety Board of Canada">Transportation Safety Board of Canada</option>
 							<option value="Canadian Nuclear Safety Commission">Canadian Nuclear Safety Commission</option>
 							<option value="Transport Canada">Transport Canada</option>
+							<option value="Service Canada">Service Canada</option>
 							<option value="Treasury Board of Canada Secretariat">Treasury Board of Canada Secretariat</option>
 							<option value="Environment and Climate Change Canada">Environment and Climate Change Canada</option>
 							<option value="Finance Canada">Finance Canada</option>

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -434,8 +434,12 @@ $document.on( "submit", ".wb-tables-filter", function( event ) {
 
 			// Verifies if regex was preset, if not preset use 'contains value' as default
 			if ( !$regex ) {
-				$value = $value.replace( /\s/g, "\\s*" );
-				$regex = "(" + $value + ")";
+				if ( $elm[ 0 ].getAttribute( "data-exact" ) ) {
+					$regex = "^" + $value + "$";
+				} else {
+					$value = $value.replace( /\s/g, "\\s*" );
+					$regex = "(" + $value + ")";
+				}
 			}
 
 			$datatable.column( $column ).search( $regex, true );


### PR DESCRIPTION
Adding exact match option for filters so that the search within a column does not include rows outside the exact value of the filter.

Changes related to WET-452