### PR TITLE
Forms: Add asterisk disable class for required fields

### DIFF
--- a/site/pages/docs/ref/formvalid/formvalid-en.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-en.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Provides generic validation and error message handling for Web forms.",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2025-02-05"
+	"dateModified": "2025-02-24"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -68,6 +68,10 @@
 		</li>
 		<li><strong>Optional:</strong>
 			<ul class="lst-spcd">
+				<li>
+					<p>Required fields are visually-prefixed with an asterisk (*) by default. To omit it, add the <code>required-no-asterisk</code> class to one of their parent elements (such as <code>&lt;div class="wb-frmvld"&gt;</code> or <code>&lt;form&gt;</code>).</p>
+					<p>Whether or not asterisks are used, it is recommended that they be implemented consistently within the same form. Please don't mix and match different asterisk styles within the same form.</p>
+				</li>
 				<li>To make a standalone checkbox field's label look consistent with text field labels (i.e. bolded), add the <code>checkbox checkbox-standalone</code> classes to the checkbox and place it in a <code>&lt;div class="form-group"&gt;</code> element.</li>
 				<li>For input fields, add one of these <a href="#SpecializedValidation">options</a> for specialized validation, or else you can use a <a href="#pattern">custom pattern validation</a> only if your pattern is very specific and is not part of the options for specialized validation.</li>
 				<li>For ASP validators add the following attributes to enable the <a href="#MergeSCE">Merge Server-Client errors functionality</a>:<br /><code>Display="Dynamic" EnableClientScript="false" CssClass="label label-danger wb-server-error"</code></li>

--- a/site/pages/docs/ref/formvalid/formvalid-fr.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-fr.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Effectue la validation de formulaires Web selon un ensemble de règles de base avant qu'ils soient soumis.",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2025-02-05"
+	"dateModified": "2025-02-24"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -71,6 +71,10 @@
 		</li>
 		<li><strong>Optional:</strong>
 			<ul class="lst-spcd">
+				<li>
+					<p>Required fields are visually-prefixed with an asterisk (*) by default. To omit it, add the <code>required-no-asterisk</code> class to one of their parent elements (such as <code>&lt;div class="wb-frmvld"&gt;</code> or <code>&lt;form&gt;</code>).</p>
+					<p>Whether or not asterisks are used, it is recommended that they be implemented consistently within the same form. Please don't mix and match different asterisk styles within the same form.</p>
+				</li>
 				<li>To make a standalone checkbox field's label look consistent with text field labels (i.e. bolded), add the <code>checkbox checkbox-standalone</code> classes to the checkbox and place it in a <code>&lt;div class="form-group"&gt;</code> element.</li>
 				<li>For input fields, add one of these <a href="#SpecializedValidation">options</a> for specialized validation, or else you can use a <a href="#pattern">custom pattern validation</a> only if your pattern is very specific and is not part of the options for specialized validation.</li>
 				<li>For ASP validators add the following attributes to enable the <a href="#MergeSCE">Merge Server-Client errors functionality</a>:<br /><code>Display="Dynamic" EnableClientScript="false" CssClass="label label-danger wb-server-error"</code></li>

