### PR TITLE
Proximity CSS: Disallow column breaks inside colcount list items

### DIFF
--- a/src/base/proximity/_base.scss
+++ b/src/base/proximity/_base.scss
@@ -255,6 +255,31 @@
 	}
 }
 
+/* Disallow column breaks inside list column items */
+%proximity-colcount-no-break {
+	break-inside: avoid-column;
+}
+
+.colcount-no-break {
+	> {
+		dd,
+		dt,
+		li {
+			@extend %proximity-colcount-no-break;
+		}
+	}
+}
+
+dl {
+	&.colcount-no-break {
+		> {
+			div {
+				@extend %proximity-colcount-no-break;
+			}
+		}
+	}
+}
+
 .colcount-xxs-2 {
 	column-count: 2;
 }

--- a/src/other/utility/utility-en.hbs
+++ b/src/other/utility/utility-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "utility",
 	"parentdir": "utility",
 	"altLangPrefix": "utility",
-	"dateModified": "2023-08-15"
+	"dateModified": "2024-03-25"
 }
 ---
 
@@ -25,6 +25,7 @@
 	<li><a href="#spacing">Spacing</a></li>
 	<li><a href="#sizing">Sizing</a></li>
 	<li><a href="#flexbox">Flexbox</a></li>
+	<li><a href="#lists">Lists</a></li>
 	<li><a href="#positioning">Positioning</a></li>
 	<li><a href="#tables">Tables</a></li>
 	<li><a href="#miscellaneous">Miscellaneous</a></li>
@@ -412,6 +413,189 @@
 		&lt;p class="well"&gt;Line 1&lt;/p&gt;
 	&lt;/div&gt;
 &lt;/div&gt;</code></pre>
