### PR TITLE
Steps form: fixing broken conditional

### DIFF
--- a/src/plugins/stepsform/stepsform.js
+++ b/src/plugins/stepsform/stepsform.js
@@ -142,7 +142,7 @@ var componentName = "wb-steps",
 					numQuestion = $( ".steps-wrapper", $elm ).length; // Calculate number of questions
 
 				// Addition to UI (Ex: progress bar)
-				if ( !$.contains( $elm, "progress" ) ) {
+				if ( !elm.querySelector( "progress" ) ) {
 					$( "form", $elm ).prepend( "<label class='full-width'><span class='wb-inv'>" + i18nText.progresslabel + "</span><progress class='progressBar' max='" + numQuestion + "'></progress><p class='progressText' role='status'></p></label>" );
 				}
 


### PR DESCRIPTION
This conditional always returned true, which caused and issue when the latest version of WET-BOEW and the Nahanni compilation in GCWeb were both on the same page.