### PR TITLE
JSON manager: Fix issues in example 2 demo

### DIFF
--- a/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "jsonmanager",
 	"parentdir": "wb-jsonmanager",
 	"altLangPage": "jsonmanager-fr.html",
-	"dateModified": "2022-10-31"
+	"dateModified": "2025-03-19"
 }
 ---
 <!--
@@ -150,7 +150,7 @@
 			{ "selector": ".event-start", "value": "/startDate" },
 			{ "selector": ".event-end", "value": "/endDate" },
 			{ "selector": ".event-location", "value": "/city" },
-			{ "selector": ".event-status", "value": "/registrationStatus/en" },
+			{ "selector": ".event-status", "value": "/registrationStatus/{{page.language}}" },
 			{ "selector": ".event-provinces", "value": "/province", "queryall": "li" },
 			{ "selector": ".event-registered", "value": "/registeredPeople",
 				"mapping": [
@@ -196,7 +196,7 @@
 		{ "op": "patches", "path": "/items", "patches": [
 			{ "op": "wb-swap", "path": "/eventLanguage", "ref": "/reference/language/{{page.language}}" },
 			{ "op": "wb-swap", "path": "/province", "ref": "/reference/province/{{page.language}}" },
-			{ "op": "wb-swap", "path": "/registrationStatus", "ref": "/reference/registrationStatus/{{page.language}}" },
+			{ "op": "wb-swap", "path": "/registrationStatus", "ref": "/reference/registrationStatus" },
 			{ "op": "wb-toDateISO", "path": "/startDate" },
 			{ "op": "wb-toDateISO", "path": "/endDate" },
 			{ "op": "patches", "path": "/registeredPeople", "patches": [
@@ -214,7 +214,7 @@
 			{ "selector": ".event-start", "value": "/startDate" },
 			{ "selector": ".event-end", "value": "/endDate" },
 			{ "selector": ".event-location", "value": "/city" },
-			{ "selector": ".event-status", "value": "/registrationStatus" },
+			{ "selector": ".event-status", "value": "/registrationStatus/{{page.language}}" },
 			{ "selector": ".event-provinces", "value": "/province", "queryall": "li" },
 			{ "selector": ".event-registered", "value": "/registeredPeople",
 				"mapping": [

--- a/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
+++ b/src/plugins/wb-jsonmanager/jsonmanager-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "jsonmanager",
 	"parentdir": "wb-jsonmanager",
 	"altLangPage": "jsonmanager-en.html",
-	"dateModified": "2022-10-31"
+	"dateModified": "2025-03-19"
 }
 ---
 <!--
@@ -133,7 +133,7 @@
 		{ "op": "patches", "path": "/items", "patches": [
 			{ "op": "wb-swap", "path": "/eventLanguage", "ref": "/reference/language/{{page.language}}" },
 			{ "op": "wb-swap", "path": "/province", "ref": "/reference/province/{{page.language}}" },
-			{ "op": "wb-swap", "path": "/registrationStatus", "ref": "/reference/registrationStatus/{{page.language}}" },
+			{ "op": "wb-swap", "path": "/registrationStatus", "ref": "/reference/registrationStatus" },
 			{ "op": "wb-toDateISO", "path": "/startDate" },
 			{ "op": "wb-toDateISO", "path": "/endDate" },
 			{ "op": "patches", "path": "/registeredPeople", "patches": [
@@ -151,7 +151,7 @@
 			{ "selector": ".event-start", "value": "/startDate" },
 			{ "selector": ".event-end", "value": "/endDate" },
 			{ "selector": ".event-location", "value": "/city" },
-			{ "selector": ".event-status", "value": "/registrationStatus" },
+			{ "selector": ".event-status", "value": "/registrationStatus/{{page.language}}" },
 			{ "selector": ".event-provinces", "value": "/province", "queryall": "li" },
 			{ "selector": ".event-registered", "value": "/registeredPeople",
 				"mapping": [
@@ -197,7 +197,7 @@
 		{ "op": "patches", "path": "/items", "patches": [
 			{ "op": "wb-swap", "path": "/eventLanguage", "ref": "/reference/language/{{page.language}}" },
 			{ "op": "wb-swap", "path": "/province", "ref": "/reference/province/{{page.language}}" },
-			{ "op": "wb-swap", "path": "/registrationStatus", "ref": "/reference/registrationStatus/{{page.language}}" },
+			{ "op": "wb-swap", "path": "/registrationStatus", "ref": "/reference/registrationStatus" },
 			{ "op": "wb-toDateISO", "path": "/startDate" },
 			{ "op": "wb-toDateISO", "path": "/endDate" },
 			{ "op": "patches", "path": "/registeredPeople", "patches": [
@@ -215,7 +215,7 @@
 			{ "selector": ".event-start", "value": "/startDate" },
 			{ "selector": ".event-end", "value": "/endDate" },
 			{ "selector": ".event-location", "value": "/city" },
-			{ "selector": ".event-status", "value": "/registrationStatus" },
+			{ "selector": ".event-status", "value": "/registrationStatus/{{page.language}}" },
 			{ "selector": ".event-provinces", "value": "/province", "queryall": "li" },
 			{ "selector": ".event-registered", "value": "/registeredPeople",
 				"mapping": [
@@ -233,6 +233,7 @@
 				&lt;p>De &lt;span class="event-start">&lt;/span> à &lt;span class="event-end">&lt;/span>&lt;/p>
 				&lt;p>Emplacement: &lt;span class="event-location">&lt;/span>&lt;/p>
 				&lt;p>Statut: &lt;span class="event-status">&lt;/span>&lt;/p>
+				&lt;p>Province(s):&lt;/p>
 				&lt;ul class="event-provinces">
 					&lt;template>
 						&lt;li>&lt;/li>


### PR DESCRIPTION
Specifically:
* English version:
  * Use ``{{page.language}}`` consistently in demos and code samples
  * Adjust HTML code sample's references to ``registrationStatus`` to match the demo
* French version
  * Adjust references to ``registrationStatus`` to match the English version:
    * Fixes the following console error: "Uncaught Error: JSON Pointer: Non-number tokens cannot be used in array context."
  * Add missing "Province(s):" paragraph to HTML code sample

CC @Garneauma