### PR TITLE
Tables: trigger plugins init when table is drawn (pagination, search, order, etc.)

### DIFF
--- a/src/plugins/tables/ajax/datasource.json
+++ b/src/plugins/tables/ajax/datasource.json
@@ -1,6 +1,6 @@
 {
   "data": [{
-    "TITLE": "<a href=\"https://www.canada.ca/en/news.html\">Biomass Program Continues to Support Transition to Renewable Energy in Manitoba</a>",
+    "TITLE": "<a class=\"wb-lbx\" href=\"#tablesWBExample\" role=\"button\">Biomass Program Continues to Support Transition to Renewable Energy in Manitoba</a>",
     "TEASER": "The governments of Canada and Manitoba are supporting a greener, more sustainable economy through the $1 million Biomass Energy Support Program, Federal Agriculture Minister Lawrence MacAulay and Manitoba Agriculture Minister Ralph Eichler announced today.",
     "PUBDATE": "2016-07-30",
     "TYPE": "News Releases",

--- a/src/plugins/tables/tables-fltrs-en.hbs
+++ b/src/plugins/tables/tables-fltrs-en.hbs
@@ -214,6 +214,10 @@
 				</tr>
 				</thead>
 			</table>
+			<section id="tablesWBExample" class="mfp-hide modal-dialog modal-content overlay-def">
+				<header class="modal-header"><h2 class="modal-title">Example</h2></header>
+				<div class="modal-body">Example modal triggered from dynamic datatables content</div>
+			</section>
 		</div>
 		<div class="col-md-12">
 			<h3>Creating Date Range, Drop-Down List and/or Checkbox Filters</h3>

--- a/src/plugins/tables/tables-fltrs-fr.hbs
+++ b/src/plugins/tables/tables-fltrs-fr.hbs
@@ -215,6 +215,10 @@
 				</tr>
 				</thead>
 			</table>
+			<section id="tablesWBExample" class="mfp-hide modal-dialog modal-content overlay-def">
+				<header class="modal-header"><h2 class="modal-title">Exemple</h2></header>
+				<div class="modal-body">Exemple de modal déclenché par le contenu dynamique des datatables</div>
+			</section>
 		</div>
 		<div class="col-md-12">
 			<h3>Creating Date Range, Drop-Down List and/or Checkbox Filters</h3>

--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -229,6 +229,14 @@ $document.on( "draw.dt", selector, function( event, settings ) {
 		updatePaginationMarkup( pagination_top );
 	}
 
+	if ( wb.isReady ) {
+		$elm
+			.find( wb.allSelectors )
+			.addClass( "wb-init" )
+			.filter( ":not(#" + $elm.id + " .wb-init .wb-init)" )
+			.trigger( "timerpoke.wb" );
+	}
+
 	// Identify that the table has been updated
 	$elm.trigger( "wb-updated" + selector, [ settings ] );
 } );


### PR DESCRIPTION
When datables includes wet-boew plugins, it only initializes them if the content is already on the page on the first load. This PR trigger the initialization of any plugin that was not previously initialized within the table.

To test, in tables-fltrs-en/fr.html, search for "Biomass" and click on the "Biomass Program Continues to Support Transition to Renewable Energy in Manitoba" link.