### PR TITLE
Tabbed interface: Use flexbox for tab markers

### DIFF
--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -141,11 +141,6 @@ $tab-margin-width: 10px;
 	box-shadow: none;
 }
 
-%tabs-carousel-border-top-none-padding-top-1 {
-	border-top: 0;
-	padding-top: 10px;
-}
-
 %tabs-display-inline-block {
 	display: inline-block;
 }
@@ -208,7 +203,8 @@ $tab-margin-width: 10px;
 
 	[role="tablist"] {
 		border-spacing: $tab-margin-width 0;
-		display: table;
+		display: flex;
+		flex-wrap: wrap;
 		list-style: none;
 		margin: 0;
 		padding: 0;
@@ -220,9 +216,7 @@ $tab-margin-width: 10px;
 
 				background: $tablist-bg-color;
 				color: $carousel-tablist-tabcount-color;
-				cursor: pointer;
-				display: table-cell;
-				left: -$tab-margin-width;
+				display: flex;
 				position: relative;
 				text-align: center;
 				border: {
@@ -239,31 +233,30 @@ $tab-margin-width: 10px;
 					// changed padding and margin from em to px to fix web-kit layout issue
 					padding: 10px;
 					text-decoration: none;
-				}
 
-				&:focus,
-				&:hover {
-					background: $tablist-hover-bg-color;
-					background: color.adjust($tablist-hover-bg-color, $alpha: -.1);
+					&:focus,
+					&:hover {
+						background: $tablist-hover-bg-color;
+						background: color.adjust($tablist-hover-bg-color, $alpha: -.1);
+					}
 				}
 
 				&.active {
-					@if $tablist-active-bg-color {
-						background: $tablist-active-bg-color;
-					} @else if $main-bg {
-						background: $main-bg
-					} @else if $content-bg {
-						background: $content-bg
-					} @else {
-						background: $body-bg;
-					}
-
 					border-bottom: 0;
-					cursor: default;
 					padding-bottom: 1px;
 					z-index: 2;
 
 					a {
+						@if $tablist-active-bg-color {
+							background: $tablist-active-bg-color;
+						} @else if $main-bg {
+							background: $main-bg
+						} @else if $content-bg {
+							background: $content-bg
+						} @else {
+							background: $body-bg;
+						}
+
 						border: {
 							color: $tablist-active-link-border-color;
 							style: $tablist-active-link-border-style;
@@ -288,12 +281,10 @@ $tab-margin-width: 10px;
 					.curr-count {
 						font-size: 1.5em;
 					}
+				}
 
-					&:focus,
-					&:hover {
-						background: transparent;
-						cursor: default;
-					}
+				& + li {
+					margin-left: $tab-margin-width;
 				}
 			}
 		}
@@ -348,30 +339,11 @@ $tab-margin-width: 10px;
 						@extend %tabs-display-inline-block;
 					}
 
-					&.prv {
-						margin-right: 5px;
-					}
-
 					&.tab-count {
 						background: none;
 						border: 0;
 						font-size: .9em;
 						padding: 0 .1em;
-						top: .55em;
-
-						&.active,
-						&:focus,
-						&:hover {
-							cursor: default;
-						}
-					}
-
-					&.active,
-					&:focus,
-					&:hover {
-						a {
-							@extend %tabs-carousel-border-top-none-padding-top-1;
-						}
 					}
 				}
 			}
@@ -444,6 +416,10 @@ $tab-margin-width: 10px;
 						}
 					}
 
