### PR TITLE
Session Timeout: Allow override of specific text elements.

### DIFF
--- a/site/pages/docs/ref/session-timeout/session-timeout-en.hbs
+++ b/site/pages/docs/ref/session-timeout/session-timeout-en.hbs
@@ -30,6 +30,7 @@
 	<h2>Working example</h2>
 	<p><a href="../../../demos/session-timeout/session-timeout-en.html">Basic example</a></p>
 	<p><a href="../../../demos/session-timeout/session-timeout-signin-en.html">Example with signInUrl option</a></p>
+	<p><a href="../../../demos/session-timeout/session-timeout-text-override-en.html">Example with text overrides</a></p>
 </section>
 
 <section>
@@ -50,7 +51,15 @@
 	"refreshOnClick": true,
 	"refreshLimit": 200000,
 	"method": "POST",
-	"additionalData": null}'&gt;&lt;/span&gt;</code></pre>
+	"additionalData": null,
+		"textOverrides": {
+			"buttonContinue": "button text",
+			"buttonEnd": "button text",
+			"buttonSignin": "button text",
+			"timeoutEnd": "message text",
+			"timeoutAlready": "message text"
+			}
+	}'&gt;&lt;/span&gt;</code></pre>
 		</li>
 	</ol>
 </section>
@@ -228,6 +237,25 @@
 						<dd>Treated as a query string of the form <code>key1=value1&amp;key2=value2</code> and sent as-is.</dd>
 						<dt>Array or object:</dt>
 						<dd>Converted to query string form before being sent with the request.</dd>
+					</dl>
+				</td>
+			</tr>
+			<tr>
+				<td><code>textOverrides</code></td>
+				<td>Optional button text and message elements to override the defaults.</td>
+				<td>Provide an object with one or more of the following properties.</td>
+				<td>
+					<dl>
+						<dt>buttonContinue</dt>
+						<dd>Text for the Continue Session button.</dd>
+						<dt>buttonEnd</dt>
+						<dd>Text for the End Session button.</dd>
+						<dt>buttonSignin</dt>
+						<dd>Text for the Sign In button.</dd>
+						<dt>timeoutEnd</dt>
+						<dd>Text for the message displayed below the timer.</dd>
+						<dt>timeoutAlready</dt>
+						<dd>Text for the message displayed when the session has expired.</dd>
 					</dl>
 				</td>
 			</tr>

--- a/site/pages/docs/ref/session-timeout/session-timeout-en.hbs
+++ b/site/pages/docs/ref/session-timeout/session-timeout-en.hbs
@@ -52,13 +52,13 @@
 	"refreshLimit": 200000,
 	"method": "POST",
 	"additionalData": null,
-		"textOverrides": {
-			"buttonContinue": "button text",
-			"buttonEnd": "button text",
-			"buttonSignin": "button text",
-			"timeoutEnd": "message text",
-			"timeoutAlready": "message text"
-			}
+	"textOverrides": {
+		"buttonContinue": "button text",
+		"buttonEnd": "button text",
+		"buttonSignin": "button text",
+		"timeoutEnd": "message text",
+		"timeoutAlready": "message text"
+		}
 	}'&gt;&lt;/span&gt;</code></pre>
 		</li>
 	</ol>

--- a/site/pages/docs/ref/session-timeout/session-timeout-fr.hbs
+++ b/site/pages/docs/ref/session-timeout/session-timeout-fr.hbs
@@ -34,6 +34,7 @@
 	<h2>Exemple pratique</h2>
 	<p><a href="../../../demos/session-timeout/session-timeout-fr.html">Exemple de base</a></p>
 	<p><a href="../../../demos/session-timeout/session-timeout-signin-fr.html">Exemple avec l'option signInUrl</a></p>
+	<p><a href="../../../demos/session-timeout/session-timeout-text-override-fr.html">Example with text overrides</a></p>
 </section>
 
 <div lang="en">
@@ -54,7 +55,17 @@
 		"signInUrl": null,
 		"refreshCallbackUrl": "./",
 		"refreshOnClick": true,
