### PR TITLE
Demos: Fix placeholder image references

### DIFF
--- a/src/other/transitions/transitions-en.hbs
+++ b/src/other/transitions/transitions-en.hbs
@@ -21,15 +21,15 @@
 	<section>
 		<h3>Fade-in</h3>
 		<p>Hover mouse over space below to trigger fade-in (300ms)</p>
-		<img src="https://via.placeholder.com/350x150&amp;text=fade-in+test" class="wb-fade-in-test" alt="placeholder" tabindex="0" />
-		<img src="https://via.placeholder.com/350x150&amp;text=fade-in+test" class="" alt="placeholder" />
+		<img src="https://dummyimage.com/350x150&amp;text=fade-in+test" class="wb-fade-in-test" alt="placeholder" tabindex="0" />
+		<img src="https://dummyimage.com/350x150&amp;text=fade-in+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
 		<h3>Fade-out</h3>
 		<p>Hover mouse over space below to trigger fade-out (500ms)</p>
-		<img src="https://via.placeholder.com/350x150&amp;text=fade-out+test" class="wb-fade-out-test" alt="placeholder" tabindex="0" />
-		<img src="https://via.placeholder.com/350x150&amp;text=fade-out+test" class="" alt="placeholder" />
+		<img src="https://dummyimage.com/350x150&amp;text=fade-out+test" class="wb-fade-out-test" alt="placeholder" tabindex="0" />
+		<img src="https://dummyimage.com/350x150&amp;text=fade-out+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
@@ -45,15 +45,15 @@
 	<section>
 		<h3>Slide-left</h3>
 		<p>Hover mouse over space below to trigger slide-left (300ms)</p>
-		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="wb-slide-left-test" alt="placeholder" tabindex="0" />
-		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
+		<img src="https://dummyimage.com/350x150&amp;text=slide-left+test" class="wb-slide-left-test" alt="placeholder" tabindex="0" />
+		<img src="https://dummyimage.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
 		<h3>Slide-right</h3>
 		<p>Hover mouse over space below to trigger slide-right (500ms)</p>
-		<img src="https://via.placeholder.com/350x150&amp;text=slide-right+test" class="wb-slide-right-test" alt="placeholder" tabindex="0" />
-		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
+		<img src="https://dummyimage.com/350x150&amp;text=slide-right+test" class="wb-slide-right-test" alt="placeholder" tabindex="0" />
+		<img src="https://dummyimage.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
 	</section>
 
 	<section>

--- a/src/other/transitions/transitions-fr.hbs
+++ b/src/other/transitions/transitions-fr.hbs
@@ -22,15 +22,15 @@
 	<section>
 		<h3>Fade-in</h3>
 		<p>Hover mouse over space below to trigger fade-in (300ms)</p>
-		<img src="https://via.placeholder.com/350x150&amp;text=fade-in+test" class="wb-fade-in-test" alt="placeholder" tabindex="0" />
-		<img src="https://via.placeholder.com/350x150&amp;text=fade-in+test" class="" alt="placeholder" />
+		<img src="https://dummyimage.com/350x150&amp;text=fade-in+test" class="wb-fade-in-test" alt="placeholder" tabindex="0" />
+		<img src="https://dummyimage.com/350x150&amp;text=fade-in+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
 		<h3>Fade-out</h3>
 		<p>Hover mouse over space below to trigger fade-out (500ms)</p>
-		<img src="https://via.placeholder.com/350x150&amp;text=fade-out+test" class="wb-fade-out-test" alt="placeholder" tabindex="0" />
-		<img src="https://via.placeholder.com/350x150&amp;text=fade-out+test" class="" alt="placeholder" />
+		<img src="https://dummyimage.com/350x150&amp;text=fade-out+test" class="wb-fade-out-test" alt="placeholder" tabindex="0" />
+		<img src="https://dummyimage.com/350x150&amp;text=fade-out+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
@@ -46,15 +46,15 @@
 	<section>
 		<h3>Slide-left</h3>
 		<p>Hover mouse over space below to trigger slide-left (300ms)</p>
-		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="wb-slide-left-test" alt="placeholder" tabindex="0" />
-		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
+		<img src="https://dummyimage.com/350x150&amp;text=slide-left+test" class="wb-slide-left-test" alt="placeholder" tabindex="0" />
+		<img src="https://dummyimage.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
 	</section>
 
 	<section>
 		<h3>Slide-right</h3>
 		<p>Hover mouse over space below to trigger slide-right (500ms)</p>
