### PR TITLE
Steps form: Remove GCWeb classes from quiz examples

### DIFF
--- a/src/plugins/stepsform/stepsform-en.hbs
+++ b/src/plugins/stepsform/stepsform-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "stepsform",
 	"parentdir": "stepsform",
 	"altLangPrefix": "stepsform",
-	"dateModified": "2025-06-02"
+	"dateModified": "2025-08-04"
 }
 ---
 <section>
@@ -172,22 +172,18 @@
 			<legend>1. Which is your favorite fruit?</legend>
 			<div>
 				<p>My favorite fruit is:</p>
-				<ul class="lst-spcd-2 gc-chckbxrdio">
+				<ul class="form-group list-unstyled">
 					<li class="radio">
-						<input type="radio" name="fruit" id="apple-1" value="apple">
-						<label for="apple-1">Apple</label>
+						<label for="apple-1"><input type="radio" name="fruit" id="apple-1" value="apple">Apple</label>
 					</li>
 					<li class="radio">
-						<input type="radio" name="fruit" id="orange-1" value="orange">
-						<label for="orange-1">Orange</label>
+						<label for="orange-1"><input type="radio" name="fruit" id="orange-1" value="orange">Orange</label>
 					</li>
 					<li class="radio">
-						<input type="radio" name="fruit" id="banana-1" value="banana">
-						<label for="banana-1">Banana</label>
+						<label for="banana-1"><input type="radio" name="fruit" id="banana-1" value="banana">Banana</label>
 					</li>
 					<li class="radio">
-						<input type="radio" name="fruit" id="kiwi-1" value="Kiwi">
-						<label for="kiwi-1">Kiwi</label>
+						<label for="kiwi-1"><input type="radio" name="fruit" id="kiwi-1" value="Kiwi">Kiwi</label>
 					</li>
 				</ul>
 			</div>
@@ -196,18 +192,15 @@
 			<legend>2. Which is your favorite pet?</legend>
 			<div>
 				<p>My favorite pet is:</p>
-				<ul class="lst-spcd-2 gc-chckbxrdio">
+				<ul class="form-group list-unstyled">
 					<li class="radio">
-						<input type="radio" name="animal" id="dog-1" value="dog">
-						<label for="dog-1">Dog</label>
+						<label for="dog-1"><input type="radio" name="animal" id="dog-1" value="dog">Dog</label>
 					</li>
 					<li class="radio">
-						<input type="radio" name="animal" id="cat-1" value="cat">
-						<label for="cat-1">Cat</label>
+						<label for="cat-1"><input type="radio" name="animal" id="cat-1" value="cat">Cat</label>
 					</li>
 					<li class="radio">
-						<input type="radio" name="animal" id="bird-1" value="bird">
-						<label for="bird-1">Bird</label>
+						<label for="bird-1"><input type="radio" name="animal" id="bird-1" value="bird">Bird</label>
 					</li>
 				</ul>
 			</div>
@@ -216,18 +209,15 @@
 			<legend>3. Condiments</legend>
 			<div>
 				<p>Choose your condiments:</p>
-				<ul class="lst-spcd-2 gc-chckbxrdio">
+				<ul class="form-group list-unstyled">
 					<li class="checkbox">
-						<input type="checkbox" id="ketchup-1" value="ketchup" name="condiments">
-						<label for="ketchup-1">Ketchup</label>
+						<label for="ketchup-1"><input type="checkbox" id="ketchup-1" value="ketchup" name="condiments">Ketchup</label>
 					</li>
 					<li class="checkbox">
-						<input type="checkbox" id="relish-1"  value="relish" name="condiments">
-						<label for="relish-1">Relish</label>
+						<label for="relish-1"><input type="checkbox" id="relish-1"  value="relish" name="condiments">Relish</label>
 					</li>
 					<li class="checkbox">
-						<input type="checkbox" id="mustard-1"  value="mustard" name="condiments">
-						<label for="mustard-1">Mustard</label>
+						<label for="mustard-1"><input type="checkbox" id="mustard-1"  value="mustard" name="condiments">Mustard</label>
 					</li>
 				</ul>
 			</div>
@@ -246,22 +236,18 @@
 			&lt;legend&gt;1. Which is your favorite fruit?&lt;/legend&gt;
 			&lt;div&gt;
 				&lt;p&gt;My favorite fruit is:&lt;/p&gt;
