### PR TITLE
Lightbox: Open role="button" links via spacebar key

### DIFF
--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -386,6 +386,21 @@ $( document ).on( "keydown", ".mfp-wrap:not(.mfp-close-btn-in)", function( event
 	}
 } );
 
+// Event handler for opening a popup via a button link and the spacebar key
+$( document ).on( "keydown", "." + componentName, function( event ) {
+	const sourceLink = event.currentTarget;
+
+	// If the link contains a role="button" attribute and the spacebar key was pressed...
+	if ( sourceLink.getAttribute( "role" ) === "button" && event.key === " " ) {
+
+		// Don't scroll down (typical spacebar behaviour)
+		event.preventDefault();
+
+		// Trigger a "fake" click on the button link
+		$( sourceLink ).trigger( "click" );
+	}
+} );
+
 // Event handler for opening a popup without a link
 $( document ).on( "open" + selector, function( event, items, modal, title, ajax ) {
 	if ( event.namespace === componentName ) {


### PR DESCRIPTION
The example links in the overlay plugin's demo page use ``role="button"`` attributes.

All of the examples that use the overlay plugin itself can be opened by "pressing" button links via the spacebar key.

However... the "centered popup" examples previously couldn't be opened via the spacebar key. Why? Because they rely on the lightbox plugin - which wasn't designed with ``role="button"`` in mind. In fact, none of the lightbox demo page's own examples use ``role="button"``.

This resolves it by adding spacebar support for ``role="button"`` links to the lightbox plugin. It works by triggering a "fake" link click event.

Related to #9494 (covers the main part of solution 2).