### PR TITLE
Menu: Use disclosure navigation menu pattern

### DIFF
--- a/src/plugins/menu/_base.scss
+++ b/src/plugins/menu/_base.scss
@@ -20,9 +20,21 @@
 	content: none;
 }
 
+.wb-menu details[open] {
+	padding-bottom: 0;
+}
+
 .wb-menu details summary {
 	border-radius: initial;
 	text-indent: initial;
+}
+
+.wb-menu details[open] > summary {
+	margin-bottom: 0;
+}
+
+.wb-menu details[open] .sm {
+	margin-left: -1.1em; /* Not very elegant... */
 }
 
 .expicon {
@@ -32,13 +44,13 @@
 
 .wb-menu {
 	.sm {
-		display: none;
+		display: none; // TODO: Not needed anymore
 		max-height: 0;
 		overflow: hidden;
 		position: relative;
 	}
 
-		.sm.open, [open] {
+		.sm.open, [open] .sm {
 			display: inline;
 			max-height: 1000px;
 			min-width: 12.5em;
@@ -99,7 +111,7 @@
 
 					/* Rehash of a[aria-haspopup] selector */
 					summary {
-							cursor: default;
+						cursor: default;
 					}
 			}
 		}
@@ -302,15 +314,15 @@
 			}
 		}
 
