### PR TITLE
Build: Remove grunt-stylelint's stylelint v17 override

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,9 +100,6 @@
   "overrides": {
     "grunt-contrib-uglify": {
       "uglify-js": "3.17.4"
-    },
-    "grunt-stylelint": {
-      "stylelint": ">=17.0.0"
     }
   }
 }


### PR DESCRIPTION
#10112 mentioned it was necessary since grunt-stylelint appeared to have been abandoned at the time.

Since then, its GitHub repo has been archived and the project has migrated to GitLab (https://gitlab.wikimedia.org/repos/ci-tools/grunt-stylelint). It's also received a new version (0.21.0) that depends on stylelint 17.x.

#10135 recently bumped WET's version of grunt-stylelint to 0.21.0. So the override is no longer necessary (at least not for the time being...).

CC @nschonni