### PR TITLE
Fixes screen readers not announcing feedback messages

### DIFF
--- a/src/plugins/wb-postback/wb-postback.js
+++ b/src/plugins/wb-postback/wb-postback.js
@@ -86,7 +86,7 @@ var $document = wb.doc,
 						if ( settings.successURL && !settings.success ) {
 							window.location.href = settings.successURL;
 						} else {
-							$selectorSuccess.removeClass( classToggle );
+							$selectorSuccess.removeClass( classToggle ).trigger( "setfocus.wb" );
 						}
 						$elm.trigger( successEvent );
 					} )
@@ -96,7 +96,7 @@ var $document = wb.doc,
 						if ( settings.failureURL && !settings.failure ) {
 							window.location.href = settings.failureURL;
 						} else {
-							$selectorFailure.removeClass( classToggle );
+							$selectorFailure.removeClass( classToggle ).trigger( "setfocus.wb" );
 						}
 						$elm.trigger( failEvent, response );
 					} )


### PR DESCRIPTION
Screen readers were not reliably announcing the feedback messages after a submission. For example, after a user clicks "Submit" screen readers weren't announcing "Thank you!".

Instead of using a status message which was proving to be inconsistent in its announcements, moving the focus to the feedback message after submission guarantees screen readers will consistently announce the text. 

This PR addresses the failed criteria (4.1.3 Status Messages) of the accessibility assessment of the Feedback area in GCWeb found in [GCWeb PR #2781](https://github.com/wet-boew/GCWeb/pull/2781)