### PR TITLE
bgimg: Adding option to have no background image in responsive format

### DIFF
--- a/site/pages/docs/ref/bgimg/bgimg-en.hbs
+++ b/site/pages/docs/ref/bgimg/bgimg-en.hbs
@@ -96,9 +96,8 @@
 	<tr>
 		<td><code>[data-bgimg-srcset]</code> String</td>
 		<td>Images to use in different situations, limited to images sizes for different situations.</td>
-		<td>Set a valid <a href="https://html.spec.whatwg.org/multipage/images.html#image-candidate-string">image candidate string</a></td>
-		<td><code>[ &lt;source-size-value&gt;# , ]? &lt;source-size-value&gt;</code>
-		</td>
+		<td>Set a valid <a href="https://html.spec.whatwg.org/multipage/images.html#image-candidate-string">image candidate string</a>.</td>
+		<td><code>[ &lt;source-size-value&gt;# , ]? &lt;source-size-value&gt;</code></td>
 	</tr>
 </table>
 

--- a/site/pages/docs/ref/bgimg/bgimg-fr.hbs
+++ b/site/pages/docs/ref/bgimg/bgimg-fr.hbs
@@ -99,8 +99,7 @@
 		<td><code>[data-bgimg-srcset]</code> String</td>
 		<td>Images to use in different situations, limited to images sizes for different situations.</td>
 		<td>Set a valid <a href="https://html.spec.whatwg.org/multipage/images.html#image-candidate-string">image candidate string</a></td>
-		<td><code>[ &lt;source-size-value&gt;# , ]? &lt;source-size-value&gt;</code>
-		</td>
+		<td><code>[ &lt;source-size-value&gt;# , ]? &lt;source-size-value&gt;</code></td>
 	</tr>
 </table>
 

--- a/src/plugins/bgimg/bgimg-en.hbs
+++ b/src/plugins/bgimg/bgimg-en.hbs
@@ -64,3 +64,27 @@
 		&lt;/div&gt;
 	&lt;/div&gt;</code></pre>
 </details>
+
+<h2>Specify no background image for a specific breakpoint</h2>
+
+<pre><code>data-bgimg-srcset="https://wet-boew.github.io/vocab/wb/utilities#no-image 600w, image2_link 960w, image3_link 1280w"</code></pre>
+
+<div class="bg-cover well" data-bgimg-srcset="https://wet-boew.github.io/vocab/wb/utilities#no-image 600w, ../../demos/tabs/img/flytheskies.jpg 960w, ../../demos/tabs/img/protect-environment.jpg 1280w">
+	<div class="well mrgn-tp-md mrgn-bttm-md">
+		<h4 class="mrgn-tp-md">Heading</h4>
+		<p>Paragraph</p>
+	</div>
+</div>
+
+<details>
+	<summary>Source code</summary>
+	<pre><code>&lt;div class="bg-cover well"
+		data-bgimg-srcset="https://wet-boew.github.io/vocab/wb/utilities#no-image 600w,
+				../../demos/tabs/img/flytheskies.jpg 960w,
+				../../demos/tabs/img/protect-environment.jpg 1280w"&gt;
+		&lt;div class="well mrgn-tp-md mrgn-bttm-md"&gt;
+			&lt;h4 class="mrgn-tp-md"&gt;Heading&lt;/h4&gt;
+			&lt;p&gt;SParagraph&lt;/p&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;</code></pre>
+</details>

--- a/src/plugins/bgimg/bgimg-fr.hbs
+++ b/src/plugins/bgimg/bgimg-fr.hbs
@@ -26,7 +26,7 @@
 </div>
 
 <details>
-	<summary>Source code</summary>
+	<summary>Code source</summary>
 	<pre><code>&lt;div class="bg-cover bg-center well" data-bgimg="../../demos/tabs/img/investinourfuture.jpg"&gt;
 		&lt;div class="well mrgn-tp-md mrgn-bttm-md"&gt;
 			&lt;h4 class="mrgn-tp-md"&gt;Titre&lt;/h4&gt;
@@ -53,9 +53,33 @@
 </div>
 
 <details>
-	<summary>Source code</summary>
+	<summary>Code source</summary>
 	<pre><code>&lt;div class="bg-cover well"
 		data-bgimg-srcset="../../demos/tabs/img/investinourfuture.jpg 600w,
+				../../demos/tabs/img/flytheskies.jpg 960w,
+				../../demos/tabs/img/protect-environment.jpg 1280w"&gt;
+		&lt;div class="well mrgn-tp-md mrgn-bttm-md"&gt;
+			&lt;h4 class="mrgn-tp-md"&gt;Titre&lt;/h4&gt;
+			&lt;p&gt;Paragraphe&lt;/p&gt;
+		&lt;/div&gt;
+	&lt;/div&gt;</code></pre>
+</details>
+
+<h2>Définir aucune image d'arrière plan pour un certain point d'arrêt - <code>[data-bgimg-srcset]</code></h2>
+
+<pre><code>data-bgimg-srcset="https://wet-boew.github.io/vocab/wb/utilities#no-image 600w, image2_link 960w, image3_link 1280w"</code></pre>
+
+<div class="bg-cover well" data-bgimg-srcset="https://wet-boew.github.io/vocab/wb/utilities#no-image 600w, ../../demos/tabs/img/flytheskies.jpg 960w, ../../demos/tabs/img/protect-environment.jpg 1280w">
+	<div class="well mrgn-tp-md mrgn-bttm-md">
+		<h4 class="mrgn-tp-md">Titre</h4>
+		<p>Paragraphe</p>
+	</div>
+</div>
+
+<details>
+	<summary>Code source</summary>
+	<pre><code>&lt;div class="bg-cover well"
+		data-bgimg-srcset="https://wet-boew.github.io/vocab/wb/utilities#no-image 600w,
 				../../demos/tabs/img/flytheskies.jpg 960w,
 				../../demos/tabs/img/protect-environment.jpg 1280w"&gt;
 		&lt;div class="well mrgn-tp-md mrgn-bttm-md"&gt;

--- a/src/plugins/bgimg/bgimg.js
+++ b/src/plugins/bgimg/bgimg.js
@@ -110,7 +110,12 @@ var $document = wb.doc,
 
 		for ( link in optimizedLink ) {
 			elm = document.getElementById( link );
-			elm.style.backgroundImage = "url(" + optimizedLink[ link ] + ")";
+
+			if ( optimizedLink[ link ] === "https://wet-boew.github.io/vocab/wb/utilities#no-image" ) {
+				elm.style.backgroundImage = "none";
+			} else {
+				elm.style.backgroundImage = "url(" + optimizedLink[ link ] + ")";
+			}
 		}
 	};
 


### PR DESCRIPTION
Adds the option to define no background image for a specific breakpoint which is rather useful when you want no background image on smaller screens.