### PR TITLE
Calendar of Events - Invalid selector error

### DIFF
--- a/src/plugins/cal-events/cal-events.js
+++ b/src/plugins/cal-events/cal-events.js
@@ -381,7 +381,7 @@ $document.on( "timerpoke.wb " + initEvent + " wb-redraw" + selector, selector, f
 			break;
 
 		case "wb-redraw":
-			$elm = $( "#" + event.target.id ),
+			var $elm = $( "#" + event.target.id );
 			$( "#" + calendarId + " .wb-clndr" ).remove();
 			processEvents( $elm );
 			$elm.trigger( "wb-updated" + selector );

--- a/src/plugins/cal-events/cal-events.js
+++ b/src/plugins/cal-events/cal-events.js
@@ -372,7 +372,6 @@ var componentName = "wb-calevt",
 $document.on( "timerpoke.wb " + initEvent + " wb-redraw" + selector, selector, function( event ) {
 
 	var eventType = event.type,
-		$elm = $( "#" + event.target.id ),
 		calendarId = event.currentTarget.dataset.calevtSrc;
 
 	switch ( eventType ) {
@@ -382,6 +381,7 @@ $document.on( "timerpoke.wb " + initEvent + " wb-redraw" + selector, selector, f
 			break;
 
 		case "wb-redraw":
+			$elm = $( "#" + event.target.id ),
 			$( "#" + calendarId + " .wb-clndr" ).remove();
 			processEvents( $elm );
 			$elm.trigger( "wb-updated" + selector );


### PR DESCRIPTION
After upgrading to jQuery 3.7.1, the plugin started throwing **Invalid Selector** errors. This was occurring in the `timerpoke.wb` event. The declaration for `$elem` referenced the `event.target.id` property.  This property was only set on the `wb-redraw` event. Moving the `$elem` declaration under the `wb-redraw` case resolved the issue.
