### PR TITLE
Build: Restore parseargs to package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1131,6 +1131,17 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@prantlf/jsonlint": {
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/@prantlf/jsonlint/-/jsonlint-14.1.0.tgz",


### PR DESCRIPTION
It was initially added via #9935, but somehow got removed in #9938.

Running ``npm install`` in node.js 24.13.0 (which uses npm 11.6.2) restores it.

**PS:**
Node.js 24.13.0 also adds ``"peer": true`` all over the place... but those have been deliberately excluded since they're caused by a bug in npm 11.6.2 (see npm/cli#8690... fixed in 11.6.3, should be bundled in a future version of node.js 24.x).

CC @nschonni @Garneauma