### PR TITLE
Focus: Assign focus more resiliently

### DIFF
--- a/src/plugins/toggle/toggle-en.hbs
+++ b/src/plugins/toggle/toggle-en.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "toggle",
 	"altLangPrefix": "toggle",
 	"css": ["demo/toggle"],
-	"dateModified": "2020-03-10"
+	"dateModified": "2024-08-14"
 }
 ---
 <span class="wb-prettify all-pre linenums"></span>
@@ -25,6 +25,7 @@
 			<a href="#setup" class="list-group-item">Plugin Setup</a>
 			<a href="#simple" class="list-group-item">Simple Example</a>
 			<a href="#details" class="list-group-item">Details Elements</a>
+			<a href="#print" class="list-group-item">Print States</a>
 			<a href="#grouped" class="list-group-item">Grouped Toggle</a>
 			<a href="#accordion" class="list-group-item">Accordion</a>
 			<a href="#persist" class="list-group-item">Persist Toggle State</a>
@@ -241,6 +242,25 @@
 				</details>
 			</div>
 
+		</section>
+
+		<section>
+			<h2 id="print">Print States</h2>
+			<p>The <code>"print": "on"</code> and <code>"print": "off"</code> settings can be used to control whether to always open/close regular <code>&lt;details&gt;</code> elements when printing:</p>
+			<ul class="list-unstyled">
+				<li>
+					<details>
+						<summary class="wb-toggle" data-toggle='{"print": "on"}'>Always open when printing (<code>"print": "on"</code>)</summary>
+						<p>Example content that provides more details.</p>
+					</details>
+				</li>
+				<li>
+					<details>
+						<summary class="wb-toggle" data-toggle='{"print": "off"}'>Always closed when printing (<code>"print": "off"</code>) (not recommended)</summary>
+						<p>Example content that provides more details.</p>
+					</details>
+				</li>
+			</ul>
 		</section>
 
 		<section>

--- a/src/plugins/toggle/toggle-fr.hbs
+++ b/src/plugins/toggle/toggle-fr.hbs
@@ -8,7 +8,7 @@
 	"parentdir": "toggle",
 	"altLangPrefix": "toggle",
 	"css": ["demo/toggle"],
-	"dateModified": "2020-03-10"
+	"dateModified": "2024-08-14"
 }
 ---
 <span class="wb-prettify all-pre linenums"></span>
@@ -25,6 +25,7 @@
 			<a href="#setup" class="list-group-item" lang="en">Plugin Setup</a>
 			<a href="#simple" class="list-group-item">Exemple simple</a>
 			<a href="#details" class="list-group-item">Details</a>
+			<a href="#print" class="list-group-item">États d’impression</a>
 			<a href="#grouped" class="list-group-item">Basculer groupe</a>
 			<a href="#accordion" class="list-group-item">Accordion</a>
 			<a href="#persist" class="list-group-item">Conserver l'état de bascule</a>
@@ -236,6 +237,26 @@
 			</div>
 
 		</section>
+
+		<section>
+			<h2 id="print">États d’impression</h2>
+			<p>Les paramètres <code>"print": "on"</code> et <code>"print": "off"</code> peuvent être utilisés pour contrôler s’il faut toujours ouvrir/fermer les éléments de <code>&lt;details&gt;</code> normaux lors de l’impression&nbsp;:</p>
+			<ul class="list-unstyled">
+				<li>
+					<details>
+						<summary class="wb-toggle" data-toggle='{"print": "on"}'>Toujours ouvert lors de l’impression (<code>"print": "on"</code>)</summary>
+						<p>Le contenu d'exemple qui fournit plus de détails.</p>
+					</details>
+				</li>
+				<li>
+					<details>
+						<summary class="wb-toggle" data-toggle='{"print": "off"}'>Toujours fermé lors de l’impression (<code>"print": "off"</code>) (pas recommandé)</summary>
+						<p>Le contenu d'exemple qui fournit plus de détails.</p>
+					</details>
+				</li>
+			</ul>
+		</section>
+
 		<section>
 			<h2 id="grouped">Basculer groupe</h2>
 			<p>


### PR DESCRIPTION
If this plugin is used to focus onto a non-interactive element, it adds a ``tabindex="-1"`` attribute (to make the destination focusable) before proceeding.

Since adding ``tabindex="-1"`` isn't always necessary, the plugin exempts elements that already have a ``tabindex`` attribute, as well as "known" interactive elements.

However...
* The plugin removed interactive elements it wasn't aware of (like ``summary``) from sequential keyboard navigation:
  * End result was WCAG 2.x failures: SC 2.1.1 and 2.4.3 (via F44)
* Tying exemptions to a list of "known" interactive elements is a bad practice:
  * Isn't future-proof
  * Keeping it up-to-date is a maintenance burden
  * [Interactive content as defined by the HTML spec](https://html.spec.whatwg.org/multipage/dom.html#interactive-content) isn't suitable for that purpose (e.g. ``details`` and ``label`` are technically interactive... but aren't keyboard-tabbable)
  * Doesn't account for different behaviours across browser rendering engines (e.g. ``video`` element without the ``controls`` attribute is tabbable in Gecko, but not in Blink)

This alleviates the need for an exemptions list by revamping how focusing works:
1. The plugin will first try to focus directly onto the element
2. If the element hasn't gained focus, the plugin will add a ``tabindex="-1"`` attribute and retry
3. If the element still hasn't gained focus... the plugin will remove ``tabindex="-1"`` and show a console error

Credit goes to @fsnoddy for initially spotting this issue (by using the toggle plugin's ``{"print": "on"}`` configuration option on a ``summary`` element). Also added "boring" print state examples to the toggle plugin's demo page to show it in action.