### PR TITLE
Implement fade transition for .wb-disable class

### DIFF
--- a/src/base/noscript.scss
+++ b/src/base/noscript.scss
@@ -15,6 +15,7 @@
 @import "../plugins/menu/noscript";
 @import "../plugins/overlay/noscript";
 @import "../plugins/lightbox/noscript";
+@import "../plugins/data-inview/noscript";
 
 /*
  Polyfills

--- a/src/base/transitions/_base.scss
+++ b/src/base/transitions/_base.scss
@@ -136,6 +136,14 @@
 	}
 }
 
+.wb-disable {
+	&.fade {
+		&.out {
+			@extend %visible;
+		}
+	}
+}
+
 @keyframes fadein {
 	0% {
 		@include invisible;

--- a/src/base/transitions/_base.scss
+++ b/src/base/transitions/_base.scss
@@ -138,9 +138,7 @@
 
 .wb-disable {
 	.fade {
-		&.out {
-			@extend %visible;
-		}
+		opacity: 1;
 	}
 }
 

--- a/src/base/transitions/_base.scss
+++ b/src/base/transitions/_base.scss
@@ -137,7 +137,7 @@
 }
 
 .wb-disable {
-	&.fade {
+	.fade {
 		&.out {
 			@extend %visible;
 		}

--- a/src/plugins/data-inview/_noscript.scss
+++ b/src/plugins/data-inview/_noscript.scss
@@ -2,8 +2,6 @@
  * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
  * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
  */
-
 .fade {
-		opacity: 1;
-	}
+	opacity: 1;
 }

--- a/src/plugins/data-inview/_noscript.scss
+++ b/src/plugins/data-inview/_noscript.scss
@@ -4,8 +4,6 @@
  */
 
 .fade {
-	&.out {
 		opacity: 1;
-		visibility: visible;
 	}
 }

--- a/src/plugins/data-inview/_noscript.scss
+++ b/src/plugins/data-inview/_noscript.scss
@@ -5,6 +5,6 @@
 
 .fade {
   &.out {
-    @extend %visible;
+    @include %visible;
   }
 }

--- a/src/plugins/data-inview/_noscript.scss
+++ b/src/plugins/data-inview/_noscript.scss
@@ -4,8 +4,8 @@
  */
 
 .fade {
-  &.out {
-	  opacity: 1;
-	  visibility: visible;
+	&.out {
+		opacity: 1;
+		visibility: visible;
 	}
 }

--- a/src/plugins/data-inview/_noscript.scss
+++ b/src/plugins/data-inview/_noscript.scss
@@ -5,6 +5,6 @@
 
 .fade {
   &.out {
-    @include %visible;
+    @include visible;
   }
 }

--- a/src/plugins/data-inview/_noscript.scss
+++ b/src/plugins/data-inview/_noscript.scss
@@ -1,0 +1,10 @@
+/*
+ * Web Experience Toolkit (WET) / Boîte à outils de l'expérience Web (BOEW)
+ * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
+ */
+
+.fade {
+  &.out {
+    @extend %visible;
+  }
+}

--- a/src/plugins/data-inview/_noscript.scss
+++ b/src/plugins/data-inview/_noscript.scss
@@ -5,6 +5,7 @@
 
 .fade {
   &.out {
-    @include visible;
-  }
+	  opacity: 1;
+	  visibility: visible;
+	}
 }


### PR DESCRIPTION
Add fade transition styles for .wb-disable class

## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

This allows the content that is hidden on load (.fade.out) to be visible if page template is set to simple HTML mode.   This will add in accessibility (content not hidden when wet4 js files are blocked)

