### PR TITLE
PII Scrub: escaping HTML before generating modal

### DIFF
--- a/src/plugins/pii-scrub/pii-scrub.js
+++ b/src/plugins/pii-scrub/pii-scrub.js
@@ -122,7 +122,7 @@ var $document = wb.doc,
 				let fieldLabel = form.querySelector( "[for=" + field.id + "] > span.field-name" ),
 					fieldLabelText = fieldLabel ? fieldLabel.innerText : form.querySelector( "[for=" + field.id + "]" ).innerText,
 					scrubbedFieldValue = wb.findPotentialPII( field.value, true, { replaceWith: form.settings.scrubChar } ),
-					scrubValHTML = wb.findPotentialPII( field.value, true, { replaceWith: "<span role='img' aria-label='" + i18nText.redacted + "'>" + form.settings.scrubChar + "</span>" } ); // Todo add i18n
+					scrubValHTML = wb.findPotentialPII( field.value.replace( /</g, "&lt;" ), true, { replaceWith: "<span role='img' aria-label='" + i18nText.redacted + "'>" + form.settings.scrubChar + "</span>" } );
 
 				form.PIIFields.push( {
 					elm: field,


### PR DESCRIPTION
This PR adds escaping of any HTML entered by the user in the text box so that it is not rendered in the generated modal.