### PR TITLE
docs: fix typo in i18n base comment (il8n → i18n)

### DIFF
--- a/src/i18n/base.js
+++ b/src/i18n/base.js
@@ -3,7 +3,7 @@
 * wet-boew.github.io/wet-boew/License-en.html / wet-boew.github.io/wet-boew/Licence-fr.html
 */
 /*
------ @lang-en@ dictionary (il8n) ---
+----- @lang-en@ dictionary (i18n) ---
 */
 ( function( wb ) {
 "use strict";


### PR DESCRIPTION
## Summary

Fix typo in the comment header of `src/i18n/base.js`:

- `il8n` → `i18n` (internationalization)

The transposed digits in the abbreviation appear only in the comment — no functional impact.

No functional changes — comment only.