### PR TITLE
Build: Bump package-lock.json "packages" to v4.0.81.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "wet-boew",
-      "version": "4.0.81.2",
+      "version": "4.0.81.3",
       "license": "MIT",
       "dependencies": {
         "bootstrap-sass": "3.4.1",


### PR DESCRIPTION
Running vanilla builds was causing package-lock.json to become polluted (outdated "packages" version reference to 4.0.81.2 changed to 4.0.81.3).

This updates the version accordingly.