### PR TITLE
Bootstrap overrides: Revert normalize.css' link outline styles

### DIFF
--- a/src/base/_wet-boew.scss
+++ b/src/base/_wet-boew.scss
@@ -14,6 +14,7 @@
 
 /*! Reset and dependencies */
 @import "bootstrap-sass/assets/stylesheets/bootstrap/normalize";
+@import "bootstrap-overrides/normalize";
 @import "bootstrap-sass/assets/stylesheets/bootstrap/print";
 @import "bootstrap-sass/assets/stylesheets/bootstrap/glyphicons";
 

--- a/src/base/bootstrap-overrides/_base.scss
+++ b/src/base/bootstrap-overrides/_base.scss
@@ -5,6 +5,7 @@
 
 @import "helper-variables";
 
+@import "normalize";
 @import "core";
 @import "core-button";
 @import "core-heading";

--- a/src/base/bootstrap-overrides/_normalize.scss
+++ b/src/base/bootstrap-overrides/_normalize.scss
@@ -1,0 +1,14 @@
+/*
+  WET-BOEW
+  @title: Bootstrap overrides for WET-BOEW - normalize.css
+ */
+
+/*
+ *	Restore user agent's "native" link outline styles
+ *	Prevents outlines from getting removed when the :focus pseudo-class is paired with :active and/or :hover
+ *	Matches normalize 6.0.0+'s default behaviour
+ */
+a:active,
+a:hover {
+	outline: revert;
+}


### PR DESCRIPTION
Bootstrap 3.4.x's normalize.css v3.0.3 dependency contains some opinionated selectors... one of which removes outlines from hovered/active links.

Apart from being of questionable use, that selector inadvertently undid the outlines of focused links that happened to be hovered and/or activated (e.g. ``:focus:hover``, ``:focus:active`` or ``:focus:hover:active``).

The selector was introduced in normalize.css's first commit and later removed in v6.0.0 (via necolas/normalize.css#649, in response to necolas/normalize.css#647).

This adds an override to undo the selector in WET (reverts to the user agent's "native" outline styles).