### PR TITLE
Filter: adding support for items using shadowDOM

### DIFF
--- a/src/plugins/filter/filter-en.hbs
+++ b/src/plugins/filter/filter-en.hbs
@@ -7,7 +7,8 @@
 	"tag": "filter",
 	"parentdir": "filter",
 	"altLangPrefix": "filter",
-	"dateModified": "2018-05-23"
+	"dateModified": "2025-08-07",
+	"css": ["https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.40.0/dist/gcds/gcds"]
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -18,6 +19,7 @@
 	<li><a href="#flt-search">Applying additional search filters</a></li>
 	<li><a href="#flt-uicontainer">Move UI to specific container</a></li>
 	<li><a href="#flt-customui">Custom UI</a></li>
+	<li><a href="#gcdsCard">GCDS Card</a></li>
 </ul>
 
 <h2 id="flt-section">Filtering items in sections</h2>
@@ -869,3 +871,73 @@
 	&lt;li>Alberta&lt;/li>
 	...
 &lt;/ul></code></pre>
+
+<h3 id="gcdsCard">GCDS Card</h3>
+<gcds-grid columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" class="wb-filter" data-wb-filter='{ "selector": "gcds-card" }'>
+	<gcds-card
+	card-title="Alberta"
+	href="#"
+	description="Known for the Rocky Mountains, vast prairies, and oil sands."
+	></gcds-card>
+	<gcds-card
+	card-title="British Columbia"
+	href="#"
+	description="A coastal province with rainforests, mountains, and vibrant cities like Vancouver."
+	></gcds-card>
+	<gcds-card
+	card-title="Manitoba"
+	href="#"
+	description="Home to the prairies, polar bears, and the cultural hub of Winnipeg."
+	></gcds-card>
+	<gcds-card
+	card-title="New Brunswick"
+	href="#"
+	description="A maritime province known for the Bay of Fundy and bilingual heritage."
+	></gcds-card>
+	<gcds-card
+	card-title="Newfoundland &amp; Labrador"
+	href="#"
+	description="Canada’s easternmost province, rich in history, cliffs, and coastal culture."
+	></gcds-card>
+	<gcds-card
+	card-title="Northwest Territories"
+	href="#"
+	description="Famous for the Northern Lights, Indigenous cultures, and the Mackenzie River."
+	></gcds-card>
+	<gcds-card
+	card-title="Nova Scotia"
+	href="#"
+	description="A scenic coastal province known for seafood, lighthouses, and maritime heritage."
+	></gcds-card>
+	<gcds-card
+	card-title="Nunavut"
+	href="#"
+	description="Canada’s newest and largest territory, home to Inuit communities and Arctic landscapes."
+	></gcds-card>
+	<gcds-card
+	card-title="Ontario"
+	href="#"
+	description="Canada’s most populous province, home to Toronto, Ottawa, and Niagara Falls."
+	></gcds-card>
+	<gcds-card
+	card-title="Prince Edward Island"
+	href="#"
+	description="Canada’s smallest province, known for red sand beaches and Anne of Green Gables."
+	></gcds-card>
+	<gcds-card
+	card-title="Quebec"
+	href="#"
+	description="A French-speaking province with rich culture, historic cities, and vast wilderness."
+	></gcds-card>
+	<gcds-card
+	card-title="Saskatchewan"
+	href="#"
+	description="Defined by open skies, wheat fields, and a strong farming tradition."
+	></gcds-card>
+	<gcds-card
+	card-title="Yukon"
+	href="#"
+	description="A rugged northern territory famous for the Klondike Gold Rush and wild landscapes."
+	></gcds-card>
+</gcds-grid>
+<script type="module" src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.40.0/dist/gcds/gcds.esm.js"></script>

--- a/src/plugins/filter/filter-fr.hbs
+++ b/src/plugins/filter/filter-fr.hbs
@@ -7,7 +7,8 @@
 	"tag": "filter",
 	"parentdir": "filter",
 	"altLangPrefix": "filter",
-	"dateModified": "2018-05-23"
+	"dateModified": "2025-08-07",
+	"css": ["https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.40.0/dist/gcds/gcds"]
 }
 ---
 <div class="wb-prettify all-pre hide"></div>
@@ -18,6 +19,7 @@
 	<li><a href="#flt-search">Application de filtres de recherche supplémentaires</a></li>
 	<li><a href="#flt-uicontainer">Déplacer l'interface vers un élément spécifique</a></li>
 	<li><a href="#flt-customui">Interface personnalisée</a></li>
