### PR TITLE
Multimedia player: fix youtube video squished if no height defined

### DIFF
--- a/src/plugins/multimedia/multimedia.js
+++ b/src/plugins/multimedia/multimedia.js
@@ -717,6 +717,15 @@ $document.on( initializedEvent, selector, function( event ) {
 			// Defaults config set on the video element
 			data.isInitMuted = $media.get( 0 ).muted;
 
+			// Set default Youtube video dimensions if none specified
+			if ( $media[ 0 ].width && $media[ 0 ].height ) {
+				data.width = $media[ 0 ].width;
+				data.height = $media[ 0 ].height;
+			} else {
+				data.width = 640;
+				data.height = 360;
+			}
+
 			if ( youTube.ready === false ) {
 				$document.one( youtubeReadyEvent, function() {
 					$this.trigger( youtubeEvent, data );


### PR DESCRIPTION
Adding default Youtube frame size if not height and width are defined on the video.

<img width="848" height="111" alt="image" src="https://github.com/user-attachments/assets/40693a42-9759-4f3a-b9a6-749e953de4c5" />

Fixes [GCWeb's issue number 2634](https://github.com/wet-boew/GCWeb/issues/2634)

(ref. wet-578)