### PR TITLE
PII Scrub: fix issue when closing modal with Escape button

### DIFF
--- a/site/pages/docs/ref/pii-scrub/pii-scrub-en.hbs
+++ b/site/pages/docs/ref/pii-scrub/pii-scrub-en.hbs
@@ -81,7 +81,7 @@
 					<ul>
 						<li>The placeholder for PII fields: <code>&lt;div data-scrub-modal-fields>&lt;/div></code>. This placeholder will be filled with the list of PII fields and their associated label.</li>
 						<li>A cancel button. This button must have the CSS class <code>popup-modal-dismiss</code>. For example: <code>&lt;button type="button" class="btn btn-link btn-block <strong>popup-modal-dismiss</strong>">Go back and edit comment&lt;/button></code></li>
-						<li>A submit button. This button must have the attribute <code>data-scrub-submit</code> and the CSS class <code>popup-modal-dismiss</code>. For example: <code>&lt;button type="button" class="btn btn-primary btn-block <strong>popup-modal-dismiss</strong>" <strong>data-scrub-submit</strong>>Submit comment&lt;/button></code></li>
+						<li>A submit button. This button must have the attribute <code>data-scrub-submit</code>. For example: <code>&lt;button type="button" class="btn btn-primary btn-block" <strong>data-scrub-submit</strong>>Submit comment&lt;/button></code></li>
 					</ul>
 				</td>
 				<td>CSS selector</td>

--- a/site/pages/docs/ref/pii-scrub/pii-scrub-fr.hbs
+++ b/site/pages/docs/ref/pii-scrub/pii-scrub-fr.hbs
@@ -80,7 +80,7 @@
 					<ul>
 						<li>L'espace réservé pour les champs IPI&nbsp;: <code>&lt;div data-scrub-modal-fields>&lt;/div></code>. Cet espace réservé sera rempli avec la liste des champs IPI et leur libellé associé.</li>
 						<li>Un bouton Annuler. Ce bouton doit avoir la classe CSS <code>popup-modal-dismiss</code>. Par exemple&nbsp;: <code>&lt;button type="button" class="btn btn-link btn-block <strong>popup-modal-dismiss</strong>">Revenir en arrière et modifier les champs&lt;/button></code></li>
-						<li>Un bouton Soumettre. Ce bouton doit avoir l'attribut <code>data-scrub-submit</code> et la classe CSS <code>popup-modal-dismiss</code>. Par exemple&nbsp;: <code>&lt;button type="button" class="btn btn-primary btn-block <strong>popup-modal-dismiss</strong>" <strong>data-scrub-submit</strong>>Envoyer le commentaire&lt;/button></code></li>
+						<li>Un bouton Soumettre. Ce bouton doit avoir l'attribut <code>data-scrub-submit</code>. Par exemple&nbsp;: <code>&lt;button type="button" class="btn btn-primary btn-block" <strong>data-scrub-submit</strong>>Envoyer le commentaire&lt;/button></code></li>
 					</ul>
 				</td>
 				<td>Sélecteur CSS</td>

--- a/src/plugins/pii-scrub/pii-scrub-en.hbs
+++ b/src/plugins/pii-scrub/pii-scrub-en.hbs
@@ -20,6 +20,7 @@
 	<li><a href="#postbackExample">Example with form Postback</a></li>
 	<li><a href="#validationExample">Example with form Form validation</a></li>
 	<li><a href="#validationandPostbackExample">Example with form Form validation and Postback</a></li>
+	<li><a href="#customUIpopupdismiss">Example with custom UI (leveraging deprecated UI instructions)</a></li>
 </ul>
 
 <h2 id="basicExample">Basic example</h2>
@@ -104,7 +105,7 @@
 		<div class="modal-footer">
 			<div class="row">
 				<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-link btn-block popup-modal-dismiss">Go back and edit comment</button></div>
-				<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-primary btn-block popup-modal-dismiss" data-scrub-submit>Submit comment</button></div>
+				<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-primary btn-block" data-scrub-submit>Submit comment</button></div>
 			</div>
 		</div>
 	</template>
@@ -153,7 +154,7 @@
 		&lt;div class="modal-footer">
 			&lt;div class="row">
 				&lt;div class="col-xs-12 col-sm-6 mrgn-tp-sm">&lt;button type="button" class="btn btn-link btn-block popup-modal-dismiss">Go back and edit comment&lt;/button>&lt;/div>
