### PR TITLE
Multimedia player: Fix demo references to TTML (XML) captions

### DIFF
--- a/src/plugins/multimedia/multimedia-en.hbs
+++ b/src/plugins/multimedia/multimedia-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "multimedia",
 	"parentdir": "multimedia",
 	"altLangPrefix": "multimedia",
-	"dateModified": "2025-05-20"
+	"dateModified": "2025-08-08"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -79,7 +79,7 @@
 				<video poster="demo/img/video2-en.jpg" title="Training and Development">
 					<source type="video/webm" src="https://wet-boew.github.io/wet-boew-attachments/videos/video2-en.webm" />
 					<source type="video/mp4" src="https://wet-boew.github.io/wet-boew-attachments/videos/video2-en.mp4" />
-					<track src="demo/img/video2-captions-en.xml" kind="captions" data-type="application/ttml+xml" srclang="en" label="English" />
+					<track src="demo/video2-captions-en.xml" kind="captions" data-type="application/ttml+xml" srclang="en" label="English" />
 				</video>
 				<figcaption>
 					<p>Training and Development (<a href="cpts-lg2-en.html">Transcript</a>)</p>
@@ -94,7 +94,7 @@
 	&lt;video poster=&quot;demo/img/video2-en.jpg&quot; title=&quot;Training and Development&quot;&gt;
 		&lt;source type=&quot;video/webm&quot; src=&quot;https://wet-boew.github.io/wet-boew-attachments/videos/video2-en.webm&quot; /&gt;
 		&lt;source type=&quot;video/mp4&quot; src=&quot;https://wet-boew.github.io/wet-boew-attachments/videos/video2-en.mp4&quot; /&gt;
-		&lt;track src=&quot;demo/img/video2-captions-en.xml&quot; kind=&quot;captions&quot; data-type=&quot;application/ttml+xml&quot; srclang=&quot;en&quot; label=&quot;English&quot; /&gt;
+		&lt;track src=&quot;demo/video2-captions-en.xml&quot; kind=&quot;captions&quot; data-type=&quot;application/ttml+xml&quot; srclang=&quot;en&quot; label=&quot;English&quot; /&gt;
 	&lt;/video&gt;
 	&lt;figcaption&gt;
 		&lt;p&gt;Training and Development (&lt;a href=&quot;cpts-lg2-en.html&quot;&gt;Transcript&lt;/a&gt;)&lt;/p&gt;

--- a/src/plugins/multimedia/multimedia-fr.hbs
+++ b/src/plugins/multimedia/multimedia-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "multimedia",
 	"parentdir": "multimedia",
 	"altLangPrefix": "multimedia",
-	"dateModified": "2025-05-20"
+	"dateModified": "2025-08-08"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -79,7 +79,7 @@
 				<video poster="demo/img/video2-fr.jpg" title="Video Example">
 					<source type="video/webm" src="https://wet-boew.github.io/wet-boew-attachments/videos/video2-fr.webm" />
 					<source type="video/mp4" src="https://wet-boew.github.io/wet-boew-attachments/videos/video2-fr.mp4" />
-					<track src="demo/img/video2-captions-fr.xml" kind="captions" data-type="application/ttml+xml" srclang="fr" label="Français" />
+					<track src="demo/video2-captions-fr.xml" kind="captions" data-type="application/ttml+xml" srclang="fr" label="Français" />
 				</video>
 				<figcaption>
 					<p>Développement des compétences (<a href="cpts-lg2-fr.html">Transcription</a>)</p>
@@ -94,7 +94,7 @@
 	&lt;video poster=&quot;demo/img/video2-fr.jpg&quot; title=&quot;Video Example&quot;&gt;
 		&lt;source type=&quot;video/webm&quot; src=&quot;https://wet-boew.github.io/wet-boew-attachments/videos/video2-fr.webm&quot; /&gt;
 		&lt;source type=&quot;video/mp4&quot; src=&quot;https://wet-boew.github.io/wet-boew-attachments/videos/video2-fr.mp4&quot; /&gt;
-		&lt;track src=&quot;demo/img/video2-captions-fr.xml&quot; kind=&quot;captions&quot; data-type=&quot;application/ttml+xml&quot; srclang=&quot;fr&quot; label=&quot;Français&quot; /&gt;
+		&lt;track src=&quot;demo/video2-captions-fr.xml&quot; kind=&quot;captions&quot; data-type=&quot;application/ttml+xml&quot; srclang=&quot;fr&quot; label=&quot;Français&quot; /&gt;
 	&lt;/video&gt;
 	&lt;figcaption&gt;
 		&lt;p&gt;Développement des compétences (&lt;a href=&quot;cpts-lg2-fr.html&quot;&gt;Transcription&lt;/a&gt;)&lt;/p&gt;


### PR DESCRIPTION
A typo in #9972 accidentally broke the references to them, which in turn broke the demo page's second example.

This resolves it.