### PR TITLE
Lightbox: Close modal popups via Escape key

### DIFF
--- a/src/plugins/lightbox/lightbox.js
+++ b/src/plugins/lightbox/lightbox.js
@@ -362,13 +362,28 @@ $document.on( "click", ".mfp-wrap a[href^='#']", function( event ) {
 	}
 } );
 
-// Event handler for closing a modal popup
+// Event handler for closing a modal popup via the close button
 $( document ).on( "click", ".popup-modal-dismiss", function( event ) {
 	if ( !this.hasAttribute( "target" ) ) {
 		event.preventDefault();
 	}
 
 	$.magnificPopup.close();
+} );
+
+// Event handler for closing a modal popup via the Escape key
+$( document ).on( "keydown", ".mfp-wrap:not(.mfp-close-btn-in)", function( event ) {
+
+	// If the Escape key was pressed...
+	if ( event.key === "Escape" ) {
+		const closeButtons = event.currentTarget.querySelectorAll( ".popup-modal-dismiss" );
+
+		// Trigger a "fake" click on the last close button
+		// Notes:
+		// -Allows Escape key presses to "piggyback" on additional functionality in close button click handlers (such as preventDefault and the session timeout plugin's confirm method)
+		// -Targets the last close button link to accomodate plugins that use multiple close buttons (such as exit script)... the last button is more likely to represent no in those scenarios
+		$( closeButtons[ closeButtons.length - 1 ] ).trigger( "click" );
+	}
 } );
 
 // Event handler for opening a popup without a link

--- a/src/plugins/session-timeout/session-timeout.js
+++ b/src/plugins/session-timeout/session-timeout.js
@@ -331,7 +331,11 @@ var $modal, $modalLink, countdownInterval, i18n, i18nText,
 
 		// Negative confirmation or the user took too long; logout
 		} else {
-			window.location.href = settings.signInUrl ? settings.signInUrl : settings.logouturl;
+
+			// Use setTimeout() to navigate asynchronously (to support lightbox Escape key presses)
+			setTimeout( function() {
+				window.location.href = settings.signInUrl ? settings.signInUrl : settings.logouturl;
+			} );
 		}
 	},
 


### PR DESCRIPTION
The lightbox plugin's documentation states that it implements the WAI-ARIA Dialog (Modal) design pattern.

The pattern's keyboard interaction documentation states that the Escape key is expected to be capable of closing the dialog. Same for Alert and Message Dialogs (stricter pattern that seems more in line with how WET's modal popups actually work).

Most of the lightbox demo page's examples can currently be closed via the Escape key, but the modal examples can't. Why? Because the lightbox plugin leverages [Magnific Popup's "modal" option](https://dimsemenov.com/plugins/magnific-popup/documentation.html#modal) - which disables the Escape key.

This restores the Escape key's expected behaviour in order to adhere to the pattern. It works by triggering a "fake" click event on the modal's last close button.

Related change:
* Session timeout (``confirm`` method): Use ``setTimeout()`` when changing ``window.location.href`` to support lightbox Escape key presses

Fixes #9134. Related to #7919.

**PS:**
The link to the pattern's documentation is currently broken, but can be found at the following locations:
* Wayback Machine snapshots:
  * [2014 (as it stood when the link was first added to the lightbox documentation)](https://web.archive.org/web/20140805134917/https://www.w3.org/TR/wai-aria-practices/#dialog_modal)
  * [2022 (just before being replaced with a move notice)](https://web.archive.org/web/20220516223228/https://www.w3.org/TR/wai-aria-practices/#dialog_modal)
* ARIA Authoring Practices Guide (APG):
  * [Dialog (Modal) Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/)
  * [Alert and Message Dialogs Pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/)