--- a/src/base/forms/_base.scss
+++ b/src/base/forms/_base.scss
@@ -12,12 +12,16 @@ label,
 legend,
 .checkbox {
 	&.required {
-		&:before {
-			@extend %forms-color-red-bold;
+		/* Set required asterisk styles... unless any parent element uses a disable class */
+		/* Credit: Stack Overflow answer (https://stackoverflow.com/a/73773370) by magda and Zach Jensz (zach-jensz) */
+		&:not(.required-no-asterisk .required) {
+			&:before {
+				@extend %forms-color-red-bold;
 
-			content: "* ";
-			margin-left: -$wb-forms-asterisk-width;
-			vertical-align: top;
+				content: "* ";
+				margin-left: -$wb-forms-asterisk-width;
+				vertical-align: top;
+			}
 		}
 
 		strong {

--- a/src/plugins/formvalid/formvalid-en.hbs
+++ b/src/plugins/formvalid/formvalid-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2022-04-13"
+	"dateModified": "2025-02-24"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -447,6 +447,93 @@
 			&lt;/div&gt;
 			&lt;div class="radio"&gt;
 				&lt;label for="status4"&gt;&lt;input type="radio" name="status" value="4" id="status4" /&gt; Other&lt;/label&gt;
+			&lt;/div&gt;
+		&lt;/fieldset&gt;</code></pre>
+			</details>
+
+			<input type="submit" value="Submit" class="btn btn-primary" /> <input type="reset" value="Reset page to defaults" class="btn btn-link btn-sm show p-0 mrgn-tp-md" />
+		</form>
+	</div>
+</section>
+<hr>
+<section>
+	<h2>Examples using required fields without asterisks</h2>
+	<p>Required fields can be alternatively styled without asterisks by adding the <code>required-no-asterisk</code> class to one of their parent elements (such as <code>&lt;div class="wb-frmvld"&gt;</code> or <code>&lt;form&gt;</code>).</p>
+	<p>Whether or not asterisks are used, it is recommended that they be implemented consistently within the same form. Please don't mix and match different asterisk styles within the same form.</p>
+	<div class="wb-frmvld required-no-asterisk">
+		<form action="#" method="get" id="validation-example-4">
+			<div class="form-group">
+				<label for="nname1" class="required"><span class="field-name">Nickname</span> <strong class="required">(required)</strong></label>
+				<input class="form-control" id="nname1" name="nname1" type="text" autocomplete="nickname" required="required" />
+			</div>
+			<details class="mrgn-bttm-md">
+				<summary>View code</summary>
+				{{>alertariahidden}}
+				<pre><code>&lt;div class="wb-frmvld required-no-asterisk"&gt;
+&lt;form action="#" method="get" id="validation-example-4"&gt;
+	...
+	&lt;div class="form-group"&gt;
+		&lt;label for="nname1" class="required required-no-asterisk"&gt;&lt;span class="field-name"&gt;Nickname&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
+		&lt;input class="form-control" id="nname1" name="nname1" type="text" autocomplete="nickname" required="required" /&gt;
+	&lt;/div&gt;</code></pre>
+			</details>
+
+			<div class="form-group">
+				<label for="cname1" class="required"><span class="field-name">Country name</span> <strong class="required">(required)</strong></label>
+				<input class="form-control" id="cname1" name="cname1" type="text" autocomplete="country-name" required="required" />
+			</div>
+			<details class="mrgn-bttm-md">
+				<summary>View code</summary>
+				{{>alertariahidden}}
+				<pre><code>&lt;div class="wb-frmvld required-no-asterisk"&gt;
+&lt;form action="#" method="get" id="validation-example-4"&gt;
+	...
+	&lt;div class="form-group"&gt;
+		&lt;label for="cname1" class="required required-no-asterisk"&gt;&lt;span class="field-name"&gt;Country name&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/label&gt;
+		&lt;input class="form-control" id="cname1" name="cname1" type="text" autocomplete="country-name" required="required" /&gt;
+	&lt;/div&gt;</code></pre>
+			</details>
+
+			<fieldset class="chkbxrdio-grp">
+				<legend class="required"><span class="field-name">Favourite web browser</span> <strong class="required">(required)</strong></legend>
+				<div class="radio">
+					<label for="fbrowser1"><input type="radio" name="fbrowser" value="1" id="fbrowser1" data-rule-required="true" /> Chrome</label>
+				</div>
+				<div class="radio">
+					<label for="fbrowser2"><input type="radio" name="fbrowser" value="2" id="fbrowser2" /> Edge</label>
+				</div>
+				<div class="radio">
+					<label for="fbrowser3"><input type="radio" name="fbrowser" value="3" id="fbrowser3" /> Firefox</label>
+				</div>
+				<div class="radio">
+					<label for="fbrowser4"><input type="radio" name="fbrowser" value="4" id="fbrowser4" /> Safari</label>
+				</div>
+				<div class="radio">
+					<label for="fbrowser5"><input type="radio" name="fbrowser" value="5" id="fbrowser5" /> Other</label>
+				</div>
+			</fieldset>
+			<details class="mrgn-bttm-md">
+				<summary>View code</summary>
+				{{>alertariahidden}}
+				<pre><code>&lt;div class="wb-frmvld required-no-asterisk"&gt;
+	&lt;form action="#" method="get" id="validation-example-4"&gt;
+		...
+		&lt;fieldset class="chkbxrdio-grp"&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Favourite web browser&lt;/span&gt; &lt;strong class="required"&gt;(required)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="fbrowser1"&gt;&lt;input type="radio" name="fbrowser" value="1" id="fbrowser1" data-rule-required="true" /&gt; Chrome&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="fbrowser2"&gt;&lt;input type="radio" name="fbrowser" value="2" id="fbrowser2" /&gt; Edge&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="fbrowser3"&gt;&lt;input type="radio" name="fbrowser" value="3" id="fbrowser3" /&gt; Firefox&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="fbrowser4"&gt;&lt;input type="radio" name="fbrowser" value="4" id="fbrowser4" /&gt; Safari&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="fbrowser5"&gt;&lt;input type="radio" name="fbrowser" value="5" id="fbrowser5" /&gt; Other&lt;/label&gt;
 			&lt;/div&gt;
 		&lt;/fieldset&gt;</code></pre>
 			</details>

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -459,7 +459,7 @@
 <section>
 	<h2>Exemples utilisant des champs obligatoires sans astérisques</h2>
 	<p>Les champs obligatoires peuvent être alternativement stylés sans astérisques en ajoutant la classe <code>required-no-asterisk</code> à l’un de leurs éléments parents (comme <code>&lt;div class="wb-frmvld"&gt;</code> ou <code>&lt;form&gt;</code>).</p>
-	<p>Que les astérisques sont utilisés, c’est recommandé qu’ils soient implémentés d’une façon uniforme dans le même formulaire. S’il vous plaît, ne mélangez pas des styles d’astérisques différents dans le même formulaire.</p>
+	<p>Que les astérisques soient utilisés ou non, il est recommandé qu’ils soient implémentés de façon uniforme dans un même formulaire. Veuillez ne pas mélanger les styles d’astérisques différents dans un même formulaire.</p>
 	<div class="wb-frmvld required-no-asterisk">
 		<form action="#" method="get" id="validation-example-4">
 			<div class="form-group">

--- a/src/plugins/formvalid/formvalid-fr.hbs
+++ b/src/plugins/formvalid/formvalid-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "formvalid",
 	"parentdir": "formvalid",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2023-12-04"
+	"dateModified": "2025-02-24"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -452,6 +452,93 @@
 			</details>
 
 			<input type="submit" value="Soumettre" class="btn btn-primary" /> <input type="reset" value="Réinitialiser la page aux valeurs par défaut" class="btn btn-link btn-sm show p-0 mrgn-tp-md" />
+		</form>
+	</div>
+</section>
+<hr>
+<section>
+	<h2>Exemples utilisant des champs obligatoires sans astérisques</h2>
+	<p>Les champs obligatoires peuvent être alternativement stylés sans astérisques en ajoutant la classe <code>required-no-asterisk</code> à l’un de leurs éléments parents (comme <code>&lt;div class="wb-frmvld"&gt;</code> ou <code>&lt;form&gt;</code>).</p>
+	<p>Que les astérisques sont utilisés, c’est recommandé qu’ils soient implémentés d’une façon uniforme dans le même formulaire. S’il vous plaît, ne mélangez pas des styles d’astérisques différents dans le même formulaire.</p>
+	<div class="wb-frmvld required-no-asterisk">
+		<form action="#" method="get" id="validation-example-4">
+			<div class="form-group">
+				<label for="nname1" class="required"><span class="field-name">Pseudonyme</span> <strong class="required">(obligatoire)</strong></label>
+				<input class="form-control" id="nname1" name="nname1" type="text" autocomplete="nickname" required="required" />
+			</div>
+			<details class="mrgn-bttm-md">
+				<summary>View code</summary>
+				{{>alertariahidden}}
+				<pre><code>&lt;div class="wb-frmvld required-no-asterisk"&gt;
+&lt;form action="#" method="get" id="validation-example-4"&gt;
+	...
+	&lt;div class="form-group"&gt;
+		&lt;label for="nname1" class="required required-no-asterisk"&gt;&lt;span class="field-name"&gt;Pseudonyme&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
+		&lt;input class="form-control" id="nname1" name="nname1" type="text" autocomplete="nickname" required="required" /&gt;
+	&lt;/div&gt;</code></pre>
+			</details>
+
+			<div class="form-group">
+				<label for="cname1" class="required"><span class="field-name">Nom du pays</span> <strong class="required">(obligatoire)</strong></label>
+				<input class="form-control" id="cname1" name="cname1" type="text" autocomplete="country-name" required="required" />
+			</div>
+			<details class="mrgn-bttm-md">
+				<summary>Voir le code</summary>
+				{{>alertariahidden}}
+				<pre><code>&lt;div class="wb-frmvld required-no-asterisk"&gt;
+&lt;form action="#" method="get" id="validation-example-4"&gt;
+	...
+	&lt;div class="form-group"&gt;
+		&lt;label for="cname1" class="required required-no-asterisk"&gt;&lt;span class="field-name"&gt;Nom du pays&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/label&gt;
+		&lt;input class="form-control" id="cname1" name="cname1" type="text" autocomplete="country-name" required="required" /&gt;
+	&lt;/div&gt;</code></pre>
+			</details>
+
+			<fieldset class="chkbxrdio-grp">
+				<legend class="required"><span class="field-name">Navigateur Web favori</span> <strong class="required">(obligatoire)</strong></legend>
+				<div class="radio">
+					<label for="fbrowser1"><input type="radio" name="fbrowser" value="1" id="fbrowser1" data-rule-required="true" /> Chrome</label>
+				</div>
+				<div class="radio">
+					<label for="fbrowser2"><input type="radio" name="fbrowser" value="2" id="fbrowser2" /> Edge</label>
+				</div>
+				<div class="radio">
+					<label for="fbrowser3"><input type="radio" name="fbrowser" value="3" id="fbrowser3" /> Firefox</label>
+				</div>
+				<div class="radio">
+					<label for="fbrowser4"><input type="radio" name="fbrowser" value="4" id="fbrowser4" /> Safari</label>
+				</div>
+				<div class="radio">
+					<label for="fbrowser5"><input type="radio" name="fbrowser" value="5" id="fbrowser5" /> Autre</label>
+				</div>
+			</fieldset>
+			<details class="mrgn-bttm-md">
+				<summary>View code</summary>
+				{{>alertariahidden}}
+				<pre><code>&lt;div class="wb-frmvld required-no-asterisk"&gt;
+	&lt;form action="#" method="get" id="validation-example-4"&gt;
+		...
+		&lt;fieldset class="chkbxrdio-grp"&gt;
+			&lt;legend class="required"&gt;&lt;span class="field-name"&gt;Favourite web browser&lt;/span&gt; &lt;strong class="required"&gt;(obligatoire)&lt;/strong&gt;&lt;/legend&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="fbrowser1"&gt;&lt;input type="radio" name="fbrowser" value="1" id="fbrowser1" data-rule-required="true" /&gt; Chrome&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="fbrowser2"&gt;&lt;input type="radio" name="fbrowser" value="2" id="fbrowser2" /&gt; Edge&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="fbrowser3"&gt;&lt;input type="radio" name="fbrowser" value="3" id="fbrowser3" /&gt; Firefox&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="fbrowser4"&gt;&lt;input type="radio" name="fbrowser" value="4" id="fbrowser4" /&gt; Safari&lt;/label&gt;
+			&lt;/div&gt;
+			&lt;div class="radio"&gt;
+				&lt;label for="fbrowser5"&gt;&lt;input type="radio" name="fbrowser" value="5" id="fbrowser5" /&gt; Other&lt;/label&gt;
+			&lt;/div&gt;
+		&lt;/fieldset&gt;</code></pre>
+			</details>
+
+			<input type="submit" value="Submit" class="btn btn-primary" /> <input type="reset" value="Reset page to defaults" class="btn btn-link btn-sm show p-0 mrgn-tp-md" />
 		</form>
 	</div>
 </section>


### PR DESCRIPTION
Required form fields are visually-prefixed with an asterisk (*) by default (via the "required" class). But asterisks aren't always desirable...

For instance:
* They aren't meaningful in and of themselves
* WET implements them as visual decorations (via a CSS pseudo-element and the ``content`` property)
* They might be perceived as visual bloat, particularly in the following scenarios:
  * Form consisting solely of one required field
  * Form consisting entirely of required fields
  * Experimental plugins like steps form (WET) and steps quiz (GCWeb) that are likely to show only one question at a time
* They're not necessary to achieve WCAG 2.x compliance:
  * [Success criterion 3.3.2's technique H90](https://www.w3.org/WAI/WCAG22/Techniques/html/H90) doesn't obligate field labels/legends to use asterisks to indicate their requiredness (although it's allowable so long as the asterisk's meaning is defined in content beforehand)

Why not just omit the "required" class when asterisks aren't desirable? Because that class is needed to make the bolded "(required)" text red (unsure if due to a bug or by design). So up to this point, it was almost a foregone conclusion that all of WET's required fields always used asterisks.

This makes it possible to disable asterisks by:
* Adding a new class ("required-no-asterisk") and setting it on any required field's parent element
* Demonstrating the class in the form validation plugin's demo page (via the "Examples using required fields without asterisks" section)
* Describing the class' purpose in the form validation plugin's documentation (in the "How to implement" section)