### PR TITLE
Utilities: Add wbdisable-show class, scripting demos

### DIFF
--- a/src/base/_component.scss
+++ b/src/base/_component.scss
@@ -10,6 +10,10 @@
 	display: none !important;
 }
 
+%components-display-block-important {
+	display: block !important;
+}
+
 /*
  Background Utility CSS
  */
@@ -66,12 +70,20 @@ Miscellaneous Utility CSS
 	@extend %components-display-none-important;
 }
 
+.wbdisable-show {
+	@extend %components-display-none-important;
+}
+
 .wb-disable {
 	.nojs-show {
-		display: block !important;
+		@extend %components-display-block-important;
 	}
 
 	.nojs-hide {
 		@extend %components-display-none-important;
+	}
+
+	.wbdisable-show {
+		@extend %components-display-block-important;
 	}
 }

--- a/src/other/utility/utility-en.hbs
+++ b/src/other/utility/utility-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "utility",
 	"parentdir": "utility",
 	"altLangPrefix": "utility",
-	"dateModified": "2024-03-25"
+	"dateModified": "2025-08-26"
 }
 ---
 
@@ -27,6 +27,7 @@
 	<li><a href="#flexbox">Flexbox</a></li>
 	<li><a href="#lists">Lists</a></li>
 	<li><a href="#positioning">Positioning</a></li>
+	<li><a href="#scripting">Scripting</a></li>
 	<li><a href="#tables">Tables</a></li>
 	<li><a href="#miscellaneous">Miscellaneous</a></li>
 	<li><a href="#dl-horizontal">Horizontal description list</a></li>
@@ -605,6 +606,34 @@
 <p class="position-relative">This is a paragraph relatively positioned.</p>
 <h4>Code sample</h4>
 <pre><code>&lt;p class="<strong>position-relative</strong>"&gt;This is a paragraph relatively positioned.&lt;/p&gt;</code></pre>
+
+<h2 id="scripting">Scripting</h2>
+
+<h3><code>nojs-hide</code></h3>
+<p>Hide content exclusively in noscript and basic HTML mode.</p>
+<h4>Working example</h4>
+<p class="nojs-hide">[Interactive content]</p>
+<h4>Code sample</h4>
+<pre><code>&lt;p class="nojs-hide"&gt;[Interactive content]&lt;/p&gt;</code></pre>
+
+<h3><code>nojs-show</code></h3>
+<p>Show content exclusively in noscript and basic HTML mode.</p>
+<h4>Working example</h4>
+<p class="nojs-show">[Fallback content]</p>
+<h4>Code sample</h4>
+<pre><code>&lt;p class="nojs-show"&gt;[Fallback content]&lt;/p&gt;</code></pre>
+
+<h3><code>wbdisable-show</code></h3>
+<p>Show content exclusively in basic HTML mode.</p>
+<p>Use this class carefully. Consider using the <code>nojs-show</code> class instead if the content applies to both noscript and basic HTML mode. Or even a combination of <code>nojs-show</code>, <code>wbdisable-show</code> and the <code>&lt;noscript&gt;</code> element for "generic" and mode-specific content.</p>
+<h4>Working example</h4>
+<p class="nojs-show">[Fallback content]</p>
+<p class="wbdisable-show">To use interactive features, please <a href="?wbdisable=false">switch to the standard version</a> of this page.</p>
+<noscript><p>To use interactive features, please enable JavaScript in your browser settings.</p></noscript>
+<h4>Code sample</h4>
+<pre><code>&lt;p class="nojs-show"&gt;[Fallback content]&lt;/p&gt;
+&lt;p class="wbdisable-show"&gt;To use interactive features, please &lt;a href="?wbdisable=false"&gt;switch to the standard version&lt;/a&gt; of this page.&lt;/p&gt;
+&lt;noscript&gt;&lt;p&gt;To use interactive features, please enable JavaScript in your browser settings.&lt;/p&gt;&lt;/noscript&gt;</code></pre>
 
 <h2 id="tables">Tables</h2>
 <h3><code>table-responsive</code></h3>

--- a/src/other/utility/utility-fr.hbs
+++ b/src/other/utility/utility-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "utility",
 	"parentdir": "utility",
 	"altLangPrefix": "utility",
-	"dateModified": "2024-03-25"
+	"dateModified": "2025-08-26"
 }
 ---
 
