### PR TITLE
Overlay - fix close text when multiple single quote

### DIFF
--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -96,7 +96,7 @@ var componentName = "wb-overlay",
 			} else {
 				closeText = i18nText.closeOverlay;
 			}
-			closeText = closeText.replace( "'", "&#39;" );
+			closeText = closeText.replaceAll( "'", "&#39;" );
 			overlayClose = "<button type='button' class='mfp-close " + closeClass +
 				"' title='" + closeText + "'>&#xd7;<span class='wb-inv'> " +
 				closeText + "</span></button>";


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

This resolved [GCWeb issue #2319](https://github.com/wet-boew/GCWeb/issues/2319). 

This minor fix prevent title attribute to be truncated when there are multiple single quotes (apostrophes) in the text from the H2 which have the "modal-title" class.