-				&lt;ul class="lst-spcd-2 gc-chckbxrdio"&gt;
+				&lt;ul class="form-group list-unstyled"&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="fruit" id="apple-1" value="apple"&gt;
-						&lt;label for="apple-1"&gt;Apple&lt;/label&gt;
+						&lt;label for="apple-1"&gt;&lt;input type="radio" name="fruit" id="apple-1" value="apple"&gt;Apple&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="fruit" id="orange-1" value="orange"&gt;
-						&lt;label for="orange-1"&gt;Orange&lt;/label&gt;
+						&lt;label for="orange-1"&gt;&lt;input type="radio" name="fruit" id="orange-1" value="orange"&gt;Orange&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="fruit" id="banana-1" value="banana"&gt;
-						&lt;label for="banana-1"&gt;Banana&lt;/label&gt;
+						&lt;label for="banana-1"&gt;&lt;input type="radio" name="fruit" id="banana-1" value="banana"&gt;Banana&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="fruit" id="kiwi-1" value="Kiwi"&gt;
-						&lt;label for="kiwi-1"&gt;Kiwi&lt;/label&gt;
+						&lt;label for="kiwi-1"&gt;&lt;input type="radio" name="fruit" id="kiwi-1" value="Kiwi"&gt;Kiwi&lt;/label&gt;
 					&lt;/li&gt;
 				&lt;/ul&gt;
 			&lt;/div&gt;
@@ -270,18 +256,15 @@
 			&lt;legend&gt;2. Which is your favorite pet?&lt;/legend&gt;
 			&lt;div&gt;
 				&lt;p&gt;My favorite pet is:&lt;/p&gt;
-				&lt;ul class="lst-spcd-2 gc-chckbxrdio"&gt;
+				&lt;ul class="form-group list-unstyled"&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="animal" id="dog-1" value="dog"&gt;
-						&lt;label for="dog-1"&gt;Dog&lt;/label&gt;
+						&lt;label for="dog-1"&gt;&lt;input type="radio" name="animal" id="dog-1" value="dog"&gt;Dog&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="animal" id="cat-1" value="cat"&gt;
-						&lt;label for="cat-1"&gt;Cat&lt;/label&gt;
+						&lt;label for="cat-1"&gt;&lt;input type="radio" name="animal" id="cat-1" value="cat"&gt;Cat&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="animal" id="bird-1" value="bird"&gt;
-						&lt;label for="bird-1"&gt;Bird&lt;/label&gt;
+						&lt;label for="bird-1"&gt;&lt;input type="radio" name="animal" id="bird-1" value="bird"&gt;Bird&lt;/label&gt;
 					&lt;/li&gt;
 				&lt;/ul&gt;
 			&lt;/div&gt;
@@ -290,18 +273,15 @@
 			&lt;legend&gt;3. Condiments&lt;/legend&gt;
 			&lt;div&gt;
 				&lt;p&gt;Choose your condiments:&lt;/p&gt;
-				&lt;ul class="lst-spcd-2 gc-chckbxrdio"&gt;
+				&lt;ul class="form-group list-unstyled"&gt;
 					&lt;li class="checkbox"&gt;
-						&lt;input type="checkbox" id="ketchup-1" value="ketchup" name="condiments"&gt;
-						&lt;label for="ketchup-1"&gt;Ketchup&lt;/label&gt;
+						&lt;label for="ketchup-1"&gt;&lt;input type="checkbox" id="ketchup-1" value="ketchup" name="condiments"&gt;Ketchup&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="checkbox"&gt;
-						&lt;input type="checkbox" id="relish-1"  value="relish" name="condiments"&gt;
-						&lt;label for="relish-1"&gt;Relish&lt;/label&gt;
+						&lt;label for="relish-1"&gt;&lt;input type="checkbox" id="relish-1"  value="relish" name="condiments"&gt;Relish&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="checkbox"&gt;
-						&lt;input type="checkbox" id="mustard-1"  value="mustard" name="condiments"&gt;
-						&lt;label for="mustard-1"&gt;Mustard&lt;/label&gt;
+						&lt;label for="mustard-1"&gt;&lt;input type="checkbox" id="mustard-1"  value="mustard" name="condiments"&gt;Mustard&lt;/label&gt;
 					&lt;/li&gt;
 				&lt;/ul&gt;
 			&lt;/div&gt;

--- a/src/plugins/stepsform/stepsform-fr.hbs
+++ b/src/plugins/stepsform/stepsform-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "stepsform",
 	"parentdir": "stepsform",
 	"altLangPrefix": "stepsform",
-	"dateModified": "2025-06-02"
+	"dateModified": "2025-08-04"
 }
 ---
 <section>
@@ -171,22 +171,18 @@
 			<legend>1. Quel est ton fruit préféré?</legend>
 			<div>
 				<p>Mon fruit préféré est:</p>
-				<ul class="lst-spcd-2 gc-chckbxrdio">
+				<ul class="form-group list-unstyled">
 					<li class="radio">
