### PR TITLE
Build: downgrade uglify-js version to fix jsonmanager issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-cssmin": "^3.0.0",
         "grunt-contrib-htmlmin": "^3.1.0",
-        "grunt-contrib-uglify": "^5.2.2",
+        "grunt-contrib-uglify": "github:wet-boew/grunt-contrib-uglify#v1.0.0",
         "grunt-contrib-watch": "^1.1.0",
         "grunt-eslint": "^23.0.0",
         "grunt-gh-pages": "^4.0.0",
@@ -7915,14 +7915,13 @@
     },
     "node_modules/grunt-contrib-uglify": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-5.2.2.tgz",
-      "integrity": "sha512-ITxiWxrjjP+RZu/aJ5GLvdele+sxlznh+6fK9Qckio5ma8f7Iv8woZjRkGfafvpuygxNefOJNc+hfjjBayRn2Q==",
+      "resolved": "git+ssh://git@github.com/wet-boew/grunt-contrib-uglify.git#df7c9e2c5cd479c322488c807c4a682ff7ff35a4",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "maxmin": "^3.0.0",
-        "uglify-js": "^3.16.1",
+        "uglify-js": "3.17.4",
         "uri-path": "^1.0.0"
       },
       "engines": {
@@ -7993,6 +7992,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/grunt-contrib-uglify/node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/grunt-contrib-watch": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-cssmin": "^3.0.0",
     "grunt-contrib-htmlmin": "^3.1.0",
-    "grunt-contrib-uglify": "^5.2.2",
+    "grunt-contrib-uglify": "github:wet-boew/grunt-contrib-uglify#v1.0.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-eslint": "^23.0.0",
     "grunt-gh-pages": "^4.0.0",


### PR DESCRIPTION
Downgraded `uglify-js` to point to version `3.17.4` inside the `grunt-contrib-uglify` project (now forked from the main project) to fix JSON Manager "too much recursion issue".

Related to WET-507