-		"refreshLimit": 200000}'&gt;&lt;/span&gt;</code></pre>
+		"refreshLimit": 200000,
+		"method": "POST",
+		"additionalData": null,
+		"textOverrides": {
+			"buttonContinue": "button text",
+			"buttonEnd": "button text",
+			"buttonSignin": "button text",
+			"timeoutEnd": "message text",
+			"timeoutAlready": "message text"
+			}
+		}'&gt;&lt;/span&gt;</code></pre>
 			</li>
 		</ol>
 	</section>
@@ -232,6 +243,25 @@
 							<dd>Treated as a query string of the form <code>key1=value1&amp;key2=value2</code> and sent as-is.</dd>
 							<dt>Array or object:</dt>
 							<dd>Converted to query string form before being sent with the request.</dd>
+						</dl>
+					</td>
+				</tr>
+				<tr>
+					<td><code>textOverrides</code></td>
+					<td>Optional button text and message elements to override the defaults.</td>
+					<td>Provide an object with one or more of the following properties.</td>
+					<td>
+						<dl>
+							<dt>buttonContinue</dt>
+							<dd>Text for the Continue Session button.</dd>
+							<dt>buttonEnd</dt>
+							<dd>Text for the End Session button.</dd>
+							<dt>buttonSignin</dt>
+							<dd>Text for the Sign In button.</dd>
+							<dt>timeoutEnd</dt>
+							<dd>Text for the message displayed below the timer.</dd>
+							<dt>timeoutAlready</dt>
+							<dd>Text for the message displayed when the session has expired.</dd>
 						</dl>
 					</td>
 				</tr>

--- a/site/pages/docs/ref/session-timeout/session-timeout-fr.hbs
+++ b/site/pages/docs/ref/session-timeout/session-timeout-fr.hbs
@@ -64,8 +64,8 @@
 			"buttonSignin": "button text",
 			"timeoutEnd": "message text",
 			"timeoutAlready": "message text"
-			}
-		}'&gt;&lt;/span&gt;</code></pre>
+		}
+	}'&gt;&lt;/span&gt;</code></pre>
 			</li>
 		</ol>
 	</section>

--- a/src/plugins/session-timeout/session-timeout-en.hbs
+++ b/src/plugins/session-timeout/session-timeout-en.hbs
@@ -13,39 +13,10 @@
 
 <span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "logouturl": "../index-en.html"}'></span>
 
-<section class="wb-prettify all-pre">
-	<h2 id="overview" class="mrgn-tp-0">Overview</h2>
-	<p>This plugin helps web page owners by providing session timeout and inactivity timeout functionality. When a user requests a page with this plugin implemented their session will begin. After the specified session period, they will be notified that their session is about to timeout. At this point, they will have the option to remain logged in by clicking "Continue session", or signing out by clicking "End session now".</p>
-	<p>At any time during the session, if the user remains idle for a specified amount of time, they will be notified that they're session is about to timeout. In either case, if the user does not respond to the timeout notification within a specified amount of time, once they click either "Continue session" or "End session now" they will be automatically redirected to the sign out page.</p>
-	<p>The plugin is setup using the following HTML:</p>
-
-	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"inactivity": 1200000, "reactionTime": 30000, "sessionalive": 1200000, "logouturl": "./", "refreshCallbackUrl": "./"}'&gt;&lt;/span&gt;</code></pre>
-
-	<p>This allows you to configure the plugin:</p>
-	<ul>
-		<li><strong>inactivity:</strong> inactivity period of time after which the modal dialog will appear (default 20 minutes).</li>
-		<li><strong>reactionTime:</strong> period of time the user has to perform an action once the modal dialog is displayed (default 3 minutes).</li>
-		<li><strong>sessionalive:</strong> period of time for the session to stay alive until the modal dialog appears (default 20 minutes).</li>
-		<li><strong>logouturl:</strong> URL used to end the session.</li>
-		<li><strong>signInUrl:</strong> URL that users are sent to when the session has expired.</li>
-		<li><strong>refreshCallback:</strong> The function used to check the response received from refreshCallbackUrl.</li>
-		<li><strong>refreshCallbackUrl:</strong> URL used to perform an ajax request to determine the validity of the session.</li>
-		<li><strong>refreshOnClick:</strong> Determines if clicking on the document should reset the inactivity timeout and perform an ajax request (if a refreshCallbackUrl has been specified).</li>
-		<li><strong>refreshLimit:</strong> Sets the amount of time that must pass before an ajax request can be made.</li>
-		<li><strong>method:</strong> Sets the request method used for ajax requests. Recommended: GET or POST.</li>
-		<li><strong>additionalData:</strong> Additional data to send with the request.</li>
-	</ul>
-	<p>The only required parameter is logouturl, all other fields are optional. The default plugin code is:</p>
-	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{logouturl: "./"}'&gt;&lt;/span&gt;</code></pre>
-	<p><strong>Note:</strong> The inactivity, reactionTime and sessionalive parameters are set in milliseconds. For help with the time values, use this <a href="https://www.calculateme.com/Time/Minutes/ToMilliseconds.htm" rel="external">time converter</a>.</p>
-	<p><strong>Note:</strong> Your sessionalive and inactivity parameters should be equal to your web server session alive time minus the reactionTime time. If you set your sessionalive time and inactivity time to the same as your web server without taking into consideration the reactionTime time then the session will have ended by the server as soon as the popup appears to extend the session.</p>
-	<p><strong>Note:</strong> The server response needs to contain a message body. Don't use a request method (e.g. HEAD) that disallows a message body in the response.</p>
-</section>
-
 <section>
 	<h2 id="how">How do I use it?</h2>
 	<p>Add the following to the page:</p>
