### PR TITLE
Twitter embedded timeline: Improve handling of missing i18n vars

### DIFF
--- a/src/plugins/twitter/twitter.js
+++ b/src/plugins/twitter/twitter.js
@@ -58,6 +58,11 @@ var componentName = "wb-twitter",
 					};
 				}
 
+				// Show a warning if the timelineTitle variable isn't a string
+				if ( typeof i18nText.startNotice !== "string" ) {
+					console.warn( componentName + ": i18n text is missing. Iframe title override and skip links will be disabled." );
+				}
+
 				// Set Chinese (Simplfified)'s language code to "zh-cn"
 				// If the link doesn't specify a widget language and its "in-page" language code is "zh-Hans"...
 				// Notes:
@@ -97,8 +102,10 @@ var componentName = "wb-twitter",
 							const mutationTarget = mutation.target;
 
 							// Override the timeline iframe's title right after Twitter's widget script adds it
-							// Note: The timeline's iframe title is English-only, uses "Twitter" and is written in title case ("Twitter Timeline")... This replaces it with an i18n version that uses "X" and is written in sentence case.
-							if ( mutationTarget.nodeName === "IFRAME" && mutationTarget.title !== i18nText.timelineTitle ) {
+							// Notes:
+							// -The timeline's iframe title is English-only, uses "Twitter" and is written in title case ("Twitter Timeline")... This replaces it with an i18n version that uses "X" and is written in sentence case.
+							// -Only proceed if the i18n variable is a string... otherwise this'll trigger an infinite loop of attribute mutations
+							if ( mutationTarget.nodeName === "IFRAME" && mutationTarget.title !== i18nText.timelineTitle && typeof i18nText.timelineTitle === "string" ) {
 								mutationTarget.title = i18nText.timelineTitle;
 							}
 							break;
@@ -161,9 +168,8 @@ var componentName = "wb-twitter",
 		let skipToEndLink;
 		let skipToStartLink;
 
-		// Abort if Twitter username is falsy
-		// Note: Unlikely to happen unless the username doesn't exist... in which case Twitter's third party widget script will have already failed and triggered an exception by this point
-		if ( !username ) {
+		// Abort if Twitter username is falsy or i18n variables aren't strings
+		if ( !username || typeof i18nText.timelineTitle !== "string" ) {
 			return;
 		}
 


### PR DESCRIPTION
#9704's changes had the potential of going into an infinite loop if one of its i18n variables was ``undefined``.

The infinite loop tied into an ``if`` condition in the MutationObserver:
* Its purpose is to replace the Twitter widget's English-only ``iframe`` ``title`` with an i18n version from WET
* It checks for attribute mutations on ``iframe`` elements and whether the ``iframe``'s ``title`` attribute matches the ``i18nText.timelineTitle`` variable
* If the current ``iframe`` ``title`` isn't strictly equal to the i18n variable, the former gets set to the latter (triggering another attribute mutation)

Normally, the ``if`` condition should become truthy in the subsequent attribute mutation.

When the i18n variable wasn't set, this never happened. Why? Because missing i18n variables are treated as ``undefined``. So the ``iframe`` ``title`` got set to "undefined" (implicit conversion of ``undefined`` into a string)... Then the next mutation's ``if`` condition didn't match ("undefined" !== ``undefined``). So the ``if`` condition attempted to set the ``iframe`` ``title`` to "undefined" once again - triggering yet another attribute mutation. This sequence of events repeated forever.

This fixes it by checking whether the i18n variable is a string before changing the ``iframe``'s ``title`` attribute.

Related changes:
* Show a console warning if the plugin's i18n variables appear to be missing
* Don't add skip links if one of its i18n variables isn't a string (prevents console errors, no point in adding the links without content)