-						<input type="radio" name="fruit" id="apple-1" value="apple">
-						<label for="apple-1">Pomme</label>
+						<label for="apple-1"><input type="radio" name="fruit" id="apple-1" value="apple">Pomme</label>
 					</li>
 					<li class="radio">
-						<input type="radio" name="fruit" id="orange-1" value="orange">
-						<label for="orange-1">Orange</label>
+						<label for="orange-1"><input type="radio" name="fruit" id="orange-1" value="orange">Orange</label>
 					</li>
 					<li class="radio">
-						<input type="radio" name="fruit" id="banana-1" value="banana">
-						<label for="banana-1">Banane</label>
+						<label for="banana-1"><input type="radio" name="fruit" id="banana-1" value="banana">Banane</label>
 					</li>
 					<li class="radio">
-						<input type="radio" name="fruit" id="kiwi-1" value="Kiwi">
-						<label for="kiwi-1">Kiwi</label>
+						<label for="kiwi-1"><input type="radio" name="fruit" id="kiwi-1" value="Kiwi">Kiwi</label>
 					</li>
 				</ul>
 			</div>
@@ -195,18 +191,15 @@
 			<legend>2. Quel est ton animal de compagnie préféré?</legend>
 			<div>
 				<p>Mon animal préféré est:</p>
-				<ul class="lst-spcd-2 gc-chckbxrdio">
+				<ul class="form-group list-unstyled">
 					<li class="radio">
-						<input type="radio" name="animal" id="dog-1" value="dog">
-						<label for="dog-1">Chien</label>
+						<label for="dog-1"><input type="radio" name="animal" id="dog-1" value="dog">Chien</label>
 					</li>
 					<li class="radio">
-						<input type="radio" name="animal" id="cat-1" value="cat">
-						<label for="cat-1">Chat</label>
+						<label for="cat-1"><input type="radio" name="animal" id="cat-1" value="cat">Chat</label>
 					</li>
 					<li class="radio">
-						<input type="radio" name="animal" id="bird-1" value="bird">
-						<label for="bird-1">Oiseau</label>
+						<label for="bird-1"><input type="radio" name="animal" id="bird-1" value="bird">Oiseau</label>
 					</li>
 				</ul>
 			</div>
@@ -215,18 +208,15 @@
 			<legend>3. Condiments</legend>
 			<div>
 				<p>Choisissez vos condiments:</p>
-				<ul class="lst-spcd-2 gc-chckbxrdio">
+				<ul class="form-group list-unstyled">
 					<li class="checkbox">
-						<input type="checkbox" id="ketchup-1" value="ketchup" name="condiments">
-						<label for="ketchup-1">Ketchup</label>
+						<label for="ketchup-1"><input type="checkbox" id="ketchup-1" value="ketchup" name="condiments">Ketchup</label>
 					</li>
 					<li class="checkbox">
-						<input type="checkbox" id="relish-1"  value="relish" name="condiments">
-						<label for="relish-1">Relish</label>
+						<label for="relish-1"><input type="checkbox" id="relish-1"  value="relish" name="condiments">Relish</label>
 					</li>
 					<li class="checkbox">
-						<input type="checkbox" id="mustard-1"  value="mustard" name="condiments">
-						<label for="mustard-1">Moutarde</label>
+						<label for="mustard-1"><input type="checkbox" id="mustard-1"  value="mustard" name="condiments">Moutarde</label>
 					</li>
 				</ul>
 			</div>
@@ -245,22 +235,18 @@
 			&lt;legend&gt;1. Quel est ton fruit préféré?&lt;/legend&gt;
 			&lt;div&gt;
 				&lt;p&gt;Mon fruit préféré est:&lt;/p&gt;
-				&lt;ul class="lst-spcd-2 gc-chckbxrdio"&gt;
+				&lt;ul class="form-group list-unstyled"&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="fruit" id="apple-1" value="apple"&gt;
-						&lt;label for="apple-1"&gt;Pomme&lt;/label&gt;
+						&lt;label for="apple-1"&gt;&lt;input type="radio" name="fruit" id="apple-1" value="apple"&gt;Pomme&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="fruit" id="orange-1" value="orange"&gt;
-						&lt;label for="orange-1"&gt;Orange&lt;/label&gt;
+						&lt;label for="orange-1"&gt;&lt;input type="radio" name="fruit" id="orange-1" value="orange"&gt;Orange&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="fruit" id="banana-1" value="banana"&gt;
-						&lt;label for="banana-1"&gt;Banane&lt;/label&gt;
+						&lt;label for="banana-1"&gt;&lt;input type="radio" name="fruit" id="banana-1" value="banana"&gt;Banane&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="fruit" id="kiwi-1" value="Kiwi"&gt;
-						&lt;label for="kiwi-1"&gt;Kiwi&lt;/label&gt;
+						&lt;label for="kiwi-1"&gt;&lt;input type="radio" name="fruit" id="kiwi-1" value="Kiwi"&gt;Kiwi&lt;/label&gt;
 					&lt;/li&gt;
 				&lt;/ul&gt;
 			&lt;/div&gt;
