### PR TITLE
Multimedia player: Don't obstruct YouTube's viewport

### DIFF
--- a/src/plugins/multimedia/_base.scss
+++ b/src/plugins/multimedia/_base.scss
@@ -84,7 +84,7 @@
 	position: relative;
 
 	&.video {
-		&:not(.playing):not(.waiting) {
+		&:not(.playing):not(.waiting):not(.youtube) {
 			@include multimedia-overlay-base;
 			@include multimedia-overlay-play;
 		}
@@ -140,16 +140,6 @@
 		&.cc_on {
 			.wb-mm-cc {
 				@extend %multimedia-display-none;
-			}
-		}
-
-		&.video {
-			&:not(.playing):not(.waiting) {
-				.display {
-					&:before {
-						background: $mm-ctrl-bg-color;
-					}
-				}
 			}
 		}
 	}

--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -819,7 +819,7 @@ $document.on( youtubeEvent, selector, function( event, data ) {
 
 		$this.addClass( "youtube" );
 
-		$media = $this.find( "#" + mId ).attr( "tabindex", -1 );
+		$media = $this.find( "#" + mId );
 
 		data.media = $media;
 		data.ytPlayer = ytPlayer;


### PR DESCRIPTION
Long ago, YouTube's embedded player was very minimalist. Its ``iframe`` player API was flexible-enough to disable virtually all YouTube branding - effectively producing a "clean" video viewport.

WET's media player's YouTube support was designed with that in mind. It presented YouTube videos as plainly as possible. It overlaid its play icon in the middle of YouTube's ``iframe`` element and even added a ``tabindex="-1"`` attribute to it. Those small touches made the player look and feel nearly identical across both YouTube and non-YouTube videos.

Unfortunately... Google has added a lot of "bloat" to YouTube's embedded player overtime. For example:
* Related videos panels were added when pausing or finishing playback.
* Some of the ``iframe`` API's most useful parameters were deprecated and removed (later removed from WET via #9934)
  * ``modestbranding`` (used to disable the YouTube logo link)
  * ``showinfo`` (used to disable video title, uploader info, share/play later links, etc)
* Distracting info overlays were added to certain videos (such as "From a national health authority of Canada" in all of Health Canada's videos)... they can't be closed.

Since all the bloat is interactive and WET wasn't doing anything to disable pointer events on YouTube's ``iframe``... it created a two-tiered experience between keyboard-only and mouse/touchscreen/etc users. It failed WCAG success criteria 2.1.1 (Keyboard) and 2.4.3 (Focus Order).

Furthermore, WET's play icon overlay could sometimes overlap the "bloat" behind it. Using an overlay might've also violated the YouTube API Terms of Service - specifically the [required minimum functionality page's overlays and frames requirements](https://developers.google.com/youtube/terms/required-minimum-functionality#overlays-and-frames).

This resolves the aforementioned issues by removing ``tabindex="-1"`` and omitting WET's play icon overlay from YouTube's ``iframe``.

Potential downsides of these changes:
* The embedded YouTube player's red play icon fails WCAG success criterion 1.4.11 (Non-text Contrast)... although it probably technically counts as [YouTube's logo](https://developers.google.com/youtube/terms/branding-guidelines#youtube_icon).
* Having to get past the ``iframe``'s bloat to reach WET's media player controls might impede usability for keyboard-only users.
* Pressing the WET media player's play/pause button doesn't show YouTube's play/pause icon animations in the same manner clicking into the ``iframe`` would.
* YouTube's player doesn't show its own play/pause icon on paused videos.