-		.sm {
-			&.open {
+		//.sm { // TODO: RTL will need to be tested
+			.sm.open, [open] .sm {
 				li {
 					a {
 						text-align: right;
 					}
 				}
 			}
-		}
+		//}
 	}
 
 	.expicon {

--- a/src/plugins/menu/_base.scss
+++ b/src/plugins/menu/_base.scss
@@ -6,6 +6,25 @@
 /*
  * Menu Sass
  */
+
+/* Extras to prevent goofy default summary styling */
+.wb-menu .menu > li summary {
+	display: inline-block !important;
+}
+
+.wb-menu summary > :first-child {
+  display: inline-block;
+}
+
+.wb-menu summary::marker {
+	content: none;
+}
+
+.wb-menu details summary {
+	border-radius: initial;
+	text-indent: initial;
+}
+
 .expicon {
 	font-size: .7em;
 	margin: 0 -.35em 0 .7em;
@@ -17,8 +36,9 @@
 		max-height: 0;
 		overflow: hidden;
 		position: relative;
+	}
 
-		&.open {
+		.sm.open, [open] {
 			display: inline;
 			max-height: 1000px;
 			min-width: 12.5em;
@@ -36,6 +56,7 @@
 			}
 		}
 
+	.sm {
 		details {
 			> {
 				* {
@@ -56,25 +77,30 @@
 				margin: 0;
 				padding: 0;
 
-				a {
+				a, summary {
 					@extend %global-text-decoration-none;
 
-					display: block;
+					display: block; /* TODO: Get rid of this property or change it to inline-block whenever I go all-in on mega menu bar summaries AND give it important */
 					padding: 1em;
 					text-align: center;
+				}
 
-					&:hover,
-					&:focus {
+					a:hover,
+					a:focus {
 						@extend %global-text-decoration-none;
 					}
 
-					&[aria-haspopup] {
+					a[aria-haspopup] {
 						&:hover,
 						&:focus {
 							cursor: default;
 						}
 					}
-				}
+
+					/* Rehash of a[aria-haspopup] selector */
+					summary {
+							cursor: default;
+					}
 			}
 		}
 	}

--- a/src/plugins/menu/_base.scss
+++ b/src/plugins/menu/_base.scss
@@ -8,33 +8,33 @@
  */
 
 /* Extras to prevent goofy default summary styling */
-.wb-menu .menu > li summary {
+.wb-menu .menu > li > details > summary { /* Prevents top-level mega menu links from becoming super wide when their submenus are open */
 	display: inline-block !important;
 }
 
-.wb-menu summary > :first-child {
+.wb-menu summary > .glyphicon:first-child { /* Undoes a default summary selector to prevent glyphicons from becoming inline and consequently causing top-level mega menu links to split across lines */
   display: inline-block;
 }
 
-.wb-menu summary::marker {
+.wb-menu .menu > li > details > summary::marker { /* Prevents summary arrows from appearing on top-level mega menu links */
 	content: none;
 }
 
-.wb-menu details[open] {
+.wb-menu details[open] { /* Undoes a default details selector to prevent a big space from appearing in the mega menu bar when any submenu is open */
 	padding-bottom: 0;
 }
 
-.wb-menu details summary {
+.wb-menu details summary { /* Undoes goofy default selectors */
 	border-radius: initial;
 	text-indent: initial;
 }
 
-.wb-menu details[open] > summary {
+.wb-menu details[open] > summary { /* Undoes a default summary selector that adds a small bottom margin */
 	margin-bottom: 0;
 }
 
 .wb-menu details[open] .sm {
-	margin-left: -1.1em; /* Not very elegant... */
+	margin-left: -1.1em; /* If I keep this, use the SASS variable (if it even exists) */
 }
 
 .expicon {
@@ -62,7 +62,7 @@
 			li {
 				@extend %global-display-block;
 
-				a {
+				a, summary {
 					text-align: left;
 				}
 			}
@@ -314,15 +314,16 @@
 			}
 		}
 
-		//.sm { // TODO: RTL will need to be tested
+		// .sm { /* TODO: RTL will need to be tested */
 			.sm.open, [open] .sm {
 				li {
-					a {
+					a, summary {
 						text-align: right;
 					}
 				}
 			}
-		//}
+
+		// }
 	}
 
 	.expicon {

--- a/src/plugins/menu/_base.scss
+++ b/src/plugins/menu/_base.scss
@@ -24,9 +24,15 @@
 	padding-bottom: 0;
 }
 
-.wb-menu details summary { /* Undoes goofy default selectors */
+.wb-menu details summary { /* Undoes goofy default selectors... should these be set to revert instead of initial? */
 	border-radius: initial;
 	text-indent: initial;
+}
+
+.wb-menu details summary.item:focus {
+	outline-offset: -2px; /* Replicate the same outline offset as focused links (to match how the old top-level mega menu links looked when focused) */
+	outline-style: revert; /* Undoes goofy default selector */
+	outline-width: revert; /* Undoes goofy default selector */
 }
 
 .wb-menu details[open] > summary { /* Undoes a default summary selector that adds a small bottom margin */

--- a/src/plugins/menu/_base.scss
+++ b/src/plugins/menu/_base.scss
@@ -131,7 +131,7 @@
 		}
 	}
 
-	.sm-open {
+	.sm-open [open] {
 		.expicon {
 			z-index: -1;
 		}

--- a/src/plugins/menu/_base.scss
+++ b/src/plugins/menu/_base.scss
@@ -39,8 +39,12 @@
 	margin-bottom: 0;
 }
 
-.wb-menu details[open] .sm {
+.wb-menu details[open] .sm { /* Prevents mega menu dropdowns from getting horizontally-misaligned */
 	margin-left: -1.1em; /* If I keep this, use the SASS variable (if it even exists) */
+}
+
+[dir="rtl"] .wb-menu details[open] .sm {
+	margin-right: -1.1em; /* If I keep this, use the SASS variable (if it even exists) */
 }
 
 .expicon {

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -93,11 +93,9 @@ var componentName = "wb-menu",
 			// if there is a submenu lets put in the aria for it
 			if ( $subMenu.length !== 0 ) {
 
-				$elm.attr( "aria-haspopup", "true" );
-
-				$subMenu.attr( {
-					"aria-expanded": "false",
-					"aria-hidden": "true"
+				$elm.attr( {
+					"aria-haspopup": "true",
+					"aria-expanded": "false"
 				} );
 
 				// recurse into submenu
@@ -120,8 +118,8 @@ var componentName = "wb-menu",
 			sectionHtml = "<li><details>" + "<summary class='mb-item" +
 				( $section.hasClass( "wb-navcurr" ) || $section.children( ".wb-navcurr" ).length !== 0 ? " wb-navcurr'" : "'" ) +
 				menuitem + sectionsLength + posinset + ( sectionIndex + 1 ) +
-				"' aria-haspopup='true'>" + $section.text() + "</summary>" +
-				"<ul class='list-unstyled mb-sm' role='menu' aria-expanded='false' aria-hidden='true'>";
+				"' aria-haspopup='true' aria-expanded='false'>" + $section.text() + "</summary>" +
+				"<ul class='list-unstyled mb-sm' role='menu'>";
 
 		// Convert each of the list items into WAI-ARIA menuitems
 		for ( k = 0; k !== itemsLength; k += 1 ) {
@@ -435,23 +433,20 @@ var componentName = "wb-menu",
 	 * @param {boolean} removeActive Whether or not to keep the active class
 	 */
 	menuClose = function( $elm, removeActive ) {
+
+		// Adjust top-level menu item's aria-expanded attribute
+		$elm
+			.find( "[aria-haspopup=true]" )
+			.attr( "aria-expanded", "false" );
+
 		$elm
 			.removeClass( "sm-open" )
 			.children( ".open" )
 			.removeClass( "open" )
-			.attr( {
-				"aria-hidden": "true",
-				"aria-expanded": "false"
-			} )
 
 		// Close nested submenus
 			.find( "details" )
-			.removeAttr( "open" )
-			.children( "ul" )
-			.attr( {
-				"aria-hidden": "true",
-				"aria-expanded": "false"
-			} );
+			.removeAttr( "open" );
 
 		if ( removeActive ) {
 			$elm.removeClass( "active" );
@@ -473,15 +468,14 @@ var componentName = "wb-menu",
 		// Ignore if doesn't have a submenu
 		if ( $menuLink.attr( "aria-haspopup" ) === "true" ) {
 
+			// Add an aria-expanded attribute to the menu link
+			menuLink.attr( "aria-expanded", "true" );
+
 			// Add the open state classes
 			$menu
 				.addClass( "sm-open" )
 				.children( ".sm" )
-				.addClass( "open" )
-				.attr( {
-					"aria-hidden": "false",
-					"aria-expanded": "true"
-				} );
+				.addClass( "open" );
 		}
 	},
 
@@ -556,7 +550,7 @@ $document.on( "mouseleave", selector + " .menu", function( event ) {
 
 // Prevent opening another menu if mouse re-enters already opened menu
 $document.on( "mouseenter", selector + " .sm", function() {
-	if ( $( this ).attr( "aria-expanded" ) === "true" ) {
+	if ( $( this ).hasClass( "open" ) ) {
 		clearTimeout( globalTimeout );
 	}
 } );
@@ -583,16 +577,14 @@ $document.on( "click", selector + " .item[aria-haspopup=true]", function( event 
 $document.on( "click", selector + " [role=menu] [aria-haspopup=true]", function( event ) {
 	var menuItem = event.currentTarget,
 		parent = menuItem.parentNode,
-		submenu = parent.getElementsByTagName( "ul" )[ 0 ],
-		isOpen = submenu.getAttribute( "aria-hidden" ) === "false",
+		isOpen = parent.hasAttribute( "open" ),
 		menuItemOffsetTop, menuContainer;
 
 	// Close any other open menus
 	if ( !isOpen ) {
 		$( parent )
 			.closest( "[role^='menu']" )
-			.find( "[aria-hidden=false]" )
-			.parent()
+			.find( "[open]" )
 			.find( "[aria-haspopup=true]" )
 			.not( menuItem )
 			.trigger( "click" );
@@ -607,8 +599,7 @@ $document.on( "click", selector + " [role=menu] [aria-haspopup=true]", function(
 		}
 	}
 
-	submenu.setAttribute( "aria-expanded", !isOpen );
-	submenu.setAttribute( "aria-hidden", isOpen );
+	parent.firstElementChild.setAttribute( "aria-expanded", !isOpen );
 } );
 
 // Clicks and touches outside of menus should close any open menus
@@ -747,13 +738,6 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 
 					// Close any other open menus
 					if ( !isOpen ) {
-						$( parent )
-							.closest( "[role^='menu']" )
-							.find( "[aria-hidden=false]" )
-							.parent()
-							.find( "[aria-haspopup=true]" )
-							.not( menuItem )
-							.trigger( "click" );
 
 						// Ensure the opened menu is in view if in a mobile panel
 						menuContainer = document.getElementById( "mb-pnl" );
@@ -768,13 +752,11 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 						$menuItem.trigger( "click" );
 					}
 
-					// Update the WAI-ARIA states and move focus to
-					// the first submenu item
+					// Update the menu item's WAI-ARIA state
+					menuItem.setAttribute( "aria-expanded", "true" );
+
+					// Move focus to the first submenu item
 					$parent.children( "ul" )
-						.attr( {
-							"aria-expanded": "true",
-							"aria-hidden": "false"
-						} )
 						.find( "[role=menuitem]:first" )
 						.trigger( focusEvent );
 				}
@@ -824,7 +806,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 							.trigger( focusEvent );
 
 					// No higher-level menu but the current submenu is open
-					} else if ( $menuItem.parent().children( "ul" ).attr( "aria-hidden" ) === "false" ) {
+					} else if ( $menuItem.parent().attr( "open" ) ) {
 						event.preventDefault();
 						$menuItem
 							.trigger( "click" )
@@ -864,7 +846,7 @@ $document.on( "keyup", selector + " [role=menuitem]", function( event ) {
 // Close the mobile panel if switching to medium, large or extra large view
 $document.on( "mediumview.wb largeview.wb xlargeview.wb", function() {
 	var mobilePanel = document.getElementById( "mb-pnl" );
-	if ( mobilePanel && mobilePanel.getAttribute( "aria-hidden" ) === "false" ) {
+	if ( mobilePanel && mobilePanel.getAttribute( "role" ) && !mobilePanel.getAttribute( "open" ) ) {
 		$( mobilePanel ).trigger( {
 			type: ( "close" ),
 			namespace: "wb-overlay",

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -367,7 +367,7 @@ var componentName = "wb-menu",
 					// Open up the secondary menu if it has wb-navcurr and has a submenu
 					//This auto-expands the left nav's details element in the mobile menu (by fake clicking its summary and adding an open attribute... attribute is probably for the polyfill)
 					$menuItem = $panel.find( "#sec-pnl .wb-navcurr.mb-item" );
-					if ( $menuItem.prop( "nodeName" ).toLowerCase() === "summary" ) {
+					if ( $menuItem.length && $menuItem.prop( "nodeName" ).toLowerCase() === "summary" ) {
 						console.log("auto-expanding the left nav's mobile details element...");
 						$menuItem
 							.trigger( "click" )
@@ -493,7 +493,7 @@ var componentName = "wb-menu",
 		}
 
 		// Ignore if doesn't have a submenu
-		if ( $menuLink.prop( "nodeName" ).toLowerCase() === "summary" ) { //TODO: This needs to be smarter than this... won't the status quo evaluate undefined to truthy and ultimately do nothing apart from TONS of pointless confusion?
+		if ( $menuLink.length && $menuLink.prop( "nodeName" ).toLowerCase() === "summary" ) {
 
 			console.log($menuLink);
 			console.log($menuLink.get(0));

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -470,6 +470,8 @@ var componentName = "wb-menu",
 	 */
 	menuClose = function( $elm, removeActive ) {
 
+		console.log("inside menuClose");
+
 		// This logic is designed with li in mind
 		console.log("my $elm:");
 		console.log($elm);
@@ -480,7 +482,7 @@ var componentName = "wb-menu",
 		$elm
 			.removeClass( "sm-open" )
 			.children( "[open]" )
-			.removeAttr( "open" )
+			.removeAttr( "open" ) // FMI: I don't this this part of the logic actually works... couldn't get Enter key presses that close the menu to work correctly without preventDefault (even though space worked fine as-is)
 
 		// Close nested submenus... is that actually necessary? Is it desirable for users to have this mindlessly reset to closed?
 		//TODO: If I keep this, remove preceding children and removeAttr method calls since there's no point removing the open attribute separately for the top-level vs deeper details elements (unless I want to do fake clicking...?)
@@ -502,12 +504,12 @@ var componentName = "wb-menu",
 
 		console.log("inside menuDisplay");
 
-		//if ($elm.find( ".active.sm-open" ).length) {
+		if ($elm.find( ".active" ).not( $elm ).length) { //prevents menuClose from getting needlessly called (like if entering the menu for the first time or collapsing the current top-level menu item)
 			console.log("yay!!!");
 			menuClose( $elm.find( ".active" ), true );
 		//} else {
-			console.log("nah!!!");
-		//}
+		//	console.log("nah!!!");
+		}
 		console.log($elm);
 		console.log($elm.find( ".active.sm-open" ));
 
@@ -617,22 +619,8 @@ $document.on( "mouseenter", selector + " .sm", function() {
 } );
 
 // Touchscreen "touches" on menubar items should close the submenu if it is open
-$document.on( "click", selector + " summary.item", function( event ) {
-	var which = event.which,
-		$this, $parent;
-
-	// Ignore middle and right mouse buttons
-	if ( !which || which === 1 ) {
-		event.preventDefault();
-		$this = $( this );
-		$parent = $this.parent();
-
-		// Open the submenu if it is closed
-		if ( !$parent.hasClass( "sm-open" ) ) {
-			$this.trigger( "focusin" );
-		}
-	}
-} );
+//NOTE: This is pointless now... scrapped it
+//Would I need to restore it to bring back the arrow icon when in a collapsed+focused state?
 
 // Click on menu items with submenus should open and close those submenus
 $document.on( "click", selector + " summary", function( event ) {
@@ -722,8 +710,10 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 
 	// Define keycodes. (Make const when WET supports ES6)
 	var TAB_KC = 9,
+		END_KC = 35,
 		ENTER_KC = 13,
 		ESC_KC = 27,
+		HOME_KC = 36,
 		LEFT_KC = 37,
 		UP_KC = 38,
 		RIGHT_KC = 39,
@@ -737,8 +727,9 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 		// Tab key = Hide all sub-menus
 		//Auto-closes the mega menu when tabbing over it (the open top-level link has the active class)... runs in the mobile menu too, but is pointless in that context
 		if ( which === TAB_KC ) {
-			console.log("Tab key = Hide all sub-menus... calling menuClose");
-			menuClose( $( selector + " .active" ), true );
+			//commenting-out since this makes it impossible to tab into the mega menu's submenu dropdowns
+			//console.log("Tab key = Hide all sub-menus... calling menuClose");
+			//menuClose( $( selector + " .active" ), true );
 
 		//Enter or spacebar on a link = follow the link and close menus
 		//Always runs when clicking links in either the mega or mobile menu (regardless of anchor vs page)
@@ -755,33 +746,67 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 
 			console.log("In inMenuBar if");
 
-			// Left / right arrow = Previous / next menu item
-			if ( which === LEFT_KC || which === RIGHT_KC ) {
+			// Left-up / right-down arrow = Previous / next menu item
+			if ( which === LEFT_KC || which === UP_KC || which === RIGHT_KC || which === DOWN_KC ) {
 				event.preventDefault();
-				console.log("Moving left/right on mega menu bar");
+				//const advancing = RIGHT_KC || DOWN_KC ? true : false;
+				console.log("Moving left-up/right-down on mega menu bar");
+
+				if ( hasPopup && $menuItem.parent().attr( "open" ) ) {
+					console.log("GOING TO FIRST SUBMENU ITEM!!!");
+					console.log($menuItem.attr( "open" ));
+					event.preventDefault();
+					let $parentLi = $menuItem.closest( "li" );
+					$subMenu = $parentLi.find( ".sm" );
+
+					// Set focus on the first submenu item
+					$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent );
+				} else {
+
+					console.log("going left/right...");
+					menuIncrement(
+						$menu.find( "> li > a, > li > details > summary" ),
+						$menuItem,
+						which === LEFT_KC || which === UP_KC ? -1 : 1
+					);
+				}
+
+			// HOME / END keys = First / last menu item
+			//NOTE: Only works on top menu bar atm
+			} else if ( which === HOME_KC || which === END_KC ) {
+				event.preventDefault();
+				console.log("Pressed HOME or END on mega menu bar");
+				const $menuItems = $menu.find( "> li > a, > li > details > summary" );
+				//TODO: Add a condition here (or in menuIncrement itself) to not needlessly call menuIncrement if curreny focus is already on the first or last item in the array (like by comparing $menuItem vs $menuItems.first() or $menuItems.last()
 				menuIncrement(
-					$menu.find( "> li > a, > li > details > summary" ),
-					$menuItem,
-					which === LEFT_KC ? -1 : 1
+					$menuItems,
+					which === HOME_KC ? $menuItems.first() : $menuItems.last(),
+					which === 0
 				);
 
-			// Enter sub-menu
-			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC || which === UP_KC || which === DOWN_KC ) ) {
-				event.preventDefault();
+			// Toggle sub-menu
+			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC ) ) {
+				event.preventDefault(); // Absolutely need this for Enter key compatibility!!!
 				console.log("inside mystery mega menu submenu logic");
-				$parent = $menuItem.closest( "li" );
-				$subMenu = $parent.find( ".sm" );
+				let $parentDetails = $menuItem.parent();
+				let $parentLi = $menuItem.closest( "li" );
+				$subMenu = $parentLi.find( ".sm" );
 
 				// Open the submenu if it is not already open
-				if ( !$subMenu.hasClass( "open" ) ) {
+				if ( !$parentDetails.attr( "open" ) ) {
 					console.log("opening the mega menu submenu");
-					menuDisplay( $menu.closest( selector ), $parent );
+					menuDisplay( $menu.closest( selector ), $parentLi );
+				} else {
+					console.log("closing the mega menu submenu");
+					menuClose( $menu.closest( selector ).find( ".active" ), false );
 				}
 
 				// Set focus on the first submenu item
-				$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent ); //oooooooooooooooooooooooooo
+				// Nerfed this to prevent pressing top-level mega menu items from auto-focusing onto the first submenu item
+				//$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent ); //oooooooooooooooooooooooooo
 
 			// Hide sub-menus and set focus
+			//NOTE: Very similar to aforementioned else if, but doesn't toggle (if I try porting it there I'd need to ensure ESC never toggles)
 			} else if ( which === ESC_KC ) {
 				event.preventDefault();
 				menuClose( $menu.closest( selector ).find( ".active" ), false );
@@ -799,14 +824,15 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 		} else {
 			console.log("In else");
 
-			// Up / down arrow = Previous / next menu item
-			if ( which === UP_KC || which === DOWN_KC ) {
+			// Up-left / down-right arrow = Previous / next menu item
+			if ( which === LEFT_KC || which === UP_KC || which === RIGHT_KC || which === DOWN_KC ) {
 				event.preventDefault();
-				console.log("Up / down arrow = Previous / next menu item... calling menuIncrement");
+				console.log("Up-left / down-right arrow = Previous / next menu item... calling menuIncrement");
 				menuIncrement(
 					$menu.children( "li" ).find( menuItemSelector ),
 					$menuItem,
-					which === UP_KC ? -1 : 1
+					which === LEFT_KC || which === UP_KC ? -1 : 1
+					//TODO: This should do the job for fixing up/down arrow support... but still need to look into the latter conditions beyond here to look into removing more right/left variable checks
 				);
 
 			// Enter, space, or right arrow with a submenu
@@ -865,7 +891,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				}
 
 				// If the parent menu is a menubar
-				if ( $parentMenu.hasClass( "menu" ) ) {
+				if ( $parentMenu.hasClass( "menu" ) ) { //MINI TODO: Should this only be checking whether the direct parent UL has a menu class? Or any super high-level parent?
 					$menuLink = $menu.siblings( "a, summary" );
 
 					// Escape key = Close menu and return to menu bar item
@@ -879,7 +905,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 						}, 100 );
 
 					// Left / right key = Next / previous menu bar item
-					} else if ( $parentMenu.hasClass( "menu" ) ) {
+					} else if ( $parentMenu.hasClass( "menu" ) ) { //MINI TODO: Should this only be checking whether the direct parent UL has a menu class? Or any super high-level parent?
 						console.log("NEW: about to increment...");
 						console.log("$parentMenu:");
 						console.log($parentMenu);

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -443,6 +443,7 @@ var componentName = "wb-menu",
 			index = $menuItems.index( $current ) + indexChange;
 
 		// Correct out-of-range indexes
+		//NOTE: this is the menu list looping logic... scrap it if I don't want it in the disclosure pattern... will need a little more logic though to trigger the focus event in a smarter manner
 		index = index === menuItemsLength ? 0 : index === -1 ? menuItemsLength - 1 : index;
 
 		// Move to the new menu item
@@ -596,7 +597,11 @@ $document.on( "click", selector + " .item[aria-haspopup=true]", function( event 
 } );
 
 // Click on menu items with submenus should open and close those submenus
-$document.on( "click", selector + " [role=menu] [aria-haspopup=true]", function( event ) {
+$document.on( "click", selector + " summary", function( event ) {
+
+	//When opening a details in the mobile menu overlay, this is what auto-closes other open details elements (basically a fake accordion)... it MIGHT work in the mega menu too... consider scrapping it if I go with native accordions
+	console.log("Closing other submenus");
+
 	var menuItem = event.currentTarget,
 		parent = menuItem.parentNode,
 		isOpen = parent.hasAttribute( "open" ),
@@ -605,9 +610,9 @@ $document.on( "click", selector + " [role=menu] [aria-haspopup=true]", function(
 	// Close any other open menus
 	if ( !isOpen ) {
 		$( parent )
-			.closest( "[role^='menu']" )
+			.closest( "ul" )
 			.find( "[open]" )
-			.find( "[aria-haspopup=true]" )
+			.find( "summary" )
 			.not( menuItem )
 			.trigger( "click" );
 
@@ -620,8 +625,6 @@ $document.on( "click", selector + " [role=menu] [aria-haspopup=true]", function(
 			menuContainer.scrollTop = menuItemOffsetTop;
 		}
 	}
-
-	parent.firstElementChild.setAttribute( "aria-expanded", !isOpen );
 } );
 
 // Clicks and touches outside of menus should close any open menus
@@ -660,12 +663,12 @@ $document.on( "mouseover focusin", selector + " .item", function( event ) {
 /*
  * Keyboard bindings
  */
-$document.on( "keydown", selector + " [role=menuitem]", function( event ) {
+$document.on( "keydown", selector + " a[href], " + selector + " summary", function( event ) {
 	var menuItem = event.currentTarget,
 		which = event.which,
 		$menuItem = $( menuItem ),
-		hasPopup = $menuItem.attr( "aria-haspopup" ) === "true",
-		$menu = $menuItem.parent().closest( "[role^='menu']" ),
+		hasPopup = menuItem.nodeName.toLowerCase( "summary" ),
+		$menu = $menuItem.parent().closest( "ul" ),
 		inMenuBar = $menu.attr( "role" ) === "menubar",
 		$menuLink, $parentMenu, $parent, $subMenu, result,
 		isOpen, menuItemOffsetTop, menuContainer;
@@ -682,20 +685,28 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 
 	if ( !( event.ctrlKey || event.altKey || event.metaKey ) ) {
 
+		// Many strange issues will likely occur as a result of the ARIA roles/etc I scrapped
+
 		// Tab key = Hide all sub-menus
+		//Auto-closes the mega menu when tabbing over it (the open top-level link has the active class)... runs in the mobile menu too, but is pointless in that context
 		if ( which === TAB_KC ) {
+			console.log("Tab key = Hide all sub-menus... calling menuClose");
 			menuClose( $( selector + " .active" ), true );
 
 		//Enter or spacebar on a link = follow the link and close menus
+		//Always runs when clicking links in either the mega or mobile menu (regardless of anchor vs page)
 		} else if ( menuItem.nodeName === "A" && menuItem.hasAttribute( "href" ) &&
 			( which === ENTER_KC || which === SPACE_KC ) ) {
 
+			console.log("Enter or spacebar on a link = follow the link and close menus... fake link click + calling menuClose");
 			event.preventDefault();
 			menuItem.click();
 			menuClose( $( selector + " .active" ), true );
 
 		// Menu item is within a menu bar
 		} else if ( inMenuBar ) {
+
+			console.log("In inMenuBar if");
 
 			// Left / right arrow = Previous / next menu item
 			if ( which === LEFT_KC || which === RIGHT_KC ) {
@@ -736,10 +747,12 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 
 		// Menu item is not within a menu bar
 		} else {
+			console.log("In else");
 
 			// Up / down arrow = Previous / next menu item
 			if ( which === UP_KC || which === DOWN_KC ) {
 				event.preventDefault();
+				console.log("Up / down arrow = Previous / next menu item... calling menuIncrement");
 				menuIncrement(
 					$menu.children( "li" ).find( menuItemSelector ),
 					$menuItem,
@@ -754,11 +767,17 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 				event.stopImmediatePropagation();
 				event.preventDefault();
 
+				console.log("Enter, space, or right arrow with a submenu... does misc stuff");
+
 				// If the menu item is a summary element
 				if ( menuItem.nodeName.toLowerCase( "summary" ) ) {
 					isOpen = !!$parent.attr( "open" );
 
+					console.log("summary element check");
+
 					// Close any other open menus
+					// BRAINDUMP: This is misleading... I don't see any logic here that would actually close other open menus... I think it's because that line comment was copied from somewhere else that actually does what it's supposed to
+					// TODO: Did I mess around with this part of the logic in my pending aria-expanded PR? Maybe I just forgot to revise the comment after gutting some of its logic? In any case, revise the comment to make sense!
 					if ( !isOpen ) {
 
 						// Ensure the opened menu is in view if in a mobile panel
@@ -771,22 +790,21 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 						}
 
 						// Ensure the menu is opened or stays open
+						console.log("fake click triggered to open the clicked summary in mobile menu");
 						$menuItem.trigger( "click" );
 					}
 
-					// Update the menu item's WAI-ARIA state
-					menuItem.setAttribute( "aria-expanded", "true" );
-
 					// Move focus to the first submenu item
 					$parent.children( "ul" )
-						.find( "[role=menuitem]:first" )
+						.find( "a[href], summary" )
+						.first()
 						.trigger( focusEvent );
 				}
 
 			// Escape, left / right arrow without a submenu
 			} else if ( which === ESC_KC || which === LEFT_KC || which === RIGHT_KC ) {
 				$parent = $menu.parent();
-				$parentMenu = $parent.closest( "[role^='menu']" );
+				$parentMenu = $parent.closest( "ul" );
 				if ( which === LEFT_KC || which === RIGHT_KC ) {
 					event.preventDefault();
 				}

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -241,6 +241,7 @@ var componentName = "wb-menu",
 				if ( $secnav.length !== 0 || $menubar.length !== 0 || $info.length !== 0 ) {
 
 					// Add the secondary menu
+					//This logic looks for a left nav and replicates it in the mobile menu
 					if ( $secnav.length !== 0 ) {
 						allProperties.push( [
 							$secnav.find( "ul" ).filter( ":not(li > ul)" ).find( " > li > *:first-child" ).get(),
@@ -364,8 +365,10 @@ var componentName = "wb-menu",
 					}
 
 					// Open up the secondary menu if it has wb-navcurr and has a submenu
+					//This auto-expands the left nav's details element in the mobile menu (by fake clicking its summary and adding an open attribute... attribute is probably for the polyfill)
 					$menuItem = $panel.find( "#sec-pnl .wb-navcurr.mb-item" );
-					if ( $menuItem.attr( "aria-haspopup" ) === "true" ) { //TODO: Unsure how this logic works, need to investigate further...
+					if ( $menuItem.prop( "nodeName" ).toLowerCase() === "summary" ) {
+						console.log("auto-expanding the left nav's mobile details element...");
 						$menuItem
 							.trigger( "click" )
 							.parent()

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -908,8 +908,11 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 } );
 
 // Prevent Firefox from double-triggering menu behaviour
-//TODO: Need to investigate this
-$document.on( "keyup", selector + " [role=menuitem]", function( event ) {
+//Leave this alone apart from the tweaked selector
+//NOTE: Unable to replicate the issue this logic claims to be resolving in Firefox... AFAIK FF+Chromium currently behave identically
+//Maybe caused by https://stackoverflow.com/a/45169196 (claims Firefox fires click events upon releasing keys) OR https://community.adobe.com/questions-652/keydown-eventlistener-firing-twice-for-some-keys-796664 (one reply says Windows works fine and others experiencing the issue say they're on macOS)
+//Guessing the mindset behind this logic was to take in the first keydown normally, then disable subsequent events after the first keyup
+$document.on( "keyup", selector + " a[href], " + selector + " summary", function( event ) {
 	event.preventDefault();
 	return false;
 } );

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -64,7 +64,7 @@ var componentName = "wb-menu",
 				//Enhance menus that don't rely on the data-ajax plugin
 				ajaxFetch = $elm.data( "ajax-replace" ) || $elm.data( "ajax-append" ) || $elm.data( "ajax-prepend" );
 				if ( !ajaxFetch ) {
-					onAjaxLoaded( $elm, $elm );
+					onAjaxLoaded( $elm, $elm ); //NOTE TO SELF: this is the logic that upgrades hardcoded mega menus that don't use AJAX fragments
 				}
 			}
 		}
@@ -210,8 +210,8 @@ var componentName = "wb-menu",
 					allProperties = [],
 					$navCurr, $menuItem, $langItems, len, i;
 
-					console.log("MY MENU:");
-					console.log($menu);
+				console.log("MY MENU:");
+				console.log($menu);
 
 				/*
 				 * Build the mobile panel
@@ -307,10 +307,6 @@ var componentName = "wb-menu",
 					initOverlay( $panel );
 				}
 
-				/*
-				 * Build the regular mega menu
-				 */
-
 				// I think this is the spot I want... the entire mobile menu has already been built by this point and a mega menu copy/paste from the AJAX fragment seems to be in place by now...
 
 				// Challenges would be... do I want this at a later point? In order to support scenarios where the mega menu was hardcoded into the page...
@@ -337,11 +333,44 @@ var componentName = "wb-menu",
 
 				// NOTE: Remove createCollapsibleSection's unused params at some point... and params from any other similar situations
 
-				if ( $menu.length !== 0 ) {
-					//drizzleAria( $menu ); //don't need any ARIA attributes... except the mega menu blows up without this ugh lol
-					$menu
-						.filter( "[aria-haspopup=true], summary" )
-						.append( "<span class='expicon glyphicon glyphicon-chevron-down'></span>" );
+
+
+				/*
+				 * Build the regular mega menu
+				 */
+
+				//drizzleAria( $menu ); //don't need any ARIA attributes... except the mega menu blows up without this ugh lol
+
+				// Revise the menu bar's structure as needed
+				if ( $menubar.length ) {
+
+					// Remove hardcoded role attributes (menu/menubar pattern leftovers...)
+					$ajaxed.find( "ul[role]" ).removeAttr( "role" );
+
+					// Loop over top-level menu items
+					$menubar.children( "li" ).each(function() {
+						const $topLevelLi = $( this );
+						const $item = $topLevelLi.find( ".item" ).first();
+						const $submenu = $item.next( ".sm" );
+						const arrowIcon = "<span class='expicon glyphicon glyphicon-chevron-down' aria-hidden='true'></span>";
+
+						// If the item has a submenu...
+						if ( $item.length && $submenu.length ) {
+
+							// Add an arrow icon
+							$item.append( arrowIcon );
+
+							// Transform link/submenu combination into a details/summary structure
+							if ( $item.prop( "nodeName" ).toLowerCase() === "a" ) {
+
+								// Create a details element, turn the link into a summary and add its submenu
+								const $newDetails = $( "<details><summary class='item'>" + $item.html() + "</summary>" + $submenu[0].outerHTML + "</details>" );
+
+								// Replace the item's contents with the details element
+								$topLevelLi.empty().append($newDetails);
+							}
+						}
+					});
 				}
 
 				// Replace elements

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -70,6 +70,7 @@ var componentName = "wb-menu",
 		}
 	},
 
+	//TODO: Scrap this entirely since it's probably no longer needed
 	/**
 	 * Lets set some aria states and attributes
 	 * @method drizzleAria
@@ -84,19 +85,8 @@ var componentName = "wb-menu",
 			$elm = $elements.eq( i );
 			$subMenu = $elm.siblings( "ul" );
 
-			$elm.attr( {
-				"aria-posinset": ( i + 1 ),
-				"aria-setsize": length,
-				role: "menuitem"
-			} );
-
 			// if there is a submenu lets put in the aria for it
 			if ( $subMenu.length !== 0 ) {
-
-				$elm.attr( {
-					"aria-haspopup": "true",
-					"aria-expanded": "false"
-				} );
 
 				// recurse into submenu
 				drizzleAria( $subMenu.children( "li" ).find( menuItemSelector ) );
@@ -149,7 +139,7 @@ var componentName = "wb-menu",
 
 		var panel = "",
 			sectionHtml, properties, sections, section, parent, $items,
-			linkHtml, i, j, len, sectionsLength, itemsLength;
+			linkHtml, i, j, len, itemsLength;
 
 		// Process the secondary and site menus
 		len = allProperties.length;
@@ -157,8 +147,7 @@ var componentName = "wb-menu",
 			properties = allProperties[ i ];
 			sectionHtml = "";
 			sections = properties[ 0 ];
-			sectionsLength = sections.length;
-			for ( j = 0; j !== sectionsLength; j += 1 ) {
+			for ( j = 0; j !== sections.length; j += 1 ) {
 				section = sections[ j ];
 				$items = $( section.parentNode ).find( "> ul > li" );
 				itemsLength = $items.length;
@@ -184,19 +173,13 @@ var componentName = "wb-menu",
 							section.innerHTML + "</a>";
 					}
 
-					// Convert the list item to a WAI-ARIA menuitem
-					sectionHtml += "<li class='no-sect'>" +
-						linkHtml.replace(
-							/(<a\s)/,
-							"$1 class='mb-item' " + "role='menuitem' aria-setsize='" +
-								sectionsLength + "' aria-posinset='" + ( j + 1 ) +
-								"' tabindex='-1' "
-						) + "</li>";
+					// Convert the list item to a menuitem
+					sectionHtml += "<li class='no-sect'>" + linkHtml + "</li>";
 				}
 			}
 
 			// Create the panel section
-			panel += "<nav role='navigation' typeof='SiteNavigationElement' id='" +
+			panel += "<nav typeof='SiteNavigationElement' id='" +
 				properties[ 1 ] + "' class='" + properties[ 1 ] + " wb-menu wb-menu-inited'>" +
 				"<h3>" + properties[ 2 ] + "</h3>" +
 				"<ul class='list-unstyled mb-menu'>" +
@@ -276,9 +259,7 @@ var componentName = "wb-menu",
 					if ( $menubar.length !== 0 ) {
 
 						// Add the menubar role if it is missing
-						if ( !$menubar.attr( "role" ) ) {
-							$menubar.attr( "role", "menubar" );
-						}
+						// TODO: Turn this into something that *removes* the menubar role if it's present?
 
 						allProperties.push( [
 							$menu.get(),
@@ -352,13 +333,8 @@ var componentName = "wb-menu",
 
 				// NOTE: Remove createCollapsibleSection's unused params at some point... and params from any other similar situations
 
-				$ajaxed
-					.find( ":discoverable" )
-					.attr( "tabindex", "-1" );
-
 				if ( $menu.length !== 0 ) {
-					$menu[ 0 ].setAttribute( "tabindex", "0" );
-					drizzleAria( $menu ); //don't need any ARIA attributes... except the mega menu blows up without this ugh lol
+					//drizzleAria( $menu ); //don't need any ARIA attributes... except the mega menu blows up without this ugh lol
 					$menu
 						.filter( "[aria-haspopup=true], summary" )
 						.append( "<span class='expicon glyphicon glyphicon-chevron-down'></span>" );
@@ -389,7 +365,7 @@ var componentName = "wb-menu",
 
 					// Open up the secondary menu if it has wb-navcurr and has a submenu
 					$menuItem = $panel.find( "#sec-pnl .wb-navcurr.mb-item" );
-					if ( $menuItem.attr( "aria-haspopup" ) === "true" ) {
+					if ( $menuItem.attr( "aria-haspopup" ) === "true" ) { //TODO: Unsure how this logic works, need to investigate further...
 						$menuItem
 							.trigger( "click" )
 							.parent()
@@ -606,7 +582,7 @@ $document.on( "mouseenter", selector + " .sm", function() {
 } );
 
 // Touchscreen "touches" on menubar items should close the submenu if it is open
-$document.on( "click", selector + " .item[aria-haspopup=true]", function( event ) {
+$document.on( "click", selector + " summary.item", function( event ) {
 	var which = event.which,
 		$this, $parent;
 
@@ -705,7 +681,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 		$menuItem = $( menuItem ),
 		hasPopup = menuItem.nodeName.toLowerCase() === "summary",
 		$menu = $menuItem.parent().closest( "ul" ),
-		inMenuBar = $menu.attr( "role" ) === "menubar",
+		inMenuBar = $menu.hasClass( "menu" ),
 		$menuLink, $parentMenu, $parent, $subMenu, result,
 		isOpen, menuItemOffsetTop, menuContainer;
 
@@ -854,7 +830,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				}
 
 				// If the parent menu is a menubar
-				if ( $parentMenu.attr( "role" ) === "menubar" ) {
+				if ( $parentMenu.hasClass( "menu" ) ) {
 					$menuLink = $menu.siblings( "a, summary" );
 
 					// Escape key = Close menu and return to menu bar item
@@ -868,7 +844,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 						}, 100 );
 
 					// Left / right key = Next / previous menu bar item
-					} else if ( $parentMenu.attr( "role" ) === "menubar" ) {
+					} else if ( $parentMenu.hasClass( "menu" ) ) {
 						console.log("NEW: about to increment...");
 						console.log("$parentMenu:");
 						console.log($parentMenu);
@@ -936,6 +912,7 @@ $document.on( "keyup", selector + " [role=menuitem]", function( event ) {
 } );
 
 // Close the mobile panel if switching to medium, large or extra large view
+//TODO: Need to investigate this
 $document.on( "mediumview.wb largeview.wb xlargeview.wb", function() {
 	var mobilePanel = document.getElementById( "mb-pnl" );
 	if ( mobilePanel && mobilePanel.getAttribute( "role" ) && !mobilePanel.getAttribute( "open" ) ) {

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -888,10 +888,11 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 					}
 
 					// Move focus to the first submenu item
-					$parent.children( "ul" )
+					//NOTE: Not needed anymore... autofocusing to the first submenu item only makes sense in the menu pattern
+					/*$parent.children( "ul" )
 						.find( "a[href], summary" )
 						.first()
-						.trigger( focusEvent );
+						.trigger( focusEvent );*/
 				}
 
 			// Escape, left / right arrow without a submenu

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -75,7 +75,6 @@ var componentName = "wb-menu",
 	 * @method drizzleAria
 	 * @param {jQuery DOM elements} $elements The collection of elements
 	 */
-	// This is currently orphaned
 	drizzleAria = function( $elements ) {
 		var length = $elements.length,
 			$elm, $subMenu, i;
@@ -111,16 +110,15 @@ var componentName = "wb-menu",
 	 */
 	createCollapsibleSection = function( section, sectionIndex, sectionsLength, $items, itemsLength ) {
 
+		// Got rid of *most* ARIA attributes in the mobile menu by nuking this method... only remainders are tabindex=0/-1 on the summaries and role=menu on the top-level UL
+
 		// Use details/summary for the collapsible mechanism
 		var k, $elm, elm, $item, $subItems, subItemsLength,
 			$section = $( section ),
-			posinset = "' aria-posinset='",
-			menuitem = " role='menuitem' aria-setsize='",
 			sectionHtml = "<li><details>" + "<summary class='mb-item" +
 				( $section.hasClass( "wb-navcurr" ) || $section.children( ".wb-navcurr" ).length !== 0 ? " wb-navcurr'" : "'" ) +
-				menuitem + sectionsLength + posinset + ( sectionIndex + 1 ) +
-				"' aria-haspopup='true' aria-expanded='false'>" + $section.text() + "</summary>" +
-				"<ul class='list-unstyled mb-sm' role='menu'>";
+				">" + $section.text() + "</summary>" +
+				"<ul class='list-unstyled mb-sm'>";
 
 		// Convert each of the list items into WAI-ARIA menuitems
 		for ( k = 0; k !== itemsLength; k += 1 ) {
@@ -131,12 +129,7 @@ var componentName = "wb-menu",
 			subItemsLength = $subItems.length;
 
 			if ( elm && subItemsLength === 0 && elm.nodeName.toLowerCase() === "a" ) {
-				sectionHtml += "<li>" + $item[ 0 ].innerHTML.replace(
-					/(<a\s)/,
-					"$1" + menuitem + itemsLength +
-							posinset + ( k + 1 ) +
-							"' tabindex='-1' "
-				) + "</li>";
+				sectionHtml += "<li>" + $item[ 0 ].innerHTML + "</li>";
 			} else {
 				sectionHtml += createCollapsibleSection( elm, k, itemsLength, $subItems, $subItems.length );
 			}
@@ -151,6 +144,9 @@ var componentName = "wb-menu",
 	 * @return {string}
 	 */
 	createMobilePanelMenu = function( allProperties ) {
+
+		// Got rid of role=menu from the top-level UL in the mobile menu
+
 		var panel = "",
 			sectionHtml, properties, sections, section, parent, $items,
 			linkHtml, i, j, len, sectionsLength, itemsLength;
@@ -203,7 +199,7 @@ var componentName = "wb-menu",
 			panel += "<nav role='navigation' typeof='SiteNavigationElement' id='" +
 				properties[ 1 ] + "' class='" + properties[ 1 ] + " wb-menu wb-menu-inited'>" +
 				"<h3>" + properties[ 2 ] + "</h3>" +
-				"<ul class='list-unstyled mb-menu' role='menu'>" +
+				"<ul class='list-unstyled mb-menu'>" +
 				sectionHtml + "</ul></nav>";
 		}
 
@@ -230,8 +226,6 @@ var componentName = "wb-menu",
 					$panel = $( panelDOM ),
 					allProperties = [],
 					$navCurr, $menuItem, $langItems, len, i;
-
-				console.log($ajaxed[0].outerHTML);
 
 				/*
 				 * Build the mobile panel
@@ -309,8 +303,6 @@ var componentName = "wb-menu",
 					}
 
 					panel += createMobilePanelMenu( allProperties );
-
-					//console.log(panel);
 				}
 
 				// Let's now populate the DOM since we have done all the work in a documentFragment
@@ -333,6 +325,25 @@ var componentName = "wb-menu",
 				/*
 				 * Build the regular mega menu
 				 */
+
+				// I think this is the spot I want... the entire mobile menu has already been built by this point and a mega menu copy/paste from the AJAX fragment seems to be in place by now...
+
+				// Challenges would be... do I want this at a later point? In order to support scenarios where the mega menu was hardcoded into the page...
+
+				// What would happen to mobile menu creation if the details/summary mega menu was hardcoded OR was already coded like that in an AJAX fragment?
+
+				// How does the menu plugin behave when the mega menu is hardcoded - WITHOUT an AJAX fragment? Do its roles/etc get set/managed? Does the mobile menu still get generated? Yes, yes and yes... everything works perfectly in all scenarios with hardcoded mega menus :S
+
+				// Don't forget about noscript and basic HTML modes
+
+				// Don't forget to remove orphaned variables (like params for some of the methods I nuked)
+
+				// Don't forget to ensure navcurr still works correctly
+
+				// Don't forget about mobile menu scrolling offset functionality
+
+				// Don't forget about the mega menu's keystroke search feature
+
 				$ajaxed
 					.find( ":discoverable" )
 					.attr( "tabindex", "-1" );
@@ -340,9 +351,6 @@ var componentName = "wb-menu",
 				if ( $menu.length !== 0 ) {
 					$menu[ 0 ].setAttribute( "tabindex", "0" );
 					drizzleAria( $menu ); //don't need any ARIA attributes... except the mega menu blows up without this ugh lol
-					console.log("hmm in");
-					console.log($menu);
-					console.log("hmm out");
 					$menu
 						.filter( "[aria-haspopup=true], summary" )
 						.append( "<span class='expicon glyphicon glyphicon-chevron-down'></span>" );
@@ -407,15 +415,13 @@ var componentName = "wb-menu",
 	 * @param {jQuery object} $panel Current panel
 	 */
 	initOverlay = function( $panel ) {
+
+		// Got rid of summary tabindex attributes in the mobile menu by nuking this method
+
 		$panel
 			.trigger( "wb-init.wb-overlay" )
 			.find( "summary" )
-			.attr( "tabindex", "-1" )
 			.trigger( detailsInitEvent );
-		$panel
-			.find( ".mb-menu > li:first-child" )
-			.find( ".mb-item" )
-			.attr( "tabindex", "0" );
 	},
 
 	/**
@@ -655,7 +661,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 		inMenuBar = $menu.attr( "role" ) === "menubar",
 		$menuLink, $parentMenu, $parent, $subMenu, result,
 		isOpen, menuItemOffsetTop, menuContainer;
-console.log("oh man I'm a keydown!!!");
+
 	// Define keycodes. (Make const when WET supports ES6)
 	var TAB_KC = 9,
 		ENTER_KC = 13,

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -452,22 +452,24 @@ var componentName = "wb-menu",
 
 	/**
 	 * @method menuClose
-	 * @param {jQuery DOM element} $elm Parent of the element to close
+	 * @param {jQuery DOM element} $elm Parent of the element to close - btw this can potentially be an ARRAY of li elements (one call to it passes-in an $openMenus variable...)
 	 * @param {boolean} removeActive Whether or not to keep the active class
 	 */
 	menuClose = function( $elm, removeActive ) {
 
-		// Adjust top-level menu item's aria-expanded attribute
-		$elm
-			.find( "[aria-haspopup=true]" )
-			.attr( "aria-expanded", "false" );
+		// This logic is designed with li in mind
+		console.log("my $elm:");
+		console.log($elm);
+		console.log($elm.get(0));
 
+		// Adjust top-level menu item's class and open attribute
 		$elm
 			.removeClass( "sm-open" )
-			.children( ".open" )
-			.removeClass( "open" )
+			.children( "[open]" )
+			.removeAttr( "open" )
 
-		// Close nested submenus
+		// Close nested submenus... is that actually necessary? Is it desirable for users to have this mindlessly reset to closed?
+		//TODO: If I keep this, remove preceding children and removeAttr method calls since there's no point removing the open attribute separately for the top-level vs deeper details elements (unless I want to do fake clicking...?)
 			.find( "details" )
 			.removeAttr( "open" );
 
@@ -482,23 +484,27 @@ var componentName = "wb-menu",
 	 * @param {jQuery DOM element} $menu The menu to display
 	 */
 	menuDisplay = function( $elm, $menu ) {
-		var $menuLink = $menu.children( "a" );
+		var $menuLink = $menu.find( "> details > summary" );
+
+		console.log("inside menuDisplay");
 
 		menuClose( $elm.find( ".active" ), true );
 
 		$menu.addClass( "active" );
 
 		// Ignore if doesn't have a submenu
-		if ( $menuLink.attr( "aria-haspopup" ) === "true" ) {
+		if ( $menuLink ) { //TODO: This needs to be smarter than this... won't the status quo evaluate undefined to truthy and ultimately do nothing apart from TONS of pointless confusion?
 
-			// Add an aria-expanded attribute to the menu link
-			menuLink.attr( "aria-expanded", "true" );
+			console.log($menuLink);
+			console.log($menuLink.get(0));
+			console.log($menuLink.parent().get(0));
+
+			// Add an open attribute to the menu link's parent details element
+			$menuLink.parent().attr( "open", "open" ); //TODO: Should this be a fake click based on whether the details is already open?
 
 			// Add the open state classes
 			$menu
-				.addClass( "sm-open" )
-				.children( ".sm" )
-				.addClass( "open" );
+				.addClass( "sm-open" );
 		}
 	},
 
@@ -645,8 +651,10 @@ $document.on( "click", function( event ) {
 
 $document.on( "mouseover focusin", selector + " .item", function( event ) {
 	var $elm = $( event.currentTarget ),
-		$parent = $elm.parent(),
+		$parent = $elm.parent().parent(), //double-parent to get to the li element... but it might make more sense if it were the first parent (details element) and that got passed over to menuDisplay... hmm... btw calling this variable parent is goofy if it now a double-parent :P
 		$container = $parent.closest( selector );
+
+	console.log("mousing over something...");
 
 	// Clear the timeout for open/closing menus
 	clearTimeout( globalTimeout );
@@ -711,8 +719,9 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 			// Left / right arrow = Previous / next menu item
 			if ( which === LEFT_KC || which === RIGHT_KC ) {
 				event.preventDefault();
+				console.log("Moving left/right on mega menu bar");
 				menuIncrement(
-					$menu.find( "> li > a" ),
+					$menu.find( "> li > details > summary" ),
 					$menuItem,
 					which === LEFT_KC ? -1 : 1
 				);
@@ -720,16 +729,18 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 			// Enter sub-menu
 			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC || which === UP_KC || which === DOWN_KC ) ) {
 				event.preventDefault();
+				console.log("inside mystery mega menu submenu logic");
 				$parent = $menuItem.parent();
 				$subMenu = $parent.find( ".sm" );
 
 				// Open the submenu if it is not already open
 				if ( !$subMenu.hasClass( "open" ) ) {
+					console.log("opening the mega menu submenu");
 					menuDisplay( $menu.closest( selector ), $parent );
 				}
 
 				// Set focus on the first submenu item
-				$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent );
+				$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent ); //oooooooooooooooooooooooooo
 
 			// Hide sub-menus and set focus
 			} else if ( which === ESC_KC ) {
@@ -773,7 +784,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				if ( menuItem.nodeName.toLowerCase( "summary" ) ) {
 					isOpen = !!$parent.attr( "open" );
 
-					console.log("summary element check");
+					console.log("summary element check... works in mobile menu and mega menu");
 
 					// Close any other open menus
 					// BRAINDUMP: This is misleading... I don't see any logic here that would actually close other open menus... I think it's because that line comment was copied from somewhere else that actually does what it's supposed to
@@ -790,7 +801,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 						}
 
 						// Ensure the menu is opened or stays open
-						console.log("fake click triggered to open the clicked summary in mobile menu");
+						console.log("fake click triggered to open the clicked summary in mobile menu... runs in mega menu too");
 						$menuItem.trigger( "click" );
 					}
 

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -900,11 +900,12 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 
 							menuContainer.scrollTop = menuItemOffsetTop;
 						}
-
-						// Ensure the menu is opened or stays open
-						console.log("fake click triggered to open the clicked summary in mobile menu... runs in mega menu too");
-						$menuItem.trigger( "click" );
 					}
+
+					// Ensure the menu is opened or stays open
+					// NOTE: Unsure why this had to be taken out of the !isOpen if condition... but it appears to fully work in both the mega+mobile menus
+					console.log("fake click triggered to open the clicked summary in mobile menu... runs in mega menu too");
+					$menuItem.trigger( "click" );
 
 					// Move focus to the first submenu item
 					//NOTE: Not needed anymore... autofocusing to the first submenu item only makes sense in the menu pattern

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -199,7 +199,7 @@ var componentName = "wb-menu",
 			inner = function() {
 				var $ajaxed = $ajaxResult && $ajaxResult.attr( "data-type" ) === "string" ? $ajaxResult : $elm,
 					$menubar = $ajaxed.find( ".menu" ),
-					$menu = $menubar.find( "> li > a" ), //TODO: this might need to cover summaries too (via > li > details > summary)... but aren't 100% sure, adjusting it currently breaks things (like adding second dropdown arrows beside the hardcoded ones in the summaries and focus plugin console errors)... should it only be targeting DROPDOWN links? As in top-level summaries exclusively?
+					$menu = $menubar.find( "> li > a, > li > details > summary" ), //TODO: this might need to cover summaries too (via > li > details > summary)... but aren't 100% sure, adjusting it currently breaks things (like adding second dropdown arrows beside the hardcoded ones in the summaries and focus plugin console errors)... should it only be targeting DROPDOWN links? As in top-level summaries exclusively?
 					target = $elm.data( "trgt" ),
 					$secnav = $( "#wb-sec" ),
 					$language = $( "#wb-lng" ),
@@ -209,6 +209,9 @@ var componentName = "wb-menu",
 					$panel = $( panelDOM ),
 					allProperties = [],
 					$navCurr, $menuItem, $langItems, len, i;
+
+					console.log("MY MENU:");
+					console.log($menu);
 
 				/*
 				 * Build the mobile panel

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -915,10 +915,10 @@ $document.on( "keyup", selector + " [role=menuitem]", function( event ) {
 } );
 
 // Close the mobile panel if switching to medium, large or extra large view
-//TODO: Need to investigate this
+//NOTE: These ARIA attributes come from the overlay plugin, so leave this logic as-is... no need to tamper with them
 $document.on( "mediumview.wb largeview.wb xlargeview.wb", function() {
 	var mobilePanel = document.getElementById( "mb-pnl" );
-	if ( mobilePanel && mobilePanel.getAttribute( "role" ) && !mobilePanel.getAttribute( "open" ) ) {
+	if ( mobilePanel && mobilePanel.getAttribute( "aria-hidden" ) === "false" ) {
 		$( mobilePanel ).trigger( {
 			type: ( "close" ),
 			namespace: "wb-overlay",

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -470,6 +470,8 @@ var componentName = "wb-menu",
 	 */
 	menuClose = function( $elm, removeActive ) {
 
+		//NOTE: Sometimes null $elm elements (like jQuery arrays with a legth of 0) get passed into this method... like when clicking out of open mega menu dropdowns or other weird circumstances
+		//TODO: Should I put all this logic into something like an if block that checks whether $elm.length is truthy? No logic truly needs it atm, but normal JS logic in this function or prop checks would risk breaking if $elm didn't actually exist...
 		console.log("inside menuClose");
 
 		// This logic is designed with li in mind
@@ -490,7 +492,18 @@ var componentName = "wb-menu",
 			.removeAttr( "open" );
 
 		if ( removeActive ) {
+			console.log("REMOVING active class");
 			$elm.removeClass( "active" );
+
+			console.log($elm);
+
+			if ($elm.length === 0) {
+				console.log("Huh? $elm doesn't exist...?");
+			}
+
+			if ($elm.length && $elm.children().first().prop( "nodeName" ).toLowerCase() === "a") {
+				console.log("HEADS-UP: Moving away from an active LINK (not summary)");
+			}
 		}
 	},
 
@@ -611,6 +624,19 @@ $document.on( "mouseleave", selector + " .menu", function( event ) {
 	}, hoverDelay );
 } );
 
+//Focus equivalent for mouseleave
+$document.on( "focusout", selector + " .menu:has(.active)", function( event ) {
+	var $currentTarget = $( event.currentTarget );
+
+	console.log("Focus is leaving the menu bar...");
+	console.log(event);
+
+	// Close the menu if the element that gained focus ISN'T a child of the menu
+	if ($currentTarget.find(event.relatedTarget).length === 0) {
+		menuClose( $currentTarget.find( ".active" ), true ); //NOTE: Can't pass event.target here directly since it's a link/summary and menuClose needs to take in an LI... although I could do closest() on event.target if I want... it's more in line with some other calls and might match faster since .item is a parent element
+	}
+} );
+
 // Prevent opening another menu if mouse re-enters already opened menu
 $document.on( "mouseenter", selector + " .sm", function() {
 	if ( $( this ).hasClass( "open" ) ) {
@@ -729,6 +755,8 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 		if ( which === TAB_KC ) {
 			//commenting-out since this makes it impossible to tab into the mega menu's submenu dropdowns
 			//console.log("Tab key = Hide all sub-menus... calling menuClose");
+
+			//console.log("Tab key pressed, calling menuClose");
 			//menuClose( $( selector + " .active" ), true );
 
 		//Enter or spacebar on a link = follow the link and close menus

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -340,9 +340,17 @@ var componentName = "wb-menu",
 
 				// Don't forget to ensure navcurr still works correctly
 
-				// Don't forget about mobile menu scrolling offset functionality
+				// Don't forget about mobile menu scrolling offset functionality (or scrap it?)
 
-				// Don't forget about the mega menu's keystroke search feature
+				// Should scrap the menu's keystroke search feature... don't want random letter key presses doing anything interactive if nothing else will
+
+				// Don't forget about Home/End support (btw the JS for them doesn't run in NVDA)
+
+				// APG disclosure pattern talks about aria-current="page" for links to the current page...
+
+				// NOTE: aria-setsize and aria-posinset don't cause anything to be announced by default... seems to only work when using certain ARIA roles
+
+				// NOTE: Remove createCollapsibleSection's unused params at some point... and params from any other similar situations
 
 				$ajaxed
 					.find( ":discoverable" )

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -75,6 +75,7 @@ var componentName = "wb-menu",
 	 * @method drizzleAria
 	 * @param {jQuery DOM elements} $elements The collection of elements
 	 */
+	// This is currently orphaned
 	drizzleAria = function( $elements ) {
 		var length = $elements.length,
 			$elm, $subMenu, i;
@@ -230,6 +231,8 @@ var componentName = "wb-menu",
 					allProperties = [],
 					$navCurr, $menuItem, $langItems, len, i;
 
+				console.log($ajaxed[0].outerHTML);
+
 				/*
 				 * Build the mobile panel
 				 */
@@ -306,6 +309,8 @@ var componentName = "wb-menu",
 					}
 
 					panel += createMobilePanelMenu( allProperties );
+
+					//console.log(panel);
 				}
 
 				// Let's now populate the DOM since we have done all the work in a documentFragment
@@ -334,9 +339,12 @@ var componentName = "wb-menu",
 
 				if ( $menu.length !== 0 ) {
 					$menu[ 0 ].setAttribute( "tabindex", "0" );
-					drizzleAria( $menu );
+					drizzleAria( $menu ); //don't need any ARIA attributes... except the mega menu blows up without this ugh lol
+					console.log("hmm in");
+					console.log($menu);
+					console.log("hmm out");
 					$menu
-						.filter( "[aria-haspopup=true]" )
+						.filter( "[aria-haspopup=true], summary" )
 						.append( "<span class='expicon glyphicon glyphicon-chevron-down'></span>" );
 				}
 
@@ -647,7 +655,7 @@ $document.on( "keydown", selector + " [role=menuitem]", function( event ) {
 		inMenuBar = $menu.attr( "role" ) === "menubar",
 		$menuLink, $parentMenu, $parent, $subMenu, result,
 		isOpen, menuItemOffsetTop, menuContainer;
-
+console.log("oh man I'm a keydown!!!");
 	// Define keycodes. (Make const when WET supports ES6)
 	var TAB_KC = 9,
 		ENTER_KC = 13,

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -748,8 +748,6 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 
 	if ( !( event.ctrlKey || event.altKey || event.metaKey ) ) {
 
-		// Many strange issues will likely occur as a result of the ARIA roles/etc I scrapped
-
 		// Tab key = Hide all sub-menus
 		//Auto-closes the mega menu when tabbing over it (the open top-level link has the active class)... runs in the mobile menu too, but is pointless in that context
 		if ( which === TAB_KC ) {
@@ -769,87 +767,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 			menuItem.click();
 			menuClose( $( selector + " .active" ), true );
 
-		// Menu item is within a menu bar
-		} else if ( inMenuBar ) {
-
-			console.log("In inMenuBar if");
-
-			// Left-up / right-down arrow = Previous / next menu item
-			if ( which === LEFT_KC || which === UP_KC || which === RIGHT_KC || which === DOWN_KC ) {
-				event.preventDefault();
-				//const advancing = RIGHT_KC || DOWN_KC ? true : false;
-				console.log("Moving left-up/right-down on mega menu bar");
-
-				// If the focused menu item is a summary for an open details element and the user is trying to advance via the right/down arrows... focus onto its submenu's first item
-				if ( hasPopup && $menuItem.parent().attr( "open" ) && ( which === RIGHT_KC || which === DOWN_KC ) ) {
-					console.log("GOING TO FIRST SUBMENU ITEM!!! Pressed right/down on an expanded summary in the mega menu...");
-					console.log($menuItem.parent().attr( "open" ));
-					event.preventDefault(); //this is pointless... it's already in the parent if condition
-					let $parentLi = $menuItem.closest( "li" );
-					$subMenu = $parentLi.find( ".sm" );
-
-					// Set focus on the first submenu item
-					$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent );
-				} else {
-
-					console.log("going left/right...");
-					menuIncrement(
-						$menu.find( "> li > a, > li > details > summary" ),
-						$menuItem,
-						which === LEFT_KC || which === UP_KC ? -1 : 1
-					);
-				}
-
-			// HOME / END keys = First / last menu item
-			//NOTE: Only works on top menu bar atm
-			} else if ( which === HOME_KC || which === END_KC ) {
-				event.preventDefault();
-				console.log("Pressed HOME or END on mega menu bar");
-				const $menuItems = $menu.children( "li" ).find( menuItemSelector );
-				//TODO: Add a condition here (or in menuIncrement itself) to not needlessly call menuIncrement if curreny focus is already on the first or last item in the array (like by comparing $menuItem vs $menuItems.first() or $menuItems.last()
-				menuIncrement(
-					$menuItems,
-					which === HOME_KC ? $menuItems.first() : $menuItems.last(),
-					which === 0
-				);
-
-			// Toggle sub-menu
-			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC ) ) {
-				event.preventDefault(); // Absolutely need this for Enter key compatibility!!!
-				console.log("inside mystery mega menu submenu logic");
-				let $parentDetails = $menuItem.parent();
-				let $parentLi = $menuItem.closest( "li" );
-				$subMenu = $parentLi.find( ".sm" );
-
-				// Open the submenu if it is not already open
-				if ( !$parentDetails.attr( "open" ) ) {
-					console.log("opening the mega menu submenu");
-					menuDisplay( $menu.closest( selector ), $parentLi );
-				} else {
-					console.log("closing the mega menu submenu");
-					menuClose( $menu.closest( selector ).find( ".active" ), false );
-				}
-
-				// Set focus on the first submenu item
-				// Nerfed this to prevent pressing top-level mega menu items from auto-focusing onto the first submenu item
-				//$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent ); //oooooooooooooooooooooooooo
-
-			// Hide sub-menus and set focus
-			//NOTE: Very similar to aforementioned else if, but doesn't toggle (if I try porting it there I'd need to ensure ESC never toggles)
-			} else if ( which === ESC_KC ) {
-				event.preventDefault();
-				menuClose( $menu.closest( selector ).find( ".active" ), false );
-
-			// Letters only
-			} else if ( which > 64 && which < 91 ) {
-				event.preventDefault();
-				selectByLetter(
-					which,
-					$menuItem.parent().find( "> ul > li > a, > ul > li > details > summary" ).get()
-				);
-			}
-
-		// Menu item is not within a menu bar
+		// Menu item is within a menu
 		} else {
 			console.log("In else");
 
@@ -861,20 +779,20 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				//const advancing = RIGHT_KC || DOWN_KC ? true : false;
 				console.log("Moving left-up/right-down on mobile menu");
 
-				// In the mobile menu... if the focused menu item is a summary for an open details element and the user is trying to advance via the right/down arrows... focus onto its submenu's first item
+				// If the focused menu item is a summary for an open details element and the user is trying to advance via the right/down arrows... focus onto its submenu's first item
 				if ( hasPopup && $menuItem.parent().attr( "open" ) && ( which === RIGHT_KC || which === DOWN_KC ) ) {
-					console.log("GOING TO FIRST SUBMENU ITEM!!! Pressed right/down on an expanded summary in the mobile menu...");
+					console.log("GOING TO FIRST SUBMENU ITEM!!! Pressed right/down on an expanded summary in the menu...");
 					console.log($menuItem);
 					console.log($menuItem.parent().attr( "open" ));
 					event.preventDefault(); //this is pointless... it's already in the parent if condition
 					let $parentLi = $menuItem.closest( "li" );
-					$subMenu = $parentLi.find( ".mb-sm" ); //NOTE: This is the same as the mega menu logic's selector, but targets a mobile flavour of its class name
+					$subMenu = $parentLi.find( ".sm, .mb-sm" ); //NOTE: Targets mega/mobile menu flavours of the same class name
 
 					// Set focus on the first submenu item
 					$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent );
 				} else {
 
-					console.log("going left/right in the mobile menu...");
+					console.log("going left/right in the menu...");
 					menuIncrement(
 						$menu.children( "li" ).find( menuItemSelector ),
 						$menuItem,
@@ -884,10 +802,9 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				}
 
 			// HOME / END keys = First / last menu item
-			//NOTE: Copy of the top menu bar's logic for "not within a menu bar" scenarios, logic hasn't changed at all... so maybe only provide the logic once
 			} else if ( which === HOME_KC || which === END_KC ) {
 				event.preventDefault();
-				console.log("Pressed HOME or END on when not within a menu bar");
+				console.log("Pressed HOME or END");
 				const $menuItems = $menu.children( "li" ).find( menuItemSelector );
 				//TODO: Add a condition here (or in menuIncrement itself) to not needlessly call menuIncrement if curreny focus is already on the first or last item in the array (like by comparing $menuItem vs $menuItems.first() or $menuItems.last()
 				menuIncrement(
@@ -896,6 +813,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 					which === 0
 				);
 
+			// Toggle sub-menu
 			// Enter or space arrow with a submenu
 			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC ) ) {
 				$parent = $menuItem.parent(); //shouldn't need to use closest() for this part since the else if condition's hasPopup check will guarantee this can only run against summaries that are top-level mega menu items

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -786,9 +786,13 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 					console.log($menuItem.parent().attr( "open" ));
 					event.preventDefault(); //this is pointless... it's already in the parent if condition
 					let $parentLi = $menuItem.closest( "li" );
-					$subMenu = $parentLi.find( ".sm, .mb-sm" ); //NOTE: Targets mega/mobile menu flavours of the same class name
+					console.log("PARENT LI:");
+					console.log($parentLi);
+					$subMenu = $parentLi.find( "ul" );
 
 					// Set focus on the first submenu item
+					console.log("TRYING TO FOCUS ONTO A LINK OR SUMMARY IN THIS CHILD:");
+					console.log($subMenu.children( "li" ));
 					$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent );
 				} else {
 

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -216,7 +216,7 @@ var componentName = "wb-menu",
 			inner = function() {
 				var $ajaxed = $ajaxResult && $ajaxResult.attr( "data-type" ) === "string" ? $ajaxResult : $elm,
 					$menubar = $ajaxed.find( ".menu" ),
-					$menu = $menubar.find( "> li > a" ),
+					$menu = $menubar.find( "> li > a" ), //TODO: this might need to cover summaries too (via > li > details > summary)... but aren't 100% sure, adjusting it currently breaks things (like adding second dropdown arrows beside the hardcoded ones in the summaries and focus plugin console errors)... should it only be targeting DROPDOWN links? As in top-level summaries exclusively?
 					target = $elm.data( "trgt" ),
 					$secnav = $( "#wb-sec" ),
 					$language = $( "#wb-lng" ),
@@ -447,6 +447,8 @@ var componentName = "wb-menu",
 		index = index === menuItemsLength ? 0 : index === -1 ? menuItemsLength - 1 : index;
 
 		// Move to the new menu item
+		console.log("NEW: about to focus onto this via menuIncrement():");
+		console.log($menuItems.eq( index )[0]);
 		$menuItems.eq( index ).trigger( focusEvent );
 	},
 
@@ -462,6 +464,7 @@ var componentName = "wb-menu",
 		console.log($elm);
 		console.log($elm.get(0));
 
+		//IDEA TO CONSIDER: Should I adjust this logic to only start running if the sm-open class exists in the first place?
 		// Adjust top-level menu item's class and open attribute
 		$elm
 			.removeClass( "sm-open" )
@@ -484,16 +487,34 @@ var componentName = "wb-menu",
 	 * @param {jQuery DOM element} $menu The menu to display
 	 */
 	menuDisplay = function( $elm, $menu ) {
-		var $menuLink = $menu.find( "> details > summary" );
+		var $menuLink = $menu.find( "> a, > details > summary" ); //the issue seems to be that menu is getting passed as the mega menu UL (instead of LI.active) when hovering over an A element in the top-level mega menu items... which means some logic that calls this method is passing crap for $menu... ACTUALLY even though that's a bug, it's not causing any console errors in practice
 
 		console.log("inside menuDisplay");
 
-		menuClose( $elm.find( ".active" ), true );
+		//if ($elm.find( ".active.sm-open" ).length) {
+			console.log("yay!!!");
+			menuClose( $elm.find( ".active" ), true );
+		//} else {
+			console.log("nah!!!");
+		//}
+		console.log($elm);
+		console.log($elm.find( ".active.sm-open" ));
 
 		$menu.addClass( "active" );
+		console.log("loggy loggy");
+		console.log("$elm:");
+		console.log($elm);
+		console.log("$menu (added active class to it too):");
+		console.log($menu);
+		console.log("$menuLink:");
+		console.log($menuLink);
+
+		if (!$menuLink.length) {
+			console.log("OH NOES, I have no length!!!");
+		}
 
 		// Ignore if doesn't have a submenu
-		if ( $menuLink ) { //TODO: This needs to be smarter than this... won't the status quo evaluate undefined to truthy and ultimately do nothing apart from TONS of pointless confusion?
+		if ( $menuLink.prop( "nodeName" ).toLowerCase() === "summary" ) { //TODO: This needs to be smarter than this... won't the status quo evaluate undefined to truthy and ultimately do nothing apart from TONS of pointless confusion?
 
 			console.log($menuLink);
 			console.log($menuLink.get(0));
@@ -651,8 +672,8 @@ $document.on( "click", function( event ) {
 
 $document.on( "mouseover focusin", selector + " .item", function( event ) {
 	var $elm = $( event.currentTarget ),
-		$parent = $elm.parent().parent(), //double-parent to get to the li element... but it might make more sense if it were the first parent (details element) and that got passed over to menuDisplay... hmm... btw calling this variable parent is goofy if it now a double-parent :P
-		$container = $parent.closest( selector );
+		$parentLi = $elm.closest( "li" ), //closest() is the best compromise between a vs summary elements.... unless I want to do an terniary element check or something (don't see a need for it)
+		$container = $parentLi.closest( selector );
 
 	console.log("mousing over something...");
 
@@ -660,10 +681,17 @@ $document.on( "mouseover focusin", selector + " .item", function( event ) {
 	clearTimeout( globalTimeout );
 
 	if ( event.type === "focusin" ) {
-		menuDisplay( $container, $parent );
+		console.log("NEW: ---");
+		console.log("NEW: focusin...");
+		console.log("NEW: $container:");
+		console.log($container);
+		console.log("NEW: $parentLi");
+		console.log($parentLi);
+		console.log("NEW: ---");
+		menuDisplay( $container, $parentLi );
 	} else {
 		globalTimeout = setTimeout( function() {
-			menuDisplay( $container, $parent );
+			menuDisplay( $container, $parentLi );
 		}, hoverDelay );
 	}
 } );
@@ -675,7 +703,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 	var menuItem = event.currentTarget,
 		which = event.which,
 		$menuItem = $( menuItem ),
-		hasPopup = menuItem.nodeName.toLowerCase( "summary" ),
+		hasPopup = menuItem.nodeName.toLowerCase() === "summary",
 		$menu = $menuItem.parent().closest( "ul" ),
 		inMenuBar = $menu.attr( "role" ) === "menubar",
 		$menuLink, $parentMenu, $parent, $subMenu, result,
@@ -721,7 +749,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				event.preventDefault();
 				console.log("Moving left/right on mega menu bar");
 				menuIncrement(
-					$menu.find( "> li > details > summary" ),
+					$menu.find( "> li > a, > li > details > summary" ),
 					$menuItem,
 					which === LEFT_KC ? -1 : 1
 				);
@@ -730,7 +758,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC || which === UP_KC || which === DOWN_KC ) ) {
 				event.preventDefault();
 				console.log("inside mystery mega menu submenu logic");
-				$parent = $menuItem.parent();
+				$parent = $menuItem.closest( "li" );
 				$subMenu = $parent.find( ".sm" );
 
 				// Open the submenu if it is not already open
@@ -772,18 +800,21 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 
 			// Enter, space, or right arrow with a submenu
 			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC || which === RIGHT_KC ) ) {
-				$parent = $menuItem.parent();
+				$parent = $menuItem.parent(); //shouldn't need to use closest() for this part since the else if condition's hasPopup check will guarantee this can only run against summaries that are top-level mega menu items
 
 				// Prevent handling by details.js polyfill
 				event.stopImmediatePropagation();
 				event.preventDefault();
 
 				console.log("Enter, space, or right arrow with a submenu... does misc stuff");
+				console.log(menuItem);
+				console.log(menuItem.nodeName.toLowerCase() === "summary");
 
 				// If the menu item is a summary element
-				if ( menuItem.nodeName.toLowerCase( "summary" ) ) {
+				if ( menuItem.nodeName.toLowerCase() === "summary" ) {
 					isOpen = !!$parent.attr( "open" );
 
+					//this is is where things are spiralling out of control... the old logic never got into this if when left/right pressing while deep inside a mega menu dropdown
 					console.log("summary element check... works in mobile menu and mega menu");
 
 					// Close any other open menus
@@ -814,15 +845,17 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 
 			// Escape, left / right arrow without a submenu
 			} else if ( which === ESC_KC || which === LEFT_KC || which === RIGHT_KC ) {
+				console.log("NEW: uh oh 1...");
 				$parent = $menu.parent();
 				$parentMenu = $parent.closest( "ul" );
 				if ( which === LEFT_KC || which === RIGHT_KC ) {
 					event.preventDefault();
+					console.log("NEW: uh oh 2...");
 				}
 
 				// If the parent menu is a menubar
 				if ( $parentMenu.attr( "role" ) === "menubar" ) {
-					$menuLink = $menu.siblings( "a" );
+					$menuLink = $menu.siblings( "a, summary" );
 
 					// Escape key = Close menu and return to menu bar item
 					if ( which === ESC_KC ) {
@@ -836,8 +869,15 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 
 					// Left / right key = Next / previous menu bar item
 					} else if ( $parentMenu.attr( "role" ) === "menubar" ) {
+						console.log("NEW: about to increment...");
+						console.log("$parentMenu:");
+						console.log($parentMenu);
+						console.log("$parentMenu.find( \"> li > a, > li > details > summary\" ):");
+						console.log($parentMenu.find( "> li > a, > li > details > summary" )); //returns a 1 item array with "some random link" A element
+						console.log("$menuLink:");
+						console.log($menuLink); //returns a 0 length array... maybe because the summaries aren't being selected
 						menuIncrement(
-							$parentMenu.find( "> li > a" ),
+							$parentMenu.find( "> li > a, > li > details > summary" ), //I think my issue is that something's wrong with this selector... I think it should be going to a summary? Btw another selector variable earlier on is a duplicate of this selector... fixed it
 							$menuLink,
 							which === LEFT_KC ? -1 : 1
 						);

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -108,7 +108,7 @@ var componentName = "wb-menu",
 	 * @method createCollapsibleSection
 	 * @return {string}
 	 */
-	createCollapsibleSection = function( section, sectionIndex, sectionsLength, $items, itemsLength ) {
+	createCollapsibleSection = function( section, $items, itemsLength ) {
 
 		// Got rid of *most* ARIA attributes in the mobile menu by nuking this method... only remainders are tabindex=0/-1 on the summaries and role=menu on the top-level UL
 
@@ -131,7 +131,7 @@ var componentName = "wb-menu",
 			if ( elm && subItemsLength === 0 && elm.nodeName.toLowerCase() === "a" ) {
 				sectionHtml += "<li>" + $item[ 0 ].innerHTML + "</li>";
 			} else {
-				sectionHtml += createCollapsibleSection( elm, k, itemsLength, $subItems, $subItems.length );
+				sectionHtml += createCollapsibleSection( elm, $subItems, $subItems.length );
 			}
 		}
 
@@ -165,7 +165,7 @@ var componentName = "wb-menu",
 
 				// Collapsible section
 				if ( itemsLength !== 0 ) {
-					sectionHtml += createCollapsibleSection( section, j, sectionsLength, $items, itemsLength );
+					sectionHtml += createCollapsibleSection( section, $items, itemsLength );
 				} else {
 					parent = section.parentNode;
 
@@ -929,6 +929,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 } );
 
 // Prevent Firefox from double-triggering menu behaviour
+//TODO: Need to investigate this
 $document.on( "keyup", selector + " [role=menuitem]", function( event ) {
 	event.preventDefault();
 	return false;

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -755,8 +755,8 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				// If the focused menu item is a summary for an open details element and the user is trying to advance via the right/down arrows... focus onto its submenu's first item
 				if ( hasPopup && $menuItem.parent().attr( "open" ) && ( which === RIGHT_KC || which === DOWN_KC ) ) {
 					console.log("GOING TO FIRST SUBMENU ITEM!!! Pressed right/down on an expanded summary in the mega menu...");
-					console.log($menuItem.attr( "open" ));
-					event.preventDefault();
+					console.log($menuItem.parent().attr( "open" ));
+					event.preventDefault(); //this is pointless... it's already in the parent if condition
 					let $parentLi = $menuItem.closest( "li" );
 					$subMenu = $parentLi.find( ".sm" );
 
@@ -825,16 +825,35 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 		} else {
 			console.log("In else");
 
-			// Up-left / down-right arrow = Previous / next menu item
+			// Left-up / right-down arrow = Previous / next menu item
 			if ( which === LEFT_KC || which === UP_KC || which === RIGHT_KC || which === DOWN_KC ) {
 				event.preventDefault();
 				console.log("Up-left / down-right arrow = Previous / next menu item... calling menuIncrement");
-				menuIncrement(
-					$menu.children( "li" ).find( menuItemSelector ),
-					$menuItem,
-					which === LEFT_KC || which === UP_KC ? -1 : 1
-					//TODO: This should do the job for fixing up/down arrow support... but still need to look into the latter conditions beyond here to look into removing more right/left variable checks
-				);
+
+				//const advancing = RIGHT_KC || DOWN_KC ? true : false;
+				console.log("Moving left-up/right-down on mobile menu");
+
+				// In the mobile menu... if the focused menu item is a summary for an open details element and the user is trying to advance via the right/down arrows... focus onto its submenu's first item
+				if ( hasPopup && $menuItem.parent().attr( "open" ) && ( which === RIGHT_KC || which === DOWN_KC ) ) {
+					console.log("GOING TO FIRST SUBMENU ITEM!!! Pressed right/down on an expanded summary in the mobile menu...");
+					console.log($menuItem);
+					console.log($menuItem.parent().attr( "open" ));
+					event.preventDefault(); //this is pointless... it's already in the parent if condition
+					let $parentLi = $menuItem.closest( "li" );
+					$subMenu = $parentLi.find( ".mb-sm" ); //NOTE: This is the same as the mega menu logic's selector, but targets a mobile flavour of its class name
+
+					// Set focus on the first submenu item
+					$subMenu.children( "li" ).eq( 0 ).find( menuItemSelector ).trigger( focusEvent );
+				} else {
+
+					console.log("going left/right in the mobile menu...");
+					menuIncrement(
+						$menu.children( "li" ).find( menuItemSelector ),
+						$menuItem,
+						which === LEFT_KC || which === UP_KC ? -1 : 1
+						//TODO: This should do the job for fixing up/down arrow support... but still need to look into the latter conditions beyond here to look into removing more right/left variable checks
+					);
+				}
 
 			// HOME / END keys = First / last menu item
 			//NOTE: Copy of the top menu bar's logic for "not within a menu bar" scenarios, logic hasn't changed at all... so maybe only provide the logic once

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -752,8 +752,9 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				//const advancing = RIGHT_KC || DOWN_KC ? true : false;
 				console.log("Moving left-up/right-down on mega menu bar");
 
-				if ( hasPopup && $menuItem.parent().attr( "open" ) ) {
-					console.log("GOING TO FIRST SUBMENU ITEM!!!");
+				// If the focused menu item is a summary for an open details element and the user is trying to advance via the right/down arrows... focus onto its submenu's first item
+				if ( hasPopup && $menuItem.parent().attr( "open" ) && ( which === RIGHT_KC || which === DOWN_KC ) ) {
+					console.log("GOING TO FIRST SUBMENU ITEM!!! Pressed right/down on an expanded summary in the mega menu...");
 					console.log($menuItem.attr( "open" ));
 					event.preventDefault();
 					let $parentLi = $menuItem.closest( "li" );

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -868,15 +868,15 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 					which === 0
 				);
 
-			// Enter, space, or right arrow with a submenu
-			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC || which === RIGHT_KC ) ) {
+			// Enter or space arrow with a submenu
+			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC ) ) {
 				$parent = $menuItem.parent(); //shouldn't need to use closest() for this part since the else if condition's hasPopup check will guarantee this can only run against summaries that are top-level mega menu items
 
 				// Prevent handling by details.js polyfill
 				event.stopImmediatePropagation();
 				event.preventDefault();
 
-				console.log("Enter, space, or right arrow with a submenu... does misc stuff");
+				console.log("Enter or space arrow with a submenu... does misc stuff");
 				console.log(menuItem);
 				console.log(menuItem.nodeName.toLowerCase() === "summary");
 

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -776,7 +776,7 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 			} else if ( which === HOME_KC || which === END_KC ) {
 				event.preventDefault();
 				console.log("Pressed HOME or END on mega menu bar");
-				const $menuItems = $menu.find( "> li > a, > li > details > summary" );
+				const $menuItems = $menu.children( "li" ).find( menuItemSelector );
 				//TODO: Add a condition here (or in menuIncrement itself) to not needlessly call menuIncrement if curreny focus is already on the first or last item in the array (like by comparing $menuItem vs $menuItems.first() or $menuItems.last()
 				menuIncrement(
 					$menuItems,
@@ -833,6 +833,19 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 					$menuItem,
 					which === LEFT_KC || which === UP_KC ? -1 : 1
 					//TODO: This should do the job for fixing up/down arrow support... but still need to look into the latter conditions beyond here to look into removing more right/left variable checks
+				);
+
+			// HOME / END keys = First / last menu item
+			//NOTE: Copy of the top menu bar's logic for "not within a menu bar" scenarios, logic hasn't changed at all... so maybe only provide the logic once
+			} else if ( which === HOME_KC || which === END_KC ) {
+				event.preventDefault();
+				console.log("Pressed HOME or END on when not within a menu bar");
+				const $menuItems = $menu.children( "li" ).find( menuItemSelector );
+				//TODO: Add a condition here (or in menuIncrement itself) to not needlessly call menuIncrement if curreny focus is already on the first or last item in the array (like by comparing $menuItem vs $menuItems.first() or $menuItems.last()
+				menuIncrement(
+					$menuItems,
+					which === HOME_KC ? $menuItems.first() : $menuItems.last(),
+					which === 0
 				);
 
 			// Enter, space, or right arrow with a submenu

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -764,6 +764,7 @@ $document.on( "mouseover focusin", selector + " .item", function( event ) {
 		console.log("NEW: ---");
 		menuDisplay( $container, $parentLi, false );
 	} else {
+		stillInMenu = true;
 		globalTimeout = setTimeout( function() {
 			menuDisplay( $container, $parentLi );
 		}, hoverDelay );

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -512,8 +512,9 @@ var componentName = "wb-menu",
 	 * @method menuDisplay
 	 * @param {jQuery DOM element} $elm The plugin element
 	 * @param {jQuery DOM element} $menu The menu to display
+	 * @param {boolean} autoExpand Whether to open the menu's dropdown
 	 */
-	menuDisplay = function( $elm, $menu ) {
+	menuDisplay = function( $elm, $menu, autoExpand = true ) {
 		var $menuLink = $menu.find( "> a, > details > summary" ); //the issue seems to be that menu is getting passed as the mega menu UL (instead of LI.active) when hovering over an A element in the top-level mega menu items... which means some logic that calls this method is passing crap for $menu... ACTUALLY even though that's a bug, it's not causing any console errors in practice
 
 		console.log("inside menuDisplay");
@@ -540,8 +541,8 @@ var componentName = "wb-menu",
 			console.log("OH NOES, I have no length!!!");
 		}
 
-		// Ignore if doesn't have a submenu
-		if ( $menuLink.length && $menuLink.prop( "nodeName" ).toLowerCase() === "summary" ) {
+		// Ignore if doesn't have a submenu or isn't meant to auto-expand
+		if ( $menuLink.length && $menuLink.prop( "nodeName" ).toLowerCase() === "summary" && autoExpand ) {
 
 			console.log($menuLink);
 			console.log($menuLink.get(0));
@@ -685,6 +686,7 @@ $document.on( "click", selector + " summary", function( event ) {
 
 	var menuItem = event.currentTarget,
 		parent = menuItem.parentNode,
+		$parentLi = $( parent.closest( "li" ) ),
 		isOpen = parent.hasAttribute( "open" ),
 		menuItemOffsetTop, menuContainer;
 
@@ -692,6 +694,17 @@ $document.on( "click", selector + " summary", function( event ) {
 	console.log(menuItem);
 	console.log("parent:");
 	console.log(parent);
+
+	// Toggle parent list item's submenu open class if it's tied to a top-level mega menu summary
+	if ( $parentLi.children( ".item.active" ).first() ) {
+		if ( !isOpen ) {
+			$parentLi
+				.addClass( "sm-open" );
+		} else {
+			$parentLi
+				.removeClass( "sm-open" );
+		}
+	}
 
 	// Close any other open menus
 	if ( !isOpen ) {
@@ -749,7 +762,7 @@ $document.on( "mouseover focusin", selector + " .item", function( event ) {
 		console.log("NEW: $parentLi");
 		console.log($parentLi);
 		console.log("NEW: ---");
-		menuDisplay( $container, $parentLi );
+		menuDisplay( $container, $parentLi, false );
 	} else {
 		globalTimeout = setTimeout( function() {
 			menuDisplay( $container, $parentLi );
@@ -1038,3 +1051,4 @@ $document.on( "mediumview.wb largeview.wb xlargeview.wb", function() {
 wb.add( selector );
 
 } )( jQuery, window, document, wb );
+

--- a/src/plugins/menu/menu.js
+++ b/src/plugins/menu/menu.js
@@ -21,6 +21,7 @@ var componentName = "wb-menu",
 	focusEvent = "setfocus.wb",
 	detailsInitEvent = "wb-init.wb-details",
 	menuItemSelector = "> a, > details > summary",
+	stillInMenu = false,
 	$document = wb.doc,
 
 	// Used for half second delay on showing/hiding menus because of mouse hover
@@ -625,16 +626,44 @@ $document.on( "mouseleave", selector + " .menu", function( event ) {
 } );
 
 //Focus equivalent for mouseleave
+//Prevents active (highlight) effect from getting "stuck" when tabbing beyond top-level mega menu links
 $document.on( "focusout", selector + " .menu:has(.active)", function( event ) {
 	var $currentTarget = $( event.currentTarget );
 
 	console.log("Focus is leaving the menu bar...");
+	console.log("Focusout event");
 	console.log(event);
+	console.log("$currentTarget:");
+	console.log($currentTarget);
+	console.log("event.relatedTarget:");
+	console.log(event.relatedTarget);
+	console.log("document.activeElement:");
+	console.log(document.activeElement);
+	console.log("stillInMenu:");
+	console.log(stillInMenu);
 
 	// Close the menu if the element that gained focus ISN'T a child of the menu
-	if ($currentTarget.find(event.relatedTarget).length === 0) {
+
+	//Debug attempt...
+	if (!event.relatedTarget) {
+		//window.alert("NOOOOOOO!!! relatedTarget is null :S!!!");
+	}
+
+	// Close the active mega menu dropdown only if focus landed outside of it
+	// Notes:
+	// * event.relatedTarget should correspond to the interactive element that's gaining focus
+	// * When pressing the Escape key to close nested dropdowns, event.relatedTarget is inexplicably null... using a flag variable (stillInMenu) to work around it
+	if ( $currentTarget.find( event.relatedTarget ).length === 0 && !stillInMenu ) {
+		console.log("Closing the menu since the element that gained focus ISN'T a child of the menu");
 		menuClose( $currentTarget.find( ".active" ), true ); //NOTE: Can't pass event.target here directly since it's a link/summary and menuClose needs to take in an LI... although I could do closest() on event.target if I want... it's more in line with some other calls and might match faster since .item is a parent element
 	}
+
+	stillInMenu = false;
+} );
+
+$document.on( "focusin", function( event ) {
+	console.log("focusing in...");
+	console.log(event);
 } );
 
 // Prevent opening another menu if mouse re-enters already opened menu
@@ -659,8 +688,15 @@ $document.on( "click", selector + " summary", function( event ) {
 		isOpen = parent.hasAttribute( "open" ),
 		menuItemOffsetTop, menuContainer;
 
+	console.log("menuItem:");
+	console.log(menuItem);
+	console.log("parent:");
+	console.log(parent);
+
 	// Close any other open menus
 	if ( !isOpen ) {
+		console.log("parent details lacks an open attribute, so close other open menus");
+
 		$( parent )
 			.closest( "ul" )
 			.find( "[open]" )
@@ -818,8 +854,8 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				);
 
 			// Toggle sub-menu
-			// Enter or space arrow with a submenu
-			} else if ( hasPopup && ( which === ENTER_KC || which === SPACE_KC ) ) {
+			// Enter, space or Escape key with a submenu
+			} else if ( hasPopup && ( ( which === ENTER_KC || which === SPACE_KC ) || (which === ESC_KC && $menuItem.parent().attr( "open" ) ) ) ) {
 				$parent = $menuItem.parent(); //shouldn't need to use closest() for this part since the else if condition's hasPopup check will guarantee this can only run against summaries that are top-level mega menu items
 
 				// Prevent handling by details.js polyfill
@@ -833,6 +869,8 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				// If the menu item is a summary element
 				if ( menuItem.nodeName.toLowerCase() === "summary" ) {
 					isOpen = !!$parent.attr( "open" );
+					console.log("isOpen:");
+					console.log(isOpen);
 
 					//this is is where things are spiralling out of control... the old logic never got into this if when left/right pressing while deep inside a mega menu dropdown
 					console.log("summary element check... works in mobile menu and mega menu");
@@ -868,8 +906,15 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 			// Escape, left / right arrow without a submenu
 			} else if ( which === ESC_KC || which === LEFT_KC || which === RIGHT_KC ) {
 				console.log("NEW: uh oh 1...");
+				console.log("ESC pressed 1");
+				console.log("$menu:");
+				console.log($menu);
 				$parent = $menu.parent();
+				console.log("$parent:");
+				console.log($parent);
 				$parentMenu = $parent.closest( "ul" );
+				console.log("$parentMenu:");
+				console.log($parentMenu);
 				if ( which === LEFT_KC || which === RIGHT_KC ) {
 					event.preventDefault();
 					console.log("NEW: uh oh 2...");
@@ -878,15 +923,21 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				// If the parent menu is a menubar
 				if ( $parentMenu.hasClass( "menu" ) ) { //MINI TODO: Should this only be checking whether the direct parent UL has a menu class? Or any super high-level parent?
 					$menuLink = $menu.siblings( "a, summary" );
+					console.log("$menuLink:");
+					console.log($menuLink);
 
 					// Escape key = Close menu and return to menu bar item
 					if ( which === ESC_KC ) {
+						console.log("NEW: uh oh 3...");
+						console.log("ESC pressed 3");
 						event.preventDefault();
 						$menuLink.trigger( focusEvent );
 
 						// Close the menu but keep the referring link active
 						setTimeout( function() {
-							menuClose( $menuLink.parent(), false );
+							console.log("ESC pressed 3... trying to close the mega menu dropdown");
+							//NOTE: Using closest fixes mega menu dropdowns when inside a top-level menu item (using parent wasn't enough on its own because it matched details... whereas menuClose expects an li as its first param)
+							menuClose( $menuLink.parent().closest( "li" ), false );
 						}, 100 );
 
 					// Left / right key = Next / previous menu bar item
@@ -909,18 +960,28 @@ $document.on( "keydown", selector + " a[href], " + selector + " summary", functi
 				// menu or close the current submenu if there isn't
 				} else if ( which !== RIGHT_KC ) {
 					$subMenu = $parentMenu.length !== 0 ? $menu : $menuItem;
+					console.log("Inside the Escape or left arrow IF condition");
 
 					// There is a higher-level menu
 					if ( $parentMenu.length !== 0 ) {
 						event.preventDefault();
+						console.log("Fake click 1");
+						stillInMenu = true;
+						console.log("closest li menuItemSelector:");
+						console.log($menu.closest( "li" ).find( menuItemSelector ));
+						console.log("COMMENCING CLICK+FOCUS OF DEATH...");
 						$menu.closest( "li" )
-							.find( menuItemSelector )
+							.find( menuItemSelector ) //TODO: Don't use this anymore, menuItemSelector's scope is too broad since it covers regular links (which will never apply in this context)
 							.trigger( "click" )
 							.trigger( focusEvent );
 
 					// No higher-level menu but the current submenu is open
+					// BRAINDUMP: When would this actually run in practice? It sounds like this is meant to collapse a nested details element if its summary has focus and gets pressed... but that scenario is impossible in the old incarnation of the menu plugin (unless it predates when auto-focusing onto the first child menu item got implemented?)
+					// TODO: This needs to be restored and tested since it's now possible to focus onto an open nested details' summary
 					} else if ( $menuItem.parent().attr( "open" ) ) {
 						event.preventDefault();
+						console.log("Fake click 2");
+						stillInMenu = true;
 						$menuItem
 							.trigger( "click" )
 							.trigger( focusEvent );

--- a/theme/menu/_base.scss
+++ b/theme/menu/_base.scss
@@ -59,7 +59,7 @@
 	}
 
 	// .sm {
-		.sm.open, [open] { //TODO: This selector's probably gonna need to be revised to target the open details' UL... making the background colour of the entire details grey will more than likely mess with what's "behind" the summary
+		.sm.open, [open] .sm {
 			background: $wb-sm-sm-open-background;
 			border-bottom: 5px solid $wb-sm-sm-open-border-bottom;
 			border-left: 0;
@@ -94,7 +94,7 @@
 			}
 		}
 
-		.sm .row {
+		.sm .row { /* Unsure what the use case for this is... */
 			background: transparent;
 
 			a {
@@ -182,7 +182,7 @@
 		}
 	}
 
-	.sm-pnl {
+	.sm-pnl { /* Top part of the mobile menu overlay */
 		@extend %wet-theme-site-menu-mb-pnl-bg;
 	}
 

--- a/theme/menu/_base.scss
+++ b/theme/menu/_base.scss
@@ -24,7 +24,7 @@
 		> {
 			li {
 				> {
-					a {
+					a, details > summary {
 						border-left: 1px solid $wb-sm-menu-li-a-border-left;
 						color: $mb-pnl-body-link-color;
 
@@ -41,7 +41,7 @@
 
 				&:last-child {
 					> {
-						a {
+						a, details > summary {
 							border-right: 1px solid $wb-sm-menu-li-last-child-border-right;
 						}
 					}
@@ -49,7 +49,7 @@
 
 				&.active {
 					> {
-						a {
+						a, details > summary {
 							@extend %wet-theme-wb-menu-hover-active;
 						}
 					}
@@ -58,8 +58,8 @@
 		}
 	}
 
-	.sm {
-		&.open {
+	// .sm {
+		.sm.open, [open] { //TODO: This selector's probably gonna need to be revised to target the open details' UL... making the background colour of the entire details grey will more than likely mess with what's "behind" the summary
 			background: $wb-sm-sm-open-background;
 			border-bottom: 5px solid $wb-sm-sm-open-border-bottom;
 			border-left: 0;
@@ -94,14 +94,15 @@
 			}
 		}
 
-		.row {
+		.sm .row {
 			background: transparent;
 
 			a {
 				color: $wb-sm-sm-row-a-color;
 			}
 		}
-	}
+
+	// }
 
 	#wb-sec-p {
 		display: none;


### PR DESCRIPTION
The plugin previously used a mix of the menubar (for the mega menu) and menu (for the mobile menu) patterns... which have numerous issues and have fallen out of fashion overtime.

This revises the plugin to use the disclosure navigation menu pattern - with some refinements.

**Differences compared to APG's disclosure navigation pattern:**
* Uses native details/summary elements in desktop (in line with the first rule of ARIA, much easier than managing element states, APG seemingly intends to move in that direction in the future)
* Doesn't use ARIA roles (no point due to native details/summary semantics)
* Arrow keys function as substitutes for Tab/Shift+Tab (APG working example traps arrow focus within dropdowns, doesn't follow its own keyboard docs when pressing left/right arrow keys when focused on an expanded disclosure button)
* Auto-expands dropdowns when top-level menu items are hovered over (similar to the pre-existing plugin)

**Notes:**
* Backwards-compatible with AJAX fragments that used the old markup (converts the old markup into a details/summary structure)
* Transforms the desktop's old mega menu's HTML markup into details/summary markup before injecting the mega menu
* Custom themes might need to revise their CSS selectors to retain colour overrides...
* Supersedes #10155
* Fixes broken touchscreen support (dropdowns auto-collapsing a couple of seconds after tapping) in medium/large views
  * Note: Seems to vary from commit to commit, will need to double-check upon finalizing the PR

**Todos:**
* [x] Undo these differences vs the APG pattern:
  * [x] Don't allow arrow keys to "loop" around lists
  * [x] Possibly remove character key shortcuts (i.e. where typing a letter/number auto-focuses on a menu item beginning with that character)
* [x] Don't auto-expand dropdowns when keyboard tabbing (doing so makes it difficult to navigate between top-level menu items)
* [ ] Drastically simplify keyboard logic (should be feasible now that mobile/desktop menus share very similar structures and interchangeable arrow/Tab key behaviour)
* [x] Add RTL support for arrow keys (invert the direction of the left/right arrow keys in RTL scenarios... should be trivial to implement in simplified keyboard logic)
* [ ] Code groups of details elements as exclusive accordions (i.e. native HTML semantics for opening only one dropdown at a time)
* [ ] Heavily polish JS logic
* [ ] Remove debugging logic (status quo is chock-full of ``console.log`` messages)
* [ ] Revise SCSS selectors
* [ ] Cleanup comments
* [ ] Fix linting issues
* [x] ~~Squash draft commits~~ (note: probably better to retain all commits)
* [ ] Probably more

CC @duboisp @Garneauma @donmcdill @fsnoddy