### PR TITLE
Remove invalid aria-pressed from Data Table pagination

### DIFF
--- a/src/plugins/tables/tables.js
+++ b/src/plugins/tables/tables.js
@@ -152,8 +152,15 @@ var componentName = "wb-tables",
 		$pagination.empty();
 		$pagination.append( ol );
 
-		// Update the aria-pressed properties on the pagination buttons
-		// Should be pushed upstream to DataTables
+		// Prefix each page number with an invisible "Page" so the link reads as
+		// "Page 2" rather than a bare "2".
+		//
+		// The current page is not marked here. DataTables sets aria-current="page"
+		// on it, which is the correct pattern for pagination. This used to add
+		// aria-pressed as well, from a time when DataTables did not, but these are
+		// anchors carrying an explicit role="link" and aria-pressed is not allowed
+		// on that role, so it was an axe aria-allowed-attr error on every page
+		// button.
 		$pagination.find( ".paginate_button" )
 			.attr( {
 				"href": "#" + navFocusOnId
@@ -167,12 +174,9 @@ var componentName = "wb-tables",
 			} )
 
 			.not( ".previous, .next" )
-			.attr( "aria-pressed", "false" )
 			.html( function( index, oldHtml ) {
 				return "<span class='wb-inv'>" + i18nText.paginate.page + " </span>" + oldHtml;
-			} )
-			.filter( ".current" )
-			.attr( "aria-pressed", "true" );
+			} );
 	};
 
 // Bind the init event of the plugin


### PR DESCRIPTION
## What does this pull request (PR) do? / Que fait cette demande « pull » (PR)?

Removes `aria-pressed` from the Data Table pagination buttons, which is the `aria-allowed-attr` error reported in #10196.

`aria-pressed` is only valid on a button role. DataTables renders these buttons as anchors with an explicit `role="link"`, so the attribute is not allowed on them and axe flags every page button as a critical violation.

It is also redundant. The comment above the code says "Should be pushed upstream to DataTables", and that has since happened: DataTables 1.13 sets `aria-current="page"` on the active button, which is the correct pattern for pagination. Nothing in WET touches `aria-current`, so it already reaches the page intact. Removing `aria-pressed` loses no information. It leaves the current page marked one correct way instead of two ways, one of them invalid.

The rendered markup after the change, unchanged apart from the removed attribute:

```html
<a class="paginate_button previous disabled" role="link">
<a class="paginate_button current"          role="link" aria-current="page">
<a class="paginate_button"                  role="link">
```

The invisible "Page" prefix on each number is untouched.

## Verification

Against `dist/unmin/demos/tables/tables-en.html` built from this branch, in Chrome, using axe-core:

| | violations | passes |
|---|---|---|
| before | **16** | 40 |
| after | **0** | 56 |

Rule set: `aria-allowed-attr`, `aria-allowed-role`, `aria-required-attr`, `aria-valid-attr-value`. The 16 violating nodes move into the pass column, and `aria-current="page"` is confirmed still present on the current button afterwards.

Build and existing tests are clean on the branch:

```
grunt                exit 0
grunt pre-mocha      exit 0
node test-runner     exit 0   118 suites, 241 tests, 241 passes, 0 failures
```

**Disclosed honestly:** I did not add a unit test. `src/plugins/tables` has no `test.js`, and standing up a DataTables harness to assert one removed attribute seemed out of proportion to a deletion, as well as a bigger call than a first contribution should make on its own. Happy to add one if you would like it, and equally happy to be told the right shape for it.

## Related issues (optional) / Requêtes associées (optionnel)

Fixes #10196

## Also noticed, not changed here

`src/plugins/paginate/paginate.js` uses `aria-current="true"` on its page buttons. That is valid, but `aria-current="page"` is the more precise token for pagination and would match what DataTables does in the tables plugin. Deliberately left out of this PR since it is a different plugin and not part of the reported bug. Glad to send it separately if wanted.
