### PR TITLE
Update _base.scss

### DIFF
--- a/src/plugins/tabs/tabs-en.hbs
+++ b/src/plugins/tabs/tabs-en.hbs
@@ -144,6 +144,10 @@
 				know they made continually for four hundred years were just as arduous
 				as a further voyage from Greenland to the coast of Canada.
 				</p>
+				<details>
+					<summary>Test</summary>
+					<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Repellendus, sapiente. Repellendus vitae odio fugiat commodi?</p>
+				</details>
 			</details>
 			<details id="details-panel30">
 				<summary>Example 3</summary>
@@ -177,6 +181,14 @@
 				in which all the names of the people were written down, with an account
 				of their forefathers and of any notable things which they had done.
 				</p>
+				<details>
+					<summary>Test 1</summary>
+					<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Repellendus, sapiente. Repellendus vitae odio fugiat commodi?</p>
+				</details>
+				<details>
+					<summary>Test 2</summary>
+					<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Repellendus, sapiente. Repellendus vitae odio fugiat commodi?</p>
+				</details>
 			</details>
 		</div>
 	</div>

--- a/src/plugins/tabs/tabs-fr.hbs
+++ b/src/plugins/tabs/tabs-fr.hbs
@@ -50,6 +50,10 @@
 				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.
 				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.
 				</p>
+				<details>
+					<summary>Test</summary>
+					<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Repellendus, sapiente. Repellendus vitae odio fugiat commodi?</p>
+				</details>
 			</details>
 			<details id="details-panel3">
 				<summary>Exemple 3</summary>
@@ -83,6 +87,14 @@
 				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.
 				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.
 				</p>
+				<details>
+					<summary>Test 1</summary>
+					<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Repellendus, sapiente. Repellendus vitae odio fugiat commodi?</p>
+				</details>
+				<details>
+					<summary>Test 2</summary>
+					<p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Repellendus, sapiente. Repellendus vitae odio fugiat commodi?</p>
+				</details>
 			</details>
 		</div>
 	</div>

--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -49,14 +49,3 @@ details {
 		}
 	}
 }
-
-// Prevent FOUC when polyfill is disabled
-.wb-disable {
-	details {
-		& > {
-			*:not(summary) {
-				display: block !important;
-			}
-		}
-	}
-}

--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -8,16 +8,8 @@ summary {
 	display: list-item !important;
 	list-style-type: none; // Prevent list bullets from appearing in browsers that lack native details/summary support (e.g. IE/Edge)
 	list-style-type: disclosure-closed; // Show summary arrows in Firefox 49.0+ and future versions of Blink/Webkit
-	visibility: visible !important;
 }
 
-%details-nested-in-hidden-details {
-	details {
-		summary {
-			display: none !important;
-		}
-	}
-}
 
 details {
 	margin-bottom: .25em;
@@ -56,48 +48,12 @@ details {
 			}
 		}
 	}
-
-	// Prevent FOUC
-	&:not([open]) {
-		@extend %details-nested-in-hidden-details;
-		visibility: hidden;
-
-		> {
-			// Need details and * to deal with specificity issues
-			details,
-			* {
-				display: none;
-			}
-		}
-	}
-
-	&.alert {
-		&:not([open]) {
-			visibility: visible;
-		}
-	}
-
-	.out {
-		@extend %details-nested-in-hidden-details;
-	}
-}
-
-.tabpanels {
-	> {
-		details {
-			&:not([open]) {
-				visibility: visible;
-			}
-		}
-	}
 }
 
 // Prevent FOUC when polyfill is disabled
 .wb-disable {
 	details {
-		visibility: visible !important;
-
-		> {
+	& > {
 			*:not(summary) {
 				display: block !important;
 			}

--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -53,7 +53,7 @@ details {
 // Prevent FOUC when polyfill is disabled
 .wb-disable {
 	details {
-	& > {
+		& > {
 			*:not(summary) {
 				display: block !important;
 			}


### PR DESCRIPTION

## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?
Change was to remove the legacy CSS code for details/summary for IE11 (which did not support this element) as its no longer required.  The removal was for the display:none and visibility:  visible/hidden styles.

This fixes two issues: 
1. It prevents the focus of the keyboard tab from moving to a hidden tab in desktop if it contains an details element thus violating WCAG SC 2.4.7 (Level AA) Focus Visible.  
2. It allows the user to use Ctrl+F5 to search for a word/phrase inside of a details element and also opens the element if the word/phrase exists.  

## Additional information (optional) / Information additionnelle (optionel)
Impact:
The only impact this will have may be for anybody with an unsupported browser that does not support detail elements (Internet Explorer), or very early browser versions.  If there is a desire to support this, a script could be written or a fallback stylesheet could be created.  Otherwise the issue should be minimal.

**General checklist / Liste de contrôle générale**
Make your own list for the purpose of your Pull request. /// Faites votre propre liste en fonction des besoins de votre demande « pull ».
No documentation needed to be added or updated.

- [X] Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
- [X] Validate changes against WCAG for accessibility /// Valider les changements avec WCAG pour l'accessibilité

**Related issues / Requêtes associées**
None

**Screenshots / Captures d'écrans**
Pure keyboard and search functionality