+					&.tab-count {
+						margin: $tab-margin-width;
+					}
+
 					&.nxt {
 						@extend %carousel-s2-prv-nxt-common;
 
@@ -470,9 +446,10 @@ $tab-margin-width: 10px;
 					&.plypause {
 						background: none;
 						border: 0;
-						float: right;
+						flex-grow: 1;
 						margin-right: 0;
 						padding: 2px 0;
+						text-align: right;
 
 						a {
 							@extend %carousel-s2-btn-common;

--- a/src/plugins/tabs/tabs-en.hbs
+++ b/src/plugins/tabs/tabs-en.hbs
@@ -7,7 +7,7 @@
 	"tag": "tabs",
 	"parentdir": "tabs",
 	"altLangPrefix": "tabs",
-	"dateModified": "2015-02-24"
+	"dateModified": "2025-10-14"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -25,7 +25,7 @@
 			<details id="details-panel1">
 				<summary>Example 1</summary>
 				<p>
-				From time immemorial the Norsemen <a href="#details-panel3">Example 3</a> were among the most daring and
+				From time immemorial the Norsemen <a href="#details-panel3">Example 3<br>(line 2)</a> were among the most daring and
 				skilful mariners ever known. They built great wooden boats with tall,
 				sweeping bows and sterns. These ships, though open and without decks,
 				were yet stout and seaworthy. Their remains have been found, at times
@@ -52,7 +52,7 @@
 				</p>
 			</details>
 			<details id="details-panel3">
-				<summary>Example 3</summary>
+				<summary>Example 3<br>(line 2)</summary>
 				<p>
 				The story of the Norsemen runs thus. Towards the end of the ninth
 				century, or nearly two hundred years before the Norman conquest, there

--- a/src/plugins/tabs/tabs-fr.hbs
+++ b/src/plugins/tabs/tabs-fr.hbs
@@ -7,7 +7,7 @@
 	"tag": "tabs",
 	"parentdir": "tabs",
 	"altLangPrefix": "tabs",
-	"dateModified": "2015-02-24"
+	"dateModified": "2025-10-14"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -25,7 +25,7 @@
 			<details id="details-panel1">
 				<summary>Exemple 1</summary>
 				<p>
-				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent. <a href="#details-panel3">Exemple 3</a> Texte d'exemple. Autre texte d'exemple.
+				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent. <a href="#details-panel3">Exemple 3<br>(ligne 2)</a> Texte d'exemple. Autre texte d'exemple.
 				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.
 				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.
 				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.
@@ -56,7 +56,7 @@
 				</details>
 			</details>
 			<details id="details-panel3">
-				<summary>Exemple 3</summary>
+				<summary>Exemple 3<br>(ligne 2)</summary>
 				<p>
 				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.
 				Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.Texte d'exemple. Autre texte d'exemple. Texte d'exemple différent.


### PR DESCRIPTION
Previously, in medium view and over, if any tab markers wrapped across multiple lines, "short" tab markers behaved strangely compared to "tall" ones.

Specifically:
* Short tab markers didn't use 100% height and looked bottom-aligned
* If the active tab used a short tab marker:
  * The marker's thick top grey border wasn't top-aligned (vs tall tab markers)
  * A thin grey border appeared above the marker
* The "linked area" of inactive short tab markers was misleading (looked as if marker links used 100% height, but didn't really):
  * Caused by hover/focus effects (like background colours and ``cursor: pointer;``) being set on ``li`` elements instead of ``a`` elements.

This resolves it by:
* Adding a second line to the third tab marker ("Example 3"/"Exemple 3") in the tabbed interface demo's first example
* Adjusting tab markers to use flexbox (to make short tab markers match the height/alignment of tall ones)
* Adjusting margins where necessary
* Tying hover/focus styles solely to links (not their parent elements)
* Removing irrelevant hover/focus styles (e.g. cursor properties, placeholder selector for a hidden element)

Notes:
* Flexbox changed carousel spacing slightly (for the better):
  * Carousel style 1:
    * Removed 10px space above the carousel
    * Reduced spacing between the next and play/pause buttons from 10px to 5px
  * Carousel style 2:
    * Added 10px space between previous button and tab counter (matches space between counter and next button) (deliberate change)
    * Fully-aligned play/pause button to the right (previously had extra space on the far right side)
    * Added hover background colour to "show-thumbs" class' thumbnails (byproduct of hover/focus style changes)

**Screenshots (Firefox):**
* **Tabbed interface - Active short tab marker**
  * **Before:** <img width="1170" height="239" alt="tabs-active-before" src="https://github.com/user-attachments/assets/6e98b31e-ce74-4b41-936e-49c02682159c" />
  * **After:** <img width="1170" height="239" alt="tabs-active-after" src="https://github.com/user-attachments/assets/b9afc40a-9c23-45b3-bd1b-d95d2ef54414" />
* **Tabbed interface - Inactive short tab marker (tab 3 active, hovering over tab 2's marker, dashed red borders illustrate linked areas)**
  * **Before:** <img width="1170" height="493" alt="tabs-inactive-before" src="https://github.com/user-attachments/assets/99b7f52f-27f5-4363-a494-125f96ed4893" />
  * **After:** <img width="1170" height="493" alt="tabs-inactive-after" src="https://github.com/user-attachments/assets/08cc5ee9-b7b6-44ba-941e-20bdc51a6f61" />
* **Carousel style 1**
  * **Before:** <img width="1170" height="550" alt="carousel-style1-before" src="https://github.com/user-attachments/assets/ccda8c5e-2757-4cdd-ab99-4fc77a9f1677" />
  * **After:** <img width="1170" height="540" alt="carousel-style1-after" src="https://github.com/user-attachments/assets/4c45319d-0970-400a-a4a0-f0390bb819ed" />
* **Carousel style 2**
  * **Before:** <img width="1170" height="565" alt="carousel-style2-before" src="https://github.com/user-attachments/assets/e50e0ec8-eb10-406d-ba87-2b965952b7da" />
  * **After:** <img width="1170" height="565" alt="carousel-style2-after" src="https://github.com/user-attachments/assets/519722c8-2192-4fbc-b661-20bba180bda5" />