### PR TITLE
Build - Continuous deployment - Run deployment with only one NodeJS version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x]
     env:
       REPO_DIST: wet-boew-dist
       REPO_DIST_CDN: wet-boew-cdn

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-boew",
-  "version": "4.0.81.2",
+  "version": "4.0.81.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wet-boew",
-  "version": "4.0.81.2",
+  "version": "4.0.81.3",
   "description": "Web Experience Toolkit (WET): Open source code library for building innovative websites that are accessible, usable, interoperable, mobile-friendly and multilingual. This collaborative open source project is led by the Government of Canada. / Boîte à outils de l’expérience Web (BOEW) : Une bibliothèque de code primée pour construire des sites Web innovants qui sont accessibles, faciles d'emploi, interopérables, optimisés pour les appareils mobiles et multilingues. Ceci est un projet à source ouverte collaboratif dirigé par le Gouvernement du Canada.",
   "main": "index.html",
   "engines": {


### PR DESCRIPTION
To fix a racing condition when deploying and creating new tags for wet-boew via our continuous deployment script.