-				&lt;div class="col-xs-12 col-sm-6 mrgn-tp-sm">&lt;button type="button" class="btn btn-primary btn-block popup-modal-dismiss" data-scrub-submit>Submit comment&lt;/button>&lt;/div>
+				&lt;div class="col-xs-12 col-sm-6 mrgn-tp-sm">&lt;button type="button" class="btn btn-primary btn-block" data-scrub-submit>Submit comment&lt;/button>&lt;/div>
 			&lt;/div>
 		&lt;/div>
 	&lt;/template>
@@ -285,4 +286,100 @@
 	&lt;p class="success-message-2 hide">Thank you!&lt;/p>
 	&lt;p class="failure-message-2 hide">Something went wrong. Please submit your information via an alternative method.&lt;/p>
 &lt;/div></code></pre>
+</details>
+
+<h2 id="customUIpopupdismiss">Example with custom UI (leveraging deprecated UI instructions)</h2>
+<p>Below is an example demonstrating the <code>modalTemplate</code> option and following the deprecated instructions for the modal template HTML structure.</p>
+<form action="pii-scrub-en.html" class="wb-pii-scrub" data-wb-pii-scrub='{"modalTemplate": "[data-scrub-modal]"}'>
+	<template data-scrub-modal>
+		<header class="modal-header">
+			<h2 class="modal-title">Personal information in your comment has been removed</h2>
+		</header>
+		<div class="modal-body">
+			<p>Comments are only used to improve our website. You will not receive a response.</p>
+			<p><strong>To protect your privacy, your comment will be submitted as:</strong></p>
+			<div data-scrub-modal-fields></div>
+			<details class="mrgn-tp-md">
+				<summary>What is considered personal information?</summary>
+				<p>Certain types of information can’t be included in this feedback form, such as your:</p>
+				<ul>
+					<li>email address</li>
+					<li>telephone number</li>
+					<li>postal code</li>
+					<li>passport number</li>
+					<li>business number</li>
+					<li>social insurance number (SIN)</li>
+				</ul>
+			</details>
+		</div>
+		<div class="modal-footer">
+			<div class="row">
+				<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-link btn-block popup-modal-dismiss">Go back and edit comment</button></div>
+				<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-primary btn-block popup-modal-dismiss" data-scrub-submit>Submit comment</button></div>
+			</div>
+		</div>
+	</template>
+	<div class="form-content">
+		<div class="form-group">
+			<label for="firstname2"><span class="field-name">First Name</span></label>
+			<input class="form-control" id="firstname2" name="firstname" type="text">
+		</div>
+		<div class="form-group">
+			<label for="lastname2"><span class="field-name">Last Name</span></label>
+			<input class="form-control" id="lastname2" name="lastname" type="text">
+		</div>
+		<div class="form-group">
+			<label for="comments3">Comments</label>
+			<textarea class="form-control" id="comments3" name="comments3" data-scrub-field rows="4" cols="50"></textarea>
+		</div>
+		<button class="btn btn-primary" name="test" value="testValue">Submit</button>
+	</div>
+</form>
+<details class="mrgn-tp-md mrgn-bttm-md">
+	<summary>View code</summary>
+	<pre><code>&lt;form action="pii-scrub-en.html" class="wb-pii-scrub" data-wb-pii-scrub='{"modalTemplate": "[data-scrub-modal]"}'>
+	&lt;template data-scrub-modal>
+		&lt;header class="modal-header">
+			&lt;h2 class="modal-title">Personal information in your comment has been removed&lt;/h2>
+		&lt;/header>
+		&lt;div class="modal-body">
+			&lt;p>Comments are only used to improve our website. You will not receive a response.&lt;/p>
+			&lt;p>&lt;strong>To protect your privacy, your comment will be submitted as:&lt;/strong>&lt;/p>
+			&lt;div data-scrub-modal-fields>&lt;/div>
+			&lt;details class="mrgn-tp-md">
+				&lt;summary>What is considered personal information?&lt;/summary>
+				&lt;p>Certain types of information can’t be included in this feedback form, such as your:&lt;/p>
+				&lt;ul>
+					&lt;li>email address&lt;/li>
+					&lt;li>telephone number&lt;/li>
+					&lt;li>postal code&lt;/li>
+					&lt;li>passport number&lt;/li>
+					&lt;li>business number&lt;/li>
+					&lt;li>social insurance number (SIN)&lt;/li>
+				&lt;/ul>
+			&lt;/details>
+		&lt;/div>
+		&lt;div class="modal-footer">
+			&lt;div class="row">
+				&lt;div class="col-xs-12 col-sm-6 mrgn-tp-sm">&lt;button type="button" class="btn btn-link btn-block popup-modal-dismiss">Go back and edit comment&lt;/button>&lt;/div>
+				&lt;div class="col-xs-12 col-sm-6 mrgn-tp-sm">&lt;button type="button" class="btn btn-primary btn-block popup-modal-dismiss" data-scrub-submit>Submit comment&lt;/button>&lt;/div>
+			&lt;/div>
+		&lt;/div>
+	&lt;/template>
+	&lt;div class="form-content">
+		&lt;div class="form-group">
+			&lt;label for="firstname2">&lt;span class="field-name">First Name&lt;/span>&lt;/label>
+			&lt;input class="form-control" id="firstname2" name="firstname" type="text">
+		&lt;/div>
+		&lt;div class="form-group">
+			&lt;label for="lastname2">&lt;span class="field-name">Last Name&lt;/span>&lt;/label>
+			&lt;input class="form-control" id="lastname2" name="lastname" type="text">
+		&lt;/div>
+		&lt;div class="form-group">
+			&lt;label for="comments">Comments&lt;/label>
+			&lt;textarea class="form-control" id="comments3" name="comments3" data-scrub-field rows="4" cols="50">&lt;/textarea>
+		&lt;/div>
+		&lt;button class="btn btn-primary" name="test" value="testValue">Submit&lt;/button>
+	&lt;/div>
+&lt;/form></code></pre>
 </details>