-	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{logouturl: "./"}'&gt;&lt;/span&gt;</code></pre>
+	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "logouturl": "../index-en.html"}'&gt;&lt;/span&gt;</code></pre>
 </section>
 
 <section>

--- a/src/plugins/session-timeout/session-timeout-fr.hbs
+++ b/src/plugins/session-timeout/session-timeout-fr.hbs
@@ -13,35 +13,9 @@
 
 <span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "logouturl": "../index-fr.html"}'></span>
 
-<section class="wb-prettify all-pre">
-	<h2 id="overview" class="mrgn-tp-0">Aperçu</h2>
-	<p>Ce plugiciel aidera les propriétaires d'actifs Web à configurer leurs actifs avec une fonction «&#160;Expiration de la session&#160;». Celle-ci sera activée en deux circonstances&#160;: après une période de temps spécifique ou lors d'inactivité.</p>
-	<p>Par exemple, si l'utilisateur demeure trop longtemps sur la même page, la fonction sera activée. De même, si l’utilisateur demeure inactif, la fonction sera activée. Le fureteur affichera alors une boîte de dialogue proposant deux options à l'utilisateur ; s’il souhaite rester connecté il devra sélectionner «&#160;Continuer la session&#160;» et ce, dans un laps de temps précis et s’il souhaite mettre fin à sa session, il n’aura qu’à choisir «&#160;Mettre fin à la session&#160;». Advenant que l'utilisateur tarde trop à faire son choix, ce sera le paramètre de déconnexion qui s’affichera.</p>
-	<p>Le code que vous êtes autorisés à modifier (dans la page) est&#160;:</p>
-	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"inactivity": 1200000, "reactionTime": 30000, "sessionalive": 1200000, "logouturl": "./", "refreshCallbackUrl": "./"}'&gt;&lt;/span&gt;</code></pre>
-	<p>Les paramètres suivants vous permettent de configurer la fonction&#160;:</p>
-	<ul>
-		<li><strong>inactivity :</strong> période de temps d'inactivité après laquelle la boîte de dialogue apparaîtra (20 minutes par défaut).</li>
-		<li><strong>reactionTime :</strong> période de temps dont dispose l'utilisateur pour faire un choix lorsque la boîte de dialogue apparaît (3 minutes par défaut).</li>
-		<li><strong>sessionalive :</strong> période de temps durant laquelle la session demeure active avant que la boîte de dialogue n’apparaisse (20 minutes par défaut).</li>
-		<li><strong>logouturl :</strong> adresse URL utilisée pour terminer la session.</li>
-		<li><strong>signInUrl :</strong> adresse URL à laquelle l’utilisateur est acheminé lorsque la session a expiré.</li>
-		<li><strong>refreshCallback :</strong> La fonction utilisée pour vérifier la réponse reçue de refreshCallbackUrl.</li>
-		<li><strong>refreshCallbackUrl :</strong> adresse URL pour effectuer une actualisation ajax, doit retourner "true".</li>
-		<li><strong>refreshOnClick :</strong> Détermine si cliquer sur le document doit réinitialiser le délai d'inactivité et effectuer une requête ajax (si un refreshCallbackUrl a été spécifié).</li>
-		<li><strong>refreshLimit :</strong> Définit le temps qui doit s'écouler avant qu'une requête ajax puisse être effectuée.</li>
-		<li><strong>method :</strong> Définit la méthode de requête utilisée pour les requêtes ajax. Recommandé : GET ou POST.</li>
-		<li><strong>additionalData :</strong> Données supplémentaires à envoyer avec la demande.</li>
-	</ul>
-	<p>Le seul paramètre requis est logouturl, tous les autres champs sont facultatifs. Le JavaScript par défaut serait&#160;:</p>
-	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"logouturl": "./"}'&gt;&lt;/span&gt;</code></pre>
-	<p><strong>Nota :</strong> Les paramètres inactivity, reactionTime et sessionAlive sont mis en millisecondes. Voici <a href="https://www.calculateme.com/Time/Minutes/ToMilliseconds.htm" rel="external">un outil (disponible en anglais seulement)</a> qui vous aidera a convertir des minutes en millisecondes.</p>
-	<p><strong>Nota :</strong> Les paramètres sessionalive et inactivity devrait être égal à votre session sur le serveur web moins le temps de reactionTime. Si vous définissez paramètres sessionalive et inactivity avec le même temps que la session sur le serveur web, sans prendre en considération le temps reactionTime, alors la session sur le serveur sera fini dès que la fenêtre contextuelle apparaît pour prolonger la session.</p>
-</section>
-
 <section><h2 id="how">Configuration</h2>
 	<p>Ajoutez les lignes suivantes à la page&#160;:</p>
