### PR TITLE
Form validation (docs): Add "required" class to label code sample

### DIFF
--- a/site/pages/docs/ref/formvalid/formvalid-en.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-en.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Provides generic validation and error message handling for Web forms.",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2022-04-13"
+	"dateModified": "2025-02-05"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -59,7 +59,7 @@
 	&lt;/form&gt;</code></pre>
 		</li>
 		<li><strong>Optional:</strong> Wrap each form field name with <code>&lt;span class="field-name"&gt;...&lt;/span&gt;</code>. This specifies the prefix to use for the error message summary.
-			<pre><code>&lt;label for="fname1"&gt;
+			<pre><code>&lt;label for="fname1" class="required"&gt;
 	&lt;span class="field-name"&gt;First Name&lt;/span&gt; &lt;strong class="required">(required)&lt;/strong&gt;
 &lt;/label&gt;</code></pre>
 		</li>

--- a/site/pages/docs/ref/formvalid/formvalid-fr.hbs
+++ b/site/pages/docs/ref/formvalid/formvalid-fr.hbs
@@ -6,7 +6,7 @@
 	"categoryfile": "plugins",
 	"description": "Effectue la validation de formulaires Web selon un ensemble de règles de base avant qu'ils soient soumis.",
 	"altLangPrefix": "formvalid",
-	"dateModified": "2022-04-13"
+	"dateModified": "2025-02-05"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -62,7 +62,7 @@
 	&lt;/form&gt;</code></pre>
 		</li>
 		<li><strong>Optional:</strong> Wrap each form field name with <code>&lt;span class="field-name"&gt;...&lt;/span&gt;</code>. This specifies the prefix to use for the error message summary.
-			<pre><code>&lt;label for="fname1"&gt;
+			<pre><code>&lt;label for="fname1" class="required"&gt;
 	&lt;span class="field-name"&gt;First Name&lt;/span&gt; &lt;strong class="required">(required)&lt;/strong&gt;
 &lt;/label&gt;</code></pre>
 		</li>


### PR DESCRIPTION
The documentation's "How to implement" section's second step contains a code sample depicting a required label... without a "required" class on the ``label`` element.

That appears to be a mistake. It's extremely unlikely any implementers would deliberately omit the "required" class in practice given that it's needed to set the bolded "(required)" text's colour to red. The class is also used across-the-board in all of the demo page's required examples.

This resolves it by adding the missing "required" class to the documentation's required label code sample.