### PR TITLE
FormValid: fix input being cleared when nested in label on page load

### DIFF
--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -115,7 +115,7 @@ var componentName = "wb-frmvld",
 							// Add space to the end of the labels (so separation between label and error when CSS turned off)
 							len = labels.length;
 							for ( i = 0; i !== len; i += 1 ) {
-								labels[ i ].innerHTML += " ";
+								labels[ i ].insertAdjacentHTML( "beforeend", " " );
 							}
 
 							// Hide "required" label text in older forms from screen readers


### PR DESCRIPTION
## What does this pull request (PR) do? 
This PR switches the label updating code to use insertAdjacentHTML which doesn't refresh the DOM/corrupt child elements
See: https://developer.mozilla.org/en-US/docs/Web/API/Element/insertAdjacentHTML#description

**General checklist**
Make your own list for the purpose of your Pull request.

- [x] Build and test PR's code 

**Related issues**
closes https://github.com/wet-boew/wet-boew/issues/9816

