### PR TITLE
Details/summary: Set outline-color to currentColor

### DIFF
--- a/src/polyfills/details/_base.scss
+++ b/src/polyfills/details/_base.scss
@@ -29,6 +29,7 @@ details {
 		}
 
 		&:focus {
+			outline-color: currentColor;
 			outline-style: dotted;
 			outline-width: 1px;
 		}

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -92,6 +92,12 @@ module.exports = {
 				"selector-no-vendor-prefix": null,
 				"selector-pseudo-element-colon-notation": null,
 				"shorthand-property-no-redundant-values": null,
+				"value-keyword-case": [
+					"lower",
+					{
+						"camelCaseSvgKeywords": true
+					}
+				],
 				"value-no-vendor-prefix": null
 			}
 		},
@@ -120,7 +126,13 @@ module.exports = {
 				"selector-class-pattern": null,
 				"selector-id-pattern": null,
 				"selector-not-notation": null,
-				"selector-pseudo-element-colon-notation": null
+				"selector-pseudo-element-colon-notation": null,
+				"value-keyword-case": [
+					"lower",
+					{
+						"camelCaseSvgKeywords": true
+					}
+				]
 			}
 		}
 	],


### PR DESCRIPTION
#8403 made summary focus outlines visible in IE11 by adjusting the details/summary polyfill's base SCSS to override the ``outline-style/width`` properties.

However...
* The polyfill's base SCSS is exposed to browsers with native details/summary support (polyfill-only styles are in details.scss):
  * That degrades modern-looking outlines (which are usually dual-toned) into older-looking dotted outlines
* In modern versions of Chromium/Blink, the lack of an ``outline-color`` override caused contrast issues in the menu plugin's mobile overlay:
  * Caused by Blink setting ``outline-color`` to ``-webkit-focus-ring-color`` (very dark grey, usually used as its "inner" dual-toned outline colour)
  * The mobile menu overlay uses two dark blue background colours... which contrasts very poorly with ``-webkit-focus-ring-color``
  * Other modern browsers use ``currentColor``... which is derived from the current text colour

This resolves the contrast issue by setting ``outline-color`` to ``currentColor``.

Also adjusts stylelint's "value-keyword-case" rule accordingly (sets "camelCaseSvgKeywords" to ``true``).

**Related research:**
* CSS module level 4 working draft states that when ``outline-color`` is set to ``auto``, it should re-use the ``accent-colour`` (if declared) or fall back to ``currentColor`` (no longer written in camel case in the working draft):
  * Source: https://drafts.csswg.org/css-ui/#propdef-outline-color
* Firefox uses ``auto`` and doesn't set an ``accent-color``... which becomes ``currentColor`` in practice:
  * Source: https://searchfox.org/firefox-main/rev/6fd3453f587cfcd74637bad0b7b67f3d4680e679/layout/style/res/ua.css#190
* WebKit uses ``auto`` and doesn't appear to sent an ``accent-color``... which likely becomes ``currentColor`` in practice:
  * Source: https://github.com/WebKit/WebKit/blob/4e8b274fb225f4424f1729114841c02fd3246b45/Source/WebCore/css/html.css#L1471-L1473
* Blink uses ``-webkit-focus-ring-color``... which is ``rgb(16, 16, 16)`` (very dark grey) in practice:
  * Source: https://chromium.googlesource.com/chromium/src/+/5eb278a1120ed6cbaacbdab107d83e1278dd5efe/third_party/blink/renderer/core/html/resources/html.css#1659
  * Colour sources:
    * My own experience/tests in Windows 11
    * https://groups.google.com/a/chromium.org/g/blink-dev/c/kfOpQdftKGE mentioned that ``-webkit-focus-ring-color`` was set to ``rgb(16, 16, 16)`` as early as 2021
    * https://stackoverflow.com/a/11684199 states that ``-webkit-focus-ring-color``'s colour is dynamically set by ``WebCore::systemFocusRingColor`` (appears to be derived from the ``color-scheme`` property)