--- a/src/plugins/pii-scrub/pii-scrub-fr.hbs
+++ b/src/plugins/pii-scrub/pii-scrub-fr.hbs
@@ -20,6 +20,7 @@
 	<li><a href="#exemplePostback">Exemple avec envoi via Ajax</a></li>
 	<li><a href="#exempleValidation">Exemple avec validation de formulaire</a></li>
 	<li><a href="#exempleValidationEtPostback">Exemple avec validation de formulaire et avec envoi via Ajax</a></li>
+	<li><a href="#popupdismissUIpersonnalise">Exemple avec interface personnalisée (utilisant les instructions obsolètes)</a></li>
 </ul>
 
 <h2 id="exempleBase">Exemple de base</h2>
@@ -104,7 +105,7 @@
 		<div class="modal-footer">
 			<div class="row">
 				<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-link btn-block popup-modal-dismiss">Fermer et modifier le commentaire</button></div>
-				<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-primary btn-block popup-modal-dismiss" data-scrub-submit>Soumettre le commentaire</button></div>
+				<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-primary btn-block" data-scrub-submit>Soumettre le commentaire</button></div>
 			</div>
 		</div>
 	</template>
@@ -153,7 +154,7 @@
 		&lt;div class="modal-footer">
 			&lt;div class="row">
 				&lt;div class="col-xs-12 col-sm-6 mrgn-tp-sm">&lt;button type="button" class="btn btn-link btn-block popup-modal-dismiss">Fermer et modifier le commentaire&lt;/button>&lt;/div>
-				&lt;div class="col-xs-12 col-sm-6 mrgn-tp-sm">&lt;button type="button" class="btn btn-primary btn-block popup-modal-dismiss" data-scrub-submit>Soumettre le commentaire&lt;/button>&lt;/div>
+				&lt;div class="col-xs-12 col-sm-6 mrgn-tp-sm">&lt;button type="button" class="btn btn-primary btn-block" data-scrub-submit>Soumettre le commentaire&lt;/button>&lt;/div>
 			&lt;/div>
 		&lt;/div>
 	&lt;/template>
@@ -285,4 +286,109 @@
 	&lt;p class="success-message-2 hide">Merci !&lt;/p>
 	&lt;p class="failure-message-2 hide">Une erreur s'est produite. Veuillez soumettre vos informations via une autre méthode.&lt;/p>
 &lt;/div></code></pre>
