### PR TITLE
Overlay: Fix reverse-tabbing from tabindex=-1 elements

### DIFF
--- a/src/plugins/overlay/overlay.js
+++ b/src/plugins/overlay/overlay.js
@@ -211,7 +211,7 @@ $document.on( "timerpoke.wb " + initEvent + " keydown open" + selector +
 						length = $focusable.length;
 						index = $focusable.index( event.target ) + ( event.shiftKey ? -1 : 1 );
 
-						if ( index < 0 || index === length ) {
+						if ( event.target === overlay || index === -1 || index === length ) {
 							event.preventDefault();
 							$focusable.eq( index < 0 ? length - 1 : 0 )
 								.trigger( setFocusEvent );


### PR DESCRIPTION
Prior to #10153, if an overlay was open and focus was set on any element with a ``tabindex="-1"`` attribute, reverse-focusing (Tab+Shift) behaved normally (went to the previous tabbable element).

However, a regression in #10153 caused the plugin to misjudge that scenario as an attempt to reverse-tab to the overlay's last tabbable element - resulting in the plugin forcing focus onto the X button.

Specifically, it was caused by the Tab key press logic's ``index`` variable getting set to ``-2`` when reverse-tabbing from any element with ``tabindex="-1"``. Why? Because those elements don't exist in the ``$focusable`` array (variable name is misleading - it only contains tabbable elements...). So when the plugin tried finding the currently-focused element's index in ``$focusable``, no hits were found and ``-1`` was returned. Then it got added to another number (``-1``) derived from pressing the Shift key. End result was that the plugin acted as if the initially-focused element was the overlay container itself.

This resolves it by revising the aforementioned logic to:
* Check whether ``event.target`` is the overlay container (new behaviour) OR if index is exactly ``-1`` (pre-#10153 behaviour)
* Focus onto the last tabbable element if ``index`` is ``< 0`` (#10153's behaviour - won't reach this point unless the first check passes)

**Note:**
To test, try reverse-tabbing while focused onto any link in the mobile menu's expanded dropdowns. Focus should return to a ``summary`` element (as opposed to the X button).