### PR TITLE
Overlay: Fix reverse-tabbing after opening overlays

### DIFF
--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -211,9 +211,9 @@ $document.on( "timerpoke.wb " + initEvent + " keydown open" + selector +
 						length = $focusable.length;
 						index = $focusable.index( event.target ) + ( event.shiftKey ? -1 : 1 );
 
-						if ( index === -1 || index === length ) {
+						if ( index < 0 || index === length ) {
 							event.preventDefault();
-							$focusable.eq( index === -1 ? length - 1 : 0 )
+							$focusable.eq( index < 0 ? length - 1 : 0 )
 								.trigger( setFocusEvent );
 						}
 					}


### PR DESCRIPTION
It was previously possible to close most overlays by reverse-tabbing after opening them - with the following exceptions:
* Focusing forward beforehand bypassed the issue
* Lightbox overlays were unaffected

The buggy behaviour was caused by the Tab key press logic's ``index`` variable being based on whether ``event.target`` existed in the ``$focusable`` array - which isn't the case when an overlay is first opened (``event.target`` is initially the overlay container itself).

Since the ``index`` variable is based on adding the event target's ``$focusable`` array index (``-1`` in this case since the container doesn't exist in the array) and a number derived from pressing the Shift key (``-1``)... the ``index`` variable ended up being ``-2``.

The plugin logic that detects whether it needs to force focus to the beginning or end of the overlay container was only designed to handle scenarios where ``index`` is ``-1`` or matches the array's length. So it became possible to unexpectedly "escape" the overlay when ``index`` was ``-2``.

This resolves it by adjusting the buggy logic to check for ``< 0`` instead of ``=== -1``.