+</details>
+
+<h2 id="popupdismissUIpersonnalise">Exemple avec interface personnalisée (utilisant les instructions obsolètes)</h2>
+<p>Vous trouverez ci-dessous un exemple illustrant l'option <code>modalTemplate</code> et suivant les instructions obsolètes pour la structure HTML du modèle modal.</p>
+<section class="panel panel-info">
+	<header class="panel-heading">
+		<h3 class="panel-title">Instructions</h3>
+	</header>
+	<div class="panel-body">
+		<p>Seul le champ <strong>Commentaires</strong> possède un attribut data-scrub.</p>
+		<p>Remplissez le champ <strong>Commentaires</strong> avec les informations suivantes&nbsp;:<br><code>Visa&nbsp;: 4916 0739.3667-6891, Master&nbsp;: 5428735149026050, NAS&nbsp;: 123 123-123, Code postal&nbsp;: K2C 3N2, numéro de permis de conduire&nbsp;: P12345678912345, Compte bancaire&nbsp;: 003-1234567</code></p>
+	</div>
+</section>
+<form action="pii-scrub-fr.html" class="wb-pii-scrub" data-wb-pii-scrub='{"modalTemplate": "[data-scrub-modal]"}'>
+	<template data-scrub-modal>
+		<header class="modal-header">
+			<h2 class="modal-title">Les informations personnelles contenues dans votre commentaire ont été supprimées</h2>
+		</header>
+		<div class="modal-body">
+			<p>Les commentaires servent uniquement à améliorer notre site. Vous ne recevrez pas de réponse.</p>
+			<p><strong>Pour protéger votre vie privée, votre commentaire sera soumis comme suit&nbsp;:</strong></p>
+			<div data-scrub-modal-fields></div>
+			<details class="mrgn-tp-md">
+				<summary>Qu’est-ce qui est considéré comme une information personnelle?</summary>
+				<p>Certains types d’informations ne peuvent pas être inclus dans ce formulaire de commentaires, tels que&nbsp;:</p>
+				<ul>
+					<li>adresse courriel</li>
+					<li>numéro de téléphone</li>
+					<li>code postal</li>
+					<li>numéro de passeport</li>
+					<li>numéro d'entreprise</li>
+					<li>numéro d'assurance sociale (NAS)</li>
+				</ul>
+			</details>
+		</div>
+		<div class="modal-footer">
+			<div class="row">
+				<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-link btn-block popup-modal-dismiss">Fermer et modifier le commentaire</button></div>
+				<div class="col-xs-12 col-sm-6 mrgn-tp-sm"><button type="button" class="btn btn-primary btn-block" data-scrub-submit>Soumettre le commentaire</button></div>
+			</div>
+		</div>
+	</template>
+	<div class="form-content">
+		<div class="form-group">
+			<label for="firstname2"><span class="field-name">Prénom</span></label>
+			<input class="form-control" id="firstname2" name="firstname" type="text">
+		</div>
+		<div class="form-group">
+			<label for="lastname2"><span class="field-name">Nom de famille</span></label>
+			<input class="form-control" id="lastname2" name="lastname" type="text">
+		</div>
+		<div class="form-group">
+			<label for="comments3">Commentaires</label>
+			<textarea class="form-control" id="comments3" name="comments3" data-scrub-field rows="4" cols="50"></textarea>
+		</div>
+		<button class="btn btn-primary" name="test" value="valeur de test">Soumettre</button>
+	</div>
+</form>
+<details class="mrgn-tp-md mrgn-bttm-md">
+	<summary>Afficher le code</summary>
+	<pre><code>&lt;form action="pii-scrub-fr.html" class="wb-pii-scrub" data-wb-pii-scrub='{"modalTemplate": "[data-scrub-modal]"}'>
+	&lt;template data-scrub-modal>
+		&lt;header class="modal-header">
+			&lt;h2 class="modal-title">Les informations personnelles contenues dans votre commentaire ont été supprimées&lt;/h2>
+		&lt;/header>
+		&lt;div class="modal-body">
+			&lt;p>Les commentaires servent uniquement à améliorer notre site. Vous ne recevrez pas de réponse.&lt;/p>
+			&lt;p>&lt;strong>Pour protéger votre vie privée, votre commentaire sera soumis comme suit&nbsp;:&lt;/strong>&lt;/p>
+			&lt;div data-scrub-modal-fields>&lt;/div>
+			&lt;details class="mrgn-tp-md">
+				&lt;summary>Qu’est-ce qui est considéré comme une information personnelle?&lt;/summary>
+				&lt;p>Certains types d’informations ne peuvent pas être inclus dans ce formulaire de commentaires, tels que&nbsp;:&lt;/p>
+				&lt;ul>
+					&lt;li>adresse courriel&lt;/li>
+					&lt;li>numéro de téléphone&lt;/li>
+					&lt;li>code postal&lt;/li>
+					&lt;li>numéro de passeport&lt;/li>
+					&lt;li>numéro d'entreprise&lt;/li>
+					&lt;li>numéro d'assurance sociale (NAS)&lt;/li>
+				&lt;/ul>
+			&lt;/details>
+		&lt;/div>
+		&lt;div class="modal-footer">
+			&lt;div class="row">
+				&lt;div class="col-xs-12 col-sm-6 mrgn-tp-sm">&lt;button type="button" class="btn btn-link btn-block popup-modal-dismiss">Fermer et modifier le commentaire&lt;/button>&lt;/div>
+				&lt;div class="col-xs-12 col-sm-6 mrgn-tp-sm">&lt;button type="button" class="btn btn-primary btn-block" data-scrub-submit>Soumettre le commentaire&lt;/button>&lt;/div>
+			&lt;/div>
+		&lt;/div>
+	&lt;/template>
+	&lt;div class="form-content">
+		&lt;div class="form-group">
+			&lt;label for="firstname2">&lt;span class="field-name">Prénom&lt;/span>&lt;/label>
+			&lt;input class="form-control" id="firstname2" name="firstname" type="text">
+		&lt;/div>
+		&lt;div class="form-group">
+			&lt;label for="lastname2">&lt;span class="field-name">Nom de famille&lt;/span>&lt;/label>
+			&lt;input class="form-control" id="lastname2" name="lastname" type="text">
+		&lt;/div>
+		&lt;div class="form-group">
+			&lt;label for="comments">Commentaires&lt;/label>
+			&lt;textarea class="form-control" id="comments3" name="comments3" data-scrub-field rows="4" cols="50">&lt;/textarea>
+		&lt;/div>
+		&lt;button class="btn btn-primary" name="test" value="valeur de test">Soumettre&lt;/button>
+	&lt;/div>
+&lt;/form></code></pre>
 </details>

