### PR TITLE
The Following dataTable Example Fails

### DIFF
--- a/src/core/dep/jquery-fix.js
+++ b/src/core/dep/jquery-fix.js
@@ -174,7 +174,8 @@ var localParseHTML = jQuery.parseHTML,
 		"<tbody/>",
 		"<tr/>",
 		"<td />",
-		"<td/>"
+		"<td/>",
+		"<tr><td></td></tr>"
 	],
 	sanitize = function( html ) {
 


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Client of Mine PSPC, tried to upgrade to a version of wet-boew > 4.0.39.1. Which implements, DOMPurify, and interferes with jquery.datatable.js

https://datatables.net/examples/api/row_details.html

In the example  the  row.child(format(row.data())).show(); line of code inserts dom structure "<tr><td></td></tr>",  that gets Stripped out by DOMPurify and causes a javascript error in the console.

Uncaught TypeError: $(...).addClass(...).html(...)[0] is undefined in Firefox

There is already an dataTableAllowedTag I just added the structure to it, and that ensures this row.child dataTable function doesn't get interfered with.

## Additional information (optional) / Information additionnelle (optionel)

**General checklist / Liste de contrôle générale**
Make your own list for the purpose of your Pull request. /// Faites votre propre liste en fonction des besoins de votre demande « pull ».

- [ ] Create/update documentation /// Créer/mettre à jour la documentation
- [x ] Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
- [ ] Validate changes against WCAG for accessibility /// Valider les changements avec WCAG pour l'accessibilité
- [ ] Ensure documentation is bilingual /// S'assurer que la documentation soit bilingue

