### PR TITLE
Correct session-timeout plugin configuration syntax

### DIFF
--- a/site/pages/docs/ref/session-timeout/session-timeout-en.hbs
+++ b/site/pages/docs/ref/session-timeout/session-timeout-en.hbs
@@ -45,7 +45,7 @@
 	"reactionTime": 30000,
 	"sessionalive": 1200000,
 	"logouturl": "./",
-	"refreshCallbackUrl": "./"
+	"refreshCallbackUrl": "./",
 	"refreshOnClick": true,
 	"refreshLimit": 200000,
 	"method": "POST",

--- a/site/pages/docs/ref/session-timeout/session-timeout-fr.hbs
+++ b/site/pages/docs/ref/session-timeout/session-timeout-fr.hbs
@@ -51,7 +51,7 @@
 		"reactionTime": 30000,
 		"sessionalive": 1200000,
 		"logouturl": "./",
-		"refreshCallbackUrl": "./"
+		"refreshCallbackUrl": "./",
 		"refreshOnClick": true,
 		"refreshLimit": 200000}'&gt;&lt;/span&gt;</code></pre>
 			</li>


### PR DESCRIPTION
## What does this pull request (PR) do?
Fixes the syntax in the "How to implement" section of the session-timeout documentation. I was working on implementing this today and took a while to realize why it wouldn't respect my parameters and revert to the defaults. Turns out there is a typo in the documentation.

## Additional information (optional)

**General checklist**
Make your own list for the purpose of your Pull request.

- [x] Create/update documentation 
- [x] Ensure documentation is bilingual 

**Related issues**
N/A

**Screenshots**
![image](https://github.com/wet-boew/wet-boew/assets/145933563/456fdc75-d691-463c-816d-ad696165e48e)
