### PR TITLE
Tabbed interface: remove border under active tab

### DIFF
--- a/src/plugins/tabs/_base.scss
+++ b/src/plugins/tabs/_base.scss
@@ -205,7 +205,7 @@ $tab-margin-width: 10px;
 		border-spacing: $tab-margin-width 0;
 		display: flex;
 		list-style: none;
-		margin: 0;
+		margin-bottom: -1px;
 		overflow-x: auto;
 		overflow-y: hidden;
 		padding: 0;
@@ -244,7 +244,6 @@ $tab-margin-width: 10px;
 
 				&.active {
 					border-bottom: 0;
-					padding-bottom: 1px;
 					z-index: 2;
 
 					a {


### PR DESCRIPTION
A previous pull request introduced a regression issue for the active tab where the border-bottom was visible. This change fixes that issue.