### PR TITLE
Menu: Move aria-expanded, scrap aria-hidden attributes

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -93,11 +93,9 @@ var componentName = "wb-menu",
 			// if there is a submenu lets put in the aria for it
 			if ( $subMenu.length !== 0 ) {
 
-				$elm.attr( "aria-haspopup", "true" );
-
-				$subMenu.attr( {
-					"aria-expanded": "false",
-					"aria-hidden": "true"
+				$elm.attr( {
+					"aria-haspopup": "true",
+					"aria-expanded": "false"
 				} );
 
 				// recurse into submenu
@@ -120,8 +118,8 @@ var componentName = "wb-menu",
 			sectionHtml = "<li><details>" + "<summary class='mb-item" +
 				( $section.hasClass( "wb-navcurr" ) || $section.children( ".wb-navcurr" ).length !== 0 ? " wb-navcurr'" : "'" ) +
 				menuitem + sectionsLength + posinset + ( sectionIndex + 1 ) +
-				"' aria-haspopup='true'>" + $section.text() + "</summary>" +
-				"<ul class='list-unstyled mb-sm' role='menu' aria-expanded='false' aria-hidden='true'>";
+				"' aria-haspopup='true' aria-expanded='false'>" + $section.text() + "</summary>" +
+				"<ul class='list-unstyled mb-sm' role='menu'>";
 
 		// Convert each of the list items into WAI-ARIA menuitems
 		for ( k = 0; k !== itemsLength; k += 1 ) {
@@ -435,23 +433,20 @@ var componentName = "wb-menu",
 	 * @param {boolean} removeActive Whether or not to keep the active class
 	 */
 	menuClose = function( $elm, removeActive ) {
+
+		// Adjust top-level menu item's aria-expanded attribute
+		$elm
+			.find( "[aria-haspopup=true]" )
+			.attr( "aria-expanded", "false" );
+
 		$elm
 			.removeClass( "sm-open" )
 			.children( ".open" )
 			.removeClass( "open" )
-			.attr( {
-				"aria-hidden": "true",
-				"aria-expanded": "false"
-			} )
 
 		// Close nested submenus
 			.find( "details" )
-			.removeAttr( "open" )
-			.children( "ul" )
-			.attr( {
-				"aria-hidden": "true",
-				"aria-expanded": "false"
-			} );
+			.removeAttr( "open" );
 
 		if ( removeActive ) {
 			$elm.removeClass( "active" );
@@ -473,15 +468,14 @@ var componentName = "wb-menu",
 		// Ignore if doesn't have a submenu
 		if ( menuLink.attr( "aria-haspopup" ) === "true" ) {
 
+			// Add an aria-expanded attribute to the menu link
+			menuLink.attr( "aria-expanded", "true" );
+
 			// Add the open state classes
 			menu
 				.addClass( "sm-open" )
 				.children( ".sm" )
-				.addClass( "open" )
-				.attr( {
-					"aria-hidden": "false",
-					"aria-expanded": "true"
-				} );
+				.addClass( "open" );
 		}
 	},
 
@@ -556,7 +550,7 @@ $document.on( "mouseleave", selector + " .menu", function( event ) {
 
 // Prevent opening another menu if mouse re-enters already opened menu
 $document.on( "mouseenter", selector + " .sm", function() {
-	if ( $( this ).attr( "aria-expanded" ) === "true" ) {
+	if ( $( this ).hasClass( "open" ) ) {
 		clearTimeout( globalTimeout );
 	}
 } );
@@ -583,16 +577,14 @@ $document.on( "click", selector + " .item[aria-haspopup=true]", function( event 
 $document.on( "click", selector + " [role=menu] [aria-haspopup=true]", function( event ) {
 	var menuItem = event.currentTarget,
 		parent = menuItem.parentNode,
-		submenu = parent.getElementsByTagName( "ul" )[ 0 ],
-		isOpen = submenu.getAttribute( "aria-hidden" ) === "false",
+		isOpen = parent.hasAttribute( "open" ),
 		menuItemOffsetTop, menuContainer;
 
 	// Close any other open menus
 	if ( !isOpen ) {
 		$( parent )
 			.closest( "[role^='menu']" )
-			.find( "[aria-hidden=false]" )
-			.parent()
+			.find( "[open]" )
 			.find( "[aria-haspopup=true]" )
 			.not( menuItem )
 			.trigger( "click" );
@@ -607,8 +599,7 @@ $document.on( "click", selector + " [role=menu] [aria-haspopup=true]", function(
 		}
 	}
 
-	submenu.setAttribute( "aria-expanded", !isOpen );
-	submenu.setAttribute( "aria-hidden", isOpen );
+	parent.firstElementChild.setAttribute( "aria-expanded", !isOpen );
 } );
 
 // Clicks and touches outside of menus should close any open menus
@@ -748,13 +739,6 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 
 					// Close any other open menus
 					if ( !isOpen ) {
-						$( parent )
-							.closest( "[role^='menu']" )
-							.find( "[aria-hidden=false]" )
-							.parent()
-							.find( "[aria-haspopup=true]" )
-							.not( menuItem )
-							.trigger( "click" );
 
 						// Ensure the opened menu is in view if in a mobile panel
 						menuContainer = document.getElementById( "mb-pnl" );
@@ -769,13 +753,11 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 						$menuItem.trigger( "click" );
 					}
 
-					// Update the WAI-ARIA states and move focus to
-					// the first submenu item
+					// Update the menu item's WAI-ARIA state
+					menuItem.setAttribute( "aria-expanded", "true" );
+
+					// Move focus to the first submenu item
 					$parent.children( "ul" )
-						.attr( {
-							"aria-expanded": "true",
-							"aria-hidden": "false"
-						} )
 						.find( "[role=menuitem]:first" )
 						.trigger( "setfocus.wb" );
 				}
@@ -825,7 +807,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 							.trigger( "setfocus.wb" );
 
 					// No higher-level menu but the current submenu is open
-					} else if ( $menuItem.parent().children( "ul" ).attr( "aria-hidden" ) === "false" ) {
+					} else if ( $menuItem.parent().attr( "open" ) ) {
 						event.preventDefault();
 						$menuItem
 							.trigger( "click" )
@@ -865,7 +847,7 @@ $document.on( "keyup", selector + " [role=menuitem]", function( event ) {
 // Close the mobile panel if switching to medium, large or extra large view
 $document.on( "mediumview.wb largeview.wb xlargeview.wb", function() {
 	var mobilePanel = document.getElementById( "mb-pnl" );
-	if ( mobilePanel && mobilePanel.getAttribute( "aria-hidden" ) === "false" ) {
+	if ( mobilePanel && mobilePanel.getAttribute( "role" ) && !mobilePanel.getAttribute( "open" ) ) {
 		$( mobilePanel ).trigger( {
 			type: ( "close" ),
 			namespace: "wb-overlay",


### PR DESCRIPTION
They were previously being used on the mega menu (menubar pattern) and mobile menu (menu pattern)'s submenu ``<ul>`` elements... which wasn't very ideal.

Issues with that setup:
* Didn't have any effect in practice (compared to if they hadn't been used... at least not in NVDA)
* The lists were already completely hidden via CSS when collapsed (``display: none;`` in the mega menu, ``content-visibility: hidden;`` via ``::details-content`` in the mobile menu)
* Setting the ``aria-expanded`` attribute on "child" content is an unusual convention (both the APG and Bootstrap's menu pattern examples place it on trigger links directly)

This resolves it by:
* Moving ``aria-expanded`` attributes to trigger links
* Removing ``aria-hidden`` attributes and revising logic that depended on it (now primarily relies on the ``open`` attribute or "open" class... along with some dead code)

Notes:
* Setting ARIA roles on ``summary`` elements violates the ARIA in HTML spec and fails HTML validation... fixing it would necessitate major changes to the menu plugin
* Decided against removing ``aria-expanded`` attributes for the following reasons:
  * It's a supported state for the ``menuitem`` role in [ARIA 1.2 and up](https://www.w3.org/TR/wai-aria-1.2/#menuitem)
  * Had concerns about how assistive technology might handle a combination of a ``summary`` with a ``menuitem`` role combined with its parent ``details`` element's intrinsic expanded/collapsed state... figured that having an explicit ``aria-expanded`` attribute would be a safer bet
* Screen reader handling of ``role="menuitem"`` and ``aria-expanded`` appears to be spotty:
  * NVDA deliberately doesn't announce the current collapsed/expanded states of menu items, unless the user is in the act of expanding (i.e. announcing "expanded" right after an expansion event occurs). Refer to https://github.com/nvaccess/nvda/issues/9096#issuecomment-1497085780 for more details.
  * Unsure about other screen readers... some might behave differently given that ARIA itself allows for that combination of roles/states