### PR TITLE
Menu: Use focusEvent consistently

### DIFF
--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -777,7 +777,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 							"aria-hidden": "false"
 						} )
 						.find( "[role=menuitem]:first" )
-						.trigger( "setfocus.wb" );
+						.trigger( focusEvent );
 				}
 
 			// Escape, left / right arrow without a submenu
@@ -822,14 +822,14 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 						$menu.closest( "li" )
 							.find( menuitemSelector )
 							.trigger( "click" )
-							.trigger( "setfocus.wb" );
+							.trigger( focusEvent );
 
 					// No higher-level menu but the current submenu is open
 					} else if ( $menuItem.parent().children( "ul" ).attr( "aria-hidden" ) === "false" ) {
 						event.preventDefault();
 						$menuItem
 							.trigger( "click" )
-							.trigger( "setfocus.wb" );
+							.trigger( focusEvent );
 					}
 				}
 


### PR DESCRIPTION
The plugin previously called a mix of ``focusEvent`` (an alias for "setfocus.wb") and "setfocus.wb" directly - which goes against the point of having a ``focusEvent`` variable.

This replaces all the direct references to "setfocus.wb" to ``focusEvent`` for the sake of consistency.

Having only one way of calling the focus plugin might also reduce the potential for confusion.