+	<li><a href="#gcdsCard">Carte SDGC</a></li>
 </ul>
 
 <h2 id="flt-section">Filtrer des items par section</h2>
@@ -840,3 +842,73 @@
 	&lt;li>Alberta&lt;/li>
 	...
 &lt;/ul></code></pre>
+
+<h3 id="gcdsCard">Carte SDGC</h3>
+<gcds-grid columns="1fr" columns-tablet="1fr 1fr" columns-desktop="1fr 1fr 1fr" class="wb-filter" data-wb-filter='{ "selector": "gcds-card" }'>
+	<gcds-card
+	card-title="Alberta"
+	href="#"
+	description="Réputée pour les montagnes Rocheuses, les vastes prairies et les sables bitumineux."
+	></gcds-card>
+	<gcds-card
+	card-title="Colombie-Britannique"
+	href="#"
+	description="Une province côtière avec des forêts pluviales, des montagnes et des villes dynamiques comme Vancouver."
+	></gcds-card>
+	<gcds-card
+	card-title="Manitoba"
+	href="#"
+	description="Connue pour ses prairies, ses ours polaires et Winnipeg, un centre culturel majeur."
+	></gcds-card>
+	<gcds-card
+	card-title="Nouveau-Brunswick"
+	href="#"
+	description="Une province maritime célèbre pour la baie de Fundy et son patrimoine bilingue."
+	></gcds-card>
+	<gcds-card
+	card-title="Terre-Neuve-et-Labrador"
+	href="#"
+	description="La province la plus à l’est du Canada, riche en histoire, falaises et culture côtière."
+	></gcds-card>
+	<gcds-card
+	card-title="Territoires du Nord-Ouest"
+	href="#"
+	description="Célèbres pour les aurores boréales, les cultures autochtones et le fleuve Mackenzie."
+	></gcds-card>
+	<gcds-card
+	card-title="Nouvelle-Écosse"
+	href="#"
+	description="Une province côtière pittoresque connue pour ses fruits de mer, ses phares et son patrimoine maritime."
+	></gcds-card>
+	<gcds-card
+	card-title="Nunavut"
+	href="#"
+	description="Le plus grand et plus récent territoire du Canada, peuplé de communautés inuites et de paysages arctiques."
+	></gcds-card>
+	<gcds-card
+	card-title="Ontario"
+	href="#"
+	description="La province la plus peuplée du Canada, abritant Toronto, Ottawa et les chutes du Niagara."
+	></gcds-card>
+	<gcds-card
+	card-title="Île-du-Prince-Édouard"
+	href="#"
+	description="La plus petite province du Canada, célèbre pour ses plages de sable rouge et Anne... la maison aux pignons verts."
+	></gcds-card>
+	<gcds-card
+	card-title="Québec"
+	href="#"
+	description="Une province francophone au riche patrimoine culturel, aux villes historiques et aux vastes forêts."
+	></gcds-card>
+	<gcds-card
+	card-title="Saskatchewan"
+	href="#"
+	description="Connue pour ses grands ciels, ses champs de blé et sa forte tradition agricole."
+	></gcds-card>
+	<gcds-card
+	card-title="Yukon"
+	href="#"
+	description="Un territoire nordique sauvage célèbre pour la ruée vers l’or du Klondike et ses paysages grandioses."
+	></gcds-card>
+</gcds-grid>
+<script type="module" src="https://cdn.design-system.alpha.canada.ca/@cdssnc/gcds-components@0.40.0/dist/gcds/gcds.esm.js"></script>

--- a/src/plugins/filter/filter.js
+++ b/src/plugins/filter/filter.js
@@ -217,7 +217,13 @@ var componentName = "wb-filter",
 
 		for ( i = 0; i < itemsLength; i += 1 ) {
 			$item = $items.eq( i );
-			text = unAccent( $item.text() );
+
+			// Get the text content of the item, either from the shadow DOM or directly
+			if ( $item[ 0 ].shadowRoot ) {
+				text = unAccent( $item[ 0 ].shadowRoot.textContent );
+			} else {
+				text = unAccent( $item.text() );
+			}
 
 			if ( !searchFilterRegularExp.test( text ) ) {
 				if ( hndParentSelector ) {


### PR DESCRIPTION
Adding support for GCDS elements using ShadowDOM in the Filter plugin.

Working example will be added in GCWeb.