### PR TITLE
Core: Add summary to focusable/discoverable/tabbable methods

### DIFF
--- a/src/core/helpers.js
+++ b/src/core/helpers.js
@@ -1551,6 +1551,7 @@ $.fn.wb = function( method ) {
 
 Derived from jQuery UI, with the following changes:
 * Adheres to WET's ESLint settings (no-eq-null: changed loose null checks into strict undefined checks)
+* Adds support for the summary element (https://github.com/jquery/jquery-ui/pull/1885 is proposing the same change to jQuery UI itself)
 * Adds an isVisible parameter to the focusable method (preset to true to behave like jQuery UI by default, can optionally be set to false)
 * Adds an extra discoverable method (leverages the focusable method with isVisible set to false)
 
@@ -1582,7 +1583,7 @@ function focusable( element, hasTabindex, isVisible = true ) {
 		return img.length > 0;
 	}
 
-	if ( /^(input|select|textarea|button|object)$/.test( nodeName ) ) {
+	if ( /^(input|select|textarea|button|object|summary)$/.test( nodeName ) ) {
 		focusableIfVisible = !element.disabled;
 
 		if ( focusableIfVisible ) {


### PR DESCRIPTION
jQuery UI's ``focusable`` method works by targeting a handful of "known" elements (``input``, ``select``, ``textarea``, ``button``, ``object``) and verifying element states (``disabled``, ``tabindex`` attributes). The same holds true for the ``tabbable`` and ``discoverable`` (WET-only) methods since they contain calls to ``focusable``.

This adds the ``summary`` element to the mix since it's a commonly-used interactive element in modern times.

Related:
* Spinoff of #10152
* Benefits #10192:
  * Will cause tabbing to focus onto the mobile menu's first ``summary`` element if preceding content is set to ``display: none;``... as opposed to auto-expanding the first ``details`` element and focusing onto the first link inside it
  * Note: Mobile menu's tabbing behaviour currently only works in that scenario because the plugin adds ``tabindex="0"`` to the first summary of every menu list (which causes ``tabbable`` to recognize summaries)... going forward, the plugin will no longer insert ``tabindex`` attributes
* jquery/jquery-ui#1885 is proposing the same change to jQuery UI itself (not yet merged due to missing unit tests)

CC @Garneauma