### PR TITLE
Data-Ajax, Data-Picture test updates for jQuery 3.7.1

### DIFF
--- a/src/plugins/data-ajax/test.js
+++ b/src/plugins/data-ajax/test.js
@@ -48,6 +48,7 @@ describe( "data-ajax test suite", function() {
 		server.respondWith( "/data-ajax.html", ajax[ "/data-ajax.html" ] );
 		server.respondWith( "/data-ajax-update.html", ajax[ "/data-ajax-update.html" ] );
 		server.respondWith( "/data-ajax-filtered.html", ajax[ "/data-ajax-filtered.html" ] );
+		server.respondWith( "/data-ajax-filtered.html#inner", ajax[ "/data-ajax-filtered.html" ] );
 
 		$document.on( "ajax-fetched.wb ajax-failed.wb", ".ajax", function() {
 			if ( typeof callback === "function" ) {

--- a/src/plugins/data-picture/test.js
+++ b/src/plugins/data-picture/test.js
@@ -66,7 +66,7 @@ describe( "[data-pic] test suite", function() {
 			var len = spy.thisValues.length,
 				isSelector = false;
 			while ( !isSelector && len-- ) {
-				isSelector = spy.thisValues[ len ].selector === "[data-pic]";
+				isSelector = spy.thisValues[ len ].attr( "data-pic" ) !== undefined;
 			}
 			expect( isSelector ).to.equal( true );
 		} );


### PR DESCRIPTION
**Data-Ajax test**
After updating to jQuery 3.7.1, the data-ajax hash selector test failed.  The fake server configuration did not have a response matching the "/data-ajax-filtered.html#inner" url, so no text was returned.  Adding an entry for that url fixed the test.

**Data-Picture test**
The data-picture test was using the jQuery `.selector` property, which was removed in 3.0.  The goal of the test was to ensure the element that triggered the `wb-pic` event had a `data-pic` attribute. I modified the test to use `.attr( "data-pic" ) !== undefined` to check for the existence of the `data-pic` attribute.
