### PR TITLE
Core: Update focusable/tabbable helper methods

### DIFF
--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -1537,63 +1537,90 @@ $.fn.wb = function( method ) {
 
 } )( jQuery );
 
+/*!
+ * jQuery UI Focusable/Tabbable
+ * https://jqueryui.com
+ *
+ * Copyright OpenJS Foundation and other contributors
+ * Released under the MIT license.
+ * https://jquery.org/license
+ */
+
 /*
-:focusable and :tabable jQuery helper expressions - https://github.com/jquery/jquery-ui/blob/24756a978a977d7abbef5e5bce403837a01d964f/ui/jquery.ui.core.js
+:focusable, :discoverable and :tabbable jQuery helper expressions
+
+Derived from jQuery UI, with the following changes:
+* Adheres to WET's ESLint settings (no-eq-null: changed loose null checks into strict undefined checks)
+* Adds an isVisible parameter to the focusable method (preset to true to behave like jQuery UI by default, can optionally be set to false)
+* Adds an extra discoverable method (leverages the focusable method with isVisible set to false)
+
+Based on:
+* https://github.com/jquery/jquery-ui/blob/e803d4f67be9d7ae9a5a125c188dd003e3e3043a/ui/focusable.js#L31-L73
+* https://github.com/jquery/jquery-ui/blob/e803d4f67be9d7ae9a5a125c188dd003e3e3043a/ui/tabbable.js#L30-L36
+* https://github.com/jquery/jquery-ui/blob/24756a978a977d7abbef5e5bce403837a01d964f/ui/jquery.ui.core.js#L121-L142 (old logic's extend structure)
 */
 ( function( $ ) {
 
 "use strict";
 
-function focusable( element, isTabIndexNotNaN, visibility ) {
-	var map, mapName, img,
-		nodeName = element.nodeName.toLowerCase( );
-	if ( nodeName === "area" ) {
+function focusable( element, hasTabindex, isVisible = true ) {
+	var map, mapName, img, focusableIfVisible, fieldset,
+		nodeName = element.nodeName.toLowerCase();
+
+	if ( "area" === nodeName ) {
 		map = element.parentNode;
 		mapName = map.name;
-		if ( !element.href || !mapName || map.nodeName.toLowerCase( ) !== "map" ) {
+		if ( !element.href || !mapName || map.nodeName.toLowerCase() !== "map" ) {
 			return false;
 		}
-		img = $( "img[usemap=#" + mapName + "]" )[ 0 ];
-		return !!img && visible( img );
-	}
-	if ( visibility ) {
-		return ( /input|select|textarea|button|object|summary/.test( nodeName ) ? !element.disabled :
-			nodeName === "a" ?
-				element.href || isTabIndexNotNaN :
-				isTabIndexNotNaN ) &&
-		visible( element ); /* the element and all of its ancestors must be visible */
-	} else {
-		return ( /input|select|textarea|button|object|summary/.test( nodeName ) ? !element.disabled :
-			nodeName === "a" ?
-				element.href || isTabIndexNotNaN :
-				isTabIndexNotNaN );
-	}
-}
+		img = $( "img[usemap='#" + mapName + "']" );
 
-function visible( element ) {
-	return $.expr.filters.visible( element ) && !$( element )
-		.parents( )
-		.addBack( )
-		.filter( function() {
-			return $.css( this, "visibility" ) === "hidden";
-		} )
-		.length;
+		if ( isVisible ) {
+			return img.length > 0 && img.is( ":visible" );
+		}
+
+		return img.length > 0;
+	}
+
+	if ( /^(input|select|textarea|button|object)$/.test( nodeName ) ) {
+		focusableIfVisible = !element.disabled;
+
+		if ( focusableIfVisible ) {
+
+			// Form controls within a disabled fieldset are disabled.
+			// However, controls within the fieldset's legend do not get disabled.
+			// Since controls generally aren't placed inside legends, we skip
+			// this portion of the check.
+			fieldset = $( element ).closest( "fieldset" )[ 0 ];
+			if ( fieldset ) {
+				focusableIfVisible = !fieldset.disabled;
+			}
+		}
+	} else if ( "a" === nodeName ) {
+		focusableIfVisible = element.href || hasTabindex;
+	} else {
+		focusableIfVisible = hasTabindex;
+	}
+
+	if ( isVisible ) {
+		return focusableIfVisible && $( element ).is( ":visible" ) &&
+			$( element ).css( "visibility" ) === "visible";
+	}
+
+	return focusableIfVisible && $( element );
 }
 
 $.extend( $.expr.pseudos, {
-	data: function( elem, index, match ) {
-		return !!$.data( elem, match[ 3 ] );
-	},
 	focusable: function( element ) {
-		return focusable( element, !isNaN( $.attr( element, "tabindex" ) ), true );
+		return focusable( element, $.attr( element, "tabindex" ) !== undefined );
 	},
 	discoverable: function( element ) {
-		return focusable( element, !isNaN( $.attr( element, "tabindex" ) ) );
+		return focusable( element, $.attr( element, "tabindex" ) !== undefined, false );
 	},
 	tabbable: function( element ) {
 		var tabIndex = $.attr( element, "tabindex" ),
-			isTabIndexNaN = isNaN( tabIndex );
-		return ( isTabIndexNaN || tabIndex >= 0 ) && focusable( element, !isTabIndexNaN );
+			hasTabindex = tabIndex !== undefined;
+		return ( !hasTabindex || tabIndex >= 0 ) && focusable( element, hasTabindex );
 	}
 } );
 

--- a/src/plugins/overlay/overlay-en.hbs
+++ b/src/plugins/overlay/overlay-en.hbs
@@ -9,7 +9,7 @@
 	"altLangPrefix": "overlay",
 	"js": ["demo/overlay"],
 	"css": ["demo/overlay"],
-	"dateModified": "2014-07-22"
+	"dateModified": "2026-06-08"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -125,6 +125,23 @@
 		&lt;h2 class=&quot;modal-title&quot;&gt;Middle screen overlay&lt;/h2&gt;
 	&lt;/header&gt;
 	&lt;div class=&quot;modal-body&quot;&gt;
+		...
+	&lt;/div&gt;
+&lt;/section&gt;</code></pre>
+			</details>
+		</li>
+		<li>
+			<p><a href="#mid-screen-hidden-link" aria-controls="mid-screen-hidden-link" class="overlay-lnk" role="button">Middle screen overlay - Beginning with a hidden link</a></p>
+			<details class="mrgn-bttm-lg">
+				<summary>View code</summary>
+				<pre><code>&lt;p&gt;&lt;a href=&quot;#mid-screen-hidden-link&quot; aria-controls=&quot;mid-screen-hidden-link&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Middle screen overlay - Beginning with a hidden link&lt;/a&gt;&lt;/p&gt;
+
+&lt;section id=&quot;mid-screen-hidden-link&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-mid&quot;&gt;
+	&lt;header class=&quot;modal-header&quot;&gt;
+		&lt;h2 class=&quot;modal-title&quot;&gt;Middle screen overlay - Beginning with a hidden link&lt;/h2&gt;
+	&lt;/header&gt;
+	&lt;div class=&quot;modal-body&quot;&gt;
+		&lt;p hidden&gt;&lt;a href="#"&gt;Hidden link&lt;/a&gt;&lt;/p&gt;
 		...
 	&lt;/div&gt;
 &lt;/section&gt;</code></pre>
@@ -392,6 +409,29 @@ wb.doc.on( "click", "#overlay-open-btn", function( event ) {
 		<h2 class="modal-title">Middle screen overlay</h2>
 	</header>
 	<div class="modal-body">
+		<ol>
+			<li>ordered list (<code>ol</code>) first level default appearance</li>
+			<li>ordered list (<code>ol</code>) first level default appearance
+				<ol>
+					<li>ordered list (<code>ol</code>) second level default appearance</li>
+					<li>ordered list (<code>ol</code>) second level default appearance
+						<ol>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+							<li>ordered list (<code>ol</code>) third level default appearance</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+	</div>
+</section>
+
+<section id="mid-screen-hidden-link" class="wb-overlay modal-content overlay-def wb-popup-mid">
+	<header class="modal-header">
+		<h2 class="modal-title">Middle screen overlay - Beginning with a hidden link</h2>
+	</header>
+	<div class="modal-body">
+		<p hidden><a href="#">Hidden link</a></p>
 		<ol>
 			<li>ordered list (<code>ol</code>) first level default appearance</li>
 			<li>ordered list (<code>ol</code>) first level default appearance

--- a/src/plugins/overlay/overlay-fr.hbs
+++ b/src/plugins/overlay/overlay-fr.hbs
@@ -9,7 +9,7 @@
 	"altLangPrefix": "overlay",
 	"js": ["demo/overlay"],
 	"css": ["demo/overlay"],
-	"dateModified": "2014-07-22"
+	"dateModified": "2026-06-08"
 }
 ---
 <span class="wb-prettify all-pre hide"></span>
@@ -125,6 +125,23 @@
 		&lt;h2 class=&quot;modal-title&quot;&gt;Contenu superposé mi-écran&lt;/h2&gt;
 	&lt;/header&gt;
 	&lt;div class=&quot;modal-body&quot;&gt;
+		...
+	&lt;/div&gt;
+&lt;/section&gt;</code></pre>
+			</details>
+		</li>
+		<li>
+			<p><a href="#cs-mi-ecran-lien-cache" aria-controls="cs-mi-ecran-lien-cache" class="overlay-lnk" role="button">Contenu superposé mi-écran - Commençant par un lien caché</a></p>
+			<details class="mrgn-bttm-lg">
+				<summary>Visualiser le code</summary>
+				<pre><code>&lt;p&gt;&lt;a href=&quot;#cs-mi-ecran-lien-cache&quot; aria-controls=&quot;cs-mi-ecran-lien-cache&quot; class=&quot;overlay-lnk&quot; role=&quot;button&quot;&gt;Contenu superposé mi-écran - Commençant par un lien caché&lt;/a&gt;&lt;/p&gt;
+
+&lt;section id=&quot;cs-mi-ecran-lien-cache&quot; class=&quot;wb-overlay modal-content overlay-def wb-popup-mid&quot;&gt;
+	&lt;header class=&quot;modal-header&quot;&gt;
+		&lt;h2 class=&quot;modal-title&quot;&gt;Contenu superposé mi-écran - Commençant par un lien caché&lt;/h2&gt;
+	&lt;/header&gt;
+	&lt;div class=&quot;modal-body&quot;&gt;
+		&lt;p hidden&gt;&lt;a href="#"&gt;Lien caché&lt;/a&gt;&lt;/p&gt;
 		...
 	&lt;/div&gt;
 &lt;/section&gt;</code></pre>
@@ -396,6 +413,30 @@ wb.doc.on( "click", "#overlay-open-btn", function( event ) {
 		<h2 class="modal-title">Contenu superposé mi-écran</h2>
 	</header>
 	<div class="modal-body">
+		<ol>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
+			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut
+				<ol>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut</li>
+					<li>liste ordonnée (<code>ol</code>) deuxième niveau - apparence par défaut
+						<ol>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+							<li>liste ordonnée (<code>ol</code>) troisième niveau - apparence par défaut</li>
+						</ol>
+					</li>
+				</ol>
+			</li>
+		</ol>
+		<p><a href="#">Lien - apparence par défaut</a></p>
+	</div>
+</section>
+
+<section id="cs-mi-ecran-lien-cache" class="wb-overlay modal-content overlay-def wb-popup-mid">
+	<header class="modal-header">
+		<h2 class="modal-title">Contenu superposé mi-écran - Commençant par un lien caché</h2>
+	</header>
+	<div class="modal-body">
+		<p hidden><a href="#">Lien caché</a></p>
 		<ol>
 			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut</li>
 			<li>liste ordonnée (<code>ol</code>) premier niveau - apparence par défaut


### PR DESCRIPTION
WET used altered copies of those methods from jQuery UI... but they were buggy and became outdated overtime. They were susceptible to selecting elements that should've been out of scope - such as hidden ones (e.g. ``<a href="#" hidden>``, ``<input type="hidden">``, etc). That in turn could result in plugins trying to focus onto them in vain.

This resolves it by updating WET's copies of those methods to jQuery UI's latest versions. Retains an extra optional parameter for WET's ``discoverable`` method.

Unlike the old logic (which used an extra ``visibility`` param that was passed-in by both the regular ``focusable``/``tabbable`` methods)... the new logic uses an ``isVisible`` param that's set to ``true`` by default. So the burden is now on the ``discoverable`` method to pass-in a ``false`` parameter to ``focusable``.

Related changes:
* Added inline MIT license block from jQuery UI (slightly-amended to combine "Focusable" and "Tabbable" on the same line)
* Fixed "tabbable" typo in comment
* Revised comment block to clarify WET's deliberate changes and exactly which code was borrowed from jQuery UI
* Removed ``visible`` method (old ``focusable`` method used it, no longer exists in latest jQuery UI logic)
* Removed ``data`` method (unused code from an old version of jQuery UI)
* ESLint: Changed ``!= null`` to ``!== undefined`` to adhere to "no-eq-null" rule

Related demo change:
* Overlay plugin: Add an alternate middle screen example that begins with a hidden link:
  * Forward-tabbing beyond the top-right X button previously failed in that scenario (since the old logic mistakenly-believed the hidden link was tabbable)