### PR TITLE
Facebook embedded pages: Add overflow-x scrollbar

### DIFF
--- a/src/base/_wet-boew.scss
+++ b/src/base/_wet-boew.scss
@@ -100,6 +100,7 @@
 @import "../plugins/dismissable-content/base";
 @import "../plugins/eqht-css/base";
 @import "../plugins/equalheight/base";
+@import "../plugins/facebook/base";
 @import "../plugins/filter/base";
 @import "../plugins/footnotes/base";
 @import "../plugins/formvalid/base";

--- a/src/plugins/facebook/_base.scss
+++ b/src/plugins/facebook/_base.scss
@@ -1,0 +1,8 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+
+.wb-facebook {
+	overflow-x: auto;
+}


### PR DESCRIPTION
Facebook's page widget isn't fully responsive:
* Default width is 340px
* Officially supports widths between 180-500px (doesn't support percentages)
* Automatically shrinks to fit within its container when inited (via ``data-adapt-container-width="true"``, default behaviour)
* Can't shrink or expand after initing (can't use CSS to resize its iframe either... width is set inside the iframe's ``body``)

As a result, if the widget initially renders itself within a wide container, resizing the viewport won't cause it to scale... So if the viewport width shrinks and the widget overflows beyond its container, the entire page will become horizontally-scrollable.

This limits the damage by adding an ``overflow-x`` property to the widget's container (to make only the widget itself scroll horizontally).