@@ -26,6 +26,7 @@
 	<li><a href="#flexbox" lang="en">Flexbox</a></li>
 	<li><a href="#listes">Listes</a></li>
 	<li><a href="#positionnement">Positionnement</a></li>
+	<li><a href="#scriptage">Scriptage</a></li>
 	<li><a href="#tables">Tables</a></li>
 	<li><a href="#divers">Divers</a></li>
 	<li><a href="#dl-horizontal">Liste descriptive horizontale</a></li>
@@ -601,6 +602,34 @@
 <p class="position-relative">Ceci est un paragraphe relativement positionné.</p>
 <h4>Exemple de code</h4>
 <pre><code>&lt;p class="<strong>position-relative</strong>"&gt;Ceci est un paragraphe relativement positionné.&lt;/p&gt;</code></pre>
+
+<h2 id="scriptage">Scriptage</h2>
+
+<h3><code>nojs-hide</code></h3>
+<p>Cachez le contenu exclusivement en noscript et le mode HTML simplifié.</p>
+<h4>Exemple pratique</h4>
+<p class="nojs-hide">[Contenu interactif]</p>
+<h4>Exemple de code</h4>
+<pre><code>&lt;p class="nojs-hide"&gt;[Contenu interactif]&lt;/p&gt;</code></pre>
+
+<h3><code>nojs-show</code></h3>
+<p>Montrez le contenu exclusivement en noscript et le mode HTML simplifié.</p>
+<h4>Exemple pratique</h4>
+<p class="nojs-show">[Contenu de secours]</p>
+<h4>Exemple de code</h4>
+<pre><code>&lt;p class="nojs-show"&gt;[Contenu de secours]&lt;/p&gt;</code></pre>
+
+<h3><code>wbdisable-show</code></h3>
+<p>Montrez le contenu exclusivement dans le mode HTML simplifié.</p>
+<p>Utilisez cette classe soigneusement. Considérez utiliser la classe <code>nojs-show</code> au lieu si le contenu s'applique à la fois à noscript et le mode HTML simplifié. Ou même une combinaison de <code>nojs-show</code>, <code>wbdisable-show</code> et l'élément <code>&lt;noscript&gt;</code> pour le contenu «&nbsp;générique&nbsp;» et spécifique au mode.</p>
+<h4>Exemple pratique</h4>
+<p class="nojs-show">[Contenu de secours]</p>
+<p class="wbdisable-show">Pour utiliser les fonctionnalités interactives, veuillez <a href="?wbdisable=false">passer à la version standard</a> de cette page.</p>
+<noscript><p>Pour utiliser les fonctionnalités interactives, veuillez activer le JavaScript dans les paramètres de votre navigateur.</p></noscript>
+<h4>Exemple de code</h4>
+<pre><code>&lt;p class="nojs-show"&gt;[Contenu de secours]&lt;/p&gt;
+&lt;p class="wbdisable-show"&gt;Pour utiliser les fonctionnalités interactives, veuillez &lt;a href="?wbdisable=false"&gt;passer à la version standard&lt;/a&gt; de cette page.&lt;/p&gt;
+&lt;noscript&gt;&lt;p&gt;Pour utiliser les fonctionnalités interactives, veuillez activer le JavaScript dans les paramètres de votre navigateur.&lt;/p&gt;&lt;/noscript&gt;</code></pre>
 
 <h2 id="tables">Tables</h2>
 <h3><code>table-responsive</code></h3>


### PR DESCRIPTION
WET's ``nojs-*`` classes can be used to show/hide content in both noscript and basic HTML mode. The ``<noscript>`` element can also be used to target noscript. But it previously wasn't possible to target basic HTML mode...

This fills the gap by introducing a ``wbdisable-show`` class. It's meant to provide an equivalent to the ``<noscript>`` element for basic HTML mode.

For example, in some scenarios it might be desirable to hide interactive content (via ``nojs-hide``), show "generic" fallback content (via ``nojs-show``), along with supplemental content specifically for noscript (via ``<noscript>``) and basic HTML (via ``wbdisable-show``). The supplemental content could consist of instructions explaining how to switch to JavaScript mode - which would differ for noscript vs basic HTML.

Also added a scripting section to the utilities demo page covering the ``nojs-*`` and ``wbdisable-show`` classes. The ``<noscript>`` element makes a cameo in the ``wbdisable-show`` class' examples.