### PR TITLE
Steps form (quiz): Remove "phantom" spacing below legends

### DIFF
--- a/src/plugins/stepsform/_base.scss
+++ b/src/plugins/stepsform/_base.scss
@@ -46,18 +46,10 @@
 
 
 		fieldset {
-			&:not(:first-child) legend {
-				border-top: 1px solid #e5e5e5;
-				padding-top: 10px;
-			}
-
-			&:not(:first-child):not(:has(legend)) {
-				border-top: 1px solid #e5e5e5;
-				padding-top: 10px;
-			}
-
 			legend {
-				float: none;
+				& + * {
+					clear: left;
+				}
 			}
 		}
 


### PR DESCRIPTION
To disable the "magic" layout of ``fieldset`` ``legend``s, WET floats ``legend``s to the left by default.

The steps form plugin's ``quiz`` option previously disabled ``legend`` floating to prevent layout issues with nested ``fieldset``s. But that in turn re-activated the ``legend``'s "magic" layout and caused an extra 10px of "phantom" space to appear below the current step's ``legend``.

This resolves it by simplifying the layout fix for nested ``fieldset``s:
* Remove the ``legend``'s ``float: none;`` and ``border/padding-top`` overrides
* Add ``clear: left;`` to any elements adjacent to ``legend``s to suppress unusual floating behaviour