### PR TITLE
Formvalid: email field validation without domain

### DIFF
--- a/src/plugins/formvalid/formvalid.js
+++ b/src/plugins/formvalid/formvalid.js
@@ -384,6 +384,11 @@ var componentName = "wb-frmvld",
 								$form.validate().element( this );
 							} );
 
+							// Ensuring email validation isn't done without the top-level domain (.com, .ca, .net, etc)
+							$.validator.methods.email = function( value, element ) {
+								return this.optional( element ) || /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9]{0,61}[a-zA-Z0-9])?)+$/i.test( value );
+							};
+
 							// Clear the form and remove error messages on reset
 							$document.on( "click", selector + " input[type=reset]", function( event ) {
 								var which = event.which,


### PR DESCRIPTION
Related to WET-699.
Fixed email address validation so that emails without top-level domains (.com, .ca, .net., etc) are not accepted.