-	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{logouturl: "./"}'&gt;&lt;/span&gt;</code></pre>
+	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "logouturl": "../index-fr.html"}'&gt;&lt;/span&gt;</code></pre>
 </section>
 
 <section><h2 id="try">Faites un essai</h2>

--- a/src/plugins/session-timeout/session-timeout-text-override-en.hbs
+++ b/src/plugins/session-timeout/session-timeout-text-override-en.hbs
@@ -11,13 +11,13 @@
 }
 ---
 
-<span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-en.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!"}}'></span>
+<span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-en.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!", "buttonSignin": "Start Over", "timeoutEnd": "Are you still there?"}}'></span>
 
 
 <section>
 	<h2 id="how">How do I use it?</h2>
 	<p>Add the <code>textOverrides</code> option to the session timeout element. Here is the current page's example:</p>
-	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-en.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!"}}'&gt;&lt;/span&gt;</code></pre>
+	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-en.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!", "buttonSignin": "Start Over", "timeoutEnd": "Are you still there?"}}'&gt;&lt;/span&gt;</code></pre>
 </section>
 
 <section>

--- a/src/plugins/session-timeout/session-timeout-text-override-en.hbs
+++ b/src/plugins/session-timeout/session-timeout-text-override-en.hbs
@@ -1,0 +1,26 @@
+---
+{
+	"title": "Session Timeout with text overrides",
+	"language": "en",
+	"category": "Plugins",
+	"description": "Helps Web asset owners to provide session timeout and inactivity timeout functionality.",
+	"tag": "session-timeout-text-override",
+	"parentdir": "session-timeout",
+	"altLangPrefix": "session-timeout-text-override",
+	"dateModified": "2024-12-16"
+}
+---
+
+<span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-en.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!"}}'></span>
+
+
+<section>
+	<h2 id="how">How do I use it?</h2>
+	<p>Add the <code>textOverrides</code> option to the session timeout element. Here is the current page's example:</p>
+	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-en.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!"}}'&gt;&lt;/span&gt;</code></pre>
+</section>
+
+<section>
+	<h2 id="try">Try it out!</h2>
+	<p>This page has a 30 seconds inactivity timeout period. You also have 30 seconds to confirm if you want to keep the session alive. Please wait for the prompt to appear.</p>
+</section>

