### PR TITLE
Core - replace `polyfill.io` endpoint

### DIFF
--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -602,7 +602,7 @@ Modernizr.load( [
 					if ( isTrident ) {
 
 						// Load an ES6 polyfill
-						Modernizr.load( "timeout=500!https://polyfill.io/v3/polyfill.min.js?features=es6" );
+						Modernizr.load( "timeout=500!https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6" );
 
 						// Specify the CDN's font URL
 						// Note: IE11 is unable to resolve this on its own


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

`wb.js` loader will load polyfill from the `polyfill.io` if running on IE. The PR replaces `polyfill.io` with `cdnjs.cloudflare.com/polyfill`.

`polyfill.io` was acquired by **a China-based CDN company** "Funnull", see [the announcement from the `polyfill.io` domain owner's Twitter](https://x.com/JakeDChampion/status/1761315227008643367) and https://github.com/polyfillpolyfill/polyfill-service/issues/2834. Despite Funnull's claims of operating in the United States, the predominance of Simplified Chinese on its website suggests otherwise, and it turns out that **"Funnull" is notorious for providing service for the betting and pornography industries**.

[The original creator of the `polyfill.io` has voiced his concern on Twitter](https://twitter.com/triblondon/status/1761852117579427975). And since the acquisition, numerous issues have emerged (https://github.com/polyfillpolyfill/polyfill-service/issues/2835, https://github.com/polyfillpolyfill/polyfill-service/issues/2838, https://github.com/alist-org/alist/issues/6100), rendering the `polyfill.io` service **extremely unstable**. Since then, Fastly ([Announcement](https://community.fastly.com/t/new-options-for-polyfill-io-users/2540)) and Cloudflare ([Announcement](https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk)) has hosted their own instances of `polyfill.io` service.

## Additional information (optional) / Information additionnelle (optionel)

**General checklist / Liste de contrôle générale**
Make your own list for the purpose of your Pull request. /// Faites votre propre liste en fonction des besoins de votre demande « pull ».

- [ ] Create/update documentation /// Créer/mettre à jour la documentation
- [x] Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
- [x] Validate changes against WCAG for accessibility /// Valider les changements avec WCAG pour l'accessibilité
- [ ] Ensure documentation is bilingual /// S'assurer que la documentation soit bilingue

**Related issues / Requêtes associées**

N/A

**Screenshots / Captures d'écrans**

N/A