-		<img src="https://via.placeholder.com/350x150&amp;text=slide-right+test" class="wb-slide-right-test" alt="placeholder" tabindex="0" />
-		<img src="https://via.placeholder.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
+		<img src="https://dummyimage.com/350x150&amp;text=slide-right+test" class="wb-slide-right-test" alt="placeholder" tabindex="0" />
+		<img src="https://dummyimage.com/350x150&amp;text=slide-left+test" class="" alt="placeholder" />
 	</section>
 
 	<section>

--- a/src/other/utility/utility-en.hbs
+++ b/src/other/utility/utility-en.hbs
@@ -338,12 +338,12 @@
 <p>Vertically centers an element. This is to be used jointly with the <a href="#d-flex"><code>d-flex</code> utility</a>.</p>
 <h4>Working example</h4>
 <div class="d-flex">
-	<img src="https://via.placeholder.com/100" alt="" class="d-flex align-self-center mrgn-rght-md" />
+	<img src="https://dummyimage.com/100" alt="" class="d-flex align-self-center mrgn-rght-md" />
 	<p class="d-flex align-self-center mrgn-lft-md">Paragraph is vertically aligned with sibling image.</p>
 </div>
 <h4>Code sample</h4>
 <pre><code>&lt;div class="d-flex"&gt;
-	&lt;img src="https://via.placeholder.com/80" alt="" class="d-flex <strong>align-self-center</strong> mrgn-rght-md" /&gt;
+	&lt;img src="https://dummyimage.com/80" alt="" class="d-flex <strong>align-self-center</strong> mrgn-rght-md" /&gt;
 	&lt;p class="d-flex <strong>align-self-center</strong> mrgn-lft-md"&gt;Paragraph is vertically aligned with sibling image.&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 
@@ -351,12 +351,12 @@
 <p>Vertically moves an element to the bottom. This is to be used jointly with the <a href="#d-flex"><code>d-flex</code> utility</a>.</p>
 <h4>Working example</h4>
 <div class="d-flex">
-	<img src="https://via.placeholder.com/100" alt="" class="d-flex mrgn-rght-md" />
+	<img src="https://dummyimage.com/100" alt="" class="d-flex mrgn-rght-md" />
 	<p class="d-flex align-self-end mrgn-lft-md">Paragraph is vertically moved to the bottom.</p>
 </div>
 <h4>Code sample</h4>
 <pre><code>&lt;div class="d-flex"&gt;
-	&lt;img src="https://via.placeholder.com/80" alt="" class="d-flex mrgn-rght-md" /&gt;
+	&lt;img src="https://dummyimage.com/80" alt="" class="d-flex mrgn-rght-md" /&gt;
 	&lt;p class="d-flex <strong>align-self-end</strong> mrgn-lft-md"&gt;Paragraph is vertically moved to the bottom.&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 
@@ -685,7 +685,7 @@
 <div class="row">
 	<div class="col-md-4">
 		<section>
-			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			<h3 class="h5"><a href="#" class="stretched-link">[Hyperlink text]</a></h3>
 			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 		</section>
@@ -696,14 +696,14 @@
 				<h3 class="panel-title"><a href="#" class="stretched-link">[Hyperlink text]</a></h3>
 			</header>
 			<div class="panel-body">
-				<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+				<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 			</div>
 		</section>
 	</div>
 	<div class="col-md-4">
 		<section class="well position-relative">
-			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			<h3 class="h5"><a href="#" class="stretched-link">[Hyperlink text]</a></h3>
 			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 		</section>
@@ -712,14 +712,14 @@
 <h4>Code sample</h4>
 <pre><code>&lt;div class="row">
 	&lt;div class="col-md-4">
-		&lt;img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+		&lt;img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 		&lt;h3 class="h5">&lt;a href="#" class="stretched-link">[Hyperlink text]&lt;/a>&lt;/h3>
 		&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/p>
 	&lt;/div>
 	&lt;div class="col-md-4">
 		&lt;div class="panel panel-default position-relative">
 			&lt;div class="panel-body">
-				&lt;img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+				&lt;img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 				&lt;h3 class="h5">&lt;a href="#" class="stretched-link">[Hyperlink text]&lt;/a>&lt;/h3>
 				&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/p>
 			&lt;/div>
@@ -727,7 +727,7 @@
 	&lt;/div>
 	&lt;div class="col-md-4">
 		&lt;div class="well position-relative">
-			&lt;img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			&lt;img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			&lt;h3 class="h5">&lt;a href="#" class="stretched-link">[Hyperlink text]&lt;/a>&lt;/h3>
 			&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/p>
 		&lt;/div>

--- a/src/other/utility/utility-fr.hbs
+++ b/src/other/utility/utility-fr.hbs
@@ -335,12 +335,12 @@
 <p>Aligne un élément au centre verticalement. Cet utilitaire doit être utilisé conjointement avec <a href="#d-flex">l'utilitaire <code>d-flex</code></a>.</p>
 <h4>Exemple pratique</h4>
 <div class="d-flex">