--- a/src/plugins/session-timeout/session-timeout-text-override-fr.hbs
+++ b/src/plugins/session-timeout/session-timeout-text-override-fr.hbs
@@ -1,0 +1,23 @@
+---
+{
+	"title": "Expiration de la session avec l'option textOverrides",
+	"language": "fr",
+	"category": "Plugiciels",
+	"description": "Ferme la session de l'utilisateur après un certain délai.",
+	"tag": "session-timeout-text-override",
+	"parentdir": "session-timeout",
+	"altLangPrefix": "session-timeout-text-override",
+	"dateModified": "2024-11-06"
+}
+---
+
+<span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-en.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!"}}'></span>
+
+<section><h2 id="how">Configuration</h2>
+	<p>Ajoutez l'option <code>textOverrides</code> à l'élément d'expiration de la session. Voici l'exemple de la page actuelle&nbsp;:</p>
+	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-en.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!"}}'&gt;&lt;/span&gt;</code></pre>
+</section>
+
+<section><h2 id="try">Faites un essai</h2>
+	<p>Cette page a été configurée pour expirer dans 30 secondes. Après ce délai, vous aurez 30 secondes pour choisir de la garder active ou non. Veuillez svp attendre que la boîte de dialogue apparaisse.</p>
+</section>

--- a/src/plugins/session-timeout/session-timeout-text-override-fr.hbs
+++ b/src/plugins/session-timeout/session-timeout-text-override-fr.hbs
@@ -11,11 +11,11 @@
 }
 ---
 
-<span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-en.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!"}}'></span>
+<span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-fr.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!", "buttonSignin": "Start Over", "timeoutEnd": "Are you still there?"}}'></span>
 
 <section><h2 id="how">Configuration</h2>
 	<p>Ajoutez l'option <code>textOverrides</code> à l'élément d'expiration de la session. Voici l'exemple de la page actuelle&nbsp;:</p>
-	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-en.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!"}}'&gt;&lt;/span&gt;</code></pre>
+	<pre><code>&lt;span class="wb-sessto" data-wb-sessto='{"inactivity": 30000, "reactionTime": 30000, "logouturl": "../index-fr.html", "textOverrides": {"buttonContinue": "Keep Going", "buttonEnd": "Goodbye", "timeoutAlready": "You took too long.  Bye!", "buttonSignin": "Start Over", "timeoutEnd": "Are you still there?"}}'&gt;&lt;/span&gt;</code></pre>
 </section>
 
 <section><h2 id="try">Faites un essai</h2>

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -39,6 +39,7 @@ var $modal, $modalLink, countdownInterval, i18n, i18nText,
 		refreshOnClick: true,		/* refresh session if user clicks on the page */
 		refreshLimit: 120000,		/* default period of 2 minutes (ajax calls happen only once during this period) */
 		method: "POST",				/* the request method to use */