+
+<h2 id="lists">Lists</h2>
+
+<h3>List columns (<code>colcount-*-*</code>)</h3>
+<p>Spreads a list over 2, 3 or 4 columns.</p>
+<p>Since columns are similar to grids, they adhere to the same breakpoints as grids.</p>
+<h4>Available classes</h4>
+<ul>
+	<li>2 columns:
+		<ul>
+			<li><code>colcount-xxs-2</code>, <code>colcount-xs-2</code>, <code>colcount-sm-2</code>, <code>colcount-md-2</code>, <code>colcount-lg-2</code>, <code>colcount-xl-2</code></li>
+		</ul>
+	</li>
+	<li>3 columns:
+		<ul>
+			<li><code>colcount-xxs-3</code>, <code>colcount-xs-3</code>, <code>colcount-sm-3</code>, <code>colcount-md-3</code>, <code>colcount-lg-3</code>, <code>colcount-xl-3</code></li>
+		</ul>
+	</li>
+	<li>4 columns:
+		<ul>
+			<li><code>colcount-xxs-4</code>, <code>colcount-xs-4</code>, <code>colcount-sm-4</code>, <code>colcount-md-4</code>, <code>colcount-lg-4</code>, <code>colcount-xl-4</code></li>
+		</ul>
+	</li>
+</ul>
+<h4>Unordered list</h4>
+<h5>Working example</h5>
+<ul class="colcount-sm-2 colcount-md-3 colcount-lg-4">
+	<li>Item 1<br>Line 2<br>Line 3</li>
+	<li>Item 2<br>Line 2<br>Line 3</li>
+	<li>Item 3</li>
+	<li>Item 4<br>Line 2<br>Line 3</li>
+	<li>Item 5<br>Line 2<br>Line 3</li>
+	<li>Item 6<br>Line 2</li>
+	<li>Item 7<br>Line 2</li>
+	<li>Item 8</li>
+</ul>
+<h5>Code sample</h5>
+<pre><code>&lt;ul class="colcount-sm-2 colcount-md-3 colcount-lg-4"&gt;
+	&lt;li&gt;Item 1&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/li&gt;
+	&lt;li&gt;Item 2&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/li&gt;
+	&lt;li&gt;Item 3&lt;/li&gt;
+	&lt;li&gt;Item 4&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/li&gt;
+	&lt;li&gt;Item 5&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/li&gt;
+	&lt;li&gt;Item 6&lt;br&gt;Line 2&lt;/li&gt;
+	&lt;li&gt;Item 7&lt;br&gt;Line 2&lt;/li&gt;
+	&lt;li&gt;Item 8&lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+<h4>Description list</h4>
+<h5>Working example</h5>
+<dl class="colcount-sm-2 colcount-md-3 colcount-lg-4">
+	<div>
+		<dt>Term 1</dt>
+		<dd>Description</dd>
+	</div>
+	<div>
+		<dt>Term 2</dt>
+		<dd>Description<br>Line 2<br>Line 3</dd>
+	</div>
+	<div>
+		<dt>Term 3</dt>
+		<dd>Description<br>Line 2<br>Line 3</dd>
+	</div>
+	<div>
+		<dt>Term 4</dt>
+		<dd>Description<br>Line 2</dd>
+	</div>
+	<div>
+		<dt>Term 5</dt>
+		<dd>Description<br>Line 2</dd>
+	</div>
+	<div>
+		<dt>Term 6</dt>
+		<dd>Description</dd>
+	</div>
+</dl>
+<h5>Code sample</h5>
+<pre><code>&lt;dl class="colcount-sm-2 colcount-md-3 colcount-lg-4"&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 1&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 2&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 3&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 4&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Line 2&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 5&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Line 2&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 6&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;/dd&gt;
+	&lt;/div&gt;
+&lt;/dl&gt;</code></pre>
+
+<h3><code>colcount-no-break</code></h3>
+<p>Prevents list items from splitting across multople list columns.</p>
+<h4>Unordered list</h4>
+<h5>Working example</h5>
+<ul class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break">
+	<li>Item 1<br>Line 2<br>Line 3</li>
+	<li>Item 2<br>Line 2<br>Line 3</li>
+	<li>Item 3</li>
+	<li>Item 4<br>Line 2<br>Line 3</li>
+	<li>Item 5<br>Line 2<br>Line 3</li>
+	<li>Item 6<br>Line 2</li>
+	<li>Item 7<br>Line 2</li>
+	<li>Item 8</li>
+</ul>
+<h5>Code sample</h5>
+<pre><code>&lt;ul class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break"&gt;
+	&lt;li&gt;Item 1&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/li&gt;
+	&lt;li&gt;Item 2&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/li&gt;
+	&lt;li&gt;Item 3&lt;/li&gt;
+	&lt;li&gt;Item 4&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/li&gt;
+	&lt;li&gt;Item 5&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/li&gt;
+	&lt;li&gt;Item 6&lt;br&gt;Line 2&lt;/li&gt;
+	&lt;li&gt;Item 7&lt;br&gt;Line 2&lt;/li&gt;
+	&lt;li&gt;Item 8&lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+<h4>Description list</h4>
+<h5>Working example</h5>
+<dl class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break">
+	<div>
+		<dt>Term 1</dt>
+		<dd>Description</dd>
+	</div>
+	<div>
+		<dt>Term 2</dt>
+		<dd>Description<br>Line 2<br>Line 3</dd>
+	</div>
+	<div>
+		<dt>Term 3</dt>
+		<dd>Description<br>Line 2<br>Line 3</dd>
+	</div>
+	<div>
+		<dt>Term 4</dt>
+		<dd>Description<br>Line 2</dd>
+	</div>
+	<div>
+		<dt>Term 5</dt>
+		<dd>Description<br>Line 2</dd>
+	</div>
+	<div>
+		<dt>Term 6</dt>
+		<dd>Description</dd>
+	</div>
+</dl>
+<h5>Code sample</h5>
+<pre><code>&lt;dl class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break"&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 1&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 2&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 3&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Line 2&lt;br&gt;Line 3&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 4&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Line 2&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 5&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Line 2&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Term 6&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;/dd&gt;
+	&lt;/div&gt;
+&lt;/dl&gt;</code></pre>
 
 <h2 id="positioning">Positioning</h2>
 

--- a/src/other/utility/utility-en.hbs
+++ b/src/other/utility/utility-en.hbs
@@ -517,7 +517,7 @@
 &lt;/dl&gt;</code></pre>
 
 <h3><code>colcount-no-break</code></h3>
-<p>Prevents list items from splitting across multople list columns.</p>
+<p>Prevents list items from splitting across multiple list columns.</p>
 <h4>Unordered list</h4>
 <h5>Working example</h5>
 <ul class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break">

--- a/src/other/utility/utility-fr.hbs
+++ b/src/other/utility/utility-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "utility",
 	"parentdir": "utility",
 	"altLangPrefix": "utility",
-	"dateModified": "2023-08-15"
+	"dateModified": "2024-03-25"
 }
 ---
 
