### PR TITLE
JSON manager docs: Remove redundant event description

### DIFF
--- a/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-en.hbs
+++ b/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-en.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Manage dataset and apply JSON Patch",
 	"altLangPage": "wb-jsonmanager-fr.html",
-	"dateModified": "2023-06-19"
+	"dateModified": "2023-08-05"
 }
 ---
 <div class="wb-prettify all-pre"></div>
@@ -644,11 +644,6 @@
 				<td><code>postpone.wb-jsonmanager</code></td>
 				<td>Triggered automatically by the json fetch plugin to let the JSON manager that other plugin depends on it.</td>
 				<td>Postpone the json fetch call until the dataset is ready.</td>
-			</tr>
-			<tr>
-				<td><code>wb-init.wb-jsonmanager</code></td>
-				<td>Triggered manually (e.g., <code>$( ".wb-jsonmanager" ).trigger( "wb-init.wb-jsonmanager" );</code>).</td>
-				<td>Used to manually initialize the wb-jsonmanager plugin. <strong>Note:</strong> The wb-jsonmanager plugin will be initialized automatically unless the required markup is added after the page has already loaded.</td>
 			</tr>
 			<tr>
 				<td><code>wb-init.wb-jsonmanager</code></td>

--- a/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-fr.hbs
+++ b/site/pages/docs/ref/wb-jsonmanager/wb-jsonmanager-fr.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Gérer des jeux de données et applique des correctifs JSON.",
 	"altLangPage": "wb-jsonmanager-en.html",
-	"dateModified": "2023-06-19"
+	"dateModified": "2024-08-05"
 }
 ---
 <div class="wb-prettify all-pre"></div>
@@ -686,12 +686,6 @@
 				<td>Triggered automatically by the json fetch plugin to let the JSON manager that other plugin depends on it.</td>
 				<td>Postpone the json fetch call until the dataset is ready.</td>
 			</tr>
-			<tr>
-				<td><code>wb-init.wb-jsonmanager</code></td>
-				<td>Triggered manually (e.g., <code>$( ".wb-jsonmanager" ).trigger( "wb-init.wb-jsonmanager" );</code>).</td>
-				<td>Used to manually initialize the wb-jsonmanager plugin. <strong>Note:</strong> The wb-jsonmanager plugin will be initialized automatically unless the required markup is added after the page has already loaded.</td>
-			</tr>
-
 			<tr>
 				<td><code>wb-init.wb-jsonmanager</code></td>
 				<td>Triggered manually (e.g., <code>$( ".wb-jsonmanager" ).trigger( "wb-init.wb-jsonmanager" );</code>).</td>


### PR DESCRIPTION
The events section covered ``wb-init.wb-jsonmanager`` twice in a row (two identical copies of the same content).

This removes the second copy of the content.