### PR TITLE
Menu: Don't focus onto mobile menu link when switching to larger views

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -866,7 +866,11 @@ $document.on( "keyup", selector + " [role=menuitem]", function( event ) {
 $document.on( "mediumview.wb largeview.wb xlargeview.wb", function() {
 	var mobilePanel = document.getElementById( "mb-pnl" );
 	if ( mobilePanel && mobilePanel.getAttribute( "aria-hidden" ) === "false" ) {
-		$( mobilePanel ).trigger( "close.wb-overlay" );
+		$( mobilePanel ).trigger( {
+			type: ( "close" ),
+			namespace: "wb-overlay",
+			noFocus: true
+		} );
 	}
 } );
 


### PR DESCRIPTION
The menu plugin is designed to close the mobile menu overlay when switching from smaller to larger views. But it previously worked in a flawed manner.

Its old behaviour was to trigger the overlay plugin's "close" event upon switching to larger views. The overlay plugin in turn attempted to focus onto the mobile menu link... which just so happens to be hidden in larger views. End result was that ``setfocus.wb`` eventually triggered console errors.

This resolves the errors by adding a ``noFocus: true`` property to the mobile menu plugin's "close" event (derived from how it's done in the data-inview plugin).