### PR TITLE
Menu: Add jQuery ($) variable prefixes

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -461,20 +461,20 @@ var componentName = "wb-menu",
 	/**
 	 * @method menuDisplay
 	 * @param {jQuery DOM element} $elm The plugin element
-	 * @param {jQuery event} menu The menu to display
+	 * @param {jQuery DOM element} $menu The menu to display
 	 */
-	menuDisplay = function( $elm, menu ) {
-		var menuLink = menu.children( "a" );
+	menuDisplay = function( $elm, $menu ) {
+		var $menuLink = $menu.children( "a" );
 
 		menuClose( $elm.find( ".active" ), true );
 
-		menu.addClass( "active" );
+		$menu.addClass( "active" );
 
 		// Ignore if doesn't have a submenu
-		if ( menuLink.attr( "aria-haspopup" ) === "true" ) {
+		if ( $menuLink.attr( "aria-haspopup" ) === "true" ) {
 
 			// Add the open state classes
-			menu
+			$menu
 				.addClass( "sm-open" )
 				.children( ".sm" )
 				.addClass( "open" )


### PR DESCRIPTION
The ``menuDisplay`` method takes in an unprefixed ``menu`` variable... only to then call on jQuery methods everywhere it's used. Another unprefixed variable even gets derived from it (``menuLink``).

To adhere to jQuery variable prefixing conventions, this adds ``$`` prefixes to both ``menu`` and ``menuLink``. Also corrects mistakes in ``menuDisplay``'s JSDoc comments.

Note:
No calls to the ``menuDisplay`` method had any prefixing issues (prefixed variables were always passed-in for the ``menu`` parameter).