+		textOverrides: null,		/* text overrides (no default) */
 		additionalData: null,		/* additional data to send with the request */
 		refreshCallback: function( response ) {	/* callback function used to check the server response */
 			return response.replace( /\s/g, "" ) === "true";
@@ -73,15 +74,28 @@ var $modal, $modalLink, countdownInterval, i18n, i18nText,
 			// Only initialize the i18nText once
 			if ( !i18nText ) {
 				i18n = wb.i18n;
-				i18nText = {
-					buttonContinue: i18n( "st-btn-cont" ),
-					buttonEnd: i18n( "st-btn-end" ),
-					buttonSignin: i18n( "tmpl-signin" ),
-					timeoutBegin: i18n( "st-to-msg-bgn" ),
-					timeoutEnd: i18n( "st-to-msg-end" ),
-					timeoutTitle: i18n( "st-msgbx-ttl" ),
-					timeoutAlready: i18n( "st-alrdy-to-msg" )
-				};
+				const textOverrides = settings.textOverrides;
+				if ( textOverrides ) {
+					i18nText = {
+						buttonContinue: Object.hasOwn( textOverrides, "buttonContinue" ) ? textOverrides.buttonContinue : i18n( "st-btn-cont" ),
+						buttonEnd: Object.hasOwn( textOverrides, "buttonEnd" ) ? textOverrides.buttonEnd : i18n( "st-btn-end" ),
+						buttonSignin: Object.hasOwn( textOverrides, "buttonSignin" ) ? textOverrides.buttonSignin : i18n( "tmpl-signin" ),
+						timeoutBegin: i18n( "st-to-msg-bgn" ),
+						timeoutEnd: Object.hasOwn( textOverrides, "timeoutEnd" ) ? textOverrides.timeoutEnd : i18n( "st-to-msg-end" ),
+						timeoutTitle: i18n( "st-msgbx-ttl" ),
+						timeoutAlready: Object.hasOwn( textOverrides, "timeoutAlready" ) ? textOverrides.timeoutAlready : i18n( "st-alrdy-to-msg" )
+					};
+				} else {
+					i18nText = {
+						buttonContinue: i18n( "st-btn-cont" ),
+						buttonEnd: i18n( "st-btn-end" ),
+						buttonSignin: i18n( "tmpl-signin" ),
+						timeoutBegin: i18n( "st-to-msg-bgn" ),
+						timeoutEnd: i18n( "st-to-msg-end" ),
+						timeoutTitle: i18n( "st-msgbx-ttl" ),
+						timeoutAlready: i18n( "st-alrdy-to-msg" )
+					};
+				}
 			}
 
 			onReady = function() {

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -77,13 +77,13 @@ var $modal, $modalLink, countdownInterval, i18n, i18nText,
 				const textOverrides = settings.textOverrides;
 				if ( textOverrides ) {
 					i18nText = {
-						buttonContinue: Object.hasOwn( textOverrides, "buttonContinue" ) ? textOverrides.buttonContinue : i18n( "st-btn-cont" ),
-						buttonEnd: Object.hasOwn( textOverrides, "buttonEnd" ) ? textOverrides.buttonEnd : i18n( "st-btn-end" ),
-						buttonSignin: Object.hasOwn( textOverrides, "buttonSignin" ) ? textOverrides.buttonSignin : i18n( "tmpl-signin" ),
+						buttonContinue: Object.hasOwn( textOverrides, "buttonContinue" ) ? DOMPurify.sanitize( textOverrides.buttonContinue ) : i18n( "st-btn-cont" ),
+						buttonEnd: Object.hasOwn( textOverrides, "buttonEnd" ) ? DOMPurify.sanitize( textOverrides.buttonEnd ) : i18n( "st-btn-end" ),
+						buttonSignin: Object.hasOwn( textOverrides, "buttonSignin" ) ? DOMPurify.sanitize( textOverrides.buttonSignin ) : i18n( "tmpl-signin" ),
 						timeoutBegin: i18n( "st-to-msg-bgn" ),
-						timeoutEnd: Object.hasOwn( textOverrides, "timeoutEnd" ) ? textOverrides.timeoutEnd : i18n( "st-to-msg-end" ),
+						timeoutEnd: Object.hasOwn( textOverrides, "timeoutEnd" ) ? DOMPurify.sanitize( textOverrides.timeoutEnd ) : i18n( "st-to-msg-end" ),
 						timeoutTitle: i18n( "st-msgbx-ttl" ),
-						timeoutAlready: Object.hasOwn( textOverrides, "timeoutAlready" ) ? textOverrides.timeoutAlready : i18n( "st-alrdy-to-msg" )
+						timeoutAlready: Object.hasOwn( textOverrides, "timeoutAlready" ) ? DOMPurify.sanitize( textOverrides.timeoutAlready ) : i18n( "st-alrdy-to-msg" )
 					};
 				} else {
 					i18nText = {


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Allow specific message elements to be customised via configuration in the data-wb-sessto attribute. An optional JSON object provides text content for any combination of the following elements:
- Continue button
- End Session button
- Sign In button
- Message displayed below the countdown timer.
- Message displayed when the session has expired.
These text elements are sanitized when the plugin is initialized.

**General checklist / Liste de contrôle générale**

- [x]  Create/update documentation /// Créer/mettre à jour la documentation
- [x]  Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
 

**Related issues / Requêtes associées**
Closes https://github.com/wet-boew/wet-boew/issues/9780