@@ -269,18 +255,15 @@
 			&lt;legend&gt;2. Quel est ton animal de compagnie préféré?&lt;/legend&gt;
 			&lt;div&gt;
 				&lt;p&gt;Mon animal préféré est:&lt;/p&gt;
-				&lt;ul class="lst-spcd-2 gc-chckbxrdio"&gt;
+				&lt;ul class="form-group list-unstyled"&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="animal" id="dog-1" value="dog"&gt;
-						&lt;label for="dog-1"&gt;Chien&lt;/label&gt;
+						&lt;label for="dog-1"&gt;&lt;input type="radio" name="animal" id="dog-1" value="dog"&gt;Chien&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="animal" id="cat-1" value="cat"&gt;
-						&lt;label for="cat-1"&gt;Chat&lt;/label&gt;
+						&lt;label for="cat-1"&gt;&lt;input type="radio" name="animal" id="cat-1" value="cat"&gt;Chat&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="radio"&gt;
-						&lt;input type="radio" name="animal" id="bird-1" value="bird"&gt;
-						&lt;label for="bird-1"&gt;Oiseau&lt;/label&gt;
+						&lt;label for="bird-1"&gt;&lt;input type="radio" name="animal" id="bird-1" value="bird"&gt;Oiseau&lt;/label&gt;
 					&lt;/li&gt;
 				&lt;/ul&gt;
 			&lt;/div&gt;
@@ -289,18 +272,15 @@
 			&lt;legend&gt;3. Condiments&lt;/legend&gt;
 			&lt;div&gt;
 				&lt;p&gt;Choisissez vos condiments:&lt;/p&gt;
-				&lt;ul class="lst-spcd-2 gc-chckbxrdio"&gt;
+				&lt;ul class="form-group list-unstyled"&gt;
 					&lt;li class="checkbox"&gt;
-						&lt;input type="checkbox" id="ketchup-1" value="ketchup" name="condiments"&gt;
-						&lt;label for="ketchup-1"&gt;Ketchup&lt;/label&gt;
+						&lt;label for="ketchup-1"&gt;&lt;input type="checkbox" id="ketchup-1" value="ketchup" name="condiments"&gt;Ketchup&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="checkbox"&gt;
-						&lt;input type="checkbox" id="relish-1"  value="relish" name="condiments"&gt;
-						&lt;label for="relish-1"&gt;Relish&lt;/label&gt;
+						&lt;label for="relish-1"&gt;&lt;input type="checkbox" id="relish-1"  value="relish" name="condiments"&gt;Relish&lt;/label&gt;
 					&lt;/li&gt;
 					&lt;li class="checkbox"&gt;
-						&lt;input type="checkbox" id="mustard-1"  value="mustard" name="condiments"&gt;
-						&lt;label for="mustard-1"&gt;Moutarde&lt;/label&gt;
+						&lt;label for="mustard-1"&gt;&lt;input type="checkbox" id="mustard-1"  value="mustard" name="condiments"&gt;Moutarde&lt;/label&gt;
 					&lt;/li&gt;
 				&lt;/ul&gt;
 			&lt;/div&gt;


### PR DESCRIPTION
This plugin's quiz feature started out as a méli-mélo project in GCWeb that was ultimately ported upstream (into WET).

However, some of the classes its examples originally used in GCWeb don't exist in WET. Therefore, there's no value in keeping them in WET's quiz examples.

Specifically:
* ``lst-spcd-2``
  * Note: The standard ``lst-spcd`` class exists in WET. [GCWeb's ``lst-spcd-2`` class styles also contain a note mulling about moving it over to WET](https://github.com/wet-boew/GCWeb/blob/c0fdaa7df0c7fc99efd3bf92ba721cbd8a06886f/common/list/_lists.scss#L115-L117) (unclear why it wasn't initially introduced in WET in the first place).
* ``gc-chckbxrdio``
*   * Note: This class overrides the behaviour of Bootstrap's ``checkbox`` and ``radio`` classes. Bootstrap's classes expect ``input``s to be nested within ``label``s, whereas GCWeb's ``gc-chckbxrdio`` class expects them to be adjacent. Using GCWeb's structure in WET causes large spaces to appear between ``input``s and ``label``s.

This fixes it revising WET's quiz examples to use "stacked" checkbox/radio buttons with ``li`` elements. It's the closest WET equivalent to what GCWeb was originally doing.