### PR TITLE
Base (SCSS): Fix nojs-* classes in print view

### DIFF
--- a/src/base/_component.scss
+++ b/src/base/_component.scss
@@ -6,6 +6,10 @@
  * Components and helpers style for WET-BOEW
  */
 
+%components-display-none-important {
+	display: none !important;
+}
+
 /*
  Background Utility CSS
  */
@@ -56,4 +60,18 @@ Miscellaneous Utility CSS
  */
 .max-content {
 	max-width: max-content;
+}
+
+.nojs-show {
+	@extend %components-display-none-important;
+}
+
+.wb-disable {
+	.nojs-show {
+		display: block !important;
+	}
+
+	.nojs-hide {
+		@extend %components-display-none-important;
+	}
 }

--- a/src/base/views/_screen.scss
+++ b/src/base/views/_screen.scss
@@ -67,20 +67,6 @@
 	white-space: nowrap;
 }
 
-.nojs-show {
-	@extend %display-none-important;
-}
-
-.wb-disable {
-	.nojs-show {
-		display: block !important;
-	}
-
-	.nojs-hide {
-		@extend %display-none-important;
-	}
-}
-
 // Column auto (col-auto) extension for Bootstrap grid
 // Baseline style for column auto - same style as defined in: assets/stylesheets/bootstrap/mixins/_grid-framework.scss
 .col-xs-auto, .col-sm-auto, .col-md-auto, .col-lg-auto {


### PR DESCRIPTION
Those class' selectors were previously declared in an SCSS file that only targets screen viewports, which in turn caused them to work in unexpected ways when printing.

For example:
* Elements using the ``nojs-show`` class unexpectedly appeared when printing in JS mode.
* Elements using the ``nojs-hide`` class appeared when printing in basic HTML mode.

This resolves it by migrating basic HTML mode's ``nojs-*`` selectors from the "all screen views" file to the "components and helper styles" file.