### PR TITLE
build: increase allowed number of Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "weekly"
   - package-ecosystem: "npm"
     directory: "/"
+    open-pull-requests-limit: 99
     schedule:
       interval: "weekly"
     groups:


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

Probably only a temporary issues, but it seems like it's hitting the 5 PR limit currently because there are a few major versions in the dependencies that are behind. The combining of the minor/patch PRs helps this, but the downside to this is more PRs means Dependabot potentially will be rebuilding more PRs if stuff lands and creates merge conflicts.

## Additional information (optional) / Information additionnelle (optionnel)

You can see that's it's currently complaining that it can't open more PRs in https://github.com/wet-boew/wet-boew/network/updates/980262536

**General checklist / Liste de contrôle générale**
Make your own list for the purpose of your Pull request. /// Faites votre propre liste en fonction des besoins de votre demande « pull ».

- [ ] Create/update documentation /// Créer/mettre à jour la documentation
- [ ] Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
- [ ] Validate changes against WCAG for accessibility /// Valider les changements avec WCAG pour l'accessibilité
- [ ] Ensure documentation is bilingual /// S'assurer que la documentation soit bilingue
