### PR TITLE
Build: Set "uglify" task's module option to false

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -765,6 +765,7 @@ module.exports = (grunt) ->
 		# Minify
 		uglify:
 			options:
+				module: false
 				output:
 					comments: (uglify,comment) ->
 						return comment.value.match /^!/i

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-cssmin": "^3.0.0",
         "grunt-contrib-htmlmin": "^3.1.0",
-        "grunt-contrib-uglify": "github:wet-boew/grunt-contrib-uglify#v1.0.0",
+        "grunt-contrib-uglify": "^5.2.2",
         "grunt-contrib-watch": "^1.1.0",
         "grunt-eslint": "^23.0.0",
         "grunt-gh-pages": "^4.0.0",
@@ -7713,13 +7713,14 @@
     },
     "node_modules/grunt-contrib-uglify": {
       "version": "5.2.2",
-      "resolved": "git+ssh://git@github.com/wet-boew/grunt-contrib-uglify.git#df7c9e2c5cd479c322488c807c4a682ff7ff35a4",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-5.2.2.tgz",
+      "integrity": "sha512-ITxiWxrjjP+RZu/aJ5GLvdele+sxlznh+6fK9Qckio5ma8f7Iv8woZjRkGfafvpuygxNefOJNc+hfjjBayRn2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
         "maxmin": "^3.0.0",
-        "uglify-js": "3.17.4",
+        "uglify-js": "^3.16.1",
         "uri-path": "^1.0.0"
       },
       "engines": {
@@ -7790,19 +7791,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/grunt-contrib-uglify/node_modules/uglify-js": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
-      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "bin": {
-        "uglifyjs": "bin/uglifyjs"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/grunt-contrib-watch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "grunt-contrib-copy": "^1.0.0",
         "grunt-contrib-cssmin": "^3.0.0",
         "grunt-contrib-htmlmin": "^3.1.0",
-        "grunt-contrib-uglify": "^5.2.2",
+        "grunt-contrib-uglify": "github:EricDunsworth/grunt-contrib-uglify#extra-options-uglify-js",
         "grunt-contrib-watch": "^1.1.0",
         "grunt-eslint": "^23.0.0",
         "grunt-gh-pages": "^4.0.0",
@@ -7713,8 +7713,7 @@
     },
     "node_modules/grunt-contrib-uglify": {
       "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-uglify/-/grunt-contrib-uglify-5.2.2.tgz",
-      "integrity": "sha512-ITxiWxrjjP+RZu/aJ5GLvdele+sxlznh+6fK9Qckio5ma8f7Iv8woZjRkGfafvpuygxNefOJNc+hfjjBayRn2Q==",
+      "resolved": "git+ssh://git@github.com/EricDunsworth/grunt-contrib-uglify.git#bbdebe7b386d5839afdb9aa9f226d5b2e4003f47",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-cssmin": "^3.0.0",
     "grunt-contrib-htmlmin": "^3.1.0",
-    "grunt-contrib-uglify": "github:wet-boew/grunt-contrib-uglify#v1.0.0",
+    "grunt-contrib-uglify": "^5.2.2",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-eslint": "^23.0.0",
     "grunt-gh-pages": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-cssmin": "^3.0.0",
     "grunt-contrib-htmlmin": "^3.1.0",
-    "grunt-contrib-uglify": "^5.2.2",
+    "grunt-contrib-uglify": "github:EricDunsworth/grunt-contrib-uglify#extra-options-uglify-js",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-eslint": "^23.0.0",
     "grunt-gh-pages": "^4.0.0",


### PR DESCRIPTION
WIP (final version won't try reverting any commits or referencing my fork).

This option doesn't currently exist in the upstream version of ``grunt-contrib-uglify``.

Related to https://github.com/wet-boew/wet-boew/pull/9920#issuecomment-2711311423.