### PR TITLE
fix: Replacing HTML whitespace character so that it doesn't render in table header tooltip

### DIFF
--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -195,7 +195,7 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 			$btn = $th.find( "button" );
 		if ( order && order.length && order[ 0 ][ 0 ] === index ) {
 			var label = ( order[ 0 ][ 1 ] === "desc" ) ? i18nText.aria.sortAscending : i18nText.aria.sortDescending;
-			label = $btn.text() + label.replace(/&#160;/g, " ");
+			label = $btn.text() + label.replace( /&#160;/g, " " );
 			$btn.attr( "title", label );
 		}
 		$th.removeAttr( "aria-label" );

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -195,7 +195,7 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 			$btn = $th.find( "button" );
 		if ( order && order.length && order[ 0 ][ 0 ] === index ) {
 			var label = ( order[ 0 ][ 1 ] === "desc" ) ? i18nText.aria.sortAscending : i18nText.aria.sortDescending;
-			label = $btn.text() + label;
+			label = $btn.text() + label.replace(/&#160;/g, " ");
 			$btn.attr( "title", label );
 		}
 		$th.removeAttr( "aria-label" );


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

The i18n csv that contains the additional information for table headers includes a leading space before the colon. This is entered as a `#&160;` which preserves the space that would otherwise be discarded. However, when the page is refreshed, as in sorting the table, this whitespace character is not rendered correctly.

The addition of a replace on the character to a `" "` should cover this. I'm not sure if there are downstream effects, or if we should instead use `&nbsp`.

## Additional information (optional) / Information additionnelle (optionnel)

**Related issues / Requêtes associées**
Related to #9806.

**Screenshots / Captures d'écrans**
***Before***
![Screenshot 2025-02-20 170937](https://github.com/user-attachments/assets/84f76d5b-6061-4815-8c96-f8432bc410df)
***After***
![Screenshot 2025-02-20 170633](https://github.com/user-attachments/assets/505f103c-13c1-48ac-912e-71fbabc36ee5)

