### PR TITLE
Multimedia: add support to define frame size for YouTube videos

### DIFF
--- a/src/plugins/multimedia/multimedia-youtube-en.hbs
+++ b/src/plugins/multimedia/multimedia-youtube-en.hbs
@@ -133,3 +133,29 @@
 		</details>
 	</section>
 </div>
+
+<div class="row">
+	<section class="col-md-6">
+		<h2>Video with defined video frame size</h2>
+		<figure class="wb-mltmd">
+			<video title="Suspect" width="720" height="1280">
+				<source type="video/youtube" src="https://www.youtube.com/watch?v=4pe_UoNdj5s" />
+			</video>
+			<figcaption>
+				<p>Suspect (<a href="https://www.canada.ca/en/health-canada/services/video/suspect.html#trans">Transcript</a>)</p>
+			</figcaption>
+		</figure>
+
+		<details class="mrgn-tp-md">
+			<summary>View code</summary>
+			<pre><code>&lt;figure class="wb-mltmd">
+	&lt;video title="Suspect" width="720" height="1280">
+		&lt;source type="video/youtube" src="https://www.youtube.com/watch?v=4pe_UoNdj5s" />
+	&lt;/video>
+	&lt;figcaption>
+		&lt;p>Suspect (&lt;a href="https://www.canada.ca/en/health-canada/services/video/suspect.html#trans">Transcript&lt;/a>)&lt;/p>
+	&lt;/figcaption>
+&lt;/figure></code></pre>
+		</details>
+	</section>
+</div>

--- a/src/plugins/multimedia/multimedia-youtube-fr.hbs
+++ b/src/plugins/multimedia/multimedia-youtube-fr.hbs
@@ -112,7 +112,7 @@
 		</section>
 
 		<details>
-			<summary>View code</summary>
+			<summary>Code source</summary>
 			<pre><code>&lt;p&gt;&lt;a class="wb-lbx lbx-modal lbx-iframe" href="#video-youtube"&gt;Ouvrir le vidéo&lt;/a&gt;&lt;/p&gt;
 		&lt;section id="video-youtube" class="mfp-hide modal-dialog modal-content overlay-def"&gt;
 			&lt;header class="modal-header"&gt;
@@ -129,6 +129,32 @@
 				&lt;/figure&gt;
 			&lt;/div&gt;
 		&lt;/section&gt;</code></pre>
+		</details>
+	</section>
+</div>
+
+<div class="row">
+	<section class="col-md-6">
+		<h2>Vidéo avec dimensions définies du cadre de la vidéo</h2>
+		<figure class="wb-mltmd">
+			<video title="Suspect" width="720" height="1280">
+				<source type="video/youtube" src="https://www.youtube.com/watch?v=YS6zbBaoSz0" />
+			</video>
+			<figcaption>
+				<p>Suspect (<a href="https://www.canada.ca/fr/sante-canada/services/video/suspect.html#trans">Transcription</a>)</p>
+			</figcaption>
+		</figure>
+
+		<details class="mrgn-tp-md">
+			<summary>Code source</summary>
+			<pre><code>&lt;figure class="wb-mltmd">
+	&lt;video title="Suspect" width="720" height="1280">
+		&lt;source type="video/youtube" src="https://www.youtube.com/watch?v=YS6zbBaoSz0" />
+	&lt;/video>
+	&lt;figcaption>
+		&lt;p>Suspect (&lt;a href="https://www.canada.ca/fr/sante-canada/services/video/suspect.html#trans">Transcription&lt;/a>)&lt;/p>
+	&lt;/figcaption>
+&lt;/figure></code></pre>
 		</details>
 	</section>
 </div>

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -653,8 +653,6 @@ $document.on( "timerpoke.wb " + initEvent, selector, init );
 
 $window.on( "resize", onResize );
 
-$document.on( "ready", onResize );
-
 $document.on( "ajax-fetched.wb " + templateLoadedEvent, selector, function( event ) {
 	var $this = $( this );
 
@@ -766,6 +764,7 @@ $document.on( initializedEvent, selector, function( event ) {
 
 		} else if ( media.error === null && media.currentSrc !== "" && media.currentSrc !== undef ) {
 			$this.trigger( renderUIEvent, [ type, data ] );
+			onResize();
 
 			// Identify that initialization has completed
 			wb.ready( $this, componentName );
@@ -784,14 +783,14 @@ $document.on( youtubeEvent, selector, function( event, data ) {
 
 		ytPlayer = new YT.Player( mId, {
 			videoId: data.youTubeId,
+			width: data.width,
+			height: data.height,
 			playerVars: {
 				autoplay: 0,
 				controls: 0,
+				hl: wb.lang,
 				origin: wb.pageUrlParts.host,
-				modestbranding: 1,
 				rel: 0,
-				showinfo: 0,
-				html5: 1,
 				cc_load_policy: 1
 			},
 			events: {
@@ -1193,20 +1192,21 @@ $document.on( resizeEvent, selector, function( event ) {
 	if ( event.namespace === componentName ) {
 		var media = event.target,
 			$media = $( media ),
-			ratio, newHeight;
+			figure = event.currentTarget,
+			ratio, newHeight,
+			heightDiff;
 
-		if ( $( event.currentTarget ).hasClass( "video" ) ) {
-			if ( media.videoWidth === 0 || media.videoWidth === undef ) {
-				ratio = $media.attr( "height" ) / $media.attr( "width" );
+		ratio = $media.attr( "height" ) / $media.attr( "width" );
 
-				// Calculate the new height based on the specified ratio or assume a default 16:9 ratio
-				newHeight = Math.round( $media.width() * ( !isNaN( ratio ) ? ratio : 0.5625 ) );
+		// Calculate the new height based on the specified ratio or assume a default 16:9 ratio
+		newHeight = Math.round( $media.width() * ( !isNaN( ratio ) ? ratio : 0.5625 ) );
 
-				$media.css( "height", newHeight + "px" );
-			} else {
-				$media.css( "height", "" );
-			}
+		if ( newHeight > window.innerHeight ) {
+			heightDiff = figure.offsetHeight - window.innerHeight;
+			newHeight = $media.height() - heightDiff;
 		}
+
+		$media.css( "height", newHeight + "px" );
 	}
 } );
 


### PR DESCRIPTION
Plugin now handles the "width" and "height" defined on the video element to resize the YouTube frame accordingly.

Also removed some deprecated/removed YouTube API options and added the language setting so that the player's interface matches the page's language.

Changes related to WET-526