@@ -24,6 +24,7 @@
 	<li><a href="#espacement">Espacement</a></li>
 	<li><a href="#dimension">Dimensionnement</a></li>
 	<li><a href="#flexbox" lang="en">Flexbox</a></li>
+	<li><a href="#listes">Listes</a></li>
 	<li><a href="#positionnement">Positionnement</a></li>
 	<li><a href="#tables">Tables</a></li>
 	<li><a href="#divers">Divers</a></li>
@@ -409,6 +410,189 @@
 		&lt;p class="well"&gt;Ligne 1&lt;/p&gt;
 	&lt;/div&gt;
 &lt;/div&gt;</code></pre>
+
+<h2 id="listes">Listes</h2>
+
+<h3>Colonnes de liste (<code>colcount-*-*</code>)</h3>
+<p>Répend une liste à travers 2, 3 ou 4 colonnes.</p>
+<p>Puisque les colonnes sont semblables à des grilles, elles sont assujetties aux mêmes points d'arrêt que les grilles.</p>
+<h4>Classes disponibles</h4>
+<ul>
+	<li>2 colonnes&nbsp;:
+		<ul>
+			<li><code>colcount-xxs-2</code>, <code>colcount-xs-2</code>, <code>colcount-sm-2</code>, <code>colcount-md-2</code>, <code>colcount-lg-2</code>, <code>colcount-xl-2</code></li>
+		</ul>
+	</li>
+	<li>3 colonnes&nbsp;:
+		<ul>
+			<li><code>colcount-xxs-3</code>, <code>colcount-xs-3</code>, <code>colcount-sm-3</code>, <code>colcount-md-3</code>, <code>colcount-lg-3</code>, <code>colcount-xl-3</code></li>
+		</ul>
+	</li>
+	<li>4 colonnes&nbsp;:
+		<ul>
+			<li><code>colcount-xxs-4</code>, <code>colcount-xs-4</code>, <code>colcount-sm-4</code>, <code>colcount-md-4</code>, <code>colcount-lg-4</code>, <code>colcount-xl-4</code></li>
+		</ul>
+	</li>
+</ul>
+<h4>Liste sans ordre</h4>
+<h5>Exemple pratique</h5>
+<ul class="colcount-sm-2 colcount-md-3 colcount-lg-4">
+	<li>Élément 1<br>Ligne 2<br>Ligne 3</li>
+	<li>Élément 2<br>Ligne 2<br>Ligne 3</li>
+	<li>Élément 3</li>
+	<li>Élément 4<br>Ligne 2<br>Ligne 3</li>
+	<li>Élément 5<br>Ligne 2<br>Ligne 3</li>
+	<li>Élément 6<br>Ligne 2</li>
+	<li>Élément 7<br>Ligne 2</li>
+	<li>Élément 8</li>
+</ul>
+<h5>Exemple de code</h5>
+<pre><code>&lt;ul class="colcount-sm-2 colcount-md-3 colcount-lg-4"&gt;
+	&lt;li&gt;Élément 1&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/li&gt;
+	&lt;li&gt;Élément 2&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/li&gt;
+	&lt;li&gt;Élément 3&lt;/li&gt;
+	&lt;li&gt;Élément 4&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/li&gt;
+	&lt;li&gt;Élément 5&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/li&gt;
+	&lt;li&gt;Élément 6&lt;br&gt;Ligne 2&lt;/li&gt;
+	&lt;li&gt;Élément 7&lt;br&gt;Ligne 2&lt;/li&gt;
+	&lt;li&gt;Élément 8&lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+<h4>Liste de descriptions</h4>
+<h5>Exemple pratique</h5>
+<dl class="colcount-sm-2 colcount-md-3 colcount-lg-4">
+	<div>
+		<dt>Terme 1</dt>
+		<dd>Description</dd>
+	</div>
+	<div>
+		<dt>Terme 2</dt>
+		<dd>Description<br>Ligne 2<br>Ligne 3</dd>
+	</div>
+	<div>
+		<dt>Terme 3</dt>
+		<dd>Description<br>Ligne 2<br>Ligne 3</dd>
+	</div>
+	<div>
+		<dt>Terme 4</dt>
+		<dd>Description<br>Ligne 2</dd>
+	</div>
+	<div>
+		<dt>Terme 5</dt>
+		<dd>Description<br>Ligne 2</dd>
+	</div>
+	<div>
+		<dt>Terme 6</dt>
+		<dd>Description</dd>
+	</div>
+</dl>
+<h5>Exemple de code</h5>
+<pre><code>&lt;dl class="colcount-sm-2 colcount-md-3 colcount-lg-4"&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 1&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 2&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 3&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 4&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Ligne 2&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 5&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Ligne 2&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 6&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;/dd&gt;
+	&lt;/div&gt;
+&lt;/dl&gt;</code></pre>
+
+<h3><code>colcount-no-break</code></h3>
+<p>Empêche les éléments de liste de se séparer à travers plusieurs colonnes de liste.</p>
+<h4>Liste sans ordre</h4>
+<h5>Exemple pratique</h5>
+<ul class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break">
+	<li>Élément 1<br>Ligne 2<br>Ligne 3</li>
+	<li>Élément 2<br>Ligne 2<br>Ligne 3</li>
+	<li>Élément 3</li>
+	<li>Élément 4<br>Ligne 2<br>Ligne 3</li>
+	<li>Élément 5<br>Ligne 2<br>Ligne 3</li>
+	<li>Élément 6<br>Ligne 2</li>
+	<li>Élément 7<br>Ligne 2</li>
+	<li>Élément 8</li>
+</ul>
+<h5>Exemple de code</h5>
+<pre><code>&lt;ul class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break"&gt;
+	&lt;li&gt;Élément 1&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/li&gt;
+	&lt;li&gt;Élément 2&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/li&gt;
+	&lt;li&gt;Élément 3&lt;/li&gt;
+	&lt;li&gt;Élément 4&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/li&gt;
+	&lt;li&gt;Élément 5&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/li&gt;
+	&lt;li&gt;Élément 6&lt;br&gt;Ligne 2&lt;/li&gt;
+	&lt;li&gt;Élément 7&lt;br&gt;Ligne 2&lt;/li&gt;
+	&lt;li&gt;Élément 8&lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+<h4>Liste de descriptions</h4>
+<h5>Exemple pratique</h5>
+<dl class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break">
+	<div>
+		<dt>Terme 1</dt>
+		<dd>Description</dd>
+	</div>
+	<div>
+		<dt>Terme 2</dt>
+		<dd>Description<br>Ligne 2<br>Ligne 3</dd>
+	</div>
+	<div>
+		<dt>Terme 3</dt>
+		<dd>Description<br>Ligne 2<br>Ligne 3</dd>
+	</div>
+	<div>
+		<dt>Terme 4</dt>
+		<dd>Description<br>Ligne 2</dd>
+	</div>
+	<div>
+		<dt>Terme 5</dt>
+		<dd>Description<br>Ligne 2</dd>
+	</div>
+	<div>
+		<dt>Terme 6</dt>
+		<dd>Description</dd>
+	</div>
+</dl>
+<h5>Exemple de code</h5>
+<pre><code>&lt;dl class="colcount-sm-2 colcount-md-3 colcount-lg-4 colcount-no-break"&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 1&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 2&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 3&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Ligne 2&lt;br&gt;Ligne 3&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 4&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Ligne 2&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 5&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;br&gt;Ligne 2&lt;/dd&gt;
+	&lt;/div&gt;
+	&lt;div&gt;
+		&lt;dt&gt;Terme 6&lt;/dt&gt;
+		&lt;dd&gt;Description&lt;/dd&gt;
+	&lt;/div&gt;
+&lt;/dl&gt;</code></pre>
 
 <h2 id="positionnement">Positionnement</h2>
 <h3><code>position-relative</code></h3>


### PR DESCRIPTION
In CSS columns, content "breaks" across columns by default. It helps keep the columns looking balanced. But it looks very strange when multi-line list items break across columns.

This adds a new class (``colcount-no-break``) to prevent it from happening. When used, each list item's content will always "stick together". The list items themselves will still be spread across multiple columns.

Also added a list columns section to the utilities page:
* Used the style guide's content as a starting point
  * Shortened the explanation
* Revised the unordered list example to:
  * Deliberately show multi-line list items splitting across columns
  * Demonstrate combinations of breakpoint classes
* Added a similar description list example
  * Uses ``div`` elements out of necessity (``dt`` and ``dd`` need a common parent to prevent them from getting "separated" across columns)

**CC:**
* @cfarquharson (added you as a co-committer since I borrowed [some of your old content/examples from the WET style guide](https://wet-boew.github.io/wet-boew-styleguide/design/lists-en.html#columns))
* @andrewnordlund (FYI)