### PR TITLE
ci: use Java 24 for latest grunt-html

### DIFF
--- a/.github/workflows/lint-html.yml
+++ b/.github/workflows/lint-html.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 8
+          java-version: "24"
           distribution: "temurin"
 
       - name: Set up Ruby

--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -835,7 +835,8 @@ module.exports = (grunt) ->
 						"Element “head” is missing a required instance of child element “title”."
 						"Element “li” not allowed as child of element “body” in this context. (Suppressing further errors from this subtree.)"
 						"Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”."
-						"Section lacks heading. Consider using “h2”-“h6” elements to add identifying headings to all sections."
+						"Section lacks heading. Consider using “h2”-“h6” elements to add identifying headings to all sections, or else use a “div” element instead for any cases where no heading is needed."
+						"Trailing slash on void elements has no effect and interacts badly with unquoted attribute values."
 					]
 					noLangDetect: true
 				src: [
@@ -855,6 +856,7 @@ module.exports = (grunt) ->
 						"The “contentinfo” role is unnecessary for element “footer”."
 						"The “navigation” role is unnecessary for element “nav”."
 						"The “banner” role is unnecessary for element “header”."
+						"Trailing slash on void elements has no effect and interacts badly with unquoted attribute values."
 					]
 				src: [
 					"dist/unmin/demos/lightbox/*.html"
@@ -870,6 +872,7 @@ module.exports = (grunt) ->
 						"The “banner” role is unnecessary for element “header”."
 						"Attribute “href” without an explicit value seen. The attribute may be dropped by IE7."
 						"The text content of element “time” was not in the required format: The literal did not satisfy the time-datetime format."
+						"Trailing slash on void elements has no effect and interacts badly with unquoted attribute values."
 					]
 				src: [
 					"dist/unmin/**/reports/*.html"
@@ -886,6 +889,7 @@ module.exports = (grunt) ->
 						"The “navigation” role is unnecessary for element “nav”."
 						"The “banner” role is unnecessary for element “header”."
 						"Attribute “href” without an explicit value seen. The attribute may be dropped by IE7."
+						"Trailing slash on void elements has no effect and interacts badly with unquoted attribute values."
 					]
 				src: [
 					"dist/unmin/**/*.html"

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "grunt-contrib-watch": "^1.1.0",
         "grunt-eslint": "^24.3.0",
         "grunt-gh-pages": "^4.0.0",
-        "grunt-html": "^15.2.2",
+        "grunt-html": "^17.1.0",
         "grunt-i18n-csv": "^0.1.0",
         "grunt-jsonlint": "^3.0.0",
         "grunt-lintspaces": "^0.12.0",
@@ -7396,18 +7396,18 @@
       "license": "ISC"
     },
     "node_modules/grunt-html": {
-      "version": "15.2.2",
-      "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-15.2.2.tgz",
-      "integrity": "sha512-/Zm1bMzmDcZtfBwtlGVkNimSRHP5OuuzajJ3+4S92TSfwcUi2iTIin7RLGNpW9Egmni66+SmEM+vI56JzTNInQ==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-html/-/grunt-html-17.1.0.tgz",
+      "integrity": "sha512-fOk/kJvDEpy6b4UvUDwVZ0nzxt3GnNvzgLwm/aXPJjsDZFmCpMPdwCw4NnDA+BfXT55/hb6q3CDK3Hib0bG3DQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "async": "^3.2.3",
-        "picocolors": "^1.0.0",
-        "vnu-jar": "21.10.12"
+        "async": "^3.2.6",
+        "picocolors": "^1.1.1",
+        "vnu-jar": "24.10.17"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=14.18"
       },
       "peerDependencies": {
         "grunt": ">=0.4.0"
@@ -17661,9 +17661,9 @@
       }
     },
     "node_modules/vnu-jar": {
-      "version": "21.10.12",
-      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-21.10.12.tgz",
-      "integrity": "sha512-tC+BEIWbLW0duLlQl75j9jWcrkPH+hSNGOe5D/FhT21c+JBqVk7Zc7gkDswT6VRlt7skJe4e31wnoAFoLDSg0Q==",
+      "version": "24.10.17",
+      "resolved": "https://registry.npmjs.org/vnu-jar/-/vnu-jar-24.10.17.tgz",
+      "integrity": "sha512-YT7gNrRY5PiJrI1GavlWRHWIwqq2o52COc6J9QeXPfoldKRiZ9BeGP4shNLLaVfi0naA+/LMksdYWkKCr4pnVg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "grunt-contrib-watch": "^1.1.0",
     "grunt-eslint": "^24.3.0",
     "grunt-gh-pages": "^4.0.0",
-    "grunt-html": "^15.2.2",
+    "grunt-html": "^17.1.0",
     "grunt-i18n-csv": "^0.1.0",
     "grunt-jsonlint": "^3.0.0",
     "grunt-lintspaces": "^0.12.0",


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

The Dependabot PR to bump to the latest `grunt-html` with a message that seems to indicate the Java 8 version isn't working now. Picked out that commit and added a separate to try and see if that resolves the build

## Additional information (optional) / Information additionnelle (optionnel)

**General checklist / Liste de contrôle générale**
Make your own list for the purpose of your Pull request. /// Faites votre propre liste en fonction des besoins de votre demande « pull ».

- [ ] Create/update documentation /// Créer/mettre à jour la documentation
- [ ] Build and test PR's code /// Rouler le script de compilation et tester le code de la PR
- [ ] Validate changes against WCAG for accessibility /// Valider les changements avec WCAG pour l'accessibilité
- [ ] Ensure documentation is bilingual /// S'assurer que la documentation soit bilingue