-	<img src="https://via.placeholder.com/100" alt="" class="d-flex align-self-center mrgn-rght-md" />
+	<img src="https://dummyimage.com/100" alt="" class="d-flex align-self-center mrgn-rght-md" />
 	<p class="d-flex align-self-center mrgn-lft-md">Paragraphe centré verticalement avec l'image à côté.</p>
 </div>
 <h4>Exemple de code</h4>
 <pre><code>&lt;div class="d-flex"&gt;
-	&lt;img src="https://via.placeholder.com/80" alt="" class="d-flex <strong>align-self-center</strong> mrgn-rght-md" /&gt;
+	&lt;img src="https://dummyimage.com/80" alt="" class="d-flex <strong>align-self-center</strong> mrgn-rght-md" /&gt;
 	&lt;p class="d-flex <strong>align-self-center</strong> mrgn-lft-md"&gt;Paragraphe centré verticalement avec l'image à côté.&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 
@@ -348,12 +348,12 @@
 <p>Aligne un élément au bas. Cet utilitaire doit être utilisé conjointement avec <a href="#d-flex">l'utilitaire <code>d-flex</code></a>.</p>
 <h4>Exemple pratique</h4>
 <div class="d-flex">
-	<img src="https://via.placeholder.com/100" alt="" class="d-flex mrgn-rght-md" />
+	<img src="https://dummyimage.com/100" alt="" class="d-flex mrgn-rght-md" />
 	<p class="d-flex align-self-end mrgn-lft-md">Paragraphe placé au bas verticalement avec l'image à côté.</p>
 </div>
 <h4>Exemple de code</h4>
 <pre><code>&lt;div class="d-flex"&gt;
-	&lt;img src="https://via.placeholder.com/80" alt="" class="d-flex mrgn-rght-md" /&gt;
+	&lt;img src="https://dummyimage.com/80" alt="" class="d-flex mrgn-rght-md" /&gt;
 	&lt;p class="d-flex <strong>align-self-end</strong> mrgn-lft-md"&gt;Paragraphe placé au bas verticalement avec l'image à côté.&lt;/p&gt;
 &lt;/div&gt;</code></pre>
 
@@ -680,7 +680,7 @@
 <div class="row">
 	<div class="col-md-4">
 		<section>
-			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			<h3 class="h5"><a href="#" class="stretched-link">[Lien hypertexte]</a></h3>
 			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 		</section>
@@ -691,14 +691,14 @@
 				<h3 class="panel-title"><a href="#" class="stretched-link">[Lien hypertexte]</a></h3>
 			</header>
 			<div class="panel-body">
-				<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+				<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 			</div>
 		</section>
 	</div>
 	<div class="col-md-4">
 		<section class="well position-relative">
-			<img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			<img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			<h3 class="h5"><a href="#" class="stretched-link">[Lien hypertexte]</a></h3>
 			<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 		</section>
@@ -707,14 +707,14 @@
 <h4>Exemple de code</h4>
 <pre><code>&lt;div class="row">
 	&lt;div class="col-md-4">
-		&lt;img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+		&lt;img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 		&lt;h3 class="h5">&lt;a href="#" class="stretched-link">[Lien hypertexte]&lt;/a>&lt;/h3>
 		&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/p>
 	&lt;/div>
 	&lt;div class="col-md-4">
 		&lt;div class="panel panel-default position-relative">
 			&lt;div class="panel-body">
-				&lt;img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+				&lt;img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 				&lt;h3 class="h5">&lt;a href="#" class="stretched-link">[Lien hypertexte]&lt;/a>&lt;/h3>
 				&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/p>
 			&lt;/div>
@@ -722,7 +722,7 @@
 	&lt;/div>
 	&lt;div class="col-md-4">
 		&lt;div class="well position-relative">
-			&lt;img src="https://via.placeholder.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
+			&lt;img src="https://dummyimage.com/360x203/000000/FFFFFF.png" alt="" class="img-responsive thumbnail mrgn-bttm-sm">
 			&lt;h3 class="h5">&lt;a href="#" class="stretched-link">[Lien hypertexte]&lt;/a>&lt;/h3>
 			&lt;p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.&lt;/p>
 		&lt;/div>


### PR DESCRIPTION
Some of WET's code samples were referencing placeholder images from [placeholder.com](https://placeholder.com/). But that site underwent changes in ownership in March 2023 and consequently ceased serving placeholder images.

This deals with it by replacing all references to via.placeholder.com with [dummyimage.com](https://dummyimage.com/).

Port of wet-boew/GCWeb#2448.