--- a/src/plugins/pii-scrub/pii-scrub.js
+++ b/src/plugins/pii-scrub/pii-scrub.js
@@ -203,7 +203,7 @@ var $document = wb.doc,
 				<div class="modal-footer">
 					<div class="row">
 						<div class="col-xs-12 col-sm-5 mrgn-tp-sm"><button type="button" class="btn btn-link btn-block popup-modal-dismiss">${ i18nText.cancelBtn }</button></div>
-						<div class="col-xs-12 col-sm-7 mrgn-tp-sm"><button type="button" class="btn btn-primary btn-block popup-modal-dismiss" ${ attrScrubSubmit }>${ i18nText.confirmBtn }</button></div>
+						<div class="col-xs-12 col-sm-7 mrgn-tp-sm"><button type="button" class="btn btn-primary btn-block" ${ attrScrubSubmit }>${ i18nText.confirmBtn }</button></div>
 					</div>
 				</div>`;
 		}
@@ -213,6 +213,10 @@ var $document = wb.doc,
 
 		// Add PII fields HTML if using a custom UI template
 		if ( modalTemplate ) {
+
+			// Fix for implementers that added the "popup-modal-dismiss" class to the submit button
+			$( ".popup-modal-dismiss[" + attrScrubSubmit + "]" ).removeClass( "popup-modal-dismiss" );
+
 			$( "#" + piiModalID + " [data-scrub-modal-fields]" ).html( piiModalFields );
 		}
 	};
@@ -232,6 +236,8 @@ $document.on( "click", "#" + piiModalID + " [" + attrScrubSubmit + "]", function
 	} else {
 		form.submit();
 	}
+
+	$.magnificPopup.close();
 } );
 
 // Add the timer poke to initialize the plugin


### PR DESCRIPTION
An issue was introduced with PR #9957 where when a user would close the PII modal using the Escape key, the form would be submitted since the confirm button had the class "popup-modal-dismiss". The class has been removed and instead thje modal is closed via the available method.

A temporary workaround has also been added to leave authors some time to implement this fix.