### PR TITLE
Background image: adding half-width utilities

### DIFF
--- a/src/base/_component.scss
+++ b/src/base/_component.scss
@@ -18,6 +18,17 @@
 .bg-norepeat {
 	background-repeat: no-repeat;
 }
+.bg-half-right,
+.bg-half-left {
+	background-repeat: no-repeat;
+	background-size: 50%;
+}
+.bg-half-right {
+	background-position: 100% center;
+}
+.bg-half-left {
+	background-position: left center;
+}
 
 /*
  Additional color

--- a/src/other/utility/utility-en.hbs
+++ b/src/other/utility/utility-en.hbs
@@ -102,6 +102,40 @@
 	&lt;/div&gt;
 &lt;/div&gt;</code></pre>
 
+<h3><code>bg-half-left</code></h3>
+<p>Make the background take the left half width of the element. Note: overwrites <code>bg-cover</code>, automatically applies <code>bg-norepeat</code>, and vertically aligns the image in the middle.</p>
+<h4>Working example</h4>
+<div class="bg-half-left well" data-bgimg="../../demos/tabs/img/investinourfuture.jpg">
+	<div class="well mrgn-tp-md mrgn-bttm-md">
+		<h4 class="mrgn-tp-md">Heading</h4>
+		<p>Paragraph</p>
+	</div>
+</div>
+<h4>Code sample</h4>
+<pre><code>&lt;div class="<strong>bg-half-left</strong> well" data-bgimg="../../demos/tabs/img/investinourfuture.jpg"&gt;
+	&lt;div class="well mrgn-tp-md mrgn-bttm-md"&gt;
+		&lt;h4 class="mrgn-tp-md"&gt;Heading&lt;/h4&gt;
+		&lt;p&gt;Paragraph&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
+<h3><code>bg-half-right</code></h3>
+<p>Make the background take the right half width of the element. Note: overwrites <code>bg-cover</code>, automatically applies <code>bg-norepeat</code>, and vertically aligns the image in the middle.</p>
+<h4>Working example</h4>
+<div class="bg-half-right well" data-bgimg="../../demos/tabs/img/investinourfuture.jpg">
+	<div class="well mrgn-tp-md mrgn-bttm-md">
+		<h4 class="mrgn-tp-md">Heading</h4>
+		<p>Paragraph</p>
+	</div>
+</div>
+<h4>Code sample</h4>
+<pre><code>&lt;div class="<strong>bg-half-right</strong> well" data-bgimg="../../demos/tabs/img/investinourfuture.jpg"&gt;
+	&lt;div class="well mrgn-tp-md mrgn-bttm-md"&gt;
+		&lt;h4 class="mrgn-tp-md"&gt;Heading&lt;/h4&gt;
+		&lt;p&gt;Paragraph&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
 <h3><code>bg-darker</code></h3>
 <p>Set a black background to an element.</p>
 <h4>Working example</h4>

--- a/src/other/utility/utility-fr.hbs
+++ b/src/other/utility/utility-fr.hbs
@@ -101,6 +101,40 @@
 	&lt;/div&gt;
 &lt;/div&gt;</code></pre>
 
+<h3><code>bg-half-left</code></h3>
+<p>Fait en sorte que l'arrière-plan prend la moitié gauche de la largeur de l'élément. Remarque&nbsp;: écrase <code>bg-cover</code>, applique automatiquement <code>bg-norepeat</code> et aligne verticalement l'image au milieu.</p>
+<h4>Working example</h4>
+<div class="bg-half-left well" data-bgimg="../../demos/tabs/img/investinourfuture.jpg">
+	<div class="well mrgn-tp-md mrgn-bttm-md">
+		<h4 class="mrgn-tp-md">En-tête</h4>
+		<p>Paragraphe</p>
+	</div>
+</div>
+<h4>Code sample</h4>
+<pre><code>&lt;div class="<strong>bg-half-left</strong> well" data-bgimg="../../demos/tabs/img/investinourfuture.jpg"&gt;
+	&lt;div class="well mrgn-tp-md mrgn-bttm-md"&gt;
+		&lt;h4 class="mrgn-tp-md"&gt;En-tête&lt;/h4&gt;
+		&lt;p&gt;Paragraphe&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
+<h3><code>bg-half-right</code></h3>
+<p>Fait en sorte que l'arrière-plan prend la moitié droite de la largeur de l'élément. Remarque&nbsp;: écrase <code>bg-cover</code>, applique automatiquement <code>bg-norepeat</code> et aligne verticalement l'image au milieu.</p>
+<h4>Working example</h4>
+<div class="bg-half-right well" data-bgimg="../../demos/tabs/img/investinourfuture.jpg">
+	<div class="well mrgn-tp-md mrgn-bttm-md">
+		<h4 class="mrgn-tp-md">En-tête</h4>
+		<p>Paragraphe</p>
+	</div>
+</div>
+<h4>Code sample</h4>
+<pre><code>&lt;div class="<strong>bg-half-right</strong> well" data-bgimg="../../demos/tabs/img/investinourfuture.jpg"&gt;
+	&lt;div class="well mrgn-tp-md mrgn-bttm-md"&gt;
+		&lt;h4 class="mrgn-tp-md"&gt;En-tête&lt;/h4&gt;
+		&lt;p&gt;Paragraphe&lt;/p&gt;
+	&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+
 <h3><code>bg-darker</code></h3>
 <p>Défini un arrère-plan noir à un élément.</p>
 <h4>Exemple pratique</h4>


### PR DESCRIPTION
Adds:
- `bg-half-left`: background image takes the left half width of the element
- `bg-half-right